### PR TITLE
Modified some field values for case sensitive backends (SQL)

### DIFF
--- a/rules/windows/image_load/sysmon_alternate_powershell_hosts_moduleload.yml
+++ b/rules/windows/image_load/sysmon_alternate_powershell_hosts_moduleload.yml
@@ -14,8 +14,8 @@ logsource:
     service: image_load
 detection:
     selection:
-        Description: 'system.management.automation'
-        ImageLoaded|contains: 'system.management.automation'
+        Description: 'System.Management.Automation'
+        ImageLoaded|contains: 'System.Management.Automation'
     filter:
         Image|endswith: '\powershell.exe'
     condition: selection and not filter

--- a/rules/windows/image_load/sysmon_powershell_execution_moduleload.yml
+++ b/rules/windows/image_load/sysmon_powershell_execution_moduleload.yml
@@ -16,8 +16,8 @@ logsource:
     product: windows
 detection:
     selection: 
-        Description: 'system.management.automation'
-        ImageLoaded|contains: 'system.management.automation'
+        Description: 'System.Management.Automation'
+        ImageLoaded|contains: 'System.Management.Automation'
     condition: selection
 fields:
     - ComputerName


### PR DESCRIPTION
By default some backends perform case sensitive match on field values (SQLite), since the real values in event logs use uppercase letters, it is better to use them in the rules.