### PR TITLE
Direct IP Request detection rule

### DIFF
--- a/rules/proxy/proxy_susp_direct_ip.yml
+++ b/rules/proxy/proxy_susp_direct_ip.yml
@@ -8,9 +8,10 @@ logsource:
   category: proxy
 detection:
   ipv4:
-    cs-host|re: '^[0-9.]+$'
+    cs-host|re: '[0-9.]+'
   ipv6:
-    cs-host|re: '^\[[0-9a-fA-F:]+\]$'
+    cs-host|contains: ':'
+    # cs-host|re: '\[[0-9a-fA-F:]+\]' #Full regex match for IPv6: Possibly more accurate, certainly worse for performance
   condition: 1 of them
 fields:
   - c-ip

--- a/rules/proxy/proxy_susp_direct_ip.yml
+++ b/rules/proxy/proxy_susp_direct_ip.yml
@@ -7,9 +7,11 @@ date: 2020/03/26
 logsource:
   category: proxy
 detection:
-  selection:
-    cs-host|re: (25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])
-  condition: selection
+  ipv4:
+    cs-host|re: '^[0-9.]+$'
+  ipv6:
+    cs-host|re: '^\[[0-9a-fA-F:]+\]$'
+  condition: 1 of them
 fields:
   - c-ip
   - c-uri

--- a/rules/proxy/proxy_susp_direct_ip.yml
+++ b/rules/proxy/proxy_susp_direct_ip.yml
@@ -1,0 +1,19 @@
+title: Suspicious Request Directly to IP
+id: 6727a9d6-0962-44c0-8662-c87acf24efb3
+status: experimental
+description: Detects suspicious requests directly to IPs
+author: NVISO
+date: 2020/03/26
+logsource:
+  category: proxy
+detection:
+  selection:
+    cs-host|re: (25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])
+  condition: selection
+fields:
+  - c-ip
+  - c-uri
+  - c-useragent
+falsepositives:
+  - Microsoft Azure Linux Guest Agent
+level: medium


### PR DESCRIPTION
Rule to detect webrequests directly to an IP in your proxy logs.