### PR TITLE
Replace '- attack.txxxx # an old one' by '- attack.old.txxxx' to keep…

### DIFF
--- a/rules/apt/apt_silence_downloader_v3.yml
+++ b/rules/apt/apt_silence_downloader_v3.yml
@@ -31,7 +31,7 @@ level: high
 tags:
     - attack.persistence
     - attack.t1547.001
-    - attack.t1060  # an old one
+    - attack.old.t1060
     - attack.discovery
     - attack.t1057
     - attack.t1082

--- a/rules/apt/apt_silence_eda.yml
+++ b/rules/apt/apt_silence_eda.yml
@@ -32,10 +32,10 @@ level: critical
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
     - attack.command_and_control
     - attack.t1071.004
-    - attack.t1071  # an old one
+    - attack.old.t1071
     - attack.t1572
     - attack.impact
     - attack.t1529

--- a/rules/cloud/aws_cloudtrail_disable_logging.yml
+++ b/rules/cloud/aws_cloudtrail_disable_logging.yml
@@ -23,4 +23,4 @@ level: medium
 tags:
     - attack.defense_evasion
     - attack.t1562.001
-    - attack.t1089  # an old one
+    - attack.old.t1089

--- a/rules/cloud/aws_config_disable_recording.yml
+++ b/rules/cloud/aws_config_disable_recording.yml
@@ -20,4 +20,4 @@ level: high
 tags:
     - attack.defense_evasion
     - attack.t1562.001
-    - attack.t1089  # an old one
+    - attack.old.t1089

--- a/rules/cloud/aws_ec2_startup_script_change.yml
+++ b/rules/cloud/aws_ec2_startup_script_change.yml
@@ -23,8 +23,8 @@ level: high
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
     - attack.t1059.003
     - attack.t1059.004
-    - attack.t1059  # an old one
-    - attack.t1064  # an old one
+    - attack.old.t1059
+    - attack.old.t1064

--- a/rules/cloud/aws_guardduty_disruption.yml
+++ b/rules/cloud/aws_guardduty_disruption.yml
@@ -20,4 +20,4 @@ level: high
 tags:
     - attack.defense_evasion
     - attack.t1562.001
-    - attack.t1089  # an old one
+    - attack.old.t1089

--- a/rules/cloud/aws_root_account_usage.yml
+++ b/rules/cloud/aws_root_account_usage.yml
@@ -21,4 +21,4 @@ level: medium
 tags:
   - attack.privilege_escalation
   - attack.t1078.004
-  - attack.t1078  # an old one
+  - attack.old.t1078

--- a/rules/linux/auditd/lnx_auditd_alter_bash_profile.yml
+++ b/rules/linux/auditd/lnx_auditd_alter_bash_profile.yml
@@ -27,6 +27,6 @@ falsepositives:
 level: medium
 tags:
     - attack.s0003
-    - attack.t1156    # an old one
+    - attack.old.t1156
     - attack.persistence
     - attack.t1546.004

--- a/rules/linux/auditd/lnx_auditd_auditing_config_change.yml
+++ b/rules/linux/auditd/lnx_auditd_auditing_config_change.yml
@@ -31,5 +31,5 @@ falsepositives:
 level: high
 tags:
     - attack.defense_evasion
-    - attack.t1054    # an old one
+    - attack.old.t1054
     - attack.t1562.006

--- a/rules/linux/auditd/lnx_auditd_create_account.yml
+++ b/rules/linux/auditd/lnx_auditd_create_account.yml
@@ -18,6 +18,6 @@ falsepositives:
     - Admin activity
 level: medium
 tags:
-    - attack.t1136    # an old one
+    - attack.old.t1136
     - attack.t1136.001
     - attack.persistence

--- a/rules/linux/auditd/lnx_auditd_logging_config_change.yml
+++ b/rules/linux/auditd/lnx_auditd_logging_config_change.yml
@@ -30,5 +30,5 @@ falsepositives:
 level: high
 tags:
     - attack.defense_evasion
-    - attack.t1054    # an old one
+    - attack.old.t1054
     - attack.t1562.006

--- a/rules/network/cisco/aaa/cisco_cli_clear_logs.yml
+++ b/rules/network/cisco/aaa/cisco_cli_clear_logs.yml
@@ -25,5 +25,5 @@ falsepositives:
 level: high
 tags:
     - attack.defense_evasion
-    - attack.t1146          # an old one
+    - attack.old.t1146
     - attack.t1070.003

--- a/rules/network/cisco/aaa/cisco_cli_collect_data.yml
+++ b/rules/network/cisco/aaa/cisco_cli_collect_data.yml
@@ -29,9 +29,9 @@ tags:
     - attack.discovery
     - attack.credential_access
     - attack.collection
-    - attack.t1087           # an old one
+    - attack.old.t1087
     - attack.t1087.001
-    - attack.t1003           # an old one
-    - attack.t1081           # an old one
+    - attack.old.t1003
+    - attack.old.t1081
     - attack.t1552.001
     - attack.t1005

--- a/rules/network/cisco/aaa/cisco_cli_crypto_actions.yml
+++ b/rules/network/cisco/aaa/cisco_cli_crypto_actions.yml
@@ -26,7 +26,7 @@ level: high
 tags:
     - attack.credential_access
     - attack.defense_evasion
-    - attack.t1130          # an old one
+    - attack.old.t1130
     - attack.t1553.004
-    - attack.t1145          # an old one
+    - attack.old.t1145
     - attack.t1552.004

--- a/rules/network/cisco/aaa/cisco_cli_disable_logging.yml
+++ b/rules/network/cisco/aaa/cisco_cli_disable_logging.yml
@@ -24,5 +24,5 @@ falsepositives:
 level: high
 tags:
     - attack.defense_evasion
-    - attack.t1089          # an old one
+    - attack.old.t1089
     - attack.t1562.001

--- a/rules/network/cisco/aaa/cisco_cli_dos.yml
+++ b/rules/network/cisco/aaa/cisco_cli_dos.yml
@@ -24,5 +24,5 @@ tags:
     - attack.impact
     - attack.t1495
     - attack.t1529
-    - attack.t1492          # an old one
+    - attack.old.t1492
     - attack.t1565.001

--- a/rules/network/cisco/aaa/cisco_cli_file_deletion.yml
+++ b/rules/network/cisco/aaa/cisco_cli_file_deletion.yml
@@ -22,9 +22,9 @@ level: medium
 tags:
     - attack.defense_evasion
     - attack.impact
-    - attack.t1107          # an old one
+    - attack.old.t1107
     - attack.t1070.004
-    - attack.t1488          # an old one
+    - attack.old.t1488
     - attack.t1561.001
-    - attack.t1487          # an old one
+    - attack.old.t1487
     - attack.t1561.002

--- a/rules/network/cisco/aaa/cisco_cli_input_capture.yml
+++ b/rules/network/cisco/aaa/cisco_cli_input_capture.yml
@@ -22,6 +22,6 @@ falsepositives:
 level: medium
 tags:
     - attack.credential_access
-    - attack.t1139          # an old one
+    - attack.old.t1139
     - attack.t1552.003
     

--- a/rules/network/cisco/aaa/cisco_cli_local_accounts.yml
+++ b/rules/network/cisco/aaa/cisco_cli_local_accounts.yml
@@ -21,6 +21,6 @@ falsepositives:
 level: high
 tags:
     - attack.persistence
-    - attack.t1136          # an old one
+    - attack.old.t1136
     - attack.t1136.001
     - attack.t1098

--- a/rules/network/cisco/aaa/cisco_cli_modify_config.yml
+++ b/rules/network/cisco/aaa/cisco_cli_modify_config.yml
@@ -30,7 +30,7 @@ tags:
     - attack.impact
     - attack.t1490
     - attack.t1505
-    - attack.t1493          # an old one
+    - attack.old.t1493
     - attack.t1565.002
-    - attack.t1168          # an old one
+    - attack.old.t1168
     - attack.t1053

--- a/rules/network/cisco/aaa/cisco_cli_moving_data.yml
+++ b/rules/network/cisco/aaa/cisco_cli_moving_data.yml
@@ -30,5 +30,5 @@ tags:
     - attack.exfiltration
     - attack.t1074
     - attack.t1105
-    - attack.t1002          # an old one
+    - attack.old.t1002
     - attack.t1560.001

--- a/rules/network/net_dns_c2_detection.yml
+++ b/rules/network/net_dns_c2_detection.yml
@@ -20,8 +20,8 @@ falsepositives:
 level: high
 tags:
     - attack.command_and_control
-    - attack.t1071 # an old one
+    - attack.old.t1071
     - attack.t1071.004
     - attack.exfiltration
-    - attack.t1048 # an old one
+    - attack.old.t1048
     - attack.t1048.003

--- a/rules/network/net_high_dns_bytes_out.yml
+++ b/rules/network/net_high_dns_bytes_out.yml
@@ -11,7 +11,7 @@ falsepositives:
 level: medium
 tags:
     - attack.exfiltration
-    - attack.t1048 # an old one
+    - attack.old.t1048
     - attack.t1048.003
 ---
 logsource:

--- a/rules/network/net_high_dns_requests_rate.yml
+++ b/rules/network/net_high_dns_requests_rate.yml
@@ -11,10 +11,10 @@ falsepositives:
 level: medium
 tags:
     - attack.exfiltration
-    - attack.t1048 # an old one
+    - attack.old.t1048
     - attack.t1048.003
     - attack.command_and_control
-    - attack.t1071 # an old one
+    - attack.old.t1071
     - attack.t1071.004
 ---
 logsource:

--- a/rules/network/net_high_null_records_requests_rate.yml
+++ b/rules/network/net_high_null_records_requests_rate.yml
@@ -17,8 +17,8 @@ falsepositives:
 level: medium
 tags:
     - attack.exfiltration
-    - attack.t1048 # an old one
+    - attack.old.t1048
     - attack.t1048.003
     - attack.command_and_control
-    - attack.t1071 # an old one
+    - attack.old.t1071
     - attack.t1071.004

--- a/rules/network/net_high_txt_records_requests_rate.yml
+++ b/rules/network/net_high_txt_records_requests_rate.yml
@@ -17,8 +17,8 @@ falsepositives:
 level: medium
 tags:
     - attack.exfiltration
-    - attack.t1048 # an old one
+    - attack.old.t1048
     - attack.t1048.003
     - attack.command_and_control
-    - attack.t1071 # an old one
+    - attack.old.t1071
     - attack.t1071.004

--- a/rules/network/net_mal_dns_cobaltstrike.yml
+++ b/rules/network/net_mal_dns_cobaltstrike.yml
@@ -20,5 +20,5 @@ falsepositives:
 level: high
 tags:
     - attack.command_and_control
-    - attack.t1071 # an old one
+    - attack.old.t1071
     - attack.t1071.004

--- a/rules/network/net_susp_dns_b64_queries.yml
+++ b/rules/network/net_susp_dns_b64_queries.yml
@@ -19,8 +19,8 @@ falsepositives:
 level: medium
 tags:
     - attack.exfiltration
-    - attack.t1048 # an old one
+    - attack.old.t1048
     - attack.t1048.003
     - attack.command_and_control
-    - attack.t1071 # an old one
+    - attack.old.t1071
     - attack.t1071.004

--- a/rules/network/net_susp_dns_txt_exec_strings.yml
+++ b/rules/network/net_susp_dns_txt_exec_strings.yml
@@ -23,5 +23,5 @@ falsepositives:
 level: high
 tags:
     - attack.command_and_control
-    - attack.t1071 # an old one
+    - attack.old.t1071
     - attack.t1071.004

--- a/rules/network/net_susp_telegram_api.yml
+++ b/rules/network/net_susp_telegram_api.yml
@@ -22,5 +22,5 @@ falsepositives:
 level: medium
 tags:
     - attack.command_and_control
-    - attack.t1102 # an old one
+    - attack.old.t1102
     - attack.t1102.002

--- a/rules/network/zeek/zeek-dce_rpc_domain_user_enumeration.yml
+++ b/rules/network/zeek/zeek-dce_rpc_domain_user_enumeration.yml
@@ -9,7 +9,7 @@ date: 2020/05/03
 modified: 2020/09/02
 tags:
     - attack.discovery
-    - attack.t1087 # an old one
+    - attack.old.t1087
     - attack.t1087.002
     - attack.t1082
 logsource:

--- a/rules/network/zeek/zeek_dce_rpc_mitre_bzar_execution.yml
+++ b/rules/network/zeek/zeek_dce_rpc_mitre_bzar_execution.yml
@@ -7,9 +7,9 @@ references:
     - https://github.com/mitre-attack/bzar#indicators-for-attck-execution
 tags:
     - attack.execution
-    - attack.t1035 # an old one
+    - attack.old.t1035
     - attack.t1047
-    - attack.t1053 # an old one
+    - attack.old.t1053
     - attack.t1053.002
     - attack.t1569.002
 logsource:

--- a/rules/network/zeek/zeek_dce_rpc_mitre_bzar_persistence.yml
+++ b/rules/network/zeek/zeek_dce_rpc_mitre_bzar_persistence.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/mitre-attack/bzar#indicators-for-attck-persistence
 tags:
     - attack.persistence
-    - attack.t1004 # an old one
+    - attack.old.t1004
     - attack.t1547.004
 logsource:
     product: zeek

--- a/rules/network/zeek/zeek_rdp_public_listener.yml
+++ b/rules/network/zeek/zeek_rdp_public_listener.yml
@@ -5,7 +5,7 @@ description: Detects connections from routable IPs to an RDP listener - which is
 references:
     - https://attack.mitre.org/techniques/T1021/001/
 tags:
-    - attack.t1021 # an old one
+    - attack.old.t1021
     - attack.t1021.001
 author: 'Josh Brower @DefensiveDepth'
 date: 2020/08/22 

--- a/rules/network/zeek/zeek_smb_converted_win_atsvc_task.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_atsvc_task.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.lateral_movement
     - attack.persistence
-    - attack.t1053 # an old one
+    - attack.old.t1053
     - car.2013-05-004
     - car.2015-04-001
     - attack.t1053.002

--- a/rules/network/zeek/zeek_smb_converted_win_impacket_secretdump.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_impacket_secretdump.yml
@@ -7,7 +7,7 @@ references:
     - https://blog.menasec.net/2019/02/threat-huting-10-impacketsecretdump.html
 tags:
     - attack.credential_access
-    - attack.t1003 # an old one
+    - attack.old.t1003
     - attack.t1003.002
     - attack.t1003.004
     - attack.t1003.003

--- a/rules/network/zeek/zeek_smb_converted_win_lm_namedpipe.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_lm_namedpipe.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/neo23x0/sigma/blob/d42e87edd741dd646db946f30964f331f92f50e6/rules/windows/builtin/win_lm_namedpipe.yml
 tags:
     - attack.lateral_movement
-    - attack.t1077 # an old one
+    - attack.old.t1077
     - attack.t1021.002
 logsource:
     product: zeek

--- a/rules/network/zeek/zeek_smb_converted_win_susp_psexec.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_susp_psexec.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/neo23x0/sigma/blob/d42e87edd741dd646db946f30964f331f92f50e6/rules/windows/builtin/win_susp_psexec.yml
 tags:
     - attack.lateral_movement
-    - attack.t1077 # an old one
+    - attack.old.t1077
     - attack.t1021.002
 logsource:
     product: zeek

--- a/rules/network/zeek/zeek_smb_converted_win_transferring_files_with_credential_data.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_transferring_files_with_credential_data.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/neo23x0/sigma/blob/373424f14574facf9e261d5c822345a282b91479/rules/windows/builtin/win_transferring_files_with_credential_data_via_network_shares.yml
 tags:
     - attack.credential_access
-    - attack.t1003 # an old one
+    - attack.old.t1003
     - attack.t1003.002
     - attack.t1003.001
     - attack.t1003.003

--- a/rules/network/zeek/zeek_susp_kerberos_rc4.yml
+++ b/rules/network/zeek/zeek_susp_kerberos_rc4.yml
@@ -7,7 +7,7 @@ references:
     - https://adsecurity.org/?p=3458
 tags:
     - attack.credential_access
-    - attack.t1208 # an old one
+    - attack.old.t1208
     - attack.t1558.003
 logsource:
     product: zeek

--- a/rules/proxy/proxy_apt40.yml
+++ b/rules/proxy/proxy_apt40.yml
@@ -23,7 +23,7 @@ level: high
 tags:
     - attack.command_and_control
     - attack.t1071.001
-    - attack.t1043  # an old one
+    - attack.old.t1043
     - attack.exfiltration
     - attack.t1567.002
-    - attack.t1048  # an old one 
+    - attack.old.t1048 

--- a/rules/proxy/proxy_chafer_malware.yml
+++ b/rules/proxy/proxy_chafer_malware.yml
@@ -22,4 +22,4 @@ level: critical
 tags:
     - attack.command_and_control
     - attack.t1071.001
-    - attack.t1043  # an old one
+    - attack.old.t1043

--- a/rules/proxy/proxy_cobalt_amazon.yml
+++ b/rules/proxy/proxy_cobalt_amazon.yml
@@ -30,4 +30,4 @@ tags:
   - attack.defense_evasion
   - attack.command_and_control
   - attack.t1071.001
-  - attack.t1043  # an old one
+  - attack.old.t1043

--- a/rules/proxy/proxy_cobalt_ocsp.yml
+++ b/rules/proxy/proxy_cobalt_ocsp.yml
@@ -11,7 +11,7 @@ tags:
     - attack.defense_evasion
     - attack.command_and_control
     - attack.t1071.001
-    - attack.t1043  # an old one
+    - attack.old.t1043
 logsource:
     category: proxy
 detection:

--- a/rules/proxy/proxy_cobalt_onedrive.yml
+++ b/rules/proxy/proxy_cobalt_onedrive.yml
@@ -24,4 +24,4 @@ tags:
     - attack.defense_evasion
     - attack.command_and_control
     - attack.t1071.001
-    - attack.t1043  # an old one
+    - attack.old.t1043

--- a/rules/proxy/proxy_download_susp_tlds_blacklist.yml
+++ b/rules/proxy/proxy_download_susp_tlds_blacklist.yml
@@ -113,4 +113,4 @@ tags:
     - attack.execution
     - attack.t1203
     - attack.t1204.002
-    - attack.t1204  # an old one
+    - attack.old.t1204

--- a/rules/proxy/proxy_download_susp_tlds_whitelist.yml
+++ b/rules/proxy/proxy_download_susp_tlds_whitelist.yml
@@ -62,4 +62,4 @@ tags:
     - attack.execution
     - attack.t1203
     - attack.t1204.002
-    - attack.t1204  # an old one
+    - attack.old.t1204

--- a/rules/proxy/proxy_downloadcradle_webdav.yml
+++ b/rules/proxy/proxy_downloadcradle_webdav.yml
@@ -27,4 +27,4 @@ level: high
 tags:
     - attack.command_and_control
     - attack.t1071.001
-    - attack.t1043  # an old one
+    - attack.old.t1043

--- a/rules/proxy/proxy_empire_ua_uri_combos.yml
+++ b/rules/proxy/proxy_empire_ua_uri_combos.yml
@@ -28,4 +28,4 @@ tags:
   - attack.defense_evasion
   - attack.command_and_control
   - attack.t1071.001
-  - attack.t1043  # an old one
+  - attack.old.t1043

--- a/rules/proxy/proxy_ios_implant.yml
+++ b/rules/proxy/proxy_ios_implant.yml
@@ -30,4 +30,4 @@ tags:
     - attack.credential_access
     - attack.t1528
     - attack.t1552.001
-    - attack.t1081  # an old one
+    - attack.old.t1081

--- a/rules/proxy/proxy_pwndrop.yml
+++ b/rules/proxy/proxy_pwndrop.yml
@@ -23,7 +23,7 @@ level: critical
 tags:
     - attack.command_and_control
     - attack.t1071.001
