### PR TITLE
win_defender_history_delete.yml

### DIFF
--- a/rules/windows/other/win_defender_history_delete.yml
+++ b/rules/windows/other/win_defender_history_delete.yml
@@ -1,0 +1,25 @@
+title: Windows Defender Malware Detection History Deletion
+id: 2afe6582-e149-11ea-87d0-0242ac130003
+status: experimental
+description: Windows Defender logs when the history of detected infections is deleted. Log file will contain the message "Windows Defender Antivirus has removed history of malware and other potentially unwanted software".
+author: Cian Heasley
+reference:
+    - https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-antivirus/troubleshoot-microsoft-defender-antivirus
+date: 2020/08/13
+tags:
+    - attack.defense_evasion
+    - attack.t1070.001
+logsource:
+    category: windows
+    product: windef
+detection:
+    selection:
+        EventID: 1013
+        EventType: 4
+    condition: selection
+fields:
+    - EventID
+    - EventType
+falsepositives:
+    - Deletion of Defender malware detections history for legitimate reasons
+level: high


### PR DESCRIPTION
Windows Defender logs when the history of detected infections is deleted. Log file will contain the message "Windows Defender Antivirus has removed history of malware and other potentially unwanted software".