### PR TITLE
Various Defender for Endpoint (mdatp) bug fixes

### DIFF
--- a/tools/sigma/backends/mdatp.py
+++ b/tools/sigma/backends/mdatp.py
@@ -19,8 +19,6 @@ from functools import wraps
 from .base import SingleTextQueryBackend
 from .exceptions import NotSupportedError
 from ..parser.modifiers.base import SigmaTypeModifier
-from ..parser.modifiers.transform import SigmaContainsModifier, SigmaStartswithModifier, SigmaEndswithModifier
-from ..parser.modifiers.type import SigmaRegularExpressionModifier
 
 
 def wrapper(method):

--- a/tools/sigma/backends/mdatp.py
+++ b/tools/sigma/backends/mdatp.py
@@ -42,10 +42,7 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
     active = True
     config_required = False
 
-    # \   -> \\
-    # \*  -> \*
-    # \\* -> \\*
-    reEscape = re.compile('("|(?<!\\\\)\\\\(?![*?\\\\]))')
+    reEscape = re.compile('(?:\\\\)?(")')
     reClear = None
     andToken = " and "
     orToken = " or "
@@ -59,7 +56,7 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
     mapExpression = "%s == %s"
     mapListsSpecialHandling = True
     mapListValueExpression = "%s in %s"
-    
+
     skip_fields = {
         "Description",
         "_exists_",
@@ -91,9 +88,9 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
                 "ParentCommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),
                 "ParentName": ("InitiatingProcessFileName", self.default_value_mapping),
                 "ParentProcessName": ("InitiatingProcessFileName", self.default_value_mapping),
-                "ParentImage": ("InitiatingProcessFolderPath", self.default_value_mapping),                
+                "ParentImage": ("InitiatingProcessFolderPath", self.default_value_mapping),
                 "SourceImage": ("InitiatingProcessFolderPath", self.default_value_mapping),
-                "TargetImage": ("FolderPath", self.default_value_mapping),                
+                "TargetImage": ("FolderPath", self.default_value_mapping),
                 "User": (self.decompose_user, ),
             },
             "DeviceEvents": {
@@ -101,28 +98,29 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
                 "CommandLine": ("ProcessCommandLine", self.default_value_mapping),
                 "DestinationHostname":  ("RemoteUrl", self.default_value_mapping),
                 "DestinationIp": ("RemoteIP", self.default_value_mapping),
-                "DestinationPort": ("RemotePort", self.default_value_mapping),
+                "DestinationPort": ("RemotePort", self.porttype_mapping),
                 "EventType": ("ActionType", self.default_value_mapping),
                 "FileName": (self.id_mapping, self.default_value_mapping),
                 "ParentCommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),
                 "ParentProcessName": ("InitiatingProcessParentFileName", self.default_value_mapping),
-                "ProcessName": ("InitiatingProcessFileName", self.default_value_mapping),  
+                "ProcessName": ("InitiatingProcessFileName", self.default_value_mapping),
                 "SourceIp": ("LocalIP", self.default_value_mapping),
-                "SourcePort": ("LocalPort", self.default_value_mapping),
+                "SourcePort": ("LocalPort", self.porttype_mapping),
                 "TargetFilename": ("FolderPath", self.default_value_mapping),
                 "TargetObject": ("RegistryKey", self.default_value_mapping),
-                "TargetImage": ("FolderPath", self.default_value_mapping),                
+                "TargetImage": ("FolderPath", self.default_value_mapping),
                 "Image": ("InitiatingProcessFolderPath", self.default_value_mapping),
                 "User":  (self.decompose_user, ),
             },
