### PR TITLE
Office persistence by addin detection

### DIFF
--- a/rules/windows/sysmon/sysmon_office_persistence.yml
+++ b/rules/windows/sysmon/sysmon_office_persistence.yml
@@ -26,7 +26,7 @@ detection:
     TargetFilename|endswith:
       - .xlam
       - .xla
-condition: selection and (wlldropped or xlldropped or generic)
+  condition: selection and (wlldropped or xlldropped or generic)
 falsepositives:
   - Legitimate add-ins
 level: high


### PR DESCRIPTION
Detects persistence by loading addins in Word or Excel. This does not detect any specific addins, and should be baselined against legitimately used addins.