### PR TITLE
Fix es-dsl aggregation generation when aggfield is not given

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -509,16 +509,22 @@ class ElasticsearchDSLBackend(DeepFieldMappingMixin, RulenameCommentMixin, Elast
                             }
                     else:  # if the condition is count() by MyGroupedField > XYZ
                         group_aggname = "{}_count".format(agg.groupfield)
+                        count_agg_name = "single_{}_count".format(agg.groupfield)
                         self.queries[-1]['aggs'] = {
                             group_aggname: {
                                 'terms': {
                                     'field': '%s' % (agg.groupfield)
                                 },
                                 'aggs': {
+                                    count_agg_name: {
+                                        'value_count': {
+                                            'field': '%s' % agg.groupfield
+                                        }
+                                    },
                                     'limit': {
                                         'bucket_selector': {
                                             'buckets_path': {
-                                                'count': group_aggname
+                                                'count': count_agg_name
                                             },
                                             'script': 'params.count %s %s' % (agg.cond_op, agg.condition)
                                         }


### PR DESCRIPTION
# Description
As reported in the issues #542 and #543, currently `count() > condition` result in a produced code, that does not work in the **es-dsl** backend.

In this PR I fixed the problem, by adding the missing keys in the produced aggregation.


Let us consider the rule reported #542 . Now, the aggregation looks like this:

```sh
 "aggs": {
    "clientip_count": {
      "terms": {
        "field": "clientip"
      },
      "aggs": {
        "single_clientip_count": {
          "value_count": {
            "field": "clientip"
          }
        },
        "limit": {
          "bucket_selector": {
            "buckets_path": {
              "count": "single_clientip_count"
            },
            "script": "params.count > 10"
          }
        }
      }
    }
  }
```




## Alternative Solutions

I report for the sake of discussion, alternative solutions, that I considered but discarded

### Consider using the min_doc_count options of terms aggregation
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_minimum_document_count_4

I discarded this solution, because:
1. the structure of the response would have been modified
2. It does not work in case of less than conditions

### Consider count() the same as count(_id)

This case would simplify significantly the code, but it would require a refactoring and I did not want to modify too much lines.
Moreover, I find `value_count` to be more explicit.


Kind regards,
Mirko
