### PR TITLE
Add keyword WinRM to remote powershell rules

### DIFF
--- a/rules/windows/builtin/win_remote_powershell_session.yml
+++ b/rules/windows/builtin/win_remote_powershell_session.yml
@@ -1,6 +1,6 @@
-title: Remote PowerShell Sessions
+title: Remote PowerShell Sessions Network Connections (WinRM)
 id: 13acf386-b8c6-4fe0-9a6e-c4756b974698
-description: Detects basic PowerShell Remoting by monitoring for network inbound connections to ports 5985 OR 5986
+description: Detects basic PowerShell Remoting (WinRM) by monitoring for network inbound connections to ports 5985 OR 5986
 status: experimental
 date: 2019/09/12
 author: Roberto Rodriguez @Cyb3rWard0g

--- a/rules/windows/builtin/win_remote_powershell_session.yml
+++ b/rules/windows/builtin/win_remote_powershell_session.yml
@@ -3,6 +3,7 @@ id: 13acf386-b8c6-4fe0-9a6e-c4756b974698
 description: Detects basic PowerShell Remoting (WinRM) by monitoring for network inbound connections to ports 5985 OR 5986
 status: experimental
 date: 2019/09/12
+modified: 2021/05/21
 author: Roberto Rodriguez @Cyb3rWard0g
 references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/02_execution/T1086_powershell/powershell_remote_session.md

--- a/rules/windows/process_creation/win_remote_powershell_session_process.yml
+++ b/rules/windows/process_creation/win_remote_powershell_session_process.yml
@@ -1,6 +1,6 @@
-title: Remote PowerShell Session
+title: Remote PowerShell Session (WinRM)
 id: 734f8d9b-42b8-41b2-bcf5-abaf49d5a3c8
-description: Detects remote PowerShell sections by monitoring for wsmprovhost as a parent or child process (sign of an active ps remote session)
+description: Detects remote PowerShell sections by monitoring for wsmprovhost (WinRM host process) as a parent or child process (sign of an active ps remote session)
 status: experimental
 date: 2019/09/12
 modified: 2019/11/10

--- a/rules/windows/process_creation/win_remote_powershell_session_process.yml
+++ b/rules/windows/process_creation/win_remote_powershell_session_process.yml
@@ -3,7 +3,7 @@ id: 734f8d9b-42b8-41b2-bcf5-abaf49d5a3c8
 description: Detects remote PowerShell sections by monitoring for wsmprovhost (WinRM host process) as a parent or child process (sign of an active ps remote session)
 status: experimental
 date: 2019/09/12
-modified: 2019/11/10
+modified: 2021/05/21
 author: Roberto Rodriguez @Cyb3rWard0g
 references:
     - https://github.com/Cyb3rWard0g/ThreatHunter-Playbook/tree/master/playbooks/windows/02_execution/T1086_powershell/powershell_remote_session.md

--- a/rules/windows/process_creation/win_remote_powershell_session_process.yml
+++ b/rules/windows/process_creation/win_remote_powershell_session_process.yml
@@ -1,4 +1,4 @@
-title: Remote PowerShell Session (WinRM)
+title: Remote PowerShell Session Host Process (WinRM)
 id: 734f8d9b-42b8-41b2-bcf5-abaf49d5a3c8
 description: Detects remote PowerShell sections by monitoring for wsmprovhost (WinRM host process) as a parent or child process (sign of an active ps remote session)
 status: experimental


### PR DESCRIPTION
Until now when searching for WinRM through the rules these rules were missing and only be found using other keywords like "powershell" or remoting. With adding the WinRM keyword it's easier to find WinRM related rules.

See https://github.com/SigmaHQ/sigma/pull/1493 for a new rule regarding WinRM too.