### PR TITLE
Correct the sysmon case-sensitive Key

### DIFF
--- a/rules/windows/network_connection/sysmon_rdp_reverse_tunnel.yml
+++ b/rules/windows/network_connection/sysmon_rdp_reverse_tunnel.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/SBousseaden/status/1096148422984384514
 author: Samir Bousseaden
 date: 2019/02/16
-modified: 2020/08/24
+modified: 2021/05/11
 tags:
     - attack.command_and_control
     - attack.t1572
@@ -25,7 +25,7 @@ detection:
     selection2:
         - DestinationIp|startswith:
             - '127.'
-        - DestinationIP:
+        - DestinationIp:
             - '::1'
     condition: selection and selection2
 falsepositives:

--- a/rules/windows/process_creation/win_hack_secutyxploded.yml
+++ b/rules/windows/process_creation/win_hack_secutyxploded.yml
@@ -6,7 +6,7 @@ references:
     - https://securityxploded.com/
     - https://cyberx-labs.com/blog/gangnam-industrial-style-apt-campaign-targets-korean-industrial-companies/
 date: 2018/12/19
-modified: 2020/09/01
+modified: 2021/05/11
 tags:
     - attack.credential_access
     - attack.t1555
@@ -21,7 +21,7 @@ detection:
     selection2:
         Image|endswith: 'PasswordDump.exe'
     selection3:
-        OriginalFilename|endswith: 'PasswordDump.exe'
+        OriginalFileName|endswith: 'PasswordDump.exe'
     condition: 1 of them
 falsepositives:
     - unlikely

--- a/rules/windows/process_creation/win_susp_csi.yml
+++ b/rules/windows/process_creation/win_susp_csi.yml
@@ -4,6 +4,7 @@ description: Csi.exe is a signed binary from Micosoft that comes with Visual Stu
 status: experimental
 author: Konstantin Grishchenko, oscd.community
 date: 2020/10/17
+modified: 2021/05/11
 references:
     - https://github.com/LOLBAS-Project/LOLBAS/blob/master/yml/OtherMSBinaries/Csi.yml
     - https://github.com/LOLBAS-Project/LOLBAS/blob/master/yml/OtherMSBinaries/Rcsi.yml
@@ -22,8 +23,8 @@ detection:
         - Image|endswith: '\csi.exe'
         - Image|endswith: '\rcsi.exe'
     renamed:    
-        - OriginalFilename: 'csi.exe'
-        - OriginalFilename: 'rcsi.exe'
+        - OriginalFileName: 'csi.exe'
+        - OriginalFileName: 'rcsi.exe'
     selection:    
         Company: 'Microsoft Corporation'
     condition: (basic or renamed) and selection

--- a/rules/windows/process_creation/win_susp_renamed_debugview.yml
+++ b/rules/windows/process_creation/win_susp_renamed_debugview.yml
@@ -15,7 +15,7 @@ detection:
             - 'Sysinternals DebugView'
             - 'Sysinternals Debugview'
     filter:
-        OriginalFilename: 'Dbgview.exe'
+        OriginalFileName: 'Dbgview.exe'
         Image|endswith: '\Dbgview.exe'
     condition: selection and not filter
 falsepositives:


### PR DESCRIPTION
Correct the sysmon case-sensitive Key .
Form the sysmon shema
`<manifest schemaversion="4.60" binaryversion="14.0">`
`<event name="SYSMONEVENT_CREATE_PROCESS" value="1" level="Informational" template="Process Create" rulename="ProcessCreate" ruledefault="include" version="5">`
`<data name="OriginalFileName" inType="win:UnicodeString" outType="xs:string" />`
`<event name="SYSMONEVENT_NETWORK_CONNECT" value="3" level="Informational" template="Network connection detected" rulename="NetworkConnect" version="5">`
`<data name="DestinationIp" inType="win:UnicodeString" outType="xs:string" />`

Test ok with :
`python sigmac --recurse -t elastalert -c config\generic\sysmon.yml -c config\TEST_ECS-sysmon.yml ..\rules\windows`