### PR TITLE
rule: add rule to detect shell spawn from WinRM host process

### DIFF
--- a/rules/windows/process_access/win_susp_shell_spawn_from_winrm.yml
+++ b/rules/windows/process_access/win_susp_shell_spawn_from_winrm.yml
@@ -1,0 +1,29 @@
+title: Suspicious Shells Spawn by WinRM
+id: 5cc2cda8-f261-4d88-a2de-e9e193c86716
+description: Detects suspicious shell spawn from WinRM host process
+status: experimental
+author: Andreas Hunkeler (@Karneades), Markus Neis
+date: 2021/05/20
+tags:
+    - attack.t1190
+    - attack.initial_access
+    - attack.persistence
+    - attack.privilege_escalation
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        ParentImage: '*\wsmprovhost.exe'
+        Image:
+            - '*\cmd.exe'
+            - '*\sh.exe'
+            - '*\bash.exe'
+            - '*\powershell.exe'
+            - '*\schtasks.exe'
+            - '*\certutil.exe'
+            - '*\whoami.exe'
+            - '*\bitsadmin.exe'
+    condition: selection
+
+level: critical


### PR DESCRIPTION
Add a rule for detecting shell/binary spawn from WinRM host process.

Note regarding PowerShell:
* WinRM is used for PowerShell remoting, therefore, PowerShell commands are mostly executed inside the WinRM host process, so a child process for powershell will be missing unless someone executes powershell.exe over WinRM.

OSCD issues having mentioned WinRM
* https://github.com/SigmaHQ/sigma/issues/1014
* https://github.com/SigmaHQ/sigma/issues/576