### PR TITLE
rule: Insecure NetLogon auth - likely Zerologon (CVE-2020-1472) attempt

### DIFF
--- a/rules/windows/builtin/win_susp_netlogon_auth.yml
+++ b/rules/windows/builtin/win_susp_netlogon_auth.yml
@@ -1,0 +1,32 @@
+title: Insecure NetLogon Authentication
+id: aef9a8d3-ba73-4996-9656-902242e12600
+status: experimental
+description:
+    Detects legacy NetLogon authentication *on unpatched systems* where Secure RPC is disabled - possibly a Zerologon (CVE-2020-1472) attempt.
+    On patched systems (August 2020), use the new event IDs 5827-5831 in the System event log instead.
+references:
+    - https://www.secura.com/blog/zero-logon
+    - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/5805bc9f-e4c9-4c8a-b191-3c3a7de7eeed
+    - https://github.com/jdu2600/Windows10EtwEvents/blob/master/mof/Active_Directory-_NetLogon.tsv
+    - https://support.microsoft.com/en-au/help/4557222/how-to-manage-the-changes-in-netlogon-secure-channel-connections-assoc
+author: John U (@jdu2600)
+date: 2020/09/20
+tags:
+    - attack.lateral_movement
+    - attack.t1210
+logsource:
+    product: windows
+    service: netlogon
+    definition:
+        Requires ETW events from the legacy 'Active Directory: NetLogon' provider {f33959b4-dbec-11d2-895b-00c04f79ab69}
+detection:
+    selection:
+        Source: 'Active Directory: NetLogon'
+        Opcode:
+            - 1  # NlServerAuth_Start
+            - 2  # NlServerAuth_End - also contains Status field indicating success/failure
+        NegotiatedFlags&0x40000000: 0  # 0x40000000 - Secure RPC is enabled
+    condition: selection
+falsepositives:
+    - Legacy NetLogon clients that don't support Secure RPC
+level: critical


### PR DESCRIPTION
The legacy NetLogon ETW provider includes NegotiatedFlags parameter of the NetrServerAuthenticate3 MS-NRPC call.
The 2nd bit is the 'Secure RPC' flag which Zerologon needs to disable.
Flagging on Netlogon authentication attempts with this flag disabled should be very high fidelity signal for Zerologon attempts. 

Issues -
I couldn't find any examples on how do do a couple of things in Sigma.
How do I specify a non-eventlog ETW provider?
How do I check a flag in Sigma? 

Bigger Issue - 
As far as I know, SilkService and Sealighter are the only two generic ETW logging services - and neither is a supported Sigma backend (yet). So nobody can use it straight away...
* https://github.com/fireeye/SilkETW
* https://github.com/pathtofile/Sealighter