### PR TITLE
Add some fun backend option for es-rule

### DIFF
--- a/tools/sigma/parser/collection.py
+++ b/tools/sigma/parser/collection.py
@@ -37,8 +37,12 @@ class SigmaCollectionParser:
         self.parsers = list()
         prevrule = None
         if filename:
-            globalyaml['yml_filename']=str(filename.name)
-            globalyaml['yml_path']=str(filename.parent)
+            try:
+                globalyaml['yml_filename']=str(filename.name)
+                globalyaml['yml_path']=str(filename.parent)
+            except:
+                filename = None
+        
         for yamldoc in self.yamls:
             action = None
             try:

--- a/tools/sigma/parser/collection.py
+++ b/tools/sigma/parser/collection.py
@@ -28,7 +28,7 @@ class SigmaCollectionParser:
     * reset: resets global attributes from previous set_global statements
     * repeat: takes attributes from this YAML document, merges into previous rule YAML and regenerates the rule
     """
-    def __init__(self, content, config=None, rulefilter=None):
+    def __init__(self, content, config=None, rulefilter=None, filename=None):
         if config is None:
             from sigma.configuration import SigmaConfiguration
             config = SigmaConfiguration()
@@ -36,6 +36,9 @@ class SigmaCollectionParser:
         globalyaml = dict()
         self.parsers = list()
         prevrule = None
+        if filename:
+            globalyaml['yml_filename']=str(filename.name)
+            globalyaml['yml_path']=str(filename.parent)
         for yamldoc in self.yamls:
             action = None
             try:
@@ -48,6 +51,9 @@ class SigmaCollectionParser:
                 deep_update_dict(globalyaml, yamldoc)
             elif action == "reset":
                 globalyaml = dict()
+                if filename:
+                    globalyaml['yml_filename']=str(filename.name)
+                    globalyaml['yml_path']=str(filename.parent) 
             elif action == "repeat":
                 if prevrule is None:
                     raise SigmaCollectionParseError("action 'repeat' is only applicable after first valid Sigma rule")

--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -233,7 +233,7 @@ def main():
                 f = sigmafile
             else:
                 f = sigmafile.open(encoding='utf-8')
-            parser = SigmaCollectionParser(f, sigmaconfigs, rulefilter)
+            parser = SigmaCollectionParser(f, sigmaconfigs, rulefilter, sigmafile)
             results = parser.generate(backend)
 
             newline_separator = '\0' if cmdargs.print0 else '\n'


### PR DESCRIPTION
# Description
Add some fun backend option to es-rule for @V1D1AN [S1EM](https://github.com/V1D1AN/S1EM)
**everything is deactivated by default**

## The start
![Siem_v0](https://user-images.githubusercontent.com/62423083/119958156-0cc8e900-bfa3-11eb-8add-2f7e0a704a8f.PNG)

## Add a custom tag
To help when manage rule in Kibana
`python sigmac --recurse -t es-rule -I -c .\config\winlogbeat-modules-enabled.yml ..\rules -o rule.ndjson -O custom_tag=SigmaHQ`
![Siem_v1](https://user-images.githubusercontent.com/62423083/119958107-00449080-bfa3-11eb-8e9c-8f2adbc03bfa.PNG)

## Add the yml name file
To keen the link to the original file
`python sigmac --recurse -t es-rule -I -c .\config\winlogbeat-modules-enabled.yml ..\rules -o rule.ndjson -C .\frack113.yml`
My frack113.yml
```YAML
put_filename_in_ref: True
convert_to_url: False
path_to_replace: '..\'
dest_base_url: 'https://github.com/SigmaHQ/sigma/tree/master/'
```
It is **not** a valide URL just some info
![Siem_v2](https://user-images.githubusercontent.com/62423083/119958380-4a2d7680-bfa3-11eb-8587-9ab3116fe6c8.PNG)

## Add the yml URL file
To keen the link to the original file
`python sigmac --recurse -t es-rule -I -c .\config\winlogbeat-modules-enabled.yml ..\rules -o rule.ndjson -C .\frack113.yml`
My frack113.yml
```YAML
put_filename_in_ref: True
convert_to_url: True
path_to_replace: '..\'
dest_base_url: 'https://github.com/SigmaHQ/sigma/tree/master/'
```
![Siem_v3](https://user-images.githubusercontent.com/62423083/119958822-b019fe00-bfa3-11eb-9e74-4d4a906123fc.PNG)

## End word
As always  :
Feel free to contribute for fun and fame, this is open source :)