### PR TITLE
fix: syntax error in THOR's config file

### DIFF
--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -30,75 +30,74 @@ logsources:
     product: windows
     service: application
     sources:
-      - 'WinEventLog:Application'
+      - "WinEventLog:Application"
   windows-security:
     product: windows
     service: security
     sources:
-      - 'WinEventLog:Security'
+      - "WinEventLog:Security"
   windows-system:
     product: windows
     service: system
     sources:
-      - 'WinEventLog:System'
+      - "WinEventLog:System"
   windows-ntlm:
     product: windows
     service: ntlm
     sources:
-      - 'WinEventLog:Microsoft-Windows-NTLM/Operational'
+      - "WinEventLog:Microsoft-Windows-NTLM/Operational"
   windows-sysmon:
     product: windows
     service: sysmon
     sources:
-      - 'WinEventLog:Microsoft-Windows-Sysmon/Operational'
+      - "WinEventLog:Microsoft-Windows-Sysmon/Operational"
   windows-powershell:
     product: windows
     service: powershell
     sources:
-      - 'WinEventLog:Microsoft-Windows-PowerShell/Operational'
+      - "WinEventLog:Microsoft-Windows-PowerShell/Operational"
   windows-taskscheduler:
     product: windows
     service: taskscheduler
     sources:
-      - 'WinEventLog:Microsoft-Windows-TaskScheduler/Operational'
+      - "WinEventLog:Microsoft-Windows-TaskScheduler/Operational"
   windows-wmi:
     product: windows
     service: wmi
     sources:
-      - 'WinEventLog:Microsoft-Windows-WMI-Activity/Operational'
+      - "WinEventLog:Microsoft-Windows-WMI-Activity/Operational"
   windows-dhcp:
     product: windows
     service: dhcp
     sources:
-      - 'WinEventLog:Microsoft-Windows-DHCP-Server/Operational'
+      - "WinEventLog:Microsoft-Windows-DHCP-Server/Operational"
   windows-applocker:
     product: windows
     service: applocker
-    conditions:
-      sources:
-        - 'WinEventLog:Microsoft-Windows-AppLocker/MSI and Script'
-        - 'WinEventLog:Microsoft-Windows-AppLocker/EXE and DLL'
-        - 'WinEventLog:Microsoft-Windows-AppLocker/Packaged app-Deployment'
-        - 'WinEventLog:Microsoft-Windows-AppLocker/Packaged app-Execution'
+    sources:
+      - "WinEventLog:Microsoft-Windows-AppLocker/MSI and Script"
+      - "WinEventLog:Microsoft-Windows-AppLocker/EXE and DLL"
+      - "WinEventLog:Microsoft-Windows-AppLocker/Packaged app-Deployment"
+      - "WinEventLog:Microsoft-Windows-AppLocker/Packaged app-Execution"
   apache:
     category: webserver
     sources:
-      - 'File:/var/log/apache/*.log'
-      - 'File:/var/log/apache2/*.log'
-      - 'File:/var/log/httpd/*.log'
+      - "File:/var/log/apache/*.log"
+      - "File:/var/log/apache2/*.log"
+      - "File:/var/log/httpd/*.log"
   linux-auth:
     product: linux
     service: auth
     sources:
-      - 'File:/var/log/auth.log'
-      - 'File:/var/log/auth.log.?'
+      - "File:/var/log/auth.log"
+      - "File:/var/log/auth.log.?"
   linux-syslog:
     product: linux
     service: syslog
     sources:
-      - 'File:/var/log/syslog'
-      - 'File:/var/log/syslog.?'
+      - "File:/var/log/syslog"
+      - "File:/var/log/syslog.?"
   logfiles:
     category: logfile
     sources:
-      - 'File:*.log'
+      - "File:*.log"


### PR DESCRIPTION
The THOR Scanner has a slightly different syntax for the log sources configuration. The newest log source for AppLocker was added with a wrong syntax (`conditions` field is not supported in THOR for log sources that are not process creation log sources).