-    - attack.t1043  # an old one
+    - attack.old.t1043
     - attack.t1102.001
     - attack.t1102.003
-    - attack.t1102  # an old one
+    - attack.old.t1102

--- a/rules/proxy/proxy_raw_paste_service_access.yml
+++ b/rules/proxy/proxy_raw_paste_service_access.yml
@@ -27,8 +27,8 @@ level: high
 tags:
     - attack.command_and_control
     - attack.t1071.001
-    - attack.t1043  # an old one
+    - attack.old.t1043
     - attack.t1102.001
     - attack.t1102.003
     - attack.defense_evasion
-    - attack.t1102  # an old one
+    - attack.old.t1102

--- a/rules/proxy/proxy_susp_flash_download_loc.yml
+++ b/rules/proxy/proxy_susp_flash_download_loc.yml
@@ -24,7 +24,7 @@ tags:
     - attack.t1189
     - attack.execution
     - attack.t1204.002
-    - attack.t1204  # an old one
+    - attack.old.t1204
     - attack.defense_evasion
     - attack.t1036.005
-    - attack.t1036  # an old one
+    - attack.old.t1036

--- a/rules/proxy/proxy_telegram_api.yml
+++ b/rules/proxy/proxy_telegram_api.yml
@@ -32,6 +32,6 @@ tags:
     - attack.defense_evasion
     - attack.command_and_control
     - attack.t1071.001
-    - attack.t1043  # an old one
+    - attack.old.t1043
     - attack.t1102.002
-    - attack.t1102  # an old one
+    - attack.old.t1102

--- a/rules/proxy/proxy_turla_comrat.yml
+++ b/rules/proxy/proxy_turla_comrat.yml
@@ -20,5 +20,5 @@ tags:
     - attack.defense_evasion
     - attack.command_and_control
     - attack.t1071.001
-    - attack.t1043  # an old one
+    - attack.old.t1043
     - attack.g0010

--- a/rules/proxy/proxy_ursnif_malware.yml
+++ b/rules/proxy/proxy_ursnif_malware.yml
@@ -51,9 +51,9 @@ level: critical
 tags:
     - attack.initial_access
     - attack.t1566.001
-    - attack.t1193  # an old one
+    - attack.old.t1193
     - attack.execution
     - attack.t1204.002
-    - attack.t1204  # an old one
+    - attack.old.t1204
     - attack.command_and_control
     - attack.t1071.001

--- a/rules/web/web_apache_segfault.yml
+++ b/rules/web/web_apache_segfault.yml
@@ -17,5 +17,5 @@ falsepositives:
 level: high
 tags:
     - attack.impact
-    - attack.t1499 # an old one
+    - attack.old.t1499
     - attack.t1499.004

--- a/rules/web/web_cve_2018_2894_weblogic_exploit.yml
+++ b/rules/web/web_cve_2018_2894_weblogic_exploit.yml
@@ -23,7 +23,7 @@ falsepositives:
     - Unknown
 level: critical
 tags:
-    - attack.t1100 # an old one
+    - attack.old.t1100
     - attack.t1190
     - attack.initial_access
     - attack.persistence

--- a/rules/web/web_cve_2020_14882_weblogic_exploit.yml
+++ b/rules/web/web_cve_2020_14882_weblogic_exploit.yml
@@ -25,7 +25,7 @@ falsepositives:
     - Unknown
 level: high
 tags:
-    - attack.t1100 # an old one
+    - attack.old.t1100
     - attack.t1190
     - attack.initial_access
     - cve.2020-14882

--- a/rules/web/web_cve_2020_3452_cisco_asa_ftd.yml
+++ b/rules/web/web_cve_2020_3452_cisco_asa_ftd.yml
@@ -31,7 +31,7 @@ falsepositives:
     - Unknown
 level: high
 tags:
-    - attack.t1100 # an old one
+    - attack.old.t1100
     - attack.t1190
     - attack.initial_access
     - cve.2020-3452

--- a/rules/web/web_webshell_keyword.yml
+++ b/rules/web/web_webshell_keyword.yml
@@ -24,5 +24,5 @@ falsepositives:
 level: high
 tags:
     - attack.persistence
-    - attack.t1100 # an old one
+    - attack.old.t1100
     - attack.t1505.003

--- a/rules/windows/builtin/win_GPO_scheduledtasks.yml
+++ b/rules/windows/builtin/win_GPO_scheduledtasks.yml
@@ -9,7 +9,7 @@ references:
 tags:
     - attack.persistence
     - attack.lateral_movement
-    - attack.t1053          # an old one
+    - attack.old.t1053
     - attack.t1053.005
 logsource:
     product: windows

--- a/rules/windows/builtin/win_account_discovery.yml
+++ b/rules/windows/builtin/win_account_discovery.yml
@@ -5,7 +5,7 @@ references:
     - https://blog.menasec.net/2019/02/threat-hunting-5-detecting-enumeration.html
 tags:
     - attack.discovery
-    - attack.t1087          # an old one
+    - attack.old.t1087
     - attack.t1087.002
 status: experimental
 author: Samir Bousseaden

--- a/rules/windows/builtin/win_ad_object_writedac_access.yml
+++ b/rules/windows/builtin/win_ad_object_writedac_access.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/05_defense_evasion/T1222_file_permissions_modification/ad_replication_user_backdoor.md
 tags:
     - attack.defense_evasion
-    - attack.t1222          # an old one
+    - attack.old.t1222
     - attack.t1222.001
 logsource:
     product: windows

--- a/rules/windows/builtin/win_ad_replication_non_machine_account.yml
+++ b/rules/windows/builtin/win_ad_replication_non_machine_account.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/06_credential_access/T1003_credential_dumping/ad_replication_non_machine_account.md
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.006
 logsource:
     product: windows

--- a/rules/windows/builtin/win_ad_user_enumeration.yml
+++ b/rules/windows/builtin/win_ad_user_enumeration.yml
@@ -11,7 +11,7 @@ references:
     - https://docs.microsoft.com/en-us/windows/win32/adschema/attributes-all # For further investigation of the accessed properties
 tags:
     - attack.discovery
-    - attack.t1087          # an old one
+    - attack.old.t1087
     - attack.t1087.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_admin_rdp_login.yml
+++ b/rules/windows/builtin/win_admin_rdp_login.yml
@@ -5,7 +5,7 @@ references:
     - https://car.mitre.org/wiki/CAR-2016-04-005
 tags:
     - attack.lateral_movement
-    - attack.t1078          # an old one
+    - attack.old.t1078
     - attack.t1078.001
     - attack.t1078.002
     - attack.t1078.003

--- a/rules/windows/builtin/win_admin_share_access.yml
+++ b/rules/windows/builtin/win_admin_share_access.yml
@@ -3,7 +3,7 @@ id: 098d7118-55bc-4912-a836-dc6483a8d150
 description: Detects access to $ADMIN share
 tags:
     - attack.lateral_movement
-    - attack.t1077          # an old one
+    - attack.old.t1077
     - attack.t1021.002
 status: experimental
 author: Florian Roth

--- a/rules/windows/builtin/win_alert_enable_weak_encryption.yml
+++ b/rules/windows/builtin/win_alert_enable_weak_encryption.yml
@@ -8,7 +8,7 @@ author: '@neu5ron'
 date: 2017/07/30
 tags:
     - attack.defense_evasion
-    - attack.t1089          # an old one
+    - attack.old.t1089
     - attack.t1562.001
 logsource:
     product: windows

--- a/rules/windows/builtin/win_alert_lsass_access.yml
+++ b/rules/windows/builtin/win_alert_lsass_access.yml
@@ -8,7 +8,7 @@ author: Markus Neis
 date: 2018/08/26
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
 # Defender Attack Surface Reduction
     - attack.t1003.001
 logsource:

--- a/rules/windows/builtin/win_alert_mimikatz_keywords.yml
+++ b/rules/windows/builtin/win_alert_mimikatz_keywords.yml
@@ -6,7 +6,7 @@ date: 2017/01/10
 modified: 2019/10/11
 tags:
     - attack.s0002
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.lateral_movement
     - attack.credential_access
     - car.2013-07-001

--- a/rules/windows/builtin/win_alert_ruler.yml
+++ b/rules/windows/builtin/win_alert_ruler.yml
@@ -14,7 +14,7 @@ tags:
     - attack.discovery
     - attack.execution
     - attack.t1087
-    - attack.t1075          # an old one
+    - attack.old.t1075
     - attack.t1114
     - attack.t1059
     - attack.t1550.002

--- a/rules/windows/builtin/win_applocker_file_was_not_allowed_to_run.yml
+++ b/rules/windows/builtin/win_applocker_file_was_not_allowed_to_run.yml
@@ -4,10 +4,10 @@ description: Detect run not allowed files. Applocker is a very useful tool, espe
 status: experimental
 tags:
     - attack.execution
-    - attack.t1086          # an old one
-    - attack.t1064          # an old one
-    - attack.t1204          # an old one
-    - attack.t1035          # an old one
+    - attack.old.t1086
+    - attack.old.t1064
+    - attack.old.t1204
+    - attack.old.t1035
     - attack.t1204.002
     - attack.t1059.001
     - attack.t1059.003

--- a/rules/windows/builtin/win_apt_apt29_tor.yml
+++ b/rules/windows/builtin/win_apt_apt29_tor.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.persistence
     - attack.g0016
-    - attack.t1050          # an old one
+    - attack.old.t1050
     - attack.t1543.003
 date: 2017/11/01
 modified: 2020/08/23

--- a/rules/windows/builtin/win_apt_carbonpaper_turla.yml
+++ b/rules/windows/builtin/win_apt_carbonpaper_turla.yml
@@ -6,7 +6,7 @@ references:
 tags:
     - attack.persistence
     - attack.g0010
-    - attack.t1050          # an old one
+    - attack.old.t1050
     - attack.t1543.003
 date: 2017/03/31
 author: Florian Roth

--- a/rules/windows/builtin/win_apt_stonedrill.yml
+++ b/rules/windows/builtin/win_apt_stonedrill.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.persistence
     - attack.g0064
-    - attack.t1050          # an old one
+    - attack.old.t1050
     - attack.t1543.003
 logsource:
     product: windows

--- a/rules/windows/builtin/win_apt_turla_service_png.yml
+++ b/rules/windows/builtin/win_apt_turla_service_png.yml
@@ -8,7 +8,7 @@ date: 2018/11/23
 tags:
     - attack.persistence
     - attack.g0010
-    - attack.t1050          # an old one
+    - attack.old.t1050
     - attack.t1543.003
 logsource:
     product: windows

--- a/rules/windows/builtin/win_atsvc_task.yml
+++ b/rules/windows/builtin/win_atsvc_task.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.lateral_movement
     - attack.persistence
-    - attack.t1053          # an old one
+    - attack.old.t1053
     - car.2013-05-004
     - car.2015-04-001
     - attack.t1053.002

--- a/rules/windows/builtin/win_dcsync.yml
+++ b/rules/windows/builtin/win_dcsync.yml
@@ -11,7 +11,7 @@ references:
 tags:
     - attack.credential_access
     - attack.s0002
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.006
 logsource:
     product: windows

--- a/rules/windows/builtin/win_disable_event_logging.yml
+++ b/rules/windows/builtin/win_disable_event_logging.yml
@@ -5,7 +5,7 @@ references:
     - https://bit.ly/WinLogsZero2Hero
 tags:
     - attack.defense_evasion
-    - attack.t1054          # an old one
+    - attack.old.t1054
     - attack.t1562.002
 author: '@neu5ron'
 date: 2017/11/19

--- a/rules/windows/builtin/win_dpapi_domain_backupkey_extraction.yml
+++ b/rules/windows/builtin/win_dpapi_domain_backupkey_extraction.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/06_credential_access/T1003_credential_dumping/domain_dpapi_backupkey_extraction.md
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.004
 logsource:
     product: windows

--- a/rules/windows/builtin/win_dpapi_domain_masterkey_backup_attempt.yml
+++ b/rules/windows/builtin/win_dpapi_domain_masterkey_backup_attempt.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/06_credential_access/T1003_credential_dumping/domain_dpapi_backupkey_extraction.md
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.004
 logsource:
     product: windows

--- a/rules/windows/builtin/win_global_catalog_enumeration.yml
+++ b/rules/windows/builtin/win_global_catalog_enumeration.yml
@@ -6,7 +6,7 @@ date: 2020/05/11
 modified: 2020/08/23
 tags:
     - attack.discovery
-    - attack.t1087          # an old one
+    - attack.old.t1087
     - attack.t1087.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_hack_smbexec.yml
+++ b/rules/windows/builtin/win_hack_smbexec.yml
@@ -9,9 +9,9 @@ references:
 tags:
     - attack.lateral_movement
     - attack.execution
-    - attack.t1077          # an old one
+    - attack.old.t1077
     - attack.t1021.002
-    - attack.t1035          # an old one
+    - attack.old.t1035
     - attack.t1569.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_impacket_secretdump.yml
+++ b/rules/windows/builtin/win_impacket_secretdump.yml
@@ -7,7 +7,7 @@ references:
     - https://blog.menasec.net/2019/02/threat-huting-10-impacketsecretdump.html
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.002
     - attack.t1003.004
     - attack.t1003.003

--- a/rules/windows/builtin/win_lm_namedpipe.yml
+++ b/rules/windows/builtin/win_lm_namedpipe.yml
@@ -7,7 +7,7 @@ references:
     - https://twitter.com/menasec1/status/1104489274387451904
 tags:
     - attack.lateral_movement
-    - attack.t1077          # an old one
+    - attack.old.t1077
     - attack.t1021.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_lsass_access_non_system_account.yml
+++ b/rules/windows/builtin/win_lsass_access_non_system_account.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/06_credential_access/T1003_credential_dumping/lsass_access_non_system_account.md
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.001
 logsource:
     product: windows

--- a/rules/windows/builtin/win_mal_creddumper.yml
+++ b/rules/windows/builtin/win_mal_creddumper.yml
@@ -11,13 +11,13 @@ references:
 tags:
     - attack.credential_access
     - attack.execution
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.001
     - attack.t1003.002
     - attack.t1003.004
     - attack.t1003.005
     - attack.t1003.006
-    - attack.t1035          # an old one
+    - attack.old.t1035
     - attack.t1569.002
     - attack.s0005
 detection:

--- a/rules/windows/builtin/win_mal_service_installs.yml
+++ b/rules/windows/builtin/win_mal_service_installs.yml
@@ -8,8 +8,8 @@ tags:
     - attack.persistence
     - attack.privilege_escalation
     - attack.t1003
-    - attack.t1035          # an old one
-    - attack.t1050          # an old one
+    - attack.old.t1035
+    - attack.old.t1050
     - car.2013-09-005
     - attack.t1543.003
     - attack.t1569.002

--- a/rules/windows/builtin/win_metasploit_authentication.yml
+++ b/rules/windows/builtin/win_metasploit_authentication.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/rapid7/metasploit-framework/blob/master/lib/rex/proto/smb/client.rb
 tags:
     - attack.lateral_movement
-    - attack.t1077          # an old one
+    - attack.old.t1077
     - attack.t1021.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_meterpreter_or_cobaltstrike_getsystem_service_installation.yml
+++ b/rules/windows/builtin/win_meterpreter_or_cobaltstrike_getsystem_service_installation.yml
@@ -10,7 +10,7 @@ references:
     - https://blog.cobaltstrike.com/2014/04/02/what-happens-when-i-type-getsystem/
 tags:
     - attack.privilege_escalation
-    - attack.t1134          # an old one
+    - attack.old.t1134
     - attack.t1134.001
     - attack.t1134.002
 detection:

--- a/rules/windows/builtin/win_mmc20_lateral_movement.yml
+++ b/rules/windows/builtin/win_mmc20_lateral_movement.yml
@@ -9,7 +9,7 @@ references:
     - https://drive.google.com/file/d/1lKya3_mLnR3UQuCoiYruO3qgu052_iS_/view?usp=sharing
 tags:
     - attack.execution
-    - attack.t1175          # an old one
+    - attack.old.t1175
     - attack.t1021.003
 logsource:
     category: process_creation

--- a/rules/windows/builtin/win_net_ntlm_downgrade.yml
+++ b/rules/windows/builtin/win_net_ntlm_downgrade.yml
@@ -9,7 +9,7 @@ date: 2018/03/20
 modified: 2020/08/23
 tags:
     - attack.defense_evasion
-    - attack.t1089          # an old one
+    - attack.old.t1089
     - attack.t1562.001
     - attack.t1112
 detection:

--- a/rules/windows/builtin/win_not_allowed_rdp_access.yml
+++ b/rules/windows/builtin/win_not_allowed_rdp_access.yml
@@ -5,7 +5,7 @@ description: This event is generated when an authenticated user who is not allow
 status: experimental
 tags:
     - attack.lateral_movement
-    - attack.t1076          # an old one
+    - attack.old.t1076
     - attack.t1021.001
 references:
     - https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4825

--- a/rules/windows/builtin/win_overpass_the_hash.yml
+++ b/rules/windows/builtin/win_overpass_the_hash.yml
@@ -8,7 +8,7 @@ author: Roberto Rodriguez (source), Dominik Schaudel (rule)
 date: 2018/02/12
 tags:
     - attack.lateral_movement
-    - attack.t1075          # an old one
+    - attack.old.t1075
     - attack.s0002
     - attack.t1550.002
 logsource:

--- a/rules/windows/builtin/win_pass_the_hash.yml
+++ b/rules/windows/builtin/win_pass_the_hash.yml
@@ -8,7 +8,7 @@ author: Ilias el Matani (rule), The Information Assurance Directorate at the NSA
 date: 2017/03/08
 tags:
     - attack.lateral_movement
-    - attack.t1075          # an old one
+    - attack.old.t1075
     - car.2016-04-004
     - attack.t1550.002
 logsource:

--- a/rules/windows/builtin/win_pass_the_hash_2.yml
+++ b/rules/windows/builtin/win_pass_the_hash_2.yml
@@ -10,7 +10,7 @@ author: Dave Kennedy, Jeff Warren (method) / David Vassallo (rule)
 date: 2019/06/14
 tags:
     - attack.lateral_movement
-    - attack.t1075          # an old one
+    - attack.old.t1075
     - attack.t1550.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_protected_storage_service_access.yml
+++ b/rules/windows/builtin/win_protected_storage_service_access.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/06_credential_access/T1003_credential_dumping/domain_dpapi_backupkey_extraction.md
 tags:
     - attack.lateral_movement
-    - attack.t1021          # an old one
+    - attack.old.t1021
     - attack.t1021.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_quarkspwdump_clearing_hive_access_history.yml
+++ b/rules/windows/builtin/win_quarkspwdump_clearing_hive_access_history.yml
@@ -7,7 +7,7 @@ date: 2017/05/15
 modified: 2019/11/13
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.002
 level: critical
 logsource:

--- a/rules/windows/builtin/win_rare_schtasks_creations.yml
+++ b/rules/windows/builtin/win_rare_schtasks_creations.yml
@@ -8,7 +8,7 @@ tags:
     - attack.execution
     - attack.privilege_escalation
     - attack.persistence
-    - attack.t1053           # an old one
+    - attack.old.t1053
     - car.2013-08-001
     - attack.t1053.005
 logsource:

--- a/rules/windows/builtin/win_rare_service_installs.yml
+++ b/rules/windows/builtin/win_rare_service_installs.yml
@@ -7,7 +7,7 @@ date: 2017/03/08
 tags:
     - attack.persistence
     - attack.privilege_escalation
-    - attack.t1050          # an old one
+    - attack.old.t1050
     - car.2013-09-005
     - attack.t1543.003
 logsource:

