### PR TITLE
Fix missing eventid when converting windows obfuscation rules

### DIFF
--- a/rules/windows/builtin/win_invoke_obfuscation_clip+_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_clip+_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated use of Clip.exe to execute PowerShell
 status: experimental
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
+modified: 2020/05/27
 references:
      - https://github.com/Neo23x0/sigma/issues/1009 #(Task 26)
 tags:
@@ -18,22 +19,25 @@ level: high
 detection:
     selection:
         - ImagePath|re: '.*cmd.{0,5}(?:\/c|\/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\\"\{\d\}.+\-f.+\"'
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
- logsource:
-     product: windows
-     service: security
- detection:
-     selection:
-         EventID: 4697
+logsource:
+    product: windows
+    service: security
+detection:
+    selection_eventid:
+        EventID: 4697

--- a/rules/windows/builtin/win_invoke_obfuscation_stdin+_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_stdin+_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated use of stdin to execute PowerShell
 status: experimental
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
+modified: 2021/05/27
 references:
      - https://github.com/Neo23x0/sigma/issues/1009 #(Task 25)
 tags:
@@ -18,22 +19,25 @@ level: high
 detection:
     selection:
         - ImagePath|re: '.*cmd.{0,5}(?:\/c|\/r).+powershell.+(?:\$\{?input\}?|noexit).+\"'
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
- logsource:
-     product: windows
-     service: security
- detection:
-     selection:
-         EventID: 4697
+logsource:
+    product: windows
+    service: security
+detection:
+    selection_eventid:
+        EventID: 4697

--- a/rules/windows/builtin/win_invoke_obfuscation_var+_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_var+_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated use of Environment Variables to execute PowerShe
 status: experimental
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
+modified: 2021/05/27
 references:
      - https://github.com/Neo23x0/sigma/issues/1009 #(Task 24)
 tags:
@@ -18,22 +19,25 @@ level: high
 detection:
     selection:
         - ImagePath|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
 logsource:
-     product: windows
-     service: security
+    product: windows
+    service: security
 detection:
-     selection:
-         EventID: 4697
+    selection_eventid:
+        EventID: 4697

--- a/rules/windows/builtin/win_invoke_obfuscation_via_compress_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_via_compress_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated Powershell via COMPRESS OBFUSCATION
 status: experimental
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
+modified: 2021/05/27
 references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task 19)
 tags:
@@ -18,22 +19,25 @@ level: medium
 detection:
     selection:
         - ImagePath|re: '(?i).*new-object.*(?:system\.io\.compression\.deflatestream|system\.io\.streamreader).*text\.encoding\]::ascii.*readtoend'
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
- logsource:
-     product: windows
-     service: security
- detection:
-     selection:
-         EventID: 4697 
+logsource:
+    product: windows
+    service: security
+detection:
+    selection_eventid:
+        EventID: 4697 

--- a/rules/windows/builtin/win_invoke_obfuscation_via_rundll_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_via_rundll_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated Powershell via RUNDLL LAUNCHER
 status: experimental
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
+modified: 2021/05/27
 references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task 23)
 tags:
@@ -18,22 +19,25 @@ level: medium
 detection:
     selection:
         - ImagePath|re: '(?i).*rundll32(?:\.exe)?(?:\s+)?shell32\.dll.*shellexec_rundll.*powershell.*\"'
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
- logsource:
-     product: windows
-     service: security
- detection:
-     selection:
-         EventID: 4697 
+logsource:
+    product: windows
+    service: security
+detection:
+    selection_eventid:
+        EventID: 4697 

--- a/rules/windows/builtin/win_invoke_obfuscation_via_stdin_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_via_stdin_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated Powershell via Stdin in Scripts
 status: experimental
 author: Nikita Nazarov, oscd.community
 date: 2020/10/12
+modified: 2021/05/27
 references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task28)
 tags:
@@ -18,22 +19,25 @@ level: high
 detection:
     selection:
         - ImagePath|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\${?input).*&&.*"'
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
- logsource:
-     product: windows
-     service: security
- detection:
-     selection:
-         EventID: 4697
+logsource:
+    product: windows
+    service: security
+detection:
+    selection_eventid:
+        EventID: 4697

--- a/rules/windows/builtin/win_invoke_obfuscation_via_use_clip_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_via_use_clip_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated Powershell via use Clip.exe in Scripts
 status: experimental
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
+modified: 2021/05/27
 references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task29)
 tags:
@@ -18,22 +19,25 @@ level: high
 detection:
     selection:
         - ImagePath|re: '(?i).*?echo.*clip.*&&.*(Clipboard|i`?n`?v`?o`?k`?e`?).*'
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
- logsource:
-     product: windows
-     service: security
- detection:
-     selection:
-         EventID: 4697
+logsource:
+    product: windows
+    service: security
+detection:
+    selection_eventid:
+        EventID: 4697

--- a/rules/windows/builtin/win_invoke_obfuscation_via_use_mshta_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_via_use_mshta_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated Powershell via use MSHTA in Scripts
 status: experimental
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
+modified: 2021/05/27
 references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task31)
 tags:
@@ -18,22 +19,25 @@ level: high
 detection:
     selection:
         - ImagePath|re: '(?i).*(set).*(&&).*(mshta).*(vbscript:createobject).*(\.run).*\(window\.close\).*"'
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
- logsource:
-     product: windows
-     service: security
- detection:
-     selection:
-         EventID: 4697
+logsource:
+    product: windows
+    service: security
+detection:
+    selection_eventid:
+        EventID: 4697

--- a/rules/windows/builtin/win_invoke_obfuscation_via_use_rundll32_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_via_use_rundll32_services.yml
@@ -5,6 +5,7 @@ description: Detects Obfuscated Powershell via use Rundll32 in Scripts
 status: experimental
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
+modified: 2021/05/27
 references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task30)
 tags:
@@ -18,22 +19,25 @@ level: high
 detection:
     selection:
         - ImagePath|re: '(?i).*&&.*rundll32.*shell32\.dll.*shellexec_rundll.*(value|invoke|comspec|iex).*"'
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
- logsource:
-     product: windows
-     service: security
- detection:
-     selection:
-         EventID: 4697
+logsource:
+    product: windows
+    service: security
+detection:
+    selection_eventid:
+        EventID: 4697

--- a/rules/windows/builtin/win_invoke_obfuscation_via_var++_services.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_via_var++_services.yml
@@ -18,22 +18,25 @@ level: high
 detection:
     selection:
         - ImagePath|re: '(?i).*&&set.*(\{\d\}){2,}\\\"\s+?\-f.*&&.*cmd.*\/c' # FPs with |\/r
-    condition: selection
+    condition: selection and selection_eventid
 ---
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_eventid:
         EventID: 7045
 ---
 logsource:
     product: windows
     category: driver_load
+detection:
+    selection_eventid:
+        EventID: 6
 ---
- logsource:
-     product: windows
-     service: security
- detection:
-     selection:
-         EventID: 4697
+logsource:
+    product: windows
+    service: security
+detection:
+    selection_eventid:
+        EventID: 4697


### PR DESCRIPTION
Hi,
finally found the solution to correct the bad conversion to SIEM.
Thanks to [Invoke-Obfuscation Obfuscated IEX Invocation](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/win_invoke_obfuscation_obfuscated_iex_services.yml)