### PR TITLE
Elastic: raise an error from the base backend if a rule has multiple conditions

### DIFF
--- a/tools/sigma/backends/base.py
+++ b/tools/sigma/backends/base.py
@@ -114,6 +114,8 @@ class BaseBackend:
 
     def generate(self, sigmaparser):
         """Method is called for each sigma rule and receives the parsed rule (SigmaParser)"""
+        if len(sigmaparser.condparsed) > 1:
+            raise NotImplementedError("Base backend doesn't support multiple conditions")
         for parsed in sigmaparser.condparsed:
             query = self.generateQuery(parsed)
             before = self.generateBefore(parsed)


### PR DESCRIPTION
The loop in the base Elastic backend returns the first condition only which is all it can do. Ultimately, this needs to be handled by the deriving classes. Until that is done, at least alert rule writers that something is wrong.