--- a/rules/windows/builtin/win_rdp_localhost_login.yml
+++ b/rules/windows/builtin/win_rdp_localhost_login.yml
@@ -7,7 +7,7 @@ date: 2019/01/28
 modified: 2019/01/29
 tags:
     - attack.lateral_movement
-    - attack.t1076          # an old one
+    - attack.old.t1076
     - car.2013-07-002
     - attack.t1021.001
 status: experimental

--- a/rules/windows/builtin/win_rdp_reverse_tunnel.yml
+++ b/rules/windows/builtin/win_rdp_reverse_tunnel.yml
@@ -12,8 +12,8 @@ tags:
     - attack.defense_evasion
     - attack.command_and_control
     - attack.lateral_movement
-    - attack.t1076          # an old one
-    - attack.t1090          # an old one
+    - attack.old.t1076
+    - attack.old.t1090
     - attack.t1090.001
     - attack.t1090.002
     - attack.t1021.001

--- a/rules/windows/builtin/win_register_new_logon_process_by_rubeus.yml
+++ b/rules/windows/builtin/win_register_new_logon_process_by_rubeus.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.lateral_movement
     - attack.privilege_escalation
-    - attack.t1208          # an old one
+    - attack.old.t1208
     - attack.t1558.003
 author: Roberto Rodriguez (source), Ilyas Ochkov (rule), oscd.community
 date: 2019/10/24

--- a/rules/windows/builtin/win_remote_powershell_session.yml
+++ b/rules/windows/builtin/win_remote_powershell_session.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/02_execution/T1086_powershell/powershell_remote_session.md
 tags:
     - attack.execution
-    - attack.t1086          # an old one
+    - attack.old.t1086
     - attack.t1059.001
 logsource:
     product: windows

--- a/rules/windows/builtin/win_scheduled_task_deletion.yml
+++ b/rules/windows/builtin/win_scheduled_task_deletion.yml
@@ -7,7 +7,7 @@ date: 2021/01/22
 tags:
     - attack.execution
     - attack.privilege_escalation
-    - attack.t1053           # an old one
+    - attack.old.t1053
     - car.2013-08-001
     - attack.t1053.005
 references:

--- a/rules/windows/builtin/win_susp_add_sid_history.yml
+++ b/rules/windows/builtin/win_susp_add_sid_history.yml
@@ -9,7 +9,7 @@ date: 2017/02/19
 tags:
     - attack.persistence
     - attack.privilege_escalation
-    - attack.t1178          # an old one
+    - attack.old.t1178
     - attack.t1134.005
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_backup_delete.yml
+++ b/rules/windows/builtin/win_susp_backup_delete.yml
@@ -9,7 +9,7 @@ author: Florian Roth (rule), Tom U. @c_APT_ure (collection)
 date: 2017/05/12
 tags:
     - attack.defense_evasion
-    - attack.t1107          # an old one
+    - attack.old.t1107
     - attack.t1070.004
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_codeintegrity_check_failure.yml
+++ b/rules/windows/builtin/win_susp_codeintegrity_check_failure.yml
@@ -7,7 +7,7 @@ date: 2019/12/03
 modified: 2020/08/23
 tags:
     - attack.defense_evasion
-    - attack.t1009          # an old one
+    - attack.old.t1009
     - attack.t1027.001
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_dhcp_config.yml
+++ b/rules/windows/builtin/win_susp_dhcp_config.yml
@@ -10,7 +10,7 @@ date: 2017/05/15
 author: Dimitrios Slamaris
 tags:
     - attack.defense_evasion
-    - attack.t1073          # an old one
+    - attack.old.t1073
     - attack.t1574.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_dhcp_config_failed.yml
+++ b/rules/windows/builtin/win_susp_dhcp_config_failed.yml
@@ -10,7 +10,7 @@ date: 2017/05/15
 modified: 2019/07/17
 tags:
     - attack.defense_evasion
-    - attack.t1073           # an old one
+    - attack.old.t1073
     - attack.t1574.002
 author: "Dimitrios Slamaris, @atc_project (fix)"
 logsource:

--- a/rules/windows/builtin/win_susp_dns_config.yml
+++ b/rules/windows/builtin/win_susp_dns_config.yml
@@ -9,7 +9,7 @@ references:
     - https://twitter.com/gentilkiwi/status/861641945944391680
 tags:
     - attack.defense_evasion
-    - attack.t1073           # an old one
+    - attack.old.t1073
     - attack.t1574.002
 author: Florian Roth
 logsource:

--- a/rules/windows/builtin/win_susp_eventlog_cleared.yml
+++ b/rules/windows/builtin/win_susp_eventlog_cleared.yml
@@ -9,7 +9,7 @@ date: 2017/01/10
 modified: 2020/08/23
 tags:
     - attack.defense_evasion
-    - attack.t1070           # an old one
+    - attack.old.t1070
     - attack.t1070.001
     - car.2016-04-002
 logsource:

--- a/rules/windows/builtin/win_susp_ldap_dataexchange.yml
+++ b/rules/windows/builtin/win_susp_ldap_dataexchange.yml
@@ -10,7 +10,7 @@ references:
     - https://blog.fox-it.com/2020/03/19/ldapfragger-command-and-control-over-ldap-attributes/
     - https://github.com/fox-it/LDAPFragger
 tags:
-    - attack.t1071          # an old one
+    - attack.old.t1071
     - attack.t1001.003
     - attack.command_and_control
 logsource:

--- a/rules/windows/builtin/win_susp_local_anon_logon_created.yml
+++ b/rules/windows/builtin/win_susp_local_anon_logon_created.yml
@@ -9,7 +9,7 @@ date: 2019/10/31
 modified: 2020/08/23
 tags:
     - attack.persistence
-    - attack.t1136          # an old one
+    - attack.old.t1136
     - attack.t1136.001
     - attack.t1136.002
 logsource:

--- a/rules/windows/builtin/win_susp_lsass_dump.yml
+++ b/rules/windows/builtin/win_susp_lsass_dump.yml
@@ -7,7 +7,7 @@ references:
     - https://twitter.com/jackcr/status/807385668833968128
 tags:
     - attack.credential_access
-    - attack.t1003           # an old one
+    - attack.old.t1003
     - attack.t1003.001
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_lsass_dump_generic.yml
+++ b/rules/windows/builtin/win_susp_lsass_dump_generic.yml
@@ -10,7 +10,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - car.2019-04-004
     - attack.t1003.001
 logsource:

--- a/rules/windows/builtin/win_susp_msmpeng_crash.yml
+++ b/rules/windows/builtin/win_susp_msmpeng_crash.yml
@@ -3,7 +3,7 @@ id: 6c82cf5c-090d-4d57-9188-533577631108
 description: This rule detects a suspicious crash of the Microsoft Malware Protection Engine
 tags:
     - attack.defense_evasion
-    - attack.t1089          # an old one
+    - attack.old.t1089
     - attack.t1211
     - attack.t1562.001
 status: experimental

--- a/rules/windows/builtin/win_susp_net_recon_activity.yml
+++ b/rules/windows/builtin/win_susp_net_recon_activity.yml
@@ -9,9 +9,9 @@ date: 2017/03/07
 modified: 2020/08/23
 tags:
     - attack.discovery
-    - attack.t1087           # an old one
+    - attack.old.t1087
     - attack.t1087.002
-    - attack.t1069           # an old one
+    - attack.old.t1069
     - attack.t1069.002
     - attack.s0039
 logsource:

--- a/rules/windows/builtin/win_susp_ntlm_auth.yml
+++ b/rules/windows/builtin/win_susp_ntlm_auth.yml
@@ -9,7 +9,7 @@ author: Florian Roth
 date: 2018/06/08
 tags:
     - attack.lateral_movement
-    - attack.t1075          # an old one
+    - attack.old.t1075
     - attack.t1550.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_psexec.yml
+++ b/rules/windows/builtin/win_susp_psexec.yml
@@ -7,7 +7,7 @@ references:
     - https://blog.menasec.net/2019/02/threat-hunting-3-detecting-psexec.html
 tags:
     - attack.lateral_movement
-    - attack.t1077           # an old one
+    - attack.old.t1077
     - attack.t1021.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_rc4_kerberos.yml
+++ b/rules/windows/builtin/win_susp_rc4_kerberos.yml
@@ -6,7 +6,7 @@ references:
     - https://www.trimarcsecurity.com/single-post/TrimarcResearch/Detecting-Kerberoasting-Activity
 tags:
     - attack.credential_access
-    - attack.t1208           # an old one
+    - attack.old.t1208
     - attack.t1558.003
 description: Detects service ticket requests using RC4 encryption type
 author: Florian Roth

--- a/rules/windows/builtin/win_susp_rottenpotato.yml
+++ b/rules/windows/builtin/win_susp_rottenpotato.yml
@@ -9,7 +9,7 @@ date: 2019/11/15
 tags:
     - attack.privilege_escalation
     - attack.credential_access
-    - attack.t1171          # an old one
+    - attack.old.t1171
     - attack.t1557.001
 logsource:
     product: windows

--- a/rules/windows/builtin/win_susp_sam_dump.yml
+++ b/rules/windows/builtin/win_susp_sam_dump.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects suspicious SAM dump activity as cause by QuarksPwDump and other password dumpers
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.002
 author: Florian Roth
 date: 2018/01/27

--- a/rules/windows/builtin/win_susp_sdelete.yml
+++ b/rules/windows/builtin/win_susp_sdelete.yml
@@ -12,9 +12,9 @@ references:
 tags:
     - attack.impact
     - attack.defense_evasion
-    - attack.t1107           # an old one
+    - attack.old.t1107
     - attack.t1070.004
-    - attack.t1066           # an old one
+    - attack.old.t1066
     - attack.t1027.005
     - attack.t1485
     - attack.t1553.002

--- a/rules/windows/builtin/win_susp_security_eventlog_cleared.yml
+++ b/rules/windows/builtin/win_susp_security_eventlog_cleared.yml
@@ -3,7 +3,7 @@ id: f2f01843-e7b8-4f95-a35a-d23584476423
 description: Some threat groups tend to delete the local 'Security' Eventlog using certain utitlities
 tags:
     - attack.defense_evasion
-    - attack.t1070          # an old one
+    - attack.old.t1070
     - attack.t1070.001
     - car.2016-04-002
 author: Florian Roth

--- a/rules/windows/builtin/win_susp_time_modification.yml
+++ b/rules/windows/builtin/win_susp_time_modification.yml
@@ -10,7 +10,7 @@ date: 2019/02/05
 midified: 2020/01/27
 tags:
     - attack.defense_evasion
-    - attack.t1099          # an old one
+    - attack.old.t1099
     - attack.t1070.006
 logsource:
     product: windows

--- a/rules/windows/builtin/win_suspicious_outbound_kerberos_connection.yml
+++ b/rules/windows/builtin/win_suspicious_outbound_kerberos_connection.yml
@@ -9,7 +9,7 @@ date: 2019/10/24
 modified: 2019/11/13
 tags:
     - attack.lateral_movement
-    - attack.t1208           # an old one
+    - attack.old.t1208
     - attack.t1558.003
 logsource:
     product: windows

--- a/rules/windows/builtin/win_svcctl_remote_service.yml
+++ b/rules/windows/builtin/win_svcctl_remote_service.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.lateral_movement
     - attack.persistence
-    - attack.t1077          # an old one
+    - attack.old.t1077
     - attack.t1021.002
 logsource:
     product: windows

--- a/rules/windows/builtin/win_transferring_files_with_credential_data_via_network_shares.yml
+++ b/rules/windows/builtin/win_transferring_files_with_credential_data_via_network_shares.yml
@@ -7,7 +7,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 tags:
     - attack.credential_access
-    - attack.t1003           # an old one
+    - attack.old.t1003
     - attack.t1003.002
     - attack.t1003.001
     - attack.t1003.003

--- a/rules/windows/builtin/win_user_couldnt_call_privileged_service_lsaregisterlogonprocess.yml
+++ b/rules/windows/builtin/win_user_couldnt_call_privileged_service_lsaregisterlogonprocess.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.lateral_movement
     - attack.privilege_escalation
-    - attack.t1208           # an old one
+    - attack.old.t1208
     - attack.t1558.003
 author: Roberto Rodriguez (source), Ilyas Ochkov (rule), oscd.community
 date: 2019/10/24

--- a/rules/windows/builtin/win_user_creation.yml
+++ b/rules/windows/builtin/win_user_creation.yml
@@ -5,7 +5,7 @@ description: Detects local user creation on windows servers, which shouldn't hap
 status: experimental
 tags:
     - attack.persistence
-    - attack.t1136           # an old one
+    - attack.old.t1136
     - attack.t1136.001
 references:
     - https://patrick-bareiss.com/detecting-local-user-creation-in-ad-with-sigma/

--- a/rules/windows/builtin/win_user_driver_loaded.yml
+++ b/rules/windows/builtin/win_user_driver_loaded.yml
@@ -6,7 +6,7 @@ references:
     - https://blog.dylan.codes/evading-sysmon-and-windows-event-logging/
     - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4673
 tags:
-    - attack.t1089          # an old one
+    - attack.old.t1089
     - attack.defense_evasion
     - attack.t1562.001
 date: 2019/04/08

--- a/rules/windows/driver_load/sysmon_susp_driver_load.yml
+++ b/rules/windows/driver_load/sysmon_susp_driver_load.yml
@@ -7,7 +7,7 @@ modified: 2020/08/23
 tags:
     - attack.persistence
     - attack.privilege_escalation
-    - attack.t1050          # an old one
+    - attack.old.t1050
     - attack.t1543.003
 logsource:
     category: driver_load

--- a/rules/windows/file_event/sysmon_creation_system_file.yml
+++ b/rules/windows/file_event/sysmon_creation_system_file.yml
@@ -7,7 +7,7 @@ date: 2020/05/26
 modified: 2020/08/23
 tags:
     - attack.defense_evasion
-    - attack.t1036          # an old one
+    - attack.old.t1036
     - attack.t1036.005
 logsource:
     category: file_event

--- a/rules/windows/file_event/sysmon_cred_dump_tools_dropped_files.yml
+++ b/rules/windows/file_event/sysmon_cred_dump_tools_dropped_files.yml
@@ -8,7 +8,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 tags:
     - attack.credential_access
-    - attack.t1003         # an old one
+    - attack.old.t1003
     - attack.t1003.001
     - attack.t1003.002
     - attack.t1003.003

--- a/rules/windows/file_event/sysmon_ghostpack_safetykatz.yml
+++ b/rules/windows/file_event/sysmon_ghostpack_safetykatz.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/GhostPack/SafetyKatz
 tags:
     - attack.credential_access
-    - attack.t1003         # an old one
+    - attack.old.t1003
     - attack.t1003.001
 author: Markus Neis
 date: 2018/07/24

--- a/rules/windows/file_event/sysmon_hack_dumpert.yml
+++ b/rules/windows/file_event/sysmon_hack_dumpert.yml
@@ -10,7 +10,7 @@ date: 2020/02/04
 modified: 2020/08/23
 tags:
     - attack.credential_access
-    - attack.t1003         # an old one
+    - attack.old.t1003
     - attack.t1003.001
 falsepositives:
     - Very unlikely

--- a/rules/windows/file_event/sysmon_lsass_memory_dump_file_creation.yml
+++ b/rules/windows/file_event/sysmon_lsass_memory_dump_file_creation.yml
@@ -8,7 +8,7 @@ date: 2019/10/22
 modified: 2020/08/23
 tags:
     - attack.credential_access
-    - attack.t1003         # an old one
+    - attack.old.t1003
     - attack.t1003.001
 logsource:
     category: file_event

--- a/rules/windows/file_event/sysmon_office_persistence.yml
+++ b/rules/windows/file_event/sysmon_office_persistence.yml
@@ -6,7 +6,7 @@ references:
     - Internal Research
 tags:
     - attack.persistence
-    - attack.t1137         # an old one
+    - attack.old.t1137
     - attack.t1137.006
 author: NVISO
 date: 2020/05/11

--- a/rules/windows/file_event/sysmon_powershell_exploit_scripts.yml
+++ b/rules/windows/file_event/sysmon_powershell_exploit_scripts.yml
@@ -6,7 +6,7 @@ references:
     - https://raw.githubusercontent.com/Neo23x0/sigma/f35c50049fa896dff91ff545cb199319172701e8/rules/windows/powershell/powershell_malicious_commandlets.yml
 tags:
     - attack.execution
-    - attack.t1086         # an old one
+    - attack.old.t1086
     - attack.t1059.001
 author: Markus Neis
 date: 2018/04/07

--- a/rules/windows/file_event/sysmon_quarkspw_filedump.yml
+++ b/rules/windows/file_event/sysmon_quarkspw_filedump.yml
@@ -9,7 +9,7 @@ date: 2018/02/10
 modified: 2020/08/23
 tags:
   - attack.credential_access
-  - attack.t1003          # an old one
+  - attack.old.t1003
   - attack.t1003.002
 level: critical
 logsource:

--- a/rules/windows/file_event/sysmon_susp_adsi_cache_usage.yml
+++ b/rules/windows/file_event/sysmon_susp_adsi_cache_usage.yml
@@ -10,7 +10,7 @@ references:
     - https://blog.fox-it.com/2020/03/19/ldapfragger-command-and-control-over-ldap-attributes/
     - https://github.com/fox-it/LDAPFragger
 tags:
-    - attack.t1071          # an old one
+    - attack.old.t1071
     - attack.t1001.003
     - attack.command_and_control
 logsource:

--- a/rules/windows/file_event/sysmon_susp_desktop_ini.yml
+++ b/rules/windows/file_event/sysmon_susp_desktop_ini.yml
@@ -9,7 +9,7 @@ date: 2020/03/19
 modified: 2020/08/23
 tags:
     - attack.persistence
-    - attack.t1023          # an old one
+    - attack.old.t1023
     - attack.t1547.009
 logsource:
     product: windows

--- a/rules/windows/file_event/sysmon_susp_procexplorer_driver_created_in_tmp_folder.yml
+++ b/rules/windows/file_event/sysmon_susp_procexplorer_driver_created_in_tmp_folder.yml
@@ -7,7 +7,7 @@ author: xknow (@xknow_infosec), xorxes (@xor_xes)
 references:
     - https://blog.dylan.codes/evading-sysmon-and-windows-event-logging/
 tags:
-    - attack.t1089          # an old one
+    - attack.old.t1089
     - attack.t1562.001
     - attack.defense_evasion
 logsource:

--- a/rules/windows/file_event/sysmon_webshell_creation_detect.yml
+++ b/rules/windows/file_event/sysmon_webshell_creation_detect.yml
@@ -9,7 +9,7 @@ date: 2019/10/22
 modified: 2020/08/23
 tags:
     - attack.persistence
-    - attack.t1100          # an old one
+    - attack.old.t1100
     - attack.t1505.003
 level: critical
 logsource:

--- a/rules/windows/file_event/sysmon_wmi_persistence_script_event_consumer_write.yml
+++ b/rules/windows/file_event/sysmon_wmi_persistence_script_event_consumer_write.yml
@@ -8,7 +8,7 @@ author: Thomas Patzke
 date: 2018/03/07
 modified: 2020/08/23
 tags:
-    - attack.t1084          # an old one
+    - attack.old.t1084
     - attack.t1546.003
     - attack.persistence
 logsource:

--- a/rules/windows/image_load/sysmon_abusing_azure_browser_sso.yml
+++ b/rules/windows/image_load/sysmon_abusing_azure_browser_sso.yml
@@ -13,7 +13,7 @@ status: experimental
 tags:
    - attack.defense_evasion
    - attack.privilege_escalation
-   - attack.t1073          # an old one
+   - attack.old.t1073
    - attack.t1574.002
 detection:
    condition: selection_dll and not filter_legit

--- a/rules/windows/image_load/sysmon_in_memory_powershell.yml
+++ b/rules/windows/image_load/sysmon_in_memory_powershell.yml
@@ -9,7 +9,7 @@ references:
     - https://adsecurity.org/?p=2921
     - https://github.com/p3nt4/PowerShdll
 tags:
-    - attack.t1086          # an old one
+    - attack.old.t1086
     - attack.t1059.001
     - attack.execution
 logsource:

--- a/rules/windows/image_load/sysmon_powershell_execution_moduleload.yml
+++ b/rules/windows/image_load/sysmon_powershell_execution_moduleload.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/hunters-forge/ThreatHunter-Playbook/blob/8869b7a58dba1cff63bae1d7ab923974b8c0539b/playbooks/WIN-190410151110.yaml
 tags:
     - attack.execution
-    - attack.t1086          # an old one
+    - attack.old.t1086
     - attack.t1059.001
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_susp_fax_dll.yml
+++ b/rules/windows/image_load/sysmon_susp_fax_dll.yml
@@ -10,8 +10,8 @@ modified: 2020/08/23
 tags:
     - attack.persistence
     - attack.defense_evasion
-    - attack.t1073          # an old one
-    - attack.t1038          # an old one
+    - attack.old.t1073
+    - attack.old.t1038
     - attack.t1574.001
     - attack.t1574.002
 logsource:

--- a/rules/windows/image_load/sysmon_susp_image_load.yml
+++ b/rules/windows/image_load/sysmon_susp_image_load.yml
@@ -9,7 +9,7 @@ date: 2018/01/07
 modified: 2020/08/23
 tags:
     - attack.defense_evasion
-    - attack.t1073          # an old one
+    - attack.old.t1073
     - attack.t1574.002
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_susp_office_dotnet_assembly_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_office_dotnet_assembly_dll_load.yml
@@ -9,7 +9,7 @@ date: 2020/02/19
 modified: 2020/08/23
 tags:
     - attack.execution
-    - attack.t1204          # an old one
+    - attack.old.t1204
     - attack.t1204.002
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_susp_office_dotnet_clr_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_office_dotnet_clr_dll_load.yml
@@ -9,7 +9,7 @@ date: 2020/02/19
 modified: 2020/08/23
 tags:
     - attack.execution
-    - attack.t1204          # an old one
+    - attack.old.t1204
     - attack.t1204.002
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_susp_office_dotnet_gac_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_office_dotnet_gac_dll_load.yml
@@ -9,7 +9,7 @@ date: 2020/02/19
 modified: 2020/08/23
 tags:
     - attack.execution
-    - attack.t1204          # an old one
+    - attack.old.t1204
     - attack.t1204.002
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_susp_office_dsparse_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_office_dsparse_dll_load.yml
@@ -9,7 +9,7 @@ date: 2020/02/19
 modified: 2020/08/23
 tags:
     - attack.execution
-    - attack.t1204          # an old one
+    - attack.old.t1204
     - attack.t1204.002
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_susp_office_kerberos_dll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_office_kerberos_dll_load.yml
@@ -9,7 +9,7 @@ date: 2020/02/19
 modified: 2020/08/23
 tags:
     - attack.execution
-    - attack.t1204          # an old one
+    - attack.old.t1204
     - attack.t1204.002
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_susp_winword_vbadll_load.yml
+++ b/rules/windows/image_load/sysmon_susp_winword_vbadll_load.yml
@@ -9,7 +9,7 @@ date: 2020/02/19
 modified: 2020/08/23
 tags:
     - attack.execution
-    - attack.t1204          # an old one
+    - attack.old.t1204
     - attack.t1204.002
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_suspicious_dbghelp_dbgcore_load.yml
+++ b/rules/windows/image_load/sysmon_suspicious_dbghelp_dbgcore_load.yml
@@ -13,7 +13,7 @@ references:
     - https://medium.com/@fsx30/bypass-edrs-memory-protection-introduction-to-hooking-2efb21acffd6
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.001
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_svchost_dll_search_order_hijack.yml
+++ b/rules/windows/image_load/sysmon_svchost_dll_search_order_hijack.yml
@@ -12,9 +12,9 @@ modified: 2020/08/23
 tags:
     - attack.persistence
     - attack.defense_evasion
-    - attack.t1073          # an old one
+    - attack.old.t1073
     - attack.t1574.002
-    - attack.t1038          # an old one
+    - attack.old.t1038
     - attack.t1574.001
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_unsigned_image_loaded_into_lsass.yml
+++ b/rules/windows/image_load/sysmon_unsigned_image_loaded_into_lsass.yml
@@ -8,7 +8,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.001
 logsource:
     category: image_load

--- a/rules/windows/image_load/sysmon_wmi_persistence_commandline_event_consumer.yml
+++ b/rules/windows/image_load/sysmon_wmi_persistence_commandline_event_consumer.yml
@@ -8,7 +8,7 @@ author: Thomas Patzke
 date: 2018/03/07
 modified: 2020/08/23
 tags:
-    - attack.t1084          # an old one
+    - attack.old.t1084
     - attack.t1546.003
     - attack.persistence
 logsource:

--- a/rules/windows/network_connection/sysmon_dllhost_net_connections.yml
+++ b/rules/windows/network_connection/sysmon_dllhost_net_connections.yml
@@ -12,7 +12,7 @@ tags:
     - attack.t1218
     - attack.execution
     - attack.t1559.001  
-    - attack.t1175  # an old one  
+    - attack.old.t1175  
 logsource:
     category: network_connection
     product: windows

--- a/rules/windows/network_connection/sysmon_malware_backconnect_ports.yml
+++ b/rules/windows/network_connection/sysmon_malware_backconnect_ports.yml
@@ -10,7 +10,7 @@ modified: 2020/08/24
 tags:
     - attack.command_and_control
     - attack.t1571
-    - attack.t1043  # an old one
+    - attack.old.t1043
 logsource:
     category: network_connection
     product: windows

--- a/rules/windows/network_connection/sysmon_powershell_network_connection.yml
+++ b/rules/windows/network_connection/sysmon_powershell_network_connection.yml
@@ -10,7 +10,7 @@ references:
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 logsource:
     category: network_connection
     product: windows

--- a/rules/windows/network_connection/sysmon_rdp_reverse_tunnel.yml
+++ b/rules/windows/network_connection/sysmon_rdp_reverse_tunnel.yml
@@ -12,7 +12,7 @@ tags:
     - attack.t1572
     - attack.lateral_movement
     - attack.t1021.001
-    - attack.t1076  # an old one
+    - attack.old.t1076
     - car.2013-07-002
 logsource:
     category: network_connection

--- a/rules/windows/network_connection/sysmon_regsvr32_network_activity.yml
+++ b/rules/windows/network_connection/sysmon_regsvr32_network_activity.yml
@@ -9,10 +9,10 @@ references:
 tags:
     - attack.execution
     - attack.t1559.001
-    - attack.t1175  # an old one
+    - attack.old.t1175
     - attack.defense_evasion
     - attack.t1218.010
-    - attack.t1117  # an old one
+    - attack.old.t1117
 author: Dmitriy Lifanov, oscd.community
 status: experimental
 date: 2019/10/25

--- a/rules/windows/network_connection/sysmon_remote_powershell_session_network.yml
+++ b/rules/windows/network_connection/sysmon_remote_powershell_session_network.yml
@@ -10,10 +10,10 @@ references:
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
     - attack.lateral_movement
     - attack.t1021.006
-    - attack.t1028  # an old one
+    - attack.old.t1028
 logsource:
     category: network_connection
     product: windows

--- a/rules/windows/network_connection/sysmon_rundll32_net_connections.yml
+++ b/rules/windows/network_connection/sysmon_rundll32_net_connections.yml
@@ -10,7 +10,7 @@ modified: 2020/08/24
 tags:
     - attack.defense_evasion
     - attack.t1218.011
-    - attack.t1085  # an old one
+    - attack.old.t1085
     - attack.execution
 logsource:
     category: network_connection

--- a/rules/windows/network_connection/sysmon_susp_rdp.yml
+++ b/rules/windows/network_connection/sysmon_susp_rdp.yml
@@ -10,7 +10,7 @@ modified: 2020/08/24
 tags:
     - attack.lateral_movement
     - attack.t1021.001
-    - attack.t1076  # an old one
+    - attack.old.t1076
     - car.2013-07-002
 logsource:
     category: network_connection

--- a/rules/windows/network_connection/sysmon_suspicious_outbound_kerberos_connection.yml
+++ b/rules/windows/network_connection/sysmon_suspicious_outbound_kerberos_connection.yml
@@ -10,10 +10,10 @@ modified: 2020/08/24
 tags:
     - attack.credential_access
     - attack.t1558
-    - attack.t1208  # an old one
+    - attack.old.t1208
     - attack.lateral_movement
     - attack.t1550.003
-    - attack.t1097  # an old one
+    - attack.old.t1097
 logsource:
     category: network_connection
     product: windows

--- a/rules/windows/network_connection/sysmon_win_binary_github_com.yml
+++ b/rules/windows/network_connection/sysmon_win_binary_github_com.yml
@@ -14,7 +14,7 @@ tags:
     - attack.t1105
     - attack.exfiltration
     - attack.t1567.001
-    - attack.t1048  # an old one
+    - attack.old.t1048
 logsource:
     category: network_connection
     product: windows

--- a/rules/windows/other/win_defender_bypass.yml
+++ b/rules/windows/other/win_defender_bypass.yml
@@ -5,7 +5,7 @@ references:
     - https://www.bleepingcomputer.com/news/security/gootkit-malware-bypasses-windows-defender-by-setting-path-exclusions/
 tags:
     - attack.defense_evasion
-    - attack.t1089           # an old one
+    - attack.old.t1089
     - attack.t1562.001
 author: "@BarryShooshooga"
 date: 2019/10/26

--- a/rules/windows/other/win_defender_disabled.yml
+++ b/rules/windows/other/win_defender_disabled.yml
@@ -8,7 +8,7 @@ references:
 status: stable
 tags:
     - attack.defense_evasion
-    - attack.t1089           # an old one
+    - attack.old.t1089
     - attack.t1562.001
 logsource:
     product: windows

--- a/rules/windows/other/win_defender_psexec_wmi_asr.yml
+++ b/rules/windows/other/win_defender_psexec_wmi_asr.yml
@@ -11,7 +11,7 @@ tags:
     - attack.execution
     - attack.lateral_movement
     - attack.t1047
-    - attack.t1035 # an old one
+    - attack.old.t1035
     - attack.t1569.002
 logsource:
     product: windows_defender

--- a/rules/windows/other/win_rare_schtask_creation.yml
+++ b/rules/windows/other/win_rare_schtask_creation.yml
@@ -4,7 +4,7 @@ status: experimental
 description: This rule detects rare scheduled task creations. Typically software gets installed on multiple systems and not only on a few. The aggregation and count function selects tasks with rare names.
 tags:
     - attack.persistence
-    - attack.t1053           # an old one
+    - attack.old.t1053
     - attack.s0111
     - attack.t1053.005
 author: Florian Roth

--- a/rules/windows/other/win_tool_psexec.yml
+++ b/rules/windows/other/win_tool_psexec.yml
@@ -11,7 +11,7 @@ references:
     - https://jpcertcc.github.io/ToolAnalysisResultSheet
 tags:
     - attack.execution
-    - attack.t1035           # an old one
+    - attack.old.t1035
     - attack.t1569.002
     - attack.s0029
 detection:

--- a/rules/windows/other/win_wmi_persistence.yml
+++ b/rules/windows/other/win_wmi_persistence.yml
@@ -11,7 +11,7 @@ references:
 tags:
     - attack.persistence
     - attack.privilege_escalation
-    - attack.t1084           # an old one
+    - attack.old.t1084
     - attack.t1546.003
 logsource:
     product: windows

--- a/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
@@ -9,7 +9,7 @@ references:
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 logsource:
     product: windows
     service: powershell

--- a/rules/windows/powershell/powershell_clear_powershell_history.yml
+++ b/rules/windows/powershell/powershell_clear_powershell_history.yml
@@ -9,7 +9,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1070.003
-    - attack.t1146  # an old one
+    - attack.old.t1146
 logsource:
     product: windows
     service: powershell

--- a/rules/windows/powershell/powershell_create_local_user.yml
+++ b/rules/windows/powershell/powershell_create_local_user.yml
@@ -7,10 +7,10 @@ references:
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
     - attack.persistence
     - attack.t1136.001
-    - attack.t1136  # an old one    
+    - attack.old.t1136    
 author: '@ROxPinTeddy'
 date: 2020/04/11
 modified: 2020/08/24

--- a/rules/windows/powershell/powershell_data_compressed.yml
+++ b/rules/windows/powershell/powershell_data_compressed.yml
@@ -24,4 +24,4 @@ level: low
 tags:
     - attack.exfiltration
     - attack.t1560
-    - attack.t1002  # an old one
+    - attack.old.t1002

--- a/rules/windows/powershell/powershell_dnscat_execution.yml
+++ b/rules/windows/powershell/powershell_dnscat_execution.yml
@@ -10,7 +10,7 @@ tags:
     - attack.t1048
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 logsource:
     product: windows
     service: powershell

--- a/rules/windows/powershell/powershell_downgrade_attack.yml
+++ b/rules/windows/powershell/powershell_downgrade_attack.yml
@@ -8,7 +8,7 @@ tags:
     - attack.defense_evasion
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 author: Florian Roth (rule), Lee Holmes (idea), Harish Segar (improvements)
 date: 2017/03/22
 logsource:

--- a/rules/windows/powershell/powershell_exe_calling_ps.yml
+++ b/rules/windows/powershell/powershell_exe_calling_ps.yml
@@ -8,7 +8,7 @@ tags:
     - attack.defense_evasion
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 author: Sean Metcalf (source), Florian Roth (rule)
 date: 2017/03/05
 logsource:

--- a/rules/windows/powershell/powershell_ntfs_ads_access.yml
+++ b/rules/windows/powershell/powershell_ntfs_ads_access.yml
@@ -7,10 +7,10 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1564.004
-    - attack.t1096  # an old one
+    - attack.old.t1096
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 author: Sami Ruohonen
 date: 2018/07/24
 modified: 2020/08/24

--- a/rules/windows/powershell/powershell_prompt_credentials.yml
+++ b/rules/windows/powershell/powershell_prompt_credentials.yml
@@ -9,7 +9,7 @@ tags:
     - attack.credential_access
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 author: John Lambert (idea), Florian Roth (rule)
 date: 2017/04/09
 logsource:

--- a/rules/windows/powershell/powershell_winlogon_helper_dll.yml
+++ b/rules/windows/powershell/powershell_winlogon_helper_dll.yml
@@ -25,4 +25,4 @@ level: medium
 tags:
     - attack.persistence
     - attack.t1547.004
-    - attack.t1004  # an old one
+    - attack.old.t1004

--- a/rules/windows/process_access/sysmon_cmstp_execution.yml
+++ b/rules/windows/process_access/sysmon_cmstp_execution.yml
@@ -5,10 +5,10 @@ description: Detects various indicators of Microsoft Connection Manager Profile 
 tags:
     - attack.defense_evasion
     - attack.t1218.003
-    - attack.t1191  # an old one
+    - attack.old.t1191
     - attack.execution
     - attack.t1559.001
-    - attack.t1175  # an old one
+    - attack.old.t1175
     - attack.g0069
     - attack.g0080
     - car.2019-04-001

--- a/rules/windows/process_access/sysmon_cred_dump_lsass_access.yml
+++ b/rules/windows/process_access/sysmon_cred_dump_lsass_access.yml
@@ -14,7 +14,7 @@ references:
 tags:
     - attack.credential_access
     - attack.t1003.001
-    - attack.t1003  # an old one
+    - attack.old.t1003
     - attack.s0002
     - car.2019-04-004
 logsource:

--- a/rules/windows/process_access/sysmon_in_memory_assembly_execution.yml
+++ b/rules/windows/process_access/sysmon_in_memory_assembly_execution.yml
@@ -16,7 +16,7 @@ tags:
     - attack.defense_evasion
     - attack.t1055.001
     - attack.t1055.002
-    - attack.t1055 # an old one
+    - attack.old.t1055
 logsource:
     category: process_access
     product: windows

--- a/rules/windows/process_access/sysmon_invoke_phantom.yml
+++ b/rules/windows/process_access/sysmon_invoke_phantom.yml
@@ -11,7 +11,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1562.002
-    - attack.t1089  # an old one
+    - attack.old.t1089
 logsource:
     category: process_access
     product: windows

--- a/rules/windows/process_access/sysmon_lsass_memdump.yml
+++ b/rules/windows/process_access/sysmon_lsass_memdump.yml
@@ -10,7 +10,7 @@ references:
 tags:
     - attack.credential_access
     - attack.t1003.001
-    - attack.t1003  # an old one
+    - attack.old.t1003
     - attack.s0002
 logsource:
     category: process_access

--- a/rules/windows/process_creation/cmstp_execution.yml
+++ b/rules/windows/process_creation/cmstp_execution.yml
@@ -5,7 +5,7 @@ description: Detects various indicators of Microsoft Connection Manager Profile 
 tags:
     - attack.defense_evasion
     - attack.execution
-    - attack.t1191          # an old one
+    - attack.old.t1191
     - attack.t1218.003
     - attack.g0069
     - car.2019-04-001

--- a/rules/windows/process_creation/sysmon_apt_muddywater_dnstunnel.yml
+++ b/rules/windows/process_creation/sysmon_apt_muddywater_dnstunnel.yml
@@ -9,7 +9,7 @@ references:
     - https://www.vmray.com/analyses/5ad401c3a568/report/overview.html
 tags:
     - attack.command_and_control
-    - attack.t1071 # an old one
+    - attack.old.t1071
     - attack.t1071.004
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/sysmon_hack_wce.yml
+++ b/rules/windows/process_creation/sysmon_hack_wce.yml
@@ -8,7 +8,7 @@ date: 2019/12/31
 modified: 2020/08/26
 tags:
     - attack.credential_access
-    - attack.t1003 # an old one
+    - attack.old.t1003
     - attack.t1003.001
     - attack.s0005
 logsource:

--- a/rules/windows/process_creation/sysmon_logon_scripts_userinitmprlogonscript_proc.yml
+++ b/rules/windows/process_creation/sysmon_logon_scripts_userinitmprlogonscript_proc.yml
@@ -5,7 +5,7 @@ description: Detects creation or execution of UserInitMprLogonScript persistence
 references:
     - https://attack.mitre.org/techniques/T1037/
 tags:
-    - attack.t1037 # an old one
+    - attack.old.t1037
     - attack.t1037.001
     - attack.persistence
 author: Tom Ueltschi (@c_APT_ure)

--- a/rules/windows/process_creation/win_apt_apt29_thinktanks.yml
+++ b/rules/windows/process_creation/win_apt_apt29_thinktanks.yml
@@ -6,8 +6,8 @@ references:
 tags:
     - attack.execution
     - attack.g0016
-    - attack.t1086 # an old one
-    - attack.t1059 # an old one
+    - attack.old.t1086
+    - attack.old.t1059
     - attack.t1059.001
 author: Florian Roth
 date: 2018/12/04

--- a/rules/windows/process_creation/win_apt_babyshark.yml
+++ b/rules/windows/process_creation/win_apt_babyshark.yml
@@ -6,15 +6,15 @@ references:
     - https://unit42.paloaltonetworks.com/new-babyshark-malware-targets-u-s-national-security-think-tanks/
 tags:
     - attack.execution
-    - attack.t1059 # an old one
-    - attack.t1086 # an old one
+    - attack.old.t1059
+    - attack.old.t1086
     - attack.t1059.003
     - attack.t1059.001
     - attack.discovery
     - attack.t1012
     - attack.defense_evasion