-            "DeviceRegistryEvents": {                
+            "DeviceRegistryEvents": {
                 "DataType": ("RegistryValueType", self.default_value_mapping),
                 "Details": ("RegistryValueData", self.default_value_mapping),
                 "EventType": ("ActionType", self.default_value_mapping),
-                "Image": ("InitiatingProcessFolderPath", self.default_value_mapping),                
+                "Image": ("InitiatingProcessFolderPath", self.default_value_mapping),
+                "CommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),
                 "ObjectValueName": ("RegistryValueName", self.default_value_mapping),
                 "ParentCommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),
-                "ProcessName": ("InitiatingProcessFileName", self.default_value_mapping),                
+                "ProcessName": ("InitiatingProcessFileName", self.default_value_mapping),
                 "ParentName": ("InitiatingProcessParentFileName", self.default_value_mapping),
                 "ParentProcessName": ("InitiatingProcessParentFileName", self.default_value_mapping),
                 "TargetObject": ("RegistryKey", self.default_value_mapping),
@@ -132,34 +130,36 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
                 "FileName": (self.id_mapping, self.default_value_mapping),
                 "OriginIp": ("FileOriginIp", self.default_value_mapping),
                 "OriginReferrer": ("FileOriginReferrerUrl", self.default_value_mapping),
-                "OriginUrl": ("FileOriginUrl", self.default_value_mapping),                
+                "OriginUrl": ("FileOriginUrl", self.default_value_mapping),
                 "Image": ("InitiatingProcessFolderPath", self.default_value_mapping),
-                "ParentCommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),                  
-                "ProcessName": ("InitiatingProcessFileName", self.default_value_mapping),                
+                "CommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),
+                "ParentCommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),
+                "ProcessName": ("InitiatingProcessFileName", self.default_value_mapping),
                 "ParentName": ("InitiatingProcessParentFileName", self.default_value_mapping),
                 "ParentProcessName": ("InitiatingProcessParentFileName", self.default_value_mapping),
-                "TargetFilename": ("FolderPath", self.default_value_mapping),              
+                "TargetFilename": ("FolderPath", self.default_value_mapping),
                 "User":  (self.decompose_user, ),
             },
-            "DeviceNetworkEvents": {                
+            "DeviceNetworkEvents": {
                 "DestinationHostname": ("RemoteUrl", self.default_value_mapping),
                 "DestinationIp": ("RemoteIP", self.default_value_mapping),
                 "DestinationIsIpv6": ("RemoteIP has \":\"", ),
-                "DestinationPort": ("RemotePort", self.default_value_mapping),
+                "DestinationPort": ("RemotePort", self.porttype_mapping),
                 "DeviceName": (self.id_mapping, self.default_value_mapping),
                 "EventType": ("ActionType", self.default_value_mapping),
                 "Image": ("InitiatingProcessFolderPath", self.default_value_mapping),
+                "CommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),
                 "Initiated": ("RemotePort", self.default_value_mapping),
                 "ParentCommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),
-                "ProcessName": ("InitiatingProcessFileName", self.default_value_mapping),           
+                "ProcessName": ("InitiatingProcessFileName", self.default_value_mapping),
                 "Protocol": ("RemoteProtocol", self.default_value_mapping),
                 "SourceIp": ("LocalIP", self.default_value_mapping),
-                "SourcePort": ("LocalPort", self.default_value_mapping),                
+                "SourcePort": ("LocalPort", self.porttype_mapping),
                 "User":  (self.decompose_user, ),
             },
             "DeviceImageLoadEvents": {
                 "DeviceName": (self.id_mapping, self.default_value_mapping),
-                "EventType": ("ActionType", self.default_value_mapping),               
+                "EventType": ("ActionType", self.default_value_mapping),
                 "FileName": (self.id_mapping, self.default_value_mapping),
                 "Image": ("InitiatingProcessFolderPath", self.default_value_mapping),
                 "ImageLoaded": ("FolderPath", self.default_value_mapping),
@@ -197,12 +197,14 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
     def default_value_mapping(self, val):
         op = "=~"
         if type(val) == str:
-            if "*" in val[1:-1]:     # value contains * inside string - use regex match
+            if "*" in val[1:-1]:
+                # value contains * inside string - use regex match
                 op = "matches regex"
                 val = re.sub('([".^$]|\\\\(?![*?]))', '\\\\\g<1>', val)
                 val = re.sub('\\*', '.*', val)
                 val = re.sub('\\?', '.', val)
-            else:                           # value possibly only starts and/or ends with *, use prefix/postfix match
+            else:
+                # value possibly only starts and/or ends with *, use prefix/postfix match
                 if val.endswith("*") and val.startswith("*"):
                     op = "contains"
                     val = self.cleanValue(val[1:-1])
@@ -214,6 +216,9 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
                     val = self.cleanValue(val[1:])
 
         return "%s \"%s\"" % (op, val)
+
+    def porttype_mapping(self, val):
+        return "%s \"%s\"" % ("==", val)
 
     def logontype_mapping(self, src):
         """Value mapping for logon events to reduced ATP LogonType set"""
@@ -299,6 +304,10 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
             return "%s" % generated
         return generated
 
+    def cleanValue(self, val):
+        if self.reEscape:
+            val = self.reEscape.sub(self.escapeSubst, val)
+        return val
 
     def mapEventId(self, event_id):
         if self.product == "windows":


### PR DESCRIPTION
This pull request fixes three issues:
| Problem | Solution | Lines | 
| --- | --- | --- |
|`CommandLine` mapping for Registry, File and Network events was missing| Mapping to `InitiatingProcessCommandLine` added |  [L118](https://github.com/SigmaHQ/sigma/pull/1411/files#diff-a0ba69d20c11067bfe3b4ed8ab54c83e17e2f2eb6ee580e5120c3f045b85ee2dR118) [L133](https://github.com/SigmaHQ/sigma/pull/1411/files#diff-a0ba69d20c11067bfe3b4ed8ab54c83e17e2f2eb6ee580e5120c3f045b85ee2dR133) [L149](https://github.com/SigmaHQ/sigma/pull/1411/files#diff-a0ba69d20c11067bfe3b4ed8ab54c83e17e2f2eb6ee580e5120c3f045b85ee2dR149) |
|`*Port` conditions were using `=~` which is not accepted by DfE for integer fields | New `porttype_mapping` function defined which uses `==`| [L218-L220](https://github.com/SigmaHQ/sigma/pull/1411/files#diff-a0ba69d20c11067bfe3b4ed8ab54c83e17e2f2eb6ee580e5120c3f045b85ee2dR218-R220) |
|Values containing double quotes (`"`) can be escaped too many times, resulting in DfE rejecting the generated rule | New override function `cleanValue` leveraging regex to prevent incorrect escaping | [L305-308](https://github.com/SigmaHQ/sigma/pull/1411/files#diff-a0ba69d20c11067bfe3b4ed8ab54c83e17e2f2eb6ee580e5120c3f045b85ee2dR305-R308) |

Additionally, unused imports were removed ([L22-L23](https://github.com/SigmaHQ/sigma/pull/1411/files#diff-a0ba69d20c11067bfe3b4ed8ab54c83e17e2f2eb6ee580e5120c3f045b85ee2dL22-L23)).