### PR TITLE
Fix contains and starts/ends with queries in ala backend

### DIFF
--- a/tools/sigma/backends/ala.py
+++ b/tools/sigma/backends/ala.py
@@ -124,7 +124,7 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
                 elif val.endswith("*"):
                     op = "startswith"
                 val = re.sub('([".^$]|(?![*?]))', '\g<1>', val)
-                val = re.sub('(\\\\\*|\*)', '.*', val)
+                val = re.sub('(\\\\\*|\*)', '', val)
                 val = re.sub('\\?', '.', val)
                 if "\\" in val:
                     return "%s @'%s'" % (op, self.cleanValue(val))


### PR DESCRIPTION
Regexes can only be used with regex operation in ala, therefore when contains, startswith, or endswith are used the string should not contain .* or even *.