### PR TITLE
Contribute AWS snapshot exfiltration rule

### DIFF
--- a/rules/cloud/aws_snapshot_backup_exfiltration.yml
+++ b/rules/cloud/aws_snapshot_backup_exfiltration.yml
@@ -1,0 +1,24 @@
+title: AWS Snapshot Backup Exfiltration
+id: abae8fec-57bd-4f87-aff6-6e3db989843d
+status: test
+description: Detects the modification of an EC2 snapshot's permissions to enable access from another account
+author: Darin Smith
+date: 2021/05/17
+references:
+  - https://www.justice.gov/file/1080281/download
+  - https://attack.mitre.org/techniques/T1537/
+logsource:
+  service: cloudtrail
+detection:
+  selection_source:
+    - eventSource: cloudtrail.amazonaws.com
+  events:
+    - eventName:
+      - ModifySnapshotAttribute
+  condition: selection_source AND events
+falsepositives:
+  - Valid change to a snapshot's permissions
+level: medium
+tags:
+  - attack.exfiltration
+  - attack.t1537


### PR DESCRIPTION
I've written a rule for a cloud exfiltration technique that I've been researching, use of AWS' "Modify Snapshot Permissions" functionality to provide another AWS account access to EC2 snapshot files. This allows exfiltration without triggering any large network transfer detections that may be in place, since everything stays within AWS. 

Hopefully the rule follows the correct format. 
