### PR TITLE
Change to have raw log in rule results with SQL/SQlite Backends

### DIFF
--- a/tools/sigma/backends/sql.py
+++ b/tools/sigma/backends/sql.py
@@ -1,6 +1,7 @@
 # Output backends for sigmac
 # Copyright 2019 Jayden Zheng
 # Copyright 2020 Jonas Hagg
+# Copyright 2021 wagga (https://github.com/wagga40/)
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -169,10 +170,10 @@ class SQLBackend(SingleTextQueryBackend):
                 group_by = ""
 
             if agg.aggfield:
-                select = "{}({}) AS agg".format(agg.aggfunc_notrans, self.fieldNameMapping(agg.aggfield, None))
+                select = "*,{}({}) AS agg".format(agg.aggfunc_notrans, self.fieldNameMapping(agg.aggfield, None))
             else:
                 if agg.aggfunc == SigmaAggregationParser.AGGFUNC_COUNT:
-                    select = "{}(*) AS agg".format(agg.aggfunc_notrans)
+                    select = "*,{}(*) AS agg".format(agg.aggfunc_notrans)
                 else:
                     raise SigmaParseError("For {} aggregation a fieldname needs to be specified".format(agg.aggfunc_notrans))
 

--- a/tools/tests/test_backend_sql.py
+++ b/tools/tests/test_backend_sql.py
@@ -125,7 +125,7 @@ class TestGenerateQuery(unittest.TestCase):
         # count
         detection = {"selection": {"fieldname": "test"},
                      "condition": "selection | count() > 5"}
