### PR TITLE
Update winlogbeat configuration file to support File Product details

### DIFF
--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -132,6 +132,7 @@ fieldmappings:
   PipeName: file.name
   ProcessCommandLine: winlog.event_data.ProcessCommandLine
   ProcessName: process.executable
+  Product: winlog.event_data.Product
   Properties: winlog.event_data.Properties
   RuleName: winlog.event_data.RuleName
   SecurityID: winlog.event_data.SecurityID

--- a/tools/config/winlogbeat-old.yml
+++ b/tools/config/winlogbeat-old.yml
@@ -117,6 +117,7 @@ fieldmappings:
   PipeName: event_data.PipeName
   ProcessCommandLine: event_data.ProcessCommandLine
   ProcessName: event_data.ProcessName
+  Product: event_data.Product
   Properties: event_data.Properties
   SecurityID: event_data.SecurityID
   ServiceFileName: event_data.ServiceFileName

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -121,6 +121,7 @@ fieldmappings:
   PipeName: winlog.event_data.PipeName
   ProcessCommandLine: winlog.event_data.ProcessCommandLine
   ProcessName: winlog.event_data.ProcessName
+  Product: winlog.event_data.Product
   Properties: winlog.event_data.Properties
   RuleName: winlog.event_data.RuleName
   SAMAccountName: winlog.event_data.SamAccountName


### PR DESCRIPTION
Sysmon process create events capture the "product" field from a file version info structure. However, this isn't reflected in the winlogbeat config.

Evidence confirming the field in winlogbeat (couldn't link directly to the field)
https://www.elastic.co/guide/en/beats/winlogbeat/master/exported-fields-winlog.html

Similar config entries for HELK: https://github.com/SigmaHQ/sigma/blob/master/tools/config/helk.yml#L128