### PR TITLE
Fix errors when import es-rule ndjson to KIBANA

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -1306,6 +1306,8 @@ class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
                 return technique
 
     def map_risk_score(self, level):
+        if level not in ["low","medium","high","critical"]:
+            level = "medium"
         if level == "low":
             return 5
         elif level == "medium":

--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -1317,6 +1317,16 @@ class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
         elif level == "critical":
             return 95
 
+    def map_severity(self, severity):
+        severity = severity.lower()
+        if severity  in ["low","medium","high","critical"]:
+            return severity
+        elif severity == "informational":
+            return "low"
+        else:
+            return "medium"
+
+
     def create_rule(self, configs, index):
         tags = configs.get("tags", [])
         tactics_list = list()
@@ -1386,7 +1396,7 @@ class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
             "meta": {
                 "from": "1m"
             },
-            "severity": configs.get("level", "medium"),
+            "severity": self.map_severity(configs.get("level", "medium")),
             "tags": new_tags,
             "to": "now",
             "type": self.rule_type,

--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -1359,10 +1359,16 @@ class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
         references = configs.get("reference")
         if references is None:
             references = configs.get("references")
+        falsepositives = []
+        yml_falsepositives = configs.get('falsepositives',["Unknown"])
+        if isinstance(yml_falsepositives,str):
+            falsepositives.append(yml_falsepositives)
+        else:
+            falsepositives=yml_falsepositives
         rule = {
             "description": configs.get("description", ""),
             "enabled": True,
-            "false_positives": configs.get('falsepositives', "Unknown"),
+            "false_positives": falsepositives,
             "filters": [],
             "from": "now-360s",
             "immutable": False,

--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -21,6 +21,7 @@ import sys
 import os
 from random import randrange
 from distutils.util import strtobool
+from uuid import uuid4
 
 import sigma
 import yaml
@@ -1221,6 +1222,7 @@ class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
     """Elasticsearch detection rule backend"""
     identifier = "es-rule"
     active = True
+    uuid_black_list = []
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1348,9 +1350,11 @@ class ElasticSearchRuleBackend(ElasticsearchQuerystringBackend):
         rule_name = configs.get("title", "").lower()
         rule_uuid = configs.get("id", "").lower()
         if rule_uuid == "":
-            rule_id = re.sub(re.compile('[()*+!,\[\].\s"]'), "_", rule_name)
-        else:
-            rule_id = re.sub(re.compile('[()*+!,\[\].\s"]'), "_", rule_uuid)
+            rule_uuid = str(uuid4())
+        if rule_uuid in self.uuid_black_list:
+            rule_uuid = str(uuid4())
+        self.uuid_black_list.append(rule_uuid)
+        rule_id = re.sub(re.compile('[()*+!,\[\].\s"]'), "_", rule_uuid)
         risk_score = self.map_risk_score(configs.get("level", "medium"))
         references = configs.get("reference")
         if references is None:


### PR DESCRIPTION
### FIX errors when import es-rule ndjson
Fix the issue  :

- #1486
-  #674

Fix all errors _400_ when import in Kibana 12.1 `Detection rules`.
- [x] uuid not unique
- [x] false_positives not valid
- [x] rish_score not valid
- [x] severity not valid

Test with 819 rules :
`python sigmac --recurse -I -t es-rule -c .\config\winlogbeat-modules-enabled.yml ..\rules\windows  -o rules-windows.ndjson`

