### PR TITLE
Resolves #1450 - Bug in es-rule backend when using "-r" argument

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -1381,6 +1381,8 @@ class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
             rule.update({"threshold": self.rule_threshold})
         if references:
             rule.update({"references": references})
+        self.rule_type = "query"
+        self.rule_threshold = {}
         return json.dumps(rule)
 
 class KibanaNdjsonBackend(ElasticsearchQuerystringBackend, MultiRuleOutputMixin):


### PR DESCRIPTION
Ref : https://github.com/SigmaHQ/sigma/issues/1450#issuecomment-840777032

This [commit](https://github.com/SigmaHQ/sigma/commit/0448e468705715cc3ba7e06c1afaffbf7c06862d#diff-a9fc01b8aa076e9d930106f26dc87e3ec565c519bb242eb4ca591620459f3f8b) introduce a bug when your are converting your rules for "es-rule" backend in recursive mode ("-r" option). In fact, the problem come from `self.rule_type = "threshold"` in `elasticsearch.py`, the backend class is directly updated in the function and not cleaned after rule generation so if you are iterating on multiple rules, the value is good as long as you don't have an aggregation in the rule. After the first rule with aggregation, all subsequent rules will have `"type": " "threshold"`.

The fastest way to correct the bug was by resetting the values of self.rule_type and self.rule_threshold after rule conversion.