### PR TITLE
fix: Distinguish Windows and Linux logfiles by path separator

### DIFF
--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -222,11 +222,13 @@ logsources:
     sources:
       - "File:/var/log/syslog"
       - "File:/var/log/syslog.?"
-  linux-log:
+  linux-logfile:
     product: linux
-    sources:
-      - "File:*.log"
-  logfiles:
     category: logfile
     sources:
-      - "File:*.log"
+      - "File:/*.log"
+  windows-logfile:
+    product: windows
+    category: logfile
+    sources:
+      - "File:?:\\*.log"


### PR DESCRIPTION
A previous commit added a log source detailing *.log files with
product: linux. This caused linux specific Sigma rules to apply to
all *.log file, including those on Windows. To distinguish these
cases, expand the file path pattern to include the typical start
for unix / windows paths ( / vs [A-Z]:\ )