-    - attack.t1170 # an old one
-    - attack.t1218 # an old one
+    - attack.old.t1170
+    - attack.old.t1218
     - attack.t1218.005
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_apt_bear_activity_gtr19.yml
+++ b/rules/windows/process_creation/win_apt_bear_activity_gtr19.yml
@@ -8,8 +8,8 @@ date: 2019/02/21
 modified: 2020/08/26
 tags:
     - attack.credential_access
-    - attack.t1081 # an old one
-    - attack.t1003 # an old one
+    - attack.old.t1081
+    - attack.old.t1003
     - attack.t1552.001
     - attack.t1003.003
 logsource:

--- a/rules/windows/process_creation/win_apt_bluemashroom.yml
+++ b/rules/windows/process_creation/win_apt_bluemashroom.yml
@@ -6,7 +6,7 @@ references:
     - https://www.virusbulletin.com/conference/vb2019/abstracts/apt-cases-exploiting-vulnerabilities-region-specific-software
 tags:
     - attack.defense_evasion
-    - attack.t1117 # an old one
+    - attack.old.t1117
     - attack.t1218.010
 author: Florian Roth
 date: 2019/10/02

--- a/rules/windows/process_creation/win_apt_chafer_mar18.yml
+++ b/rules/windows/process_creation/win_apt_chafer_mar18.yml
@@ -7,15 +7,15 @@ references:
 tags:
     - attack.persistence
     - attack.g0049
-    - attack.t1053 # an old one
+    - attack.old.t1053
     - attack.t1053.005
     - attack.s0111
-    - attack.t1050 # an old one
+    - attack.old.t1050
     - attack.t1543.003
     - attack.defense_evasion
     - attack.t1112
     - attack.command_and_control
-    - attack.t1071 # an old one
+    - attack.old.t1071
     - attack.t1071.004
 date: 2018/03/23
 modified: 2020/08/26

--- a/rules/windows/process_creation/win_apt_cloudhopper.yml
+++ b/rules/windows/process_creation/win_apt_cloudhopper.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.execution
     - attack.g0045
-    - attack.t1064 # an old one
+    - attack.old.t1064
     - attack.t1059.005
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_apt_elise.yml
+++ b/rules/windows/process_creation/win_apt_elise.yml
@@ -9,7 +9,7 @@ tags:
     - attack.g0050
     - attack.s0081
     - attack.execution
-    - attack.t1059 # an old one
+    - attack.old.t1059
     - attack.t1059.003
 author: Florian Roth
 date: 2018/01/31

--- a/rules/windows/process_creation/win_apt_emissarypanda_sep19.yml
+++ b/rules/windows/process_creation/win_apt_emissarypanda_sep19.yml
@@ -7,7 +7,7 @@ references:
     - https://twitter.com/cyb3rops/status/1168863899531132929
 tags:
     - attack.defense_evasion
-    - attack.t1073 # an old one
+    - attack.old.t1073
     - attack.t1574.002
 author: Florian Roth
 date: 2018/09/03

--- a/rules/windows/process_creation/win_apt_empiremonkey.yml
+++ b/rules/windows/process_creation/win_apt_empiremonkey.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1218.010
-    - attack.t1117  # an old one
+    - attack.old.t1117
 date: 2019/04/02
 modified: 2020/08/27
 author: Markus Neis

--- a/rules/windows/process_creation/win_apt_equationgroup_dll_u_load.yml
+++ b/rules/windows/process_creation/win_apt_equationgroup_dll_u_load.yml
@@ -11,7 +11,7 @@ references:
 tags:
     - attack.g0020
     - attack.defense_evasion
-    - attack.t1085 # an old one
+    - attack.old.t1085
     - attack.t1218.011
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_apt_evilnum_jul20.yml
+++ b/rules/windows/process_creation/win_apt_evilnum_jul20.yml
@@ -10,7 +10,7 @@ date: 2020/07/10
 modified: 2020/08/27
 tags:
     - attack.defense_evasion
-    - attack.t1085 # an old one
+    - attack.old.t1085
     - attack.t1218.011
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_apt_greenbug_may20.yml
+++ b/rules/windows/process_creation/win_apt_greenbug_may20.yml
@@ -15,7 +15,7 @@ tags:
     - attack.command_and_control
     - attack.t1105
     - attack.defense_evasion
-    - attack.t1036  # an old one
+    - attack.old.t1036
     - attack.t1036.005
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_apt_judgement_panda_gtr19.yml
+++ b/rules/windows/process_creation/win_apt_judgement_panda_gtr19.yml
@@ -10,10 +10,10 @@ tags:
     - attack.lateral_movement
     - attack.g0010
     - attack.credential_access
-    - attack.t1003 # an old one
+    - attack.old.t1003
     - attack.t1003.001
     - attack.exfiltration
-    - attack.t1002 # an old one
+    - attack.old.t1002
     - attack.t1560.001
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_apt_ke3chang_regadd.yml
+++ b/rules/windows/process_creation/win_apt_ke3chang_regadd.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.g0004
     - attack.defense_evasion
-    - attack.t1089 # an old one
+    - attack.old.t1089
     - attack.t1562.001
 author: Markus Neis, Swisscom 
 date: 2020/06/18

--- a/rules/windows/process_creation/win_apt_lazarus_session_highjack.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_session_highjack.yml
@@ -6,7 +6,7 @@ references:
     - https://media.kasperskycontenthub.com/wp-content/uploads/sites/43/2018/03/07180244/Lazarus_Under_The_Hood_PDF_final.pdf
 tags:
     - attack.defense_evasion
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.005
 author: Trent Liffick (@tliffick), Bartlomiej Czyz (@bczyz1)
 date: 2020/06/03

--- a/rules/windows/process_creation/win_apt_sofacy.yml
+++ b/rules/windows/process_creation/win_apt_sofacy.yml
@@ -12,10 +12,10 @@ references:
 tags:
     - attack.g0007
     - attack.execution
-    - attack.t1059 # an old one
+    - attack.old.t1059
     - attack.t1059.003
     - attack.defense_evasion
-    - attack.t1085 # an old one
+    - attack.old.t1085
     - car.2013-10-002
     - attack.t1218.011
 logsource:

--- a/rules/windows/process_creation/win_apt_ta17_293a_ps.yml
+++ b/rules/windows/process_creation/win_apt_ta17_293a_ps.yml
@@ -6,7 +6,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.g0035
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.003
     - car.2013-05-009
 author: Florian Roth

--- a/rules/windows/process_creation/win_apt_taidoor.yml
+++ b/rules/windows/process_creation/win_apt_taidoor.yml
@@ -8,7 +8,7 @@ author: Florian Roth
 date: 2020/07/30
 tags:
     - attack.execution
-    - attack.t1055 # an old one
+    - attack.old.t1055
     - attack.t1055.001
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_apt_tropictrooper.yml
+++ b/rules/windows/process_creation/win_apt_tropictrooper.yml
@@ -9,7 +9,7 @@ references:
     - https://cloudblogs.microsoft.com/microsoftsecure/2018/11/28/windows-defender-atp-device-risk-score-exposes-new-cyberattack-drives-conditional-access-to-protect-networks/
 tags:
     - attack.execution
-    - attack.t1059 # an old one
+    - attack.old.t1059
     - attack.t1059.001
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_apt_turla_commands.yml
+++ b/rules/windows/process_creation/win_apt_turla_commands.yml
@@ -10,7 +10,7 @@ tags:
     - attack.execution
     - attack.t1059
     - attack.lateral_movement
-    - attack.t1077 # an old one
+    - attack.old.t1077
     - attack.t1021.002
     - attack.discovery
     - attack.t1083

--- a/rules/windows/process_creation/win_apt_turla_comrat_may20.yml
+++ b/rules/windows/process_creation/win_apt_turla_comrat_may20.yml
@@ -7,9 +7,9 @@ references:
 tags:
     - attack.g0010
     - attack.execution
-    - attack.t1086 # an old one
+    - attack.old.t1086
     - attack.t1059.001
-    - attack.t1053 # an old one
+    - attack.old.t1053
     - attack.t1053.005
     - attack.t1027
 author: Florian Roth

--- a/rules/windows/process_creation/win_apt_unidentified_nov_18.yml
+++ b/rules/windows/process_creation/win_apt_unidentified_nov_18.yml
@@ -12,7 +12,7 @@ modified: 2020/08/26
 tags:
     - attack.execution
     - attack.t1218.011
-    - attack.t1085  # an old one
+    - attack.old.t1085
 detection:
     condition: 1 of them
 level: high

--- a/rules/windows/process_creation/win_apt_winnti_mal_hk_jan20.yml
+++ b/rules/windows/process_creation/win_apt_winnti_mal_hk_jan20.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1574.002
-    - attack.t1073  # an old one
+    - attack.old.t1073
     - attack.g0044
 author: Florian Roth, Markus Neis
 date: 2020/02/01

--- a/rules/windows/process_creation/win_apt_winnti_pipemon.yml
+++ b/rules/windows/process_creation/win_apt_winnti_pipemon.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1574.002
-    - attack.t1073  # an old one
+    - attack.old.t1073
     - attack.g0044
 author: Florian Roth
 date: 2020/07/30

--- a/rules/windows/process_creation/win_apt_wocao.yml
+++ b/rules/windows/process_creation/win_apt_wocao.yml
@@ -12,13 +12,13 @@ tags:
     - attack.t1012
     - attack.defense_evasion
     - attack.t1036.004
-    - attack.t1036  # an old one
+    - attack.old.t1036
     - attack.t1027
     - attack.execution
     - attack.t1053.005
-    - attack.t1053  # an old one
+    - attack.old.t1053
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 date: 2019/12/20
 modified: 2020/08/26
 falsepositives:

--- a/rules/windows/process_creation/win_apt_zxshell.yml
+++ b/rules/windows/process_creation/win_apt_zxshell.yml
@@ -9,10 +9,10 @@ references:
 tags:
     - attack.execution
     - attack.t1059.003
-    - attack.t1059  # an old one
+    - attack.old.t1059
     - attack.defense_evasion
     - attack.t1218.011
-    - attack.t1085  # an old one
+    - attack.old.t1085
     - attack.s0412
     - attack.g0001
 logsource:

--- a/rules/windows/process_creation/win_attrib_hiding_files.yml
+++ b/rules/windows/process_creation/win_attrib_hiding_files.yml
@@ -26,7 +26,7 @@ fields:
 tags:
     - attack.defense_evasion
     - attack.t1564.001
-    - attack.t1158  # an old one
+    - attack.old.t1158
 falsepositives:
     - igfxCUIService.exe hiding *.cui files via .bat script (attrib.exe a child of cmd.exe and igfxCUIService.exe is the parent of the cmd.exe)
     - msiexec.exe hiding desktop.ini

--- a/rules/windows/process_creation/win_bypass_squiblytwo.yml
+++ b/rules/windows/process_creation/win_bypass_squiblytwo.yml
@@ -12,7 +12,7 @@ tags:
     - attack.execution
     - attack.t1059.005
     - attack.t1059.007
-    - attack.t1059  # an old one
+    - attack.old.t1059
 author: Markus Neis / Florian Roth
 date: 2019/01/16
 modified: 2020/08/27

--- a/rules/windows/process_creation/win_change_default_file_association.yml
+++ b/rules/windows/process_creation/win_change_default_file_association.yml
@@ -31,4 +31,4 @@ level: low
 tags:
     - attack.persistence
     - attack.t1546.001
-    - attack.t1042  # an old one
+    - attack.old.t1042

--- a/rules/windows/process_creation/win_cmdkey_recon.yml
+++ b/rules/windows/process_creation/win_cmdkey_recon.yml
@@ -10,7 +10,7 @@ date: 2019/01/16
 tags:
     - attack.credential_access
     - attack.t1003.005
-    - attack.t1003  # an old one
+    - attack.old.t1003
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_cmstp_com_object_access.yml
+++ b/rules/windows/process_creation/win_cmstp_com_object_access.yml
@@ -7,9 +7,9 @@ tags:
     - attack.defense_evasion
     - attack.privilege_escalation
     - attack.t1548.002
-    - attack.t1088  # an old one
+    - attack.old.t1088
     - attack.t1218.003
-    - attack.t1191  # an old one
+    - attack.old.t1191
     - attack.g0069
     - car.2019-04-001
 author: Nik Seetharaman

--- a/rules/windows/process_creation/win_commandline_path_traversal.yml
+++ b/rules/windows/process_creation/win_commandline_path_traversal.yml
@@ -10,7 +10,7 @@ references:
 tags:
     - attack.execution
     - attack.t1059.003
-    - attack.t1059  # an old one
+    - attack.old.t1059
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_control_panel_item.yml
+++ b/rules/windows/process_creation/win_control_panel_item.yml
@@ -9,7 +9,7 @@ tags:
     - attack.execution
     - attack.defense_evasion
     - attack.t1218.002
-    - attack.t1196  # an old one
+    - attack.old.t1196
     - attack.persistence
     - attack.t1546
 author: Kyaw Min Thein, Furkan Caliskan (@caliskanfurkan_)

--- a/rules/windows/process_creation/win_copying_sensitive_files_with_credential_data.yml
+++ b/rules/windows/process_creation/win_copying_sensitive_files_with_credential_data.yml
@@ -13,7 +13,7 @@ tags:
     - attack.credential_access
     - attack.t1003.002
     - attack.t1003.003
-    - attack.t1003  # an old one
+    - attack.old.t1003
     - car.2013-07-001
     - attack.s0404
 logsource:

--- a/rules/windows/process_creation/win_crime_fireball.yml
+++ b/rules/windows/process_creation/win_crime_fireball.yml
@@ -12,7 +12,7 @@ tags:
     - attack.execution
     - attack.defense_evasion
     - attack.t1218.011
-    - attack.t1085  # an old one
+    - attack.old.t1085
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_crime_maze_ransomware.yml
+++ b/rules/windows/process_creation/win_crime_maze_ransomware.yml
@@ -12,7 +12,7 @@ modified: 2020/08/29
 tags:
     - attack.execution
     - attack.t1204.002
-    - attack.t1204  # an old one
+    - attack.old.t1204
     - attack.t1047
     - attack.impact
     - attack.t1490

--- a/rules/windows/process_creation/win_data_compressed_with_rar.yml
+++ b/rules/windows/process_creation/win_data_compressed_with_rar.yml
@@ -29,6 +29,6 @@ falsepositives:
 level: low
 tags:
     - attack.exfiltration  # an old one
-    - attack.t1002  # an old one
+    - attack.old.t1002
     - attack.collection
     - attack.t1560.001

--- a/rules/windows/process_creation/win_dns_exfiltration_tools_execution.yml
+++ b/rules/windows/process_creation/win_dns_exfiltration_tools_execution.yml
@@ -8,12 +8,12 @@ modified: 2020/08/29
 tags:
     - attack.exfiltration
     - attack.t1048.001
-    - attack.t1048  # an old one
+    - attack.old.t1048
     - attack.command_and_control
     - attack.t1071.004
-    - attack.t1071  # an old one
+    - attack.old.t1071
     - attack.t1132.001
-    - attack.t1132  # an old one
+    - attack.old.t1132
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_encoded_frombase64string.yml
+++ b/rules/windows/process_creation/win_encoded_frombase64string.yml
@@ -9,7 +9,7 @@ tags:
     - attack.t1140
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_encoded_iex.yml
+++ b/rules/windows/process_creation/win_encoded_iex.yml
@@ -8,7 +8,7 @@ modified: 2020/08/29
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_exfiltration_and_tunneling_tools_execution.yml
+++ b/rules/windows/process_creation/win_exfiltration_and_tunneling_tools_execution.yml
@@ -8,7 +8,7 @@ modified: 2020/08/29
 tags:
     - attack.exfiltration
     - attack.command_and_control
-    - attack.t1043   # an old one
+    - attack.old.t1043
     - attack.t1041
     - attack.t1572
     - attack.t1071.001

--- a/rules/windows/process_creation/win_exploit_cve_2015_1641.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2015_1641.yml
@@ -10,7 +10,7 @@ date: 2018/02/22
 tags:
     - attack.defense_evasion
     - attack.t1036.005
-    - attack.t1036  # an old one
+    - attack.old.t1036
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_exploit_cve_2017_0261.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2017_0261.yml
@@ -11,10 +11,10 @@ tags:
   - attack.execution
   - attack.t1203
   - attack.t1204.002
-  - attack.t1204  # an old one
+  - attack.old.t1204
   - attack.initial_access
   - attack.t1566.001
-  - attack.t1193  # an old one
+  - attack.old.t1193
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_exploit_cve_2017_11882.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2017_11882.yml
@@ -12,10 +12,10 @@ tags:
     - attack.execution
     - attack.t1203
     - attack.t1204.002
-    - attack.t1204  # an old one
+    - attack.old.t1204
     - attack.initial_access
     - attack.t1566.001
-    - attack.t1193  # an old one
+    - attack.old.t1193
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_exploit_cve_2017_8759.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2017_8759.yml
@@ -8,10 +8,10 @@ tags:
     - attack.execution
     - attack.t1203
     - attack.t1204.002
-    - attack.t1204  # an old one
+    - attack.old.t1204
     - attack.initial_access
     - attack.t1566.001
-    - attack.t1193  # an old one
+    - attack.old.t1193
 author: Florian Roth
 date: 2017/09/15
 modified: 2020/08/29

--- a/rules/windows/process_creation/win_exploit_cve_2019_1378.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2019_1378.yml
@@ -12,7 +12,7 @@ tags:
   - attack.t1068
   - attack.execution
   - attack.t1059.003
-  - attack.t1059  # an old one
+  - attack.old.t1059
   - attack.t1574
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_exploit_cve_2020_10189.yml
+++ b/rules/windows/process_creation/win_exploit_cve_2020_10189.yml
@@ -14,9 +14,9 @@ tags:
     - attack.t1190
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
     - attack.t1059.003
-    - attack.t1059  # an old one
+    - attack.old.t1059
     - attack.s0190    
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_grabbing_sensitive_hives_via_reg.yml
+++ b/rules/windows/process_creation/win_grabbing_sensitive_hives_via_reg.yml
@@ -12,7 +12,7 @@ tags:
     - attack.t1003.002
     - attack.t1003.004
     - attack.t1003.005
-    - attack.t1003  # an old one
+    - attack.old.t1003
     - car.2013-07-001
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_hack_bloodhound.yml
+++ b/rules/windows/process_creation/win_hack_bloodhound.yml
@@ -11,14 +11,14 @@ tags:
     - attack.discovery
     - attack.t1087.001
     - attack.t1087.002
-    - attack.t1087  # an old one
+    - attack.old.t1087
     - attack.t1482
     - attack.t1069.001
     - attack.t1069.002
-    - attack.t1069  # an old one
+    - attack.old.t1069
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_hack_koadic.yml
+++ b/rules/windows/process_creation/win_hack_koadic.yml
@@ -9,10 +9,10 @@ references:
 tags:
     - attack.execution
     - attack.t1059.003
-    - attack.t1059  # an old one
+    - attack.old.t1059
     - attack.t1059.005
     - attack.t1059.007
-    - attack.t1064  # an old one
+    - attack.old.t1064
 date: 2020/01/12
 modified: 2020/09/01
 author: wagga

--- a/rules/windows/process_creation/win_hack_rubeus.yml
+++ b/rules/windows/process_creation/win_hack_rubeus.yml
@@ -9,10 +9,10 @@ tags:
     - attack.credential_access
     - attack.t1003
     - attack.t1558.003
-    - attack.t1558  # an old one
+    - attack.old.t1558
     - attack.lateral_movement 
     - attack.t1550.003
-    - attack.t1097  # an old one
+    - attack.old.t1097
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_hack_secutyxploded.yml
+++ b/rules/windows/process_creation/win_hack_secutyxploded.yml
@@ -10,8 +10,8 @@ modified: 2020/09/01
 tags:
     - attack.credential_access
     - attack.t1555
