### PR TITLE
Fix convert eventid

### DIFF
--- a/rules/windows/builtin/win_invoke_obfuscation_via_rundll_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_via_rundll_services.yml
@@ -18,22 +18,25 @@ level: medium
 detection:
     selection:
         - ImagePath|re: '(?i).*rundll32(?:\.exe)?(?:\s+)?shell32\.dll.*shellexec_rundll.*powershell.*\"'
-    condition: selection
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_id:
         EventID: 7045
+    condition: selection and selection_id
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    condition: selection
 ---
  logsource:
      product: windows
      service: security
  detection:
-     selection:
-         EventID: 4697 
+     selection_id:
+         EventID: 4697
+     condition: selection and selection_id

--- a/rules/windows/builtin/win_invoke_obfuscation_via_rundll_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_via_rundll_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated Powershell via RUNDLL LAUNCHER
 status: experimental
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
+modified: 2020/05/25
 references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task 23)
 tags:


### PR DESCRIPTION
Hello,
Fix the missing EvendId when convert 
cmd ` python sigmac -t es-qs -c .\config\winlogbeat-modules-enabled.yml D:\FrackSigma\Sigma\rules\windows\builtin\win_invoke_obfuscation_via_rundll_services.yml`

### Before
`
winlog.event_data.ImagePath.keyword:/(?i).*rundll32(?:\.exe)?(?:\s+)?shell32\.dll.*shellexec_rundll.*powershell.*\"/
winlog.event_data.ImagePath.keyword:/(?i).*rundll32(?:\.exe)?(?:\s+)?shell32\.dll.*shellexec_rundll.*powershell.*\"/
(winlog.channel:"Security" AND winlog.event_data.ImagePath.keyword:/(?i).*rundll32(?:\.exe)?(?:\s+)?shell32\.dll.*shellexec_rundll.*powershell.*\"/)`

### After
`
(winlog.event_data.ImagePath.keyword:/(?i).*rundll32(?:\.exe)?(?:\s+)?shell32\.dll.*shellexec_rundll.*powershell.*\"/ AND winlog.event_id:"7045")
winlog.event_data.ImagePath.keyword:/(?i).*rundll32(?:\.exe)?(?:\s+)?shell32\.dll.*shellexec_rundll.*powershell.*\"/
(winlog.channel:"Security" AND winlog.event_data.ImagePath.keyword:/(?i).*rundll32(?:\.exe)?(?:\s+)?shell32\.dll.*shellexec_rundll.*powershell.*\"/ AND winlog.event_id:"4697")
`