### PR TITLE
feat: generic registry events compatible with native audit logging

### DIFF
--- a/rules/windows/process_creation/win_apt_chafer_mar18.yml
+++ b/rules/windows/process_creation/win_apt_chafer_mar18.yml
@@ -54,11 +54,6 @@ detection:
         TargetObject|endswith: 
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\UMe'
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\UT'
-        EventType: 'SetValue'
-    selection_reg2:
-        TargetObject|endswith: '\Control\SecurityProviders\WDigest\UseLogonCredential'
-        EventType: 'SetValue'
-        Details: 'DWORD (0x00000001)'
 ---
 logsource:
     category: process_creation

--- a/rules/windows/registry_event/sysmon_comhijack_sdclt.yml
+++ b/rules/windows/registry_event/sysmon_comhijack_sdclt.yml
@@ -18,8 +18,6 @@ detection:
     selection:
         TargetObject:
             - 'HKCU\Software\Classes\Folder\shell\open\command\DelegateExecute'
-        EventType:
-            - SetValue
     condition: selection
 falsepositives:
     - unknown

--- a/rules/windows/registry_event/sysmon_cve-2020-1048.yml
+++ b/rules/windows/registry_event/sysmon_cve-2020-1048.yml
@@ -18,10 +18,6 @@ logsource:
 detection:        
     selection:
         TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Ports'
-        EventType:
-            - SetValue
-            - DeleteValue
-            - CreateValue
         Details|contains:
             - '.dll'
             - '.exe'

--- a/rules/windows/registry_event/sysmon_reg_office_security.yml
+++ b/rules/windows/registry_event/sysmon_reg_office_security.yml
@@ -19,10 +19,6 @@ detection:
             - '\Security\Trusted Documents\TrustRecords'
             - '\Security\AccessVBOM'
             - '\Security\VBAWarnings'
-        EventType:
-            - SetValue
-            - DeleteValue
-            - CreateValue
     condition: sec_settings
 falsepositives:
     - Valid Macros and/or internal documents

--- a/rules/windows/registry_event/sysmon_reg_silentprocessexit.yml
+++ b/rules/windows/registry_event/sysmon_reg_silentprocessexit.yml
@@ -16,9 +16,6 @@ detection:
     selection:       
         TargetObject|contains: 'Microsoft\Windows NT\CurrentVersion\SilentProcessExit'
         Details|contains: 'MonitorProcess'
-        EventType:
-            - SetValue
-            - CreateValue
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/registry_event/sysmon_reg_silentprocessexit_lsass.yml
+++ b/rules/windows/registry_event/sysmon_reg_silentprocessexit_lsass.yml
@@ -15,9 +15,6 @@ logsource:
 detection:
     selection:       
         TargetObject|contains: 'Microsoft\Windows NT\CurrentVersion\SilentProcessExit\lsass.exe'
-        EventType:
-            - SetValue
-            - CreateValue
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/registry_event/sysmon_runonce_persistence.yml
+++ b/rules/windows/registry_event/sysmon_runonce_persistence.yml
@@ -15,7 +15,6 @@ logsource:
     category: registry_event
 detection:
     selection:
-      EventType: 'SetValue'
       TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Active Setup\Installed Components'
       TargetObject|endswith: '\StubPath'
     condition: selection

--- a/rules/windows/registry_event/sysmon_stickykey_like_backdoor.yml
+++ b/rules/windows/registry_event/sysmon_stickykey_like_backdoor.yml
@@ -31,7 +31,6 @@ detection:
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Magnify.exe\Debugger'
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\Narrator.exe\Debugger'
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DisplaySwitch.exe\Debugger'
-        EventType: 'SetValue'
     condition: 1 of them
 ---
 logsource:

--- a/rules/windows/registry_event/sysmon_win_reg_persistence.yml
+++ b/rules/windows/registry_event/sysmon_win_reg_persistence.yml
@@ -13,7 +13,6 @@ detection:
     selection_reg1:
         TargetObject|contains:
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
-        EventType: SetValue
     selection_reg2:
         - TargetObject|contains|all:
             - '\Image File Execution Options\'

--- a/rules/windows/registry_event/sysmon_win_reg_telemetry_persistence.yml
+++ b/rules/windows/registry_event/sysmon_win_reg_telemetry_persistence.yml
@@ -19,7 +19,6 @@ detection:
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\TelemetryController\'
             - '\Command'
         Details|contains: '.exe'
-        EventType: 'SetValue'
     filter:
         Details|contains: 
             - '\system32\CompatTelRunner.exe'

--- a/tools/config/generic/windows-audit.yml
+++ b/tools/config/generic/windows-audit.yml
@@ -14,10 +14,13 @@ logsources:
         product: windows
         conditions:
             EventID: 4657
+            OperationType:
+                - 'New registry value created'
+                - 'Existing registry value modified'
         rewrite:
             product: windows
             service: security
 fieldmappings:
     Image: NewProcessName
     ParentImage: ParentProcessName
-    EventType: OperationType
+    Details: NewValue

--- a/tools/config/generic/windows-audit.yml
+++ b/tools/config/generic/windows-audit.yml
@@ -1,4 +1,4 @@
-title: Conversion of generic process_creation rules into Security/4688
+title: Conversion for Windows Native Auditing Events
 order: 10
 logsources:
     process_creation:
@@ -9,6 +9,15 @@ logsources:
         rewrite:
             product: windows
             service: security
+    registry_event:
+        category: registry_event
+        product: windows
+        conditions:
+            EventID: 4657
+        rewrite:
+            product: windows
+            service: security
 fieldmappings:
     Image: NewProcessName
     ParentImage: ParentProcessName
+    EventType: OperationType


### PR DESCRIPTION
this pull request
- removes the "SetValue", "CreateValue" etc. EventTypes from the rules in category "registry_event" 
- it adds condition für EventID 4657 and the Operation Type to queries in the Windows native auditing config