### PR TITLE
Map CommandLine appropriately

### DIFF
--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -84,7 +84,7 @@ fieldmappings:
   CallingProcessName: winlog.event_data.CallingProcessName
   CallTrace: winlog.event_data.CallTrace
   Channel: winlog.channel
-  CommandLine: process.args
+  CommandLine: process.command_line
   ComputerName: winlog.ComputerName
   CurrentDirectory: process.working_directory
   Description: winlog.event_data.Description
@@ -125,7 +125,7 @@ fieldmappings:
   ObjectName: winlog.event_data.ObjectName
   ObjectType: winlog.event_data.ObjectType
   ObjectValueName: winlog.event_data.ObjectValueName
-  ParentCommandLine: process.parent.args
+  ParentCommandLine: process.parent.command_line
   ParentProcessName: process.parent.name
   ParentImage: process.parent.executable
   Path: winlog.event_data.Path


### PR DESCRIPTION
Args is an array of the exploded command line and causes many rules to misfire. See rules/windows/process_creation/win_susp_svchost_no_cli.yml as an example. If CommandLine is mapped to process.args, there will always be an element of the args array that matches when svchost.exe is executed, whether or not there are process arguments.