### PR TITLE
Add ScriptBlockText to Winlogbeat Configs

### DIFF
--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -135,6 +135,7 @@ fieldmappings:
   Product: winlog.event_data.Product
   Properties: winlog.event_data.Properties
   RuleName: winlog.event_data.RuleName
+  ScriptBlockText: winlog.event_data.ScriptBlockText
   SecurityID: winlog.event_data.SecurityID
   ServiceFileName: winlog.event_data.ServiceFileName
   ServiceName: winlog.event_data.ServiceName

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -135,7 +135,7 @@ fieldmappings:
   Product: winlog.event_data.Product
   Properties: winlog.event_data.Properties
   RuleName: winlog.event_data.RuleName
-  ScriptBlockText: winlog.event_data.ScriptBlockText
+  ScriptBlockText: powershell.file.script_block_text
   SecurityID: winlog.event_data.SecurityID
   ServiceFileName: winlog.event_data.ServiceFileName
   ServiceName: winlog.event_data.ServiceName

--- a/tools/config/winlogbeat-old.yml
+++ b/tools/config/winlogbeat-old.yml
@@ -119,6 +119,7 @@ fieldmappings:
   ProcessName: event_data.ProcessName
   Product: event_data.Product
   Properties: event_data.Properties
+  ScriptBlockText: winlog.event_data.ScriptBlockText
   SecurityID: event_data.SecurityID
   ServiceFileName: event_data.ServiceFileName
   ServiceName: event_data.ServiceName

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -125,6 +125,7 @@ fieldmappings:
   Properties: winlog.event_data.Properties
   RuleName: winlog.event_data.RuleName
   SAMAccountName: winlog.event_data.SamAccountName
+  ScriptBlockText: winlog.event_data.ScriptBlockText
   SecurityID: winlog.event_data.SecurityID
   ServiceFileName: winlog.event_data.ServiceFileName
   ServiceName: winlog.event_data.ServiceName


### PR DESCRIPTION
Added ScriptBlockText as a field for winlogbeat configs as per https://www.elastic.co/guide/en/beats/winlogbeat/master/exported-fields-winlog.html. 

This enables using Sigma queries for ScriptBlock Logging in ElasticSearch SIEM instances. 