### PR TITLE
Update rule regarding other named pipe

### DIFF
--- a/rules/windows/pipe_created/sysmon_mal_cobaltstrike.yml
+++ b/rules/windows/pipe_created/sysmon_mal_cobaltstrike.yml
@@ -17,13 +17,15 @@ logsource:
    category: pipe_created
    definition: 'Note that you have to configure logging for Named Pipe Events in Sysmon config (Event ID 17)'
 detection:
-   selection_start:
+   selection_MSSE_start:
       PipeName|startswith: '\MSSE-' 
-   selection_end:
+   selection_MSSE_end:
       PipeName|endswith: '-server'
-   selection_others:
+   selection_postex:
+      PipeName|startswith: '\postex_'
+   selection_msagent:
       PipeName|startswith: '\msagent_'
-   condition: selection_start and selection_end
+   condition: selection_MSSE_start and selection_MSSE_end or selection_postex or selection_msagent 
 falsepositives:
    - Unknown
 level: critical

--- a/rules/windows/pipe_created/sysmon_mal_cobaltstrike.yml
+++ b/rules/windows/pipe_created/sysmon_mal_cobaltstrike.yml
@@ -6,8 +6,9 @@ references:
     - https://twitter.com/d4rksystem/status/1357010969264873472
     - https://labs.f-secure.com/blog/detecting-cobalt-strike-default-modules-via-named-pipe-analysis/
     - https://github.com/Neo23x0/sigma/issues/253
-date: 2021/04/23
-author: Florian Roth
+    - https://blog.cobaltstrike.com/2021/02/09/learn-pipe-fitting-for-all-of-your-offense-projects/
+date: 2021/05/25
+author: Florian Roth, Wojciech Lesicki
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
@@ -15,7 +16,7 @@ tags:
 logsource:
    product: windows
    category: pipe_created
-   definition: 'Note that you have to configure logging for Named Pipe Events in Sysmon config (Event ID 17)'
+   definition: 'Note that you have to configure logging for Named Pipe Events in Sysmon config (Event ID 17 and Event ID 18). In the current popular sysmon configuration (https://github.com/SwiftOnSecurity/sysmon-config) this is not there, you have to add it yourself.'
 detection:
    selection_MSSE_start:
       PipeName|startswith: '\MSSE-' 
@@ -23,9 +24,11 @@ detection:
       PipeName|endswith: '-server'
    selection_postex:
       PipeName|startswith: '\postex_'
+   selection_postex_ssh:
+      PipeName|startswith: '\postex_ssh_'
    selection_msagent:
       PipeName|startswith: '\msagent_'
-   condition: selection_MSSE_start and selection_MSSE_end or selection_postex or selection_msagent 
+   condition: selection_MSSE_start and selection_MSSE_end or selection_postex or or selection_postex_ssh or selection_msagent 
 falsepositives:
    - Unknown
 level: critical

--- a/rules/windows/pipe_created/sysmon_mal_cobaltstrike.yml
+++ b/rules/windows/pipe_created/sysmon_mal_cobaltstrike.yml
@@ -26,9 +26,11 @@ detection:
       PipeName|startswith: '\postex_'
    selection_postex_ssh:
       PipeName|startswith: '\postex_ssh_'
+   selection_status:
+      PipeName|startswith: '\status_'
    selection_msagent:
       PipeName|startswith: '\msagent_'
-   condition: selection_MSSE_start and selection_MSSE_end or selection_postex or or selection_postex_ssh or selection_msagent 
+   condition: selection_MSSE_start and selection_MSSE_end or selection_postex or selection_postex_ssh or selection_status or selection_msagent 
 falsepositives:
    - Unknown
 level: critical


### PR DESCRIPTION
Hi,
I added three more named pipe to this rule. According Cobalt Strike documentation (https://blog.cobaltstrike.com/2021/02/09/learn-pipe-fitting-for-all-of-your-offense-projects/) and some test especial \\.\pipe\postex_ is use during e.g. fork&run post-exploitation jobs. And status is use by command jump psexec_psh (lateral movement).

I also changed naming convention in "selection" section. I think looking for \msagent_ is a valid detection that's why I would suggest to put it also to condition section.

If you need some other info, proof - let me know. I tested this update with powershell generated by sigmac
`Get-WinEvent -LogName "Microsoft-Windows-Sysmon/Operational"| where {(($_.ID -eq "17" -or $_.ID -eq "18") -and (($_.message -match "PipeName.*\\MSSE-.*" -and $_.message -match "PipeName.*.*-server") -or $_.message -match "PipeName.*\\postex_.*" -or $_.message -match "PipeName.*\\postex_ssh_.*" -or $_.message -match "PipeName.*\\status_.*" -or $_.message -match "PipeName.*\\msagent_.*")) } | select TimeCreated,Id,RecordId,ProcessId,MachineName,Message`

`-LogName "Microsoft-Windows-Sysmon/Operational"|` was added manually.

And one more thing - for consideration if the rule should change its status to test.