### PR TITLE
[Add Rule] Zeek Suspicious DNS Z Flag Set

### DIFF
--- a/rules/network/zeek/zeek_dns_suspicious_zbit_flag.yml
+++ b/rules/network/zeek/zeek_dns_suspicious_zbit_flag.yml
@@ -1,0 +1,61 @@
+title: Suspicious DNS Z Flag Bit Set
+id: ede05abc-2c9e-4624-9944-9ff17fdc0bf5
+description: 'The DNS Z flag is bit within the DNS protocol header that is, per the IETF design, meant to be used reserved (unused). Although recently it has been used in DNSSec, the value being set to anything other than 0 should be rare. Otherwise if it is set to non 0 and DNSSec is being used, then excluding the legitimate domains is low effort and high reward. Determine if multiple of these files were accessed in a short period of time to further enhance the possibility of seeing if this was a one off or the possibility of larger sensitive file gathering. This Sigma query is designed to accompany the Corelight Threat Hunting Guide, which can be found here: https://www3.corelight.com/corelights-introductory-guide-to-threat-hunting-with-zeek-bro-logs'
+references:
+  - 'https://twitter.com/neu5ron/status/1346245602502443009'
+  - 'https://tdm.socprime.com/tdm/info/eLbyj4JjI15v#sigma'
+  - 'https://tools.ietf.org/html/rfc2929#section-2.1'
+  - 'https://www.netresec.com/?page=Blog&month=2021-01&post=Finding-Targeted-SUNBURST-Victims-with-pDNS'
+author: '@neu5ron, SOC Prime Team, Corelight'
+tags:
+  - attack.t1094
+  - attack.t1043
+  - attack.command_and_control
+logsource:
+  product: zeek
+  service: dns
+detection:
+  z_flag_unset:
+    Z: '0'
+  most_probable_valid_domain:
+    query|contains: '.'
+  exclude_tlds:
+    query|endswith:
+      - '.arpa'
+      - '.local'
+      - '.ultradns.net'
+      - '.twtrdns.net'
+      - '.azuredns-prd.info'
+      - '.azure-dns.com'
+      - '.azuredns-ff.info'
+      - '.azuredns-ff.org'
+      - '.azuregov-dns.org'
+  exclude_query_types:
+    qtype_name:
+      - 'NS'
+      - 'ns'
+  exclude_responses:
+    answers|endswith: '\\x00'
+  condition: NOT z_flag_unset AND most_probable_valid_domain AND NOT (exclude_tlds OR exclude_tlds OR exclude_query_types OR exclude_responses)
+falsepositive:
+  - 'Internal or legitimate external domains using DNSSec. Verify if these are legitimate DNSSec domains and then exclude them.'
+  - 'If you work in a Public Sector then it may be good to exclude things like endswith ".edu", ".gov" and or ".mil"'
+level: medium
+fields:
+- ts
+- id.orig_h
+- id.orig_p
+- id.resp_h
+- id.resp_p
+- proto
+- qtype_name
+- qtype
+- query
+- answers
+- rcode
+- rcode_name
+- trans_id
+- qtype
+- ttl
+- AA
+- uid

--- a/rules/network/zeek/zeek_dns_suspicious_zbit_flag.yml
+++ b/rules/network/zeek/zeek_dns_suspicious_zbit_flag.yml
@@ -1,6 +1,7 @@
 title: Suspicious DNS Z Flag Bit Set
 id: ede05abc-2c9e-4624-9944-9ff17fdc0bf5
 description: 'The DNS Z flag is bit within the DNS protocol header that is, per the IETF design, meant to be used reserved (unused). Although recently it has been used in DNSSec, the value being set to anything other than 0 should be rare. Otherwise if it is set to non 0 and DNSSec is being used, then excluding the legitimate domains is low effort and high reward. Determine if multiple of these files were accessed in a short period of time to further enhance the possibility of seeing if this was a one off or the possibility of larger sensitive file gathering. This Sigma query is designed to accompany the Corelight Threat Hunting Guide, which can be found here: https://www3.corelight.com/corelights-introductory-guide-to-threat-hunting-with-zeek-bro-logs'
+date: 2021/05/04
 references:
   - 'https://twitter.com/neu5ron/status/1346245602502443009'
   - 'https://tdm.socprime.com/tdm/info/eLbyj4JjI15v#sigma'

--- a/rules/network/zeek/zeek_dns_suspicious_zbit_flag.yml
+++ b/rules/network/zeek/zeek_dns_suspicious_zbit_flag.yml
@@ -36,26 +36,31 @@ detection:
       - 'ns'
   exclude_responses:
     answers|endswith: '\\x00'
-  condition: NOT z_flag_unset AND most_probable_valid_domain AND NOT (exclude_tlds OR exclude_tlds OR exclude_query_types OR exclude_responses)
+  exclude_netbios:
+    id.resp_p:
+      - '137'
+      - '138'
+      - '139'
+  condition: NOT z_flag_unset AND most_probable_valid_domain AND NOT (exclude_tlds OR exclude_tlds OR exclude_query_types OR exclude_responses OR exclude_netbios)
 falsepositive:
   - 'Internal or legitimate external domains using DNSSec. Verify if these are legitimate DNSSec domains and then exclude them.'
   - 'If you work in a Public Sector then it may be good to exclude things like endswith ".edu", ".gov" and or ".mil"'
 level: medium
 fields:
-- ts
-- id.orig_h
-- id.orig_p
-- id.resp_h
-- id.resp_p
-- proto
-- qtype_name
-- qtype
-- query
-- answers
-- rcode
-- rcode_name
-- trans_id
-- qtype
-- ttl
-- AA
-- uid
+  - ts
+  - id.orig_h
+  - id.orig_p
+  - id.resp_h
+  - id.resp_p
+  - proto
+  - qtype_name
+  - qtype
+  - query
+  - answers
+  - rcode
+  - rcode_name
+  - trans_id
+  - qtype
+  - ttl
+  - AA
+  - uid


### PR DESCRIPTION
The DNS Z flag is bit within the DNS protocol header that is, per the IETF design, meant to be used reserved (unused). Although recently it has been used in DNSSec, the value being set to anything other than 0 should be rare. Otherwise if it is set to non 0 and DNSSec is being used, then excluding the legitimate domains is low effort and high reward.
references:
  - 'https://twitter.com/neu5ron/status/1346245602502443009'
  - 'https://tools.ietf.org/html/rfc2929#section-2.1'
  - 'https://www.netresec.com/?page=Blog&month=2021-01&post=Finding-Targeted-SUNBURST-Victims-with-pDNS'