-    - attack.t1003  # an old one
-    - attack.t1503  # an old one
+    - attack.old.t1003
+    - attack.old.t1503
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_hh_chm.yml
+++ b/rules/windows/process_creation/win_hh_chm.yml
@@ -12,7 +12,7 @@ tags:
     - attack.defense_evasion
     - attack.t1218.001
     - attack.execution  # an old one
-    - attack.t1223  # an old one
+    - attack.old.t1223
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_hktl_createminidump.yml
+++ b/rules/windows/process_creation/win_hktl_createminidump.yml
@@ -9,7 +9,7 @@ date: 2019/12/22
 tags:
     - attack.credential_access
     - attack.t1003.001
-    - attack.t1003  # an old one
+    - attack.old.t1003
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/win_html_help_spawn.yml
+++ b/rules/windows/process_creation/win_html_help_spawn.yml
@@ -13,7 +13,7 @@ tags:
     - attack.t1218.010
     - attack.t1218.011
     - attack.execution
-    - attack.t1223  # an old one
+    - attack.old.t1223
     - attack.t1059.001
     - attack.t1059.003
     - attack.t1059.005

--- a/rules/windows/process_creation/win_hwp_exploits.yml
+++ b/rules/windows/process_creation/win_hwp_exploits.yml
@@ -11,11 +11,11 @@ references:
 tags:
     - attack.initial_access
     - attack.t1566.001
-    - attack.t1193  # an old one
+    - attack.old.t1193
     - attack.execution
     - attack.t1203
     - attack.t1059.003
-    - attack.t1059  # an old one
+    - attack.old.t1059
     - attack.g0032
 author: Florian Roth
 date: 2019/10/24

--- a/rules/windows/process_creation/win_impacket_lateralization.yml
+++ b/rules/windows/process_creation/win_impacket_lateralization.yml
@@ -54,9 +54,9 @@ tags:
     - attack.execution
     - attack.t1047
     - attack.lateral_movement
-    - attack.t1175  # an old one
+    - attack.old.t1175
     - attack.t1021.003
-    - attack.t1021  # an old one
+    - attack.old.t1021
 falsepositives:
     - pentesters
 level: critical

--- a/rules/windows/process_creation/win_install_reg_debugger_backdoor.yml
+++ b/rules/windows/process_creation/win_install_reg_debugger_backdoor.yml
@@ -8,7 +8,7 @@ tags:
     - attack.persistence
     - attack.privilege_escalation
     - attack.t1546.008
-    - attack.t1015  # an old one
+    - attack.old.t1015
 author: Florian Roth
 date: 2019/09/06
 logsource:

--- a/rules/windows/process_creation/win_interactive_at.yml
+++ b/rules/windows/process_creation/win_interactive_at.yml
@@ -11,7 +11,7 @@ modified: 2019/11/11
 tags:
     - attack.privilege_escalation
     - attack.t1053.002
-    - attack.t1053  # an old one
+    - attack.old.t1053
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_lethalhta.yml
+++ b/rules/windows/process_creation/win_lethalhta.yml
@@ -8,7 +8,7 @@ tags:
     - attack.defense_evasion
     - attack.t1218.005
     - attack.execution  # an old one
-    - attack.t1170  # an old one
+    - attack.old.t1170
 author: Markus Neis
 date: 2018/06/07
 logsource:

--- a/rules/windows/process_creation/win_local_system_owner_account_discovery.yml
+++ b/rules/windows/process_creation/win_local_system_owner_account_discovery.yml
@@ -62,4 +62,4 @@ tags:
     - attack.discovery
     - attack.t1033
     - attack.t1087.001
-    - attack.t1087  # an old one
+    - attack.old.t1087

--- a/rules/windows/process_creation/win_lsass_dump.yml
+++ b/rules/windows/process_creation/win_lsass_dump.yml
@@ -12,7 +12,7 @@ references:
 tags:
     - attack.credential_access
     - attack.t1003.001
-    - attack.t1003  # an old one
+    - attack.old.t1003
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_mal_adwind.yml
+++ b/rules/windows/process_creation/win_mal_adwind.yml
@@ -13,7 +13,7 @@ tags:
     - attack.execution
     - attack.t1059.005
     - attack.t1059.007
-    - attack.t1064  # an old one
+    - attack.old.t1064
 detection:
     condition: selection
 level: high

--- a/rules/windows/process_creation/win_malware_emotet.yml
+++ b/rules/windows/process_creation/win_malware_emotet.yml
@@ -8,7 +8,7 @@ modified: 2020/09/01
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086  # an old one
+    - attack.old.t1086
     - attack.defense_evasion
     - attack.t1027
 references:

--- a/rules/windows/process_creation/win_malware_notpetya.yml
+++ b/rules/windows/process_creation/win_malware_notpetya.yml
@@ -12,12 +12,12 @@ tags:
     - attack.defense_evasion
     - attack.t1218.011
     - attack.execution  # an old one
-    - attack.t1085  # an old one
+    - attack.old.t1085
     - attack.t1070.001
-    - attack.t1070  # an old one
+    - attack.old.t1070
     - attack.credential_access
     - attack.t1003.001
-    - attack.t1003  # an old one
+    - attack.old.t1003
     - car.2016-04-002
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_malware_qbot.yml
+++ b/rules/windows/process_creation/win_malware_qbot.yml
@@ -9,7 +9,7 @@ tags:
     - attack.execution
     - attack.t1059.005
     - attack.defense_evasion  # an old one
-    - attack.t1064  # an old one
+    - attack.old.t1064
 references:
     - https://twitter.com/killamjr/status/1179034907932315648
     - https://app.any.run/tasks/2e0647b7-eb86-4f72-904b-d2d0ecac07d1/

--- a/rules/windows/process_creation/win_malware_ryuk.yml
+++ b/rules/windows/process_creation/win_malware_ryuk.yml
@@ -8,7 +8,7 @@ modified: 2020/09/01
 tags:
     - attack.persistence
     - attack.t1547.001
-    - attack.t1060  # an old one
+    - attack.old.t1060
 references:
     - https://app.any.run/tasks/d860402c-3ff4-4c1f-b367-0237da714ed1/
 logsource:

--- a/rules/windows/process_creation/win_malware_script_dropper.yml
+++ b/rules/windows/process_creation/win_malware_script_dropper.yml
@@ -10,7 +10,7 @@ tags:
     - attack.t1059.005
     - attack.t1059.007
     - attack.defense_evasion  # an old one
-    - attack.t1064  # an old one
+    - attack.old.t1064
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_malware_wannacry.yml
+++ b/rules/windows/process_creation/win_malware_wannacry.yml
@@ -14,7 +14,7 @@ tags:
     - attack.t1083
     - attack.defense_evasion
     - attack.t1222.001
-    - attack.t1222  # an old one
+    - attack.old.t1222
     - attack.impact
     - attack.t1486
     - attack.t1490

--- a/rules/windows/process_creation/win_mavinject_proc_inj.yml
+++ b/rules/windows/process_creation/win_mavinject_proc_inj.yml
@@ -10,7 +10,7 @@ author: Florian Roth
 date: 2018/12/12
 modified: 2020/09/01
 tags:
-    - attack.t1055          # an old one
+    - attack.old.t1055
     - attack.t1055.001
     - attack.t1218
 logsource:

--- a/rules/windows/process_creation/win_meterpreter_or_cobaltstrike_getsystem_service_start.yml
+++ b/rules/windows/process_creation/win_meterpreter_or_cobaltstrike_getsystem_service_start.yml
@@ -9,7 +9,7 @@ references:
     - https://blog.cobaltstrike.com/2014/04/02/what-happens-when-i-type-getsystem/
 tags:
     - attack.privilege_escalation
-    - attack.t1134          # an old one
+    - attack.old.t1134
     - attack.t1134.001
     - attack.t1134.002
 logsource:

--- a/rules/windows/process_creation/win_mimikatz_command_line.yml
+++ b/rules/windows/process_creation/win_mimikatz_command_line.yml
@@ -8,7 +8,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.001
     - attack.t1003.002
     - attack.t1003.004

--- a/rules/windows/process_creation/win_mmc_spawn_shell.yml
+++ b/rules/windows/process_creation/win_mmc_spawn_shell.yml
@@ -9,7 +9,7 @@ references:
     - https://enigma0x3.net/2017/01/05/lateral-movement-using-the-mmc20-application-com-object/
 tags:
     - attack.lateral_movement
-    - attack.t1175          # an old one
+    - attack.old.t1175
     - attack.t1021.003
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_mshta_javascript.yml
+++ b/rules/windows/process_creation/win_mshta_javascript.yml
@@ -10,7 +10,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1170/T1170.yaml
 tags:
     - attack.defense_evasion
-    - attack.t1170          # an old one
+    - attack.old.t1170
     - attack.t1218.005
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_mshta_spawn_shell.yml
+++ b/rules/windows/process_creation/win_mshta_spawn_shell.yml
@@ -29,7 +29,7 @@ fields:
     - ParentCommandLine
 tags:
     - attack.defense_evasion
-    - attack.t1170          # an old one
+    - attack.old.t1170
     - attack.t1218.005
     - car.2013-02-003
     - car.2013-03-001

--- a/rules/windows/process_creation/win_net_user_add.yml
+++ b/rules/windows/process_creation/win_net_user_add.yml
@@ -10,7 +10,7 @@ date: 2018/10/30
 modified: 2020/09/01
 tags:
     - attack.persistence
-    - attack.t1136          # an old one
+    - attack.old.t1136
     - attack.t1136.001
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_netsh_allow_port_rdp.yml
+++ b/rules/windows/process_creation/win_netsh_allow_port_rdp.yml
@@ -7,7 +7,7 @@ date: 2020/05/23
 modified: 2020/09/01
 tags:
     - attack.defense_evasion
-    - attack.t1089          # an old one
+    - attack.old.t1089
     - attack.t1562.004
 status: experimental
 author: Sander Wiebing

--- a/rules/windows/process_creation/win_netsh_fw_add.yml
+++ b/rules/windows/process_creation/win_netsh_fw_add.yml
@@ -8,7 +8,7 @@ date: 2019/01/29
 modified: 2020/09/01
 tags:
     - attack.defense_evasion
-    - attack.t1089          # an old one
+    - attack.old.t1089
     - attack.t1562.004
 status: experimental
 author: Markus Neis, Sander Wiebing

--- a/rules/windows/process_creation/win_netsh_fw_add_susp_image.yml
+++ b/rules/windows/process_creation/win_netsh_fw_add_susp_image.yml
@@ -8,7 +8,7 @@ date: 2020/05/25
 modified: 2020/09/01
 tags:
     - attack.defense_evasion
-    - attack.t1089          # an old one
+    - attack.old.t1089
     - attack.t1562.004
 status: experimental
 author: Sander Wiebing

--- a/rules/windows/process_creation/win_new_service_creation.yml
+++ b/rules/windows/process_creation/win_new_service_creation.yml
@@ -8,7 +8,7 @@ modified: 2019/11/04
 tags:
     - attack.persistence
     - attack.privilege_escalation
-    - attack.t1050          # an old one
+    - attack.old.t1050
     - attack.t1543.003
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1050/T1050.yaml

--- a/rules/windows/process_creation/win_non_interactive_powershell.yml
+++ b/rules/windows/process_creation/win_non_interactive_powershell.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/02_execution/T1086_powershell/basic_powershell_execution.md
 tags:
     - attack.execution
-    - attack.t1086          # an old one
+    - attack.old.t1086
     - attack.t1059.001
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_office_shell.yml
+++ b/rules/windows/process_creation/win_office_shell.yml
@@ -7,7 +7,7 @@ references:
     - https://mgreen27.github.io/posts/2018/04/02/DownloadCradle.html
 tags:
     - attack.execution
-    - attack.t1204          # an old one
+    - attack.old.t1204
     - attack.t1204.002
 author: Michael Haag, Florian Roth, Markus Neis, Elastic, FPT.EagleEye Team
 date: 2018/04/06

--- a/rules/windows/process_creation/win_office_spawn_exe_from_users_directory.yml
+++ b/rules/windows/process_creation/win_office_spawn_exe_from_users_directory.yml
@@ -7,7 +7,7 @@ references:
     - https://blog.morphisec.com/fin7-not-finished-morphisec-spots-new-campaign
 tags:
     - attack.execution
-    - attack.t1204          # an old one
+    - attack.old.t1204
     - attack.t1204.002
     - FIN7
     - car.2013-05-002

--- a/rules/windows/process_creation/win_plugx_susp_exe_locations.yml
+++ b/rules/windows/process_creation/win_plugx_susp_exe_locations.yml
@@ -10,7 +10,7 @@ date: 2017/06/12
 tags:
     - attack.s0013
     - attack.defense_evasion
-    - attack.t1073          # an old one
+    - attack.old.t1073
     - attack.t1574.002
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_possible_applocker_bypass.yml
+++ b/rules/windows/process_creation/win_possible_applocker_bypass.yml
@@ -10,13 +10,13 @@ date: 2019/01/16
 modified: 2020/09/01
 tags:
     - attack.defense_evasion
-    - attack.t1118          # an old one
+    - attack.old.t1118
     - attack.t1218.004
-    - attack.t1121          # an old one
+    - attack.old.t1121
     - attack.t1218.009
-    - attack.t1127          # an old one
+    - attack.old.t1127
     - attack.t1127.001
-    - attack.t1170          # an old one
+    - attack.old.t1170
     - attack.t1218.005
     - attack.t1218 # no way to map 1:1, so the technique level is required
 logsource:

--- a/rules/windows/process_creation/win_possible_privilege_escalation_using_rotten_potato.yml
+++ b/rules/windows/process_creation/win_possible_privilege_escalation_using_rotten_potato.yml
@@ -6,7 +6,7 @@ references:
     - https://foxglovesecurity.com/2016/09/26/rotten-potato-privilege-escalation-from-service-accounts-to-system/
 tags:
     - attack.privilege_escalation
-    - attack.t1134           # an old one
+    - attack.old.t1134
     - attack.t1134.002
 status: experimental
 author: Teymur Kheirkhabarov

--- a/rules/windows/process_creation/win_powershell_amsi_bypass.yml
+++ b/rules/windows/process_creation/win_powershell_amsi_bypass.yml
@@ -7,7 +7,7 @@ references:
     - https://www.hybrid-analysis.com/sample/0ced17419e01663a0cd836c9c2eb925e3031ffb5b18ccf35f4dea5d586d0203e?environmentId=120
 tags:
     - attack.defense_evasion
-    - attack.t1089         # an old one
+    - attack.old.t1089
     - attack.t1562.001
 author: Markus Neis
 date: 2018/08/17

--- a/rules/windows/process_creation/win_powershell_dll_execution.yml
+++ b/rules/windows/process_creation/win_powershell_dll_execution.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/p3nt4/PowerShdll/blob/master/README.md
 tags:
     - attack.defense_evasion
-    - attack.t1085          # an old one
+    - attack.old.t1085
     - attack.t1218.011
 author: Markus Neis
 date: 2018/08/25

--- a/rules/windows/process_creation/win_powershell_downgrade_attack.yml
+++ b/rules/windows/process_creation/win_powershell_downgrade_attack.yml
@@ -10,7 +10,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.execution
-    - attack.t1086          # an old one
+    - attack.old.t1086
     - attack.t1059.001
 author: Harish Segar (rule)
 date: 2020/03/20

--- a/rules/windows/process_creation/win_powershell_download.yml
+++ b/rules/windows/process_creation/win_powershell_download.yml
@@ -5,7 +5,7 @@ description: Detects a Powershell process that contains download commands in its
 author: Florian Roth
 date: 2019/01/16
 tags:
-    - attack.t1086  # an old one
+    - attack.old.t1086
     - attack.execution
     - attack.t1059.001
 logsource:

--- a/rules/windows/process_creation/win_powershell_suspicious_parameter_variation.yml
+++ b/rules/windows/process_creation/win_powershell_suspicious_parameter_variation.yml
@@ -6,7 +6,7 @@ references:
     - http://www.danielbohannon.com/blog-1/2017/3/12/powershell-execution-argument-obfuscation-how-it-can-make-detection-easier
 tags:
     - attack.execution
-    - attack.t1086 # an old one
+    - attack.old.t1086
     - attack.t1059.001
 author: Florian Roth (rule), Daniel Bohannon (idea), Roberto Rodriguez (Fix)
 date: 2019/01/16

--- a/rules/windows/process_creation/win_powershell_xor_commandline.yml
+++ b/rules/windows/process_creation/win_powershell_xor_commandline.yml
@@ -7,7 +7,7 @@ date: 2018/09/05
 modified: 2020/09/06
 tags:
     - attack.defense_evasion
-    - attack.t1086 # an old one
+    - attack.old.t1086
     - attack.t1059.001
     - attack.t1140
     - attack.t1027    

--- a/rules/windows/process_creation/win_powersploit_empire_schtasks.yml
+++ b/rules/windows/process_creation/win_powersploit_empire_schtasks.yml
@@ -25,8 +25,8 @@ tags:
     - attack.execution
     - attack.persistence
     - attack.privilege_escalation
-    - attack.t1053 # an old one
-    - attack.t1086 # an old one
+    - attack.old.t1053
+    - attack.old.t1086
     - attack.s0111
     - attack.g0022
     - attack.g0060

--- a/rules/windows/process_creation/win_proc_wrong_parent.yml
+++ b/rules/windows/process_creation/win_proc_wrong_parent.yml
@@ -12,7 +12,7 @@ date: 2019/02/23
 modified: 2020/09/06
 tags:
     - attack.defense_evasion
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.003
     - attack.t1036.005
 logsource:

--- a/rules/windows/process_creation/win_process_dump_rundll32_comsvcs.yml
+++ b/rules/windows/process_creation/win_process_dump_rundll32_comsvcs.yml
@@ -11,7 +11,7 @@ tags:
     - attack.defense_evasion
     - attack.t1036
     - attack.credential_access
-    - attack.t1003 # an old one
+    - attack.old.t1003
     - car.2013-05-009
     - attack.t1003.001
 logsource:

--- a/rules/windows/process_creation/win_psexesvc_start.yml
+++ b/rules/windows/process_creation/win_psexesvc_start.yml
@@ -6,7 +6,7 @@ date: 2018/03/13
 modified: 2012/12/11
 tags:
     - attack.execution
-    - attack.t1035 # an old one
+    - attack.old.t1035
     - attack.s0029
     - attack.t1569.002
 logsource:

--- a/rules/windows/process_creation/win_redmimicry_winnti_proc.yml
+++ b/rules/windows/process_creation/win_redmimicry_winnti_proc.yml
@@ -9,7 +9,7 @@ modified: 2020/09/06
 tags:
     - attack.execution
     - attack.defense_evasion
-    - attack.t1059 # an old one
+    - attack.old.t1059
     - attack.t1106
     - attack.t1059.003
     - attack.t1218.011    

--- a/rules/windows/process_creation/win_remote_powershell_session_process.yml
+++ b/rules/windows/process_creation/win_remote_powershell_session_process.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/02_execution/T1086_powershell/powershell_remote_session.md
 tags:
     - attack.execution
-    - attack.t1086 # an old one
+    - attack.old.t1086
     - attack.t1059.001
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_renamed_binary.yml
+++ b/rules/windows/process_creation/win_renamed_binary.yml
@@ -11,7 +11,7 @@ references:
     - https://mgreen27.github.io/posts/2019/05/29/BinaryRename2.html
 tags:
     - attack.defense_evasion
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.003
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_renamed_binary_highly_relevant.yml
+++ b/rules/windows/process_creation/win_renamed_binary_highly_relevant.yml
@@ -11,7 +11,7 @@ references:
     - https://mgreen27.github.io/posts/2019/05/29/BinaryRename2.html
 tags:
     - attack.defense_evasion
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.003
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_renamed_jusched.yml
+++ b/rules/windows/process_creation/win_renamed_jusched.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.execution
     - attack.defense_evasion
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.003    
 author: Markus Neis, Swisscom
 date: 2019/06/04