-        inner_query = 'SELECT count(*) AS agg FROM {} WHERE fieldname = "test"'.format(
+        inner_query = 'SELECT *,count(*) AS agg FROM {} WHERE fieldname = "test"'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg > 5'.format(inner_query)
         self.validate(detection, expected_result)
@@ -133,7 +133,7 @@ class TestGenerateQuery(unittest.TestCase):
         # min
         detection = {"selection": {"fieldname1": "test"},
                      "condition": "selection | min(fieldname2) > 5"}
-        inner_query = 'SELECT min(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
+        inner_query = 'SELECT *,min(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg > 5'.format(inner_query)
         self.validate(detection, expected_result)
@@ -141,7 +141,7 @@ class TestGenerateQuery(unittest.TestCase):
         # max
         detection = {"selection": {"fieldname1": "test"},
                      "condition": "selection | max(fieldname2) > 5"}
-        inner_query = 'SELECT max(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
+        inner_query = 'SELECT *,max(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg > 5'.format(inner_query)
         self.validate(detection, expected_result)
@@ -149,7 +149,7 @@ class TestGenerateQuery(unittest.TestCase):
         # avg
         detection = {"selection": {"fieldname1": "test"},
                      "condition": "selection | avg(fieldname2) > 5"}
-        inner_query = 'SELECT avg(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
+        inner_query = 'SELECT *,avg(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg > 5'.format(inner_query)
         self.validate(detection, expected_result)
@@ -157,7 +157,7 @@ class TestGenerateQuery(unittest.TestCase):
         # sum
         detection = {"selection": {"fieldname1": "test"},
                      "condition": "selection | sum(fieldname2) > 5"}
-        inner_query = 'SELECT sum(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
+        inner_query = 'SELECT *,sum(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg > 5'.format(inner_query)
         self.validate(detection, expected_result)
@@ -165,7 +165,7 @@ class TestGenerateQuery(unittest.TestCase):
         # <
         detection = {"selection": {"fieldname1": "test"},
                      "condition": "selection | sum(fieldname2) < 5"}
-        inner_query = 'SELECT sum(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
+        inner_query = 'SELECT *,sum(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg < 5'.format(inner_query)
         self.validate(detection, expected_result)
@@ -173,7 +173,7 @@ class TestGenerateQuery(unittest.TestCase):
         # ==
         detection = {"selection": {"fieldname1": "test"},
                      "condition": "selection | sum(fieldname2) == 5"}
-        inner_query = 'SELECT sum(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
+        inner_query = 'SELECT *,sum(fieldname2) AS agg FROM {} WHERE fieldname1 = "test"'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg == 5'.format(inner_query)
         self.validate(detection, expected_result)
@@ -181,7 +181,7 @@ class TestGenerateQuery(unittest.TestCase):
         # group by
         detection = {"selection": {"fieldname1": "test"},
                      "condition": "selection | sum(fieldname2) by fieldname3 == 5"}
-        inner_query = 'SELECT sum(fieldname2) AS agg FROM {} WHERE fieldname1 = "test" GROUP BY fieldname3'.format(
+        inner_query = 'SELECT *,sum(fieldname2) AS agg FROM {} WHERE fieldname1 = "test" GROUP BY fieldname3'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg == 5'.format(inner_query)
         self.validate(detection, expected_result)
@@ -189,7 +189,7 @@ class TestGenerateQuery(unittest.TestCase):
         # multiple conditions
         detection = {"selection": {"fieldname1": "test"}, "filter": {
             "fieldname2": "tessst"}, "condition": "selection OR filter | sum(fieldname2) == 5"}
-        inner_query = 'SELECT sum(fieldname2) AS agg FROM {} WHERE (fieldname1 = "test" OR fieldname2 = "tessst")'.format(
+        inner_query = 'SELECT *,sum(fieldname2) AS agg FROM {} WHERE (fieldname1 = "test" OR fieldname2 = "tessst")'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg == 5'.format(inner_query)
         self.validate(detection, expected_result)

--- a/tools/tests/test_backend_sqlite.py
+++ b/tools/tests/test_backend_sqlite.py
@@ -71,14 +71,14 @@ class TestFullTextSearch(unittest.TestCase):
         # aggregation with fts
         detection = {"selection": ["test"],
                      "condition": "selection | count() > 5"}
-        inner_query = 'SELECT count(*) AS agg FROM {0} WHERE {0} MATCH (\'"test"\')'.format(
+        inner_query = 'SELECT *,count(*) AS agg FROM {0} WHERE {0} MATCH (\'"test"\')'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg > 5'.format(inner_query)
         self.validate(detection, expected_result)
 
         detection = {"selection": ["test1", "test2"],
                      "condition": "selection | count() > 5"}
-        inner_query = 'SELECT count(*) AS agg FROM {0} WHERE ({0} MATCH (\'"test1" OR "test2"\'))'.format(
+        inner_query = 'SELECT *,count(*) AS agg FROM {0} WHERE ({0} MATCH (\'"test1" OR "test2"\'))'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg > 5'.format(inner_query)
         self.validate(detection, expected_result)
@@ -86,7 +86,7 @@ class TestFullTextSearch(unittest.TestCase):
         # aggregation + group by + fts
         detection = {"selection": ["test1", "test2"],
                      "condition": "selection | count() by fieldname > 5"}
-        inner_query = 'SELECT count(*) AS agg FROM {0} WHERE ({0} MATCH (\'"test1" OR "test2"\')) GROUP BY fieldname'.format(
+        inner_query = 'SELECT *,count(*) AS agg FROM {0} WHERE ({0} MATCH (\'"test1" OR "test2"\')) GROUP BY fieldname'.format(
             self.table)
         expected_result = 'SELECT * FROM ({}) WHERE agg > 5'.format(inner_query)
         self.validate(detection, expected_result)


### PR DESCRIPTION
When using SQL backends, rules with aggregates are converted into a SQL query looking like that : 

```sql
# Rare Scheduled Task Creations 
SELECT * FROM (SELECT count(*) AS agg FROM logs WHERE (Channel = "Microsoft-Windows-TaskScheduler/Operational" AND EventID = "106") GROUP BY TaskName) WHERE agg < 5
```

After execution, if there is a successful match the result is like :
| agg |
|-----|
|  1     | 

So, we loose all the information of the log that have successfully matched against the rule. To correct this, it is better to add all the missing fields in the query : 

```sql
# Rare Scheduled Task Creations 
SELECT * FROM (SELECT *, count(*) AS agg FROM logs WHERE (Channel = "Microsoft-Windows-TaskScheduler/Operational" AND EventID = "106") GROUP BY TaskName) WHERE agg < 5
```

This commit implement this behaviour (only for avg, sum, count, min, max SQL functions).
