### PR TITLE
[bugfix] netwitness and netwitness-epl backends have incoherent null expressions

### DIFF
--- a/tools/sigma/backends/netwitness-epl.py
+++ b/tools/sigma/backends/netwitness-epl.py
@@ -55,8 +55,8 @@ class NetWitnessEplBackend(SingleTextQueryBackend):
     listSeparator = ", "
     valueExpression = "\'%s\'"
     keyExpression = "%s"
-    nullExpression = "%s exists"
-    notNullExpression = "%s exists"
+    nullExpression = "%s is null"
+    notNullExpression = "%s is not null"
     mapExpression = "(%s=%s)"
     mapListsSpecialHandling = True
 

--- a/tools/sigma/backends/netwitness.py
+++ b/tools/sigma/backends/netwitness.py
@@ -37,7 +37,7 @@ class NetWitnessBackend(SingleTextQueryBackend):
     listSeparator = ", "
     valueExpression = "\'%s\'"
     keyExpression = "%s"
-    nullExpression = "%s exists"
+    nullExpression = "%s !exists"
     notNullExpression = "%s exists"
     mapExpression = "(%s=%s)"
     mapListsSpecialHandling = True


### PR DESCRIPTION
Incoherent null expressions:

```
nullExpression = "%s exists"
notNullExpression = "%s exists"
```

changed to coherent and fixed EPL to use `not null` instead of `exists`

Ref: http://esper.espertech.com/release-7.1.0/esper-reference/html/epl-operator.html#epl-operator-ref-logical-null