--- a/rules/windows/process_creation/win_renamed_paexec.yml
+++ b/rules/windows/process_creation/win_renamed_paexec.yml
@@ -7,7 +7,7 @@ references:
     - https://summit.fireeye.com/content/dam/fireeye-www/summit/cds-2018/presentations/cds18-technical-s05-att&cking-fin7.pdf
 tags:
     - attack.defense_evasion
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.003
     - FIN7
     - car.2013-05-009

--- a/rules/windows/process_creation/win_renamed_powershell.yml
+++ b/rules/windows/process_creation/win_renamed_powershell.yml
@@ -10,7 +10,7 @@ modified: 2020/09/06
 tags:
     - car.2013-05-009
     - attack.defense_evasion
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.003    
 logsource:
     product: windows

--- a/rules/windows/process_creation/win_renamed_procdump.yml
+++ b/rules/windows/process_creation/win_renamed_procdump.yml
@@ -9,7 +9,7 @@ date: 2019/11/18
 modified: 2020/09/06
 tags:
     - attack.defense_evasion
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.003
 logsource:
     product: windows

--- a/rules/windows/process_creation/win_renamed_psexec.yml
+++ b/rules/windows/process_creation/win_renamed_psexec.yml
@@ -10,7 +10,7 @@ modified: 2020/09/06
 tags:
     - car.2013-05-009
     - attack.defense_evasion
-    - attack.t1036 # an old one
+    - attack.old.t1036
     - attack.t1036.003
 logsource:
     product: windows

--- a/rules/windows/process_creation/win_run_powershell_script_from_ads.yml
+++ b/rules/windows/process_creation/win_run_powershell_script_from_ads.yml
@@ -8,7 +8,7 @@ author: Sergey Soldatov, Kaspersky Lab, oscd.community
 date: 2019/10/30
 tags:
     - attack.defense_evasion
-    - attack.t1096 # an old one
+    - attack.old.t1096
     - attack.t1564.004
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_sdbinst_shim_persistence.yml
+++ b/rules/windows/process_creation/win_sdbinst_shim_persistence.yml
@@ -8,7 +8,7 @@ tags:
     - attack.persistence
     - attack.privilege_escalation
     - attack.t1546.011
-    - attack.t1138 # an old one
+    - attack.old.t1138
 author: Markus Neis
 date: 2019/01/16
 modified: 2020/09/06

--- a/rules/windows/process_creation/win_service_execution.yml
+++ b/rules/windows/process_creation/win_service_execution.yml
@@ -22,5 +22,5 @@ falsepositives:
 level: low
 tags:
     - attack.execution
-    - attack.t1035 # an old one
+    - attack.old.t1035
     - attack.t1569.002

--- a/rules/windows/process_creation/win_shadow_copies_access_symlink.yml
+++ b/rules/windows/process_creation/win_shadow_copies_access_symlink.yml
@@ -7,7 +7,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 tags:
     - attack.credential_access
-    - attack.t1003 # an old one
+    - attack.old.t1003
     - attack.t1003.002
     - attack.t1003.003
 logsource:

--- a/rules/windows/process_creation/win_shell_spawn_susp_program.yml
+++ b/rules/windows/process_creation/win_shell_spawn_susp_program.yml
@@ -10,7 +10,7 @@ modified: 2020/09/06
 tags:
     - attack.execution
     - attack.defense_evasion
-    - attack.t1064 # an old one
+    - attack.old.t1064
     - attack.t1059.005
     - attack.t1059.001
     - attack.t1218    

--- a/rules/windows/process_creation/win_spn_enum.yml
+++ b/rules/windows/process_creation/win_spn_enum.yml
@@ -9,7 +9,7 @@ date: 2018/11/14
 tags:
     - attack.credential_access
     - attack.t1558.003
-    - attack.t1208      # an old one
+    - attack.old.t1208
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_bcdedit.yml
+++ b/rules/windows/process_creation/win_susp_bcdedit.yml
@@ -11,7 +11,7 @@ tags:
     - attack.t1070
     - attack.persistence
     - attack.t1542.003
-    - attack.t1067      # an old one
+    - attack.old.t1067
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_compression_params.yml
+++ b/rules/windows/process_creation/win_susp_compression_params.yml
@@ -8,8 +8,8 @@ tags:
     - attack.collection
     - attack.t1560.001
     - attack.exfiltration # an old one
-    - attack.t1020 # an old one
-    - attack.t1002 # an old one
+    - attack.old.t1020
+    - attack.old.t1002
 author: Florian Roth, Samir Bousseaden
 date: 2019/10/15
 modified: 2020/09/05

--- a/rules/windows/process_creation/win_susp_comsvcs_procdump.yml
+++ b/rules/windows/process_creation/win_susp_comsvcs_procdump.yml
@@ -29,7 +29,7 @@ tags:
     - attack.t1218.011
     - attack.credential_access
     - attack.t1003.001
-    - attack.t1003      # an old one
+    - attack.old.t1003
 falsepositives:
     - unknown
 level: medium

--- a/rules/windows/process_creation/win_susp_control_dll_load.yml
+++ b/rules/windows/process_creation/win_susp_control_dll_load.yml
@@ -9,7 +9,7 @@ references:
     - https://twitter.com/rikvduijn/status/853251879320662017
 tags:
     - attack.defense_evasion
-    - attack.t1085      # an old one
+    - attack.old.t1085
     - attack.t1218.011
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_susp_copy_lateral_movement.yml
+++ b/rules/windows/process_creation/win_susp_copy_lateral_movement.yml
@@ -13,7 +13,7 @@ tags:
     - attack.command_and_control 
     - attack.t1105
     - attack.s0106
-    - attack.t1077      # an old one
+    - attack.old.t1077
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_covenant.yml
+++ b/rules/windows/process_creation/win_susp_covenant.yml
@@ -11,7 +11,7 @@ tags:
     - attack.defense_evasion
     - attack.t1059.001
     - attack.t1564.003
-    - attack.t1086        # an old one
+    - attack.old.t1086
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_crackmapexec_execution.yml
+++ b/rules/windows/process_creation/win_susp_crackmapexec_execution.yml
@@ -11,7 +11,7 @@ tags:
     - attack.t1059.003  
     - attack.t1059.001
     - attack.s0106
-    - attack.t1086      # an old one
+    - attack.old.t1086
 author: Thomas Patzke
 date: 2020/05/22
 logsource:

--- a/rules/windows/process_creation/win_susp_crackmapexec_powershell_obfuscation.yml
+++ b/rules/windows/process_creation/win_susp_crackmapexec_powershell_obfuscation.yml
@@ -10,8 +10,8 @@ tags:
     - attack.t1059.001
     - attack.defense_evasion
     - attack.t1027.005
-    - attack.t1027      # an old one
-    - attack.t1086      # an old one
+    - attack.old.t1027
+    - attack.old.t1086
 author: Thomas Patzke
 date: 2020/05/22
 logsource:

--- a/rules/windows/process_creation/win_susp_csc.yml
+++ b/rules/windows/process_creation/win_susp_csc.yml
@@ -12,7 +12,7 @@ tags:
     - attack.t1059.005
     - attack.t1059.007
     - attack.defense_evasion
-    - attack.t1500  # an old one
+    - attack.old.t1500
     - attack.t1218.005
     - attack.t1027.004
 logsource:

--- a/rules/windows/process_creation/win_susp_csc_folder.yml
+++ b/rules/windows/process_creation/win_susp_csc_folder.yml
@@ -12,7 +12,7 @@ date: 2019/08/24
 modified: 2021/02/01
 tags:
     - attack.defense_evasion
-    - attack.t1500 # an old one
+    - attack.old.t1500
     - attack.t1027.004
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_susp_dctask64_proc_inject.yml
+++ b/rules/windows/process_creation/win_susp_dctask64_proc_inject.yml
@@ -12,7 +12,7 @@ modified: 2020/08/30
 tags:
     - attack.defense_evasion
     - attack.t1055.001
-    - attack.t1055      # an old one
+    - attack.old.t1055
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_direct_asep_reg_keys_modification.yml
+++ b/rules/windows/process_creation/win_susp_direct_asep_reg_keys_modification.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.persistence
     - attack.t1547.001
-    - attack.t1060      # an old one
+    - attack.old.t1060
 date: 2019/10/25
 modified: 2019/11/10
 author: Victor Sergeev, Daniil Yugoslavskiy, oscd.community

--- a/rules/windows/process_creation/win_susp_disable_ie_features.yml
+++ b/rules/windows/process_creation/win_susp_disable_ie_features.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1562.001
-    - attack.t1089      # an old one
+    - attack.old.t1089
 author: Florian Roth 
 date: 2020/06/19
 logsource:

--- a/rules/windows/process_creation/win_susp_ditsnap.yml
+++ b/rules/windows/process_creation/win_susp_ditsnap.yml
@@ -10,7 +10,7 @@ date: 2020/07/04
 tags:
     - attack.credential_access
     - attack.t1003.003
-    - attack.t1003 # an old one
+    - attack.old.t1003
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_double_extension.yml
+++ b/rules/windows/process_creation/win_susp_double_extension.yml
@@ -9,7 +9,7 @@ date: 2019/06/26
 tags:
     - attack.initial_access
     - attack.t1566.001
-    - attack.t1193      # an old one
+    - attack.old.t1193
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_eventlog_clear.yml
+++ b/rules/windows/process_creation/win_susp_eventlog_clear.yml
@@ -10,7 +10,7 @@ modified: 2019/11/11
 tags:
     - attack.defense_evasion
     - attack.t1070.001
-    - attack.t1070      # an old one
+    - attack.old.t1070
     - car.2016-04-002
 level: high
 logsource:

--- a/rules/windows/process_creation/win_susp_execution_path_webserver.yml
+++ b/rules/windows/process_creation/win_susp_execution_path_webserver.yml
@@ -7,7 +7,7 @@ date: 2019/01/16
 tags:
     - attack.persistence
     - attack.t1505.003
-    - attack.t1100      # an old one
+    - attack.old.t1100
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/win_susp_file_characteristics.yml
@@ -12,7 +12,7 @@ tags:
     - attack.execution
     - attack.t1059.006
     - attack.defense_evasion        # an old one
-    - attack.t1064      # an old one
+    - attack.old.t1064
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/win_susp_gup.yml
+++ b/rules/windows/process_creation/win_susp_gup.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1574.002
-    - attack.t1073      # an old one
+    - attack.old.t1073
 author: Florian Roth
 date: 2019/02/06
 modified: 2020/11/09

--- a/rules/windows/process_creation/win_susp_iss_module_install.yml
+++ b/rules/windows/process_creation/win_susp_iss_module_install.yml
@@ -9,7 +9,7 @@ date: 2012/12/11
 tags:
     - attack.persistence
     - attack.t1505.003
-    - attack.t1100      # an old one
+    - attack.old.t1100
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_msiexec_cwd.yml
+++ b/rules/windows/process_creation/win_susp_msiexec_cwd.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1036.005
-    - attack.t1036      # an old one
+    - attack.old.t1036
 author: Florian Roth
 date: 2019/11/14
 logsource:

--- a/rules/windows/process_creation/win_susp_net_execution.yml
+++ b/rules/windows/process_creation/win_susp_net_execution.yml
@@ -22,7 +22,7 @@ tags:
     - attack.t1087.002
     - attack.lateral_movement    
     - attack.t1021.002
-    - attack.t1077      # an old one
+    - attack.old.t1077
     - attack.s0039
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
+++ b/rules/windows/process_creation/win_susp_netsh_dll_persistence.yml
@@ -8,7 +8,7 @@ tags:
     - attack.persistence
     - attack.t1546.007
     - attack.s0108
-    - attack.t1128      # an old one
+    - attack.old.t1128
 date: 2019/10/25
 modified: 2020/08/30
 author: Victor Sergeev, oscd.community

--- a/rules/windows/process_creation/win_susp_ntdsutil.yml
+++ b/rules/windows/process_creation/win_susp_ntdsutil.yml
@@ -9,7 +9,7 @@ date: 2019/01/16
 tags:
     - attack.credential_access
     - attack.t1003.003
-    - attack.t1003      # an old one    
+    - attack.old.t1003    
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_odbcconf.yml
+++ b/rules/windows/process_creation/win_susp_odbcconf.yml
@@ -12,7 +12,7 @@ tags:
     - attack.defense_evasion
     - attack.t1218.008
     - attack.execution      # an old one
-    - attack.t1218      # an old one
+    - attack.old.t1218
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_powershell_empire_launch.yml
+++ b/rules/windows/process_creation/win_susp_powershell_empire_launch.yml
@@ -13,7 +13,7 @@ modified: 2020/07/13
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086          # an old one
+    - attack.old.t1086
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_powershell_empire_uac_bypass.yml
+++ b/rules/windows/process_creation/win_susp_powershell_empire_uac_bypass.yml
@@ -23,7 +23,7 @@ tags:
     - attack.defense_evasion
     - attack.privilege_escalation
     - attack.t1548.002
-    - attack.t1088      # an old one
+    - attack.old.t1088
     - car.2019-04-001
 falsepositives:
     - unknown

--- a/rules/windows/process_creation/win_susp_powershell_enc_cmd.yml
+++ b/rules/windows/process_creation/win_susp_powershell_enc_cmd.yml
@@ -10,7 +10,7 @@ modified: 2020/10/20
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086      # an old one
+    - attack.old.t1086
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_powershell_encoded_param.yml
+++ b/rules/windows/process_creation/win_susp_powershell_encoded_param.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086      # an old one
+    - attack.old.t1086
     - attack.defense_evasion
     - attack.t1027
 author: Florian Roth

--- a/rules/windows/process_creation/win_susp_powershell_hidden_b64_cmd.yml
+++ b/rules/windows/process_creation/win_susp_powershell_hidden_b64_cmd.yml
@@ -7,7 +7,7 @@ references:
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086      # an old one
+    - attack.old.t1086
 author: John Lambert (rule)
 date: 2019/01/16
 logsource:

--- a/rules/windows/process_creation/win_susp_powershell_parent_combo.yml
+++ b/rules/windows/process_creation/win_susp_powershell_parent_combo.yml
@@ -9,7 +9,7 @@ references:
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086      # an old one
+    - attack.old.t1086
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_powershell_parent_process.yml
+++ b/rules/windows/process_creation/win_susp_powershell_parent_process.yml
@@ -9,7 +9,7 @@ date: 2020/03/20
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086      # an old one   
+    - attack.old.t1086   
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_procdump.yml
+++ b/rules/windows/process_creation/win_susp_procdump.yml
@@ -12,7 +12,7 @@ tags:
     - attack.t1036
     - attack.credential_access
     - attack.t1003.001
-    - attack.t1003      # an old one     
+    - attack.old.t1003     
     - car.2013-05-009
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_susp_ps_appdata.yml
+++ b/rules/windows/process_creation/win_susp_ps_appdata.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086      # an old one     
+    - attack.old.t1086     
 author: Florian Roth
 date: 2019/01/09
 logsource:

--- a/rules/windows/process_creation/win_susp_ps_downloadfile.yml
+++ b/rules/windows/process_creation/win_susp_ps_downloadfile.yml
@@ -9,7 +9,7 @@ date: 2020/08/28
 tags:
     - attack.execution
     - attack.t1059.001
-    - attack.t1086      # an old one     
+    - attack.old.t1086     
     - attack.command_and_control
     - attack.t1104
     - attack.t1105

--- a/rules/windows/process_creation/win_susp_rar_flags.yml
+++ b/rules/windows/process_creation/win_susp_rar_flags.yml
@@ -11,7 +11,7 @@ tags:
     - attack.collection
     - attack.t1560.001
     - attack.exfiltration # an old one  
-    - attack.t1002        # an old one  
+    - attack.old.t1002  
 
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_susp_rasdial_activity.yml
+++ b/rules/windows/process_creation/win_susp_rasdial_activity.yml
@@ -10,7 +10,7 @@ tags:
     - attack.defense_evasion
     - attack.execution
     - attack.t1059
-    - attack.t1064      # an old one 
+    - attack.old.t1064 
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_recon_activity.yml
+++ b/rules/windows/process_creation/win_susp_recon_activity.yml
@@ -12,7 +12,7 @@ tags:
     - attack.discovery
     - attack.t1087.001
     - attack.t1087.002
-    - attack.t1087      # an old one 
+    - attack.old.t1087 
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_regsvr32_anomalies.yml
+++ b/rules/windows/process_creation/win_susp_regsvr32_anomalies.yml
@@ -11,7 +11,7 @@ tags:
     - attack.defense_evasion
     - attack.t1218.010      
     - attack.execution  # an old one  
-    - attack.t1117      # an old one  
+    - attack.old.t1117  
     - car.2019-04-002
     - car.2019-04-003
 

--- a/rules/windows/process_creation/win_susp_regsvr32_flags_anomaly.yml
+++ b/rules/windows/process_creation/win_susp_regsvr32_flags_anomaly.yml
@@ -9,7 +9,7 @@ references:
 tags:
     - attack.defense_evasion
     - attack.t1218.010
-    - attack.t1117      # an old one 
+    - attack.old.t1117 
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_rundll32_activity.yml
+++ b/rules/windows/process_creation/win_susp_rundll32_activity.yml
@@ -10,7 +10,7 @@ tags:
     - attack.defense_evasion
     - attack.execution  # an old one 
     - attack.t1218.011
-    - attack.t1085      # an old one 
+    - attack.old.t1085 
 author: juju4
 date: 2019/01/16
 logsource:

--- a/rules/windows/process_creation/win_susp_rundll32_by_ordinal.yml
+++ b/rules/windows/process_creation/win_susp_rundll32_by_ordinal.yml
@@ -10,7 +10,7 @@ tags:
     - attack.defense_evasion
     - attack.execution  # an old one
     - attack.t1218.011
-    - attack.t1085      # an old one
+    - attack.old.t1085
 author: Florian Roth
 date: 2019/10/22
 logsource:

--- a/rules/windows/process_creation/win_susp_schtask_creation.yml
+++ b/rules/windows/process_creation/win_susp_schtask_creation.yml
@@ -22,7 +22,7 @@ tags:
     - attack.persistence
     - attack.privilege_escalation
     - attack.t1053.005
-    - attack.t1053     # an old one 
+    - attack.old.t1053 
     - attack.s0111
     - car.2013-08-001
 falsepositives:

--- a/rules/windows/process_creation/win_susp_script_execution.yml
+++ b/rules/windows/process_creation/win_susp_script_execution.yml
@@ -9,7 +9,7 @@ tags:
     - attack.execution
     - attack.t1059.005
     - attack.t1059.007
-    - attack.t1064      # an old one     
+    - attack.old.t1064     
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_service_path_modification.yml
+++ b/rules/windows/process_creation/win_susp_service_path_modification.yml
@@ -8,7 +8,7 @@ tags:
     - attack.persistence
     - attack.privilege_escalation
     - attack.t1543.003
-    - attack.t1031      # an old one     
+    - attack.old.t1031     
 date: 2019/10/21
 modified: 2020/08/28
 author: Victor Sergeev, oscd.community

--- a/rules/windows/process_creation/win_susp_svchost.yml
+++ b/rules/windows/process_creation/win_susp_svchost.yml
@@ -5,7 +5,7 @@ description: Detects a suspicious svchost process start
 tags:
     - attack.defense_evasion
     - attack.t1036.005
-    - attack.t1036      # an old one
+    - attack.old.t1036
 author: Florian Roth
 date: 2017/08/15
 modified: 2020/08/28

--- a/rules/windows/process_creation/win_susp_sysvol_access.yml
+++ b/rules/windows/process_creation/win_susp_sysvol_access.yml
@@ -11,7 +11,7 @@ modified: 2020/08/28
 tags:
     - attack.credential_access
     - attack.t1552.006
