### PR TITLE
FIx ElasticSearchRuleBackend to use uuid instead of title for the rule id

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -1346,7 +1346,11 @@ class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
                         tactics_list.append(tact)
         threat = self.create_threat_description(tactics_list=tactics_list, techniques_list=technics_list)
         rule_name = configs.get("title", "").lower()
-        rule_id = re.sub(re.compile('[()*+!,\[\].\s"]'), "_", rule_name)
+        rule_uuid = configs.get("id", "").lower()
+        if rule_uuid == "":
+            rule_id = re.sub(re.compile('[()*+!,\[\].\s"]'), "_", rule_name)
+        else:
+            rule_id = re.sub(re.compile('[()*+!,\[\].\s"]'), "_", rule_uuid)
         risk_score = self.map_risk_score(configs.get("level", "medium"))
         references = configs.get("reference")
         if references is None:


### PR DESCRIPTION
`es-rule` use title for the id rule even if it is a uuid.
I have changed the behavior to have the uuid.
But if it is null I've keep the title.