### PR TITLE
Detection rule for 'ISO mounts'

### DIFF
--- a/rules/windows/builtin/win_iso_mount.yml
+++ b/rules/windows/builtin/win_iso_mount.yml
@@ -14,7 +14,7 @@ tags:
 logsource:
     product: windows
     service: security
-        definition: 'The advanced audit policy setting "Object Access > Audit Removable Storage" must be configured for Success/Failure'
+    definition: 'The advanced audit policy setting "Object Access > Audit Removable Storage" must be configured for Success/Failure'
 detection:
     selection: 
         EventID: 4663

--- a/rules/windows/builtin/win_iso_mount.yml
+++ b/rules/windows/builtin/win_iso_mount.yml
@@ -1,14 +1,20 @@
-title: Mounting of ISO Images
+title: ISO Image Mount
 id: 0248a7bc-8a9a-4cd8-a57e-3ae8e073a073
 description: Detects the mount of ISO images on an endpoint
 status: experimental
-date: 29/05/2021
+date: 2021/05/29
 author: Syed Hasan (@syedhasan009)
+references: 
+    - https://www.trendmicro.com/vinfo/hk-en/security/news/cybercrime-and-digital-threats/malicious-spam-campaign-uses-iso-image-files-to-deliver-lokibot-and-nanocore
+    - https://www.proofpoint.com/us/blog/threat-insight/threat-actor-profile-ta2719-uses-colorful-lures-deliver-rats-local-languages
+    - https://twitter.com/MsftSecIntel/status/1257324139515269121
 tags:
     - attack.initial_access
+    - attack.t1566.001
 logsource:
     product: windows
     service: security
+        definition: 'The advanced audit policy setting "Object Access > Audit Removable Storage" must be configured for Success/Failure'
 detection:
     selection: 
         EventID: 4663
@@ -18,4 +24,4 @@ detection:
     condition: selection
 falsepositives:
     - Software installation ISO files
-level: Medium
+level: medium

--- a/rules/windows/builtin/win_iso_mount.yml
+++ b/rules/windows/builtin/win_iso_mount.yml
@@ -1,0 +1,21 @@
+title: Mounting of ISO Images
+id: 0248a7bc-8a9a-4cd8-a57e-3ae8e073a073
+description: Detects the mount of ISO images on an endpoint
+status: experimental
+date: 29/05/2021
+author: Syed Hasan (@syedhasan009)
+tags:
+    - attack.initial_access
+logsource:
+    product: windows
+    service: security
+detection:
+    selection: 
+        EventID: 4663
+        ObjectServer: 'Security'
+        ObjectType: 'File'
+        ObjectName: '\Device\CdRom*'
+    condition: selection
+falsepositives:
+    - Software installation ISO files
+level: Medium


### PR DESCRIPTION
- Rule is based on Windows logging
- Object access logging for 'Removable Storage' is required

Does that need to be added in?