-    - attack.t1003      # an old one
+    - attack.old.t1003
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_tscon_rdp_redirect.yml
+++ b/rules/windows/process_creation/win_susp_tscon_rdp_redirect.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.lateral_movement
     - attack.t1563.002
-    - attack.t1076      # an old one
+    - attack.old.t1076
     - attack.t1021.001
     - car.2013-07-002
 author: Florian Roth

--- a/rules/windows/process_creation/win_task_folder_evasion.yml
+++ b/rules/windows/process_creation/win_task_folder_evasion.yml
@@ -13,8 +13,8 @@ tags:
     - attack.persistence
     - attack.execution
     - attack.t1574.002
-    - attack.t1059  # an old one
-    - attack.t1064  # an old one
+    - attack.old.t1059
+    - attack.old.t1064
 
 logsource:
     product: Windows

--- a/rules/windows/process_creation/win_uac_cmstp.yml
+++ b/rules/windows/process_creation/win_uac_cmstp.yml
@@ -13,8 +13,8 @@ tags:
     - attack.defense_evasion
     - attack.t1548.002
     - attack.t1218.003
-    - attack.t1191      # an old one
-    - attack.t1088      # an old one
+    - attack.old.t1191
+    - attack.old.t1088
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_uac_fodhelper.yml
+++ b/rules/windows/process_creation/win_uac_fodhelper.yml
@@ -11,7 +11,7 @@ references:
 tags:
     - attack.privilege_escalation
     - attack.t1548.002
-    - attack.t1088      # an old one
+    - attack.old.t1088
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_uac_wsreset.yml
+++ b/rules/windows/process_creation/win_uac_wsreset.yml
@@ -10,7 +10,7 @@ references:
 tags:
     - attack.privilege_escalation
     - attack.t1548.002
-    - attack.t1088      # an old one
+    - attack.old.t1088
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_webshell_detection.yml
+++ b/rules/windows/process_creation/win_webshell_detection.yml
@@ -14,7 +14,7 @@ tags:
     - attack.t1033
     - attack.t1087
     - attack.privilege_escalation       # an old one
-    - attack.t1100      # an old one
+    - attack.old.t1100
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_webshell_recon_detection.yml
+++ b/rules/windows/process_creation/win_webshell_recon_detection.yml
@@ -10,7 +10,7 @@ tags:
     - attack.persistence
     - attack.t1505.003
     - attack.privilege_escalation       # an old one
-    - attack.t1100      # an old one
+    - attack.old.t1100
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_win10_sched_task_0day.yml
+++ b/rules/windows/process_creation/win_win10_sched_task_0day.yml
@@ -20,6 +20,6 @@ falsepositives:
 tags:
     - attack.privilege_escalation
     - attack.t1053.005
-    - attack.t1053      # an old one
+    - attack.old.t1053
     - car.2013-08-001
 level: high

--- a/rules/windows/process_creation/win_wmi_backdoor_exchange_transport_agent.yml
+++ b/rules/windows/process_creation/win_wmi_backdoor_exchange_transport_agent.yml
@@ -13,7 +13,7 @@ logsource:
 tags:
     - attack.persistence
     - attack.t1546.003
-    - attack.t1084      # an old one
+    - attack.old.t1084
 detection:
     selection:
         ParentImage: '*\EdgeTransport.exe'

--- a/rules/windows/process_creation/win_wmi_persistence_script_event_consumer.yml
+++ b/rules/windows/process_creation/win_wmi_persistence_script_event_consumer.yml
@@ -11,7 +11,7 @@ tags:
     - attack.persistence
     - attack.privilege_escalation
     - attack.t1546.003
-    - attack.t1047 # an old one
+    - attack.old.t1047
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_wmi_spwns_powershell.yml
+++ b/rules/windows/process_creation/win_wmi_spwns_powershell.yml
@@ -13,7 +13,7 @@ tags:
     - attack.t1047
     - attack.t1059.001
     - attack.defense_evasion # an old one
-    - attack.t1064      # an old one
+    - attack.old.t1064
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_wsreset_uac_bypass.yml
+++ b/rules/windows/process_creation/win_wsreset_uac_bypass.yml
@@ -13,7 +13,7 @@ tags:
     - attack.privilege_escalation
     - attack.defense_evasion 
     - attack.t1548.002
-    - attack.t1088      # an old one
+    - attack.old.t1088
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/registry_event/sysmon_apt_leviathan.yml
+++ b/rules/windows/registry_event/sysmon_apt_leviathan.yml
@@ -6,7 +6,7 @@ references:
     - https://www.elastic.co/blog/advanced-techniques-used-in-malaysian-focused-apt-campaign
 tags:
     - attack.persistence
-    - attack.t1060 # an old one
+    - attack.old.t1060
     - attack.t1547.001
 author: Aidan Bracher
 date: 2020/07/07

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1060/T1060.yaml
 tags:
     - attack.persistence
-    - attack.t1060 # an old one
+    - attack.old.t1060
     - attack.t1547.001
 date: 2019/10/21
 modified: 2020/09/06

--- a/rules/windows/registry_event/sysmon_cmstp_execution.yml
+++ b/rules/windows/registry_event/sysmon_cmstp_execution.yml
@@ -5,7 +5,7 @@ description: Detects various indicators of Microsoft Connection Manager Profile 
 tags:
     - attack.defense_evasion
     - attack.execution
-    - attack.t1191 # an old one
+    - attack.old.t1191
     - attack.t1218.003
     - attack.g0069
     - car.2019-04-001

--- a/rules/windows/registry_event/sysmon_dhcp_calloutdll.yml
+++ b/rules/windows/registry_event/sysmon_dhcp_calloutdll.yml
@@ -11,7 +11,7 @@ date: 2017/05/15
 author: Dimitrios Slamaris
 tags:
     - attack.defense_evasion
-    - attack.t1073 # an old one
+    - attack.old.t1073
     - attack.t1574.002
     - attack.t1112
 logsource:

--- a/rules/windows/registry_event/sysmon_disable_security_events_logging_adding_reg_key_minint.yml
+++ b/rules/windows/registry_event/sysmon_disable_security_events_logging_adding_reg_key_minint.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/0gtweet/status/1182516740955226112
 tags:
     - attack.defense_evasion
-    - attack.t1089 # an old one
+    - attack.old.t1089
     - attack.t1562.001
     - attack.t1112
 author: Ilyas Ochkov, oscd.community

--- a/rules/windows/registry_event/sysmon_dns_serverlevelplugindll.yml
+++ b/rules/windows/registry_event/sysmon_dns_serverlevelplugindll.yml
@@ -11,7 +11,7 @@ modified: 2020/09/06
 author: Florian Roth
 tags:
     - attack.defense_evasion
-    - attack.t1073 # an old one
+    - attack.old.t1073
     - attack.t1574.002
     - attack.t1112
 fields:

--- a/rules/windows/registry_event/sysmon_hack_wce_reg.yml
+++ b/rules/windows/registry_event/sysmon_hack_wce_reg.yml
@@ -8,7 +8,7 @@ date: 2019/12/31
 modified: 2020/09/06
 tags:
     - attack.credential_access
-    - attack.t1003 # an old one
+    - attack.old.t1003
     - attack.t1003.001
     - attack.s0005
 logsource:

--- a/rules/windows/registry_event/sysmon_logon_scripts_userinitmprlogonscript_reg.yml
+++ b/rules/windows/registry_event/sysmon_logon_scripts_userinitmprlogonscript_reg.yml
@@ -5,7 +5,7 @@ description: Detects creation or execution of UserInitMprLogonScript persistence
 references:
     - https://attack.mitre.org/techniques/T1037/
 tags:
-    - attack.t1037 # an old one
+    - attack.old.t1037
     - attack.t1037.001
     - attack.persistence
     - attack.lateral_movement

--- a/rules/windows/registry_event/sysmon_narrator_feedback_persistance.yml
+++ b/rules/windows/registry_event/sysmon_narrator_feedback_persistance.yml
@@ -5,7 +5,7 @@ references:
     - https://giuliocomi.blogspot.com/2019/10/abusing-windows-10-narrators-feedback.html
 tags:
     - attack.persistence
-    - attack.t1060 # an old one
+    - attack.old.t1060
     - attack.t1547.001
 author: Dmitriy Lifanov, oscd.community
 status: experimental

--- a/rules/windows/registry_event/sysmon_new_dll_added_to_appcertdlls_registry_key.yml
+++ b/rules/windows/registry_event/sysmon_new_dll_added_to_appcertdlls_registry_key.yml
@@ -8,7 +8,7 @@ references:
     - https://eqllib.readthedocs.io/en/latest/analytics/14f90406-10a0-4d36-a672-31cabe149f2f.html
 tags:
     - attack.persistence
-    - attack.t1182 # an old one
+    - attack.old.t1182
     - attack.t1546.009
 author: Ilyas Ochkov, oscd.community
 date: 2019/10/25

--- a/rules/windows/registry_event/sysmon_new_dll_added_to_appinit_dlls_registry_key.yml
+++ b/rules/windows/registry_event/sysmon_new_dll_added_to_appinit_dlls_registry_key.yml
@@ -7,7 +7,7 @@ references:
     - https://eqllib.readthedocs.io/en/latest/analytics/822dc4c5-b355-4df8-bd37-29c458997b8f.html
 tags:
     - attack.persistence
-    - attack.t1103 # an old one
+    - attack.old.t1103
     - attack.t1546.010
 author: Ilyas Ochkov, oscd.community
 date: 2019/10/25

--- a/rules/windows/registry_event/sysmon_possible_privilege_escalation_via_service_registry_permissions_weakness.yml
+++ b/rules/windows/registry_event/sysmon_possible_privilege_escalation_via_service_registry_permissions_weakness.yml
@@ -6,7 +6,7 @@ references:
     - https://pentestlab.blog/2017/03/31/insecure-registry-permissions/
 tags:
     - attack.privilege_escalation
-    - attack.t1058 # an old one
+    - attack.old.t1058
     - attack.t1574.011
 status: experimental
 author: Teymur Kheirkhabarov

--- a/rules/windows/registry_event/sysmon_registry_persistence_search_order.yml
+++ b/rules/windows/registry_event/sysmon_registry_persistence_search_order.yml
@@ -9,7 +9,7 @@ date: 2020/04/14
 modified: 2020/09/06
 tags:
     - attack.persistence
-    - attack.t1038 # an old one
+    - attack.old.t1038
     - attack.t1574.001
 logsource:
     category: registry_event

--- a/rules/windows/registry_event/sysmon_registry_trust_record_modification.yml
+++ b/rules/windows/registry_event/sysmon_registry_trust_record_modification.yml
@@ -10,7 +10,7 @@ date: 2020/02/19
 modified: 2020/09/06
 tags:
     - attack.initial_access
-    - attack.t1193 # an old one
+    - attack.old.t1193
     - attack.t1566.001
 logsource:
     category: registry_event

--- a/rules/windows/registry_event/sysmon_ssp_added_lsa_config.yml
+++ b/rules/windows/registry_event/sysmon_ssp_added_lsa_config.yml
@@ -7,7 +7,7 @@ references:
     - https://powersploit.readthedocs.io/en/latest/Persistence/Install-SSP/
 tags:
     - attack.persistence
-    - attack.t1101 # an old one
+    - attack.old.t1101
     - attack.t1547.005
 author: iwillkeepwatch
 date: 2019/01/18

--- a/rules/windows/registry_event/sysmon_stickykey_like_backdoor.yml
+++ b/rules/windows/registry_event/sysmon_stickykey_like_backdoor.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.privilege_escalation
     - attack.persistence
-    - attack.t1015 # an old one
+    - attack.old.t1015
     - attack.t1546.008
     - car.2014-11-003
     - car.2014-11-008

--- a/rules/windows/registry_event/sysmon_susp_download_run_key.yml
+++ b/rules/windows/registry_event/sysmon_susp_download_run_key.yml
@@ -9,7 +9,7 @@ date: 2019/10/01
 modified: 2020/09/06
 tags:
     - attack.persistence
-    - attack.t1060 # an old one
+    - attack.old.t1060
     - attack.t1547.001
 logsource:
     category: registry_event

--- a/rules/windows/registry_event/sysmon_susp_lsass_dll_load.yml
+++ b/rules/windows/registry_event/sysmon_susp_lsass_dll_load.yml
@@ -20,7 +20,7 @@ detection:
 tags:
     - attack.execution
     - attack.persistence
-    - attack.t1177 # an old one
+    - attack.old.t1177
     - attack.t1547.008
 falsepositives:
     - Unknown

--- a/rules/windows/registry_event/sysmon_susp_reg_persist_explorer_run.yml
+++ b/rules/windows/registry_event/sysmon_susp_reg_persist_explorer_run.yml
@@ -24,7 +24,7 @@ detection:
     condition: selection
 tags:
     - attack.persistence
-    - attack.t1060 # an old one
+    - attack.old.t1060
     - attack.t1547.001
     - capec.270
 fields:

--- a/rules/windows/registry_event/sysmon_susp_run_key_img_folder.yml
+++ b/rules/windows/registry_event/sysmon_susp_run_key_img_folder.yml
@@ -7,7 +7,7 @@ references:
 author: Florian Roth, Markus Neis, Sander Wiebing
 tags:
     - attack.persistence
-    - attack.t1060 # an old one
+    - attack.old.t1060
     - attack.t1547.001
 date: 2018/08/25
 modified: 2020/09/06

--- a/rules/windows/registry_event/sysmon_susp_service_installed.yml
+++ b/rules/windows/registry_event/sysmon_susp_service_installed.yml
@@ -7,7 +7,7 @@ author: xknow (@xknow_infosec), xorxes (@xor_xes)
 references:
     - https://blog.dylan.codes/evading-sysmon-and-windows-event-logging/
 tags:
-    - attack.t1089 # an old one
+    - attack.old.t1089
     - attack.t1562.001
     - attack.defense_evasion
 logsource:

--- a/rules/windows/registry_event/sysmon_uac_bypass_eventvwr.yml
+++ b/rules/windows/registry_event/sysmon_uac_bypass_eventvwr.yml
@@ -12,7 +12,7 @@ modified: 2020/09/06
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
-    - attack.t1088 # an old one
+    - attack.old.t1088
     - attack.t1548.002
     - car.2019-04-001
 falsepositives:

--- a/rules/windows/registry_event/sysmon_uac_bypass_sdclt.yml
+++ b/rules/windows/registry_event/sysmon_uac_bypass_sdclt.yml
@@ -18,7 +18,7 @@ detection:
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
-    - attack.t1088 # an old one
+    - attack.old.t1088
     - attack.t1548.002
     - car.2019-04-001
 falsepositives:

--- a/rules/windows/registry_event/sysmon_win_reg_persistence.yml
+++ b/rules/windows/registry_event/sysmon_win_reg_persistence.yml
@@ -21,7 +21,7 @@ tags:
     - attack.privilege_escalation
     - attack.persistence
     - attack.defense_evasion
-    - attack.t1183 # an old one
+    - attack.old.t1183
     - attack.t1546.012
     - car.2013-01-002
 falsepositives:

--- a/rules/windows/sysmon/sysmon_ads_executable.yml
+++ b/rules/windows/sysmon/sysmon_ads_executable.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/0xrawsec/status/1002478725605273600?s=21
 tags:
     - attack.defense_evasion
-    - attack.t1027          # an old one
+    - attack.old.t1027
     - attack.s0139
     - attack.t1564.004
 author: Florian Roth, @0xrawsec

--- a/rules/windows/sysmon/sysmon_alternate_powershell_hosts_pipe.yml
+++ b/rules/windows/sysmon/sysmon_alternate_powershell_hosts_pipe.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/02_execution/T1086_powershell/alternate_signed_powershell_hosts.md
 tags:
     - attack.execution
-    - attack.t1086          # an old one
+    - attack.old.t1086
     - attack.t1059.001
 logsource:
     product: windows

--- a/rules/windows/sysmon/sysmon_cactustorch.yml
+++ b/rules/windows/sysmon/sysmon_cactustorch.yml
@@ -25,10 +25,10 @@ detection:
     condition: selection
 tags:
     - attack.defense_evasion
-    - attack.t1093          # an old one
+    - attack.old.t1093
     - attack.t1055.012
     - attack.execution
-    - attack.t1064          # an old one
+    - attack.old.t1064
     - attack.t1059.005
     - attack.t1059.007
     - attack.t1218.005

--- a/rules/windows/sysmon/sysmon_cobaltstrike_process_injection.yml
+++ b/rules/windows/sysmon/sysmon_cobaltstrike_process_injection.yml
@@ -6,7 +6,7 @@ references:
     - https://blog.cobaltstrike.com/2018/04/09/cobalt-strike-3-11-the-snake-that-eats-its-tail/
 tags:
     - attack.defense_evasion
-    - attack.t1055          # an old one
+    - attack.old.t1055
     - attack.t1055.001
 status: experimental
 author: Olaf Hartong, Florian Roth, Aleksey Potapov, oscd.community

--- a/rules/windows/sysmon/sysmon_createremotethread_loadlibrary.yml
+++ b/rules/windows/sysmon/sysmon_createremotethread_loadlibrary.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/05_defense_evasion/T1055_process_injection/dll_injection_createremotethread_loadlibrary.md
 tags:
     - attack.defense_evasion
-    - attack.t1055          # an old one
+    - attack.old.t1055
     - attack.t1055.001
 logsource:
     product: windows

--- a/rules/windows/sysmon/sysmon_cred_dump_tools_named_pipes.yml
+++ b/rules/windows/sysmon/sysmon_cred_dump_tools_named_pipes.yml
@@ -8,7 +8,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.t1003.001
     - attack.t1003.002
     - attack.t1003.004

--- a/rules/windows/sysmon/sysmon_password_dumper_lsass.yml
+++ b/rules/windows/sysmon/sysmon_password_dumper_lsass.yml
@@ -17,7 +17,7 @@ detection:
     condition: selection
 tags:
     - attack.credential_access
-    - attack.t1003          # an old one
+    - attack.old.t1003
     - attack.s0005
     - attack.t1003.001
 falsepositives:

--- a/rules/windows/sysmon/sysmon_susp_powershell_rundll32.yml
+++ b/rules/windows/sysmon/sysmon_susp_powershell_rundll32.yml
@@ -18,9 +18,9 @@ detection:
 tags:
     - attack.defense_evasion
     - attack.execution
-    - attack.t1085          # an old one
+    - attack.old.t1085
     - attack.t1218.011
-    - attack.t1086          # an old one
+    - attack.old.t1086
     - attack.t1059.001
 falsepositives:
     - Unkown

--- a/rules/windows/sysmon/sysmon_wmi_event_subscription.yml
+++ b/rules/windows/sysmon/sysmon_wmi_event_subscription.yml
@@ -3,7 +3,7 @@ id: 0f06a3a5-6a09-413f-8743-e6cf35561297
 status: experimental
 description: Detects creation of WMI event subscription persistence method
 tags:
-    - attack.t1084          # an old one
+    - attack.old.t1084
     - attack.persistence
     - attack.t1546.003
 author: Tom Ueltschi (@c_APT_ure)

--- a/rules/windows/sysmon/sysmon_wmi_susp_scripting.yml
+++ b/rules/windows/sysmon/sysmon_wmi_susp_scripting.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/Neo23x0/signature-base/blob/master/yara/gen_susp_lnk_files.yar#L19
 date: 2019/04/15
 tags:
-    - attack.t1086          # an old one
+    - attack.old.t1086
     - attack.execution
     - attack.t1059.005
 logsource:


### PR DESCRIPTION
It is very interesting to keep the information of the previous technique id.
However pyYaml does not retrieve the comments and the old technique id is therefore impossible to distinguish from the new one (possibly using ruamel).
I propose here to replace '- attack.txxxx # an old one' by '- attack.old.txxxx' in the rules.