### PR TITLE
Fax Service DLL search order hijacking detection

### DIFF
--- a/rules/windows/sysmon/sysmon_susp_fax_dll.yml
+++ b/rules/windows/sysmon/sysmon_susp_fax_dll.yml
@@ -1,0 +1,31 @@
+title: Fax Service DLL Search Order Hijack
+id: 828af599-4c53-4ed2-ba4a-a9f835c434ea
+status: experimental
+description: The Fax service attempts to load ualapi.dll, which is non-existent. An attacker can then (side)load their own malicious DLL using this service.
+references:
+  - https://windows-internals.com/faxing-your-way-to-system/
+author: NVISO
+date: 2020/05/04
+tags:
+  - attack.persistence
+  - attack.defense_evasion
+  - attack.t1073
+  - attack.t1038
+  - attack.t1112
+logsource:
+  product: windows
+  service: sysmon
+detection:
+  selection:
+    EventID: 7 #ImageLoaded
+    Image|endswith:
+      - fxssvc.exe
+    ImageLoaded|endswith:
+      - ualapi.dll
+  filter:
+    ImageLoaded|startswith:
+      - C:\Windows\WinSxS\
+  condition: selection and not filter
+falsepositives:
+  - Unlikely
+level: high


### PR DESCRIPTION
Rule to detect the hijacking of `ualapi.dll`, as described in [this blogpost](https://windows-internals.com/faxing-your-way-to-system/).