### PR TITLE
make powershell_alternate_powershell_hosts more accurate 

### DIFF
--- a/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
@@ -1,8 +1,10 @@
+action: global
 title: Alternate PowerShell Hosts
 id: 64e8e417-c19a-475a-8d19-98ea705394cc
 description: Detects alternate PowerShell hosts potentially bypassing detections looking for powershell.exe
 status: experimental
 date: 2019/08/11
+modified: 2021/06/01
 author: Roberto Rodriguez @Cyb3rWard0g
 references:
     - https://threathunterplaybook.com/notebooks/windows/02_execution/WIN-190815181010.html
@@ -10,6 +12,20 @@ tags:
     - attack.execution
     - attack.t1059.001
     - attack.t1086  # an old one
+falsepositives:
+    - Programs using PowerShell directly without invocation of a dedicated interpreter
+    - MSP Detection Searcher
+    - Citrix ConfigSync.ps1
+level: medium   
+detection:
+    filter:
+        - ContextInfo: 'powershell.exe'
+        - Message: 'powershell.exe'
+        # Both fields contain key=value pairs where the key HostApplication is relevant but
+        # can't be referred directly as event field.
+    condition: selection and not filter
+ 
+---
 logsource:
     product: windows
     service: powershell
@@ -17,16 +33,13 @@ detection:
     selection:
         EventID:
             - 4103
+        ContextInfo: '*'
+---
+logsource:
+    product: windows
+    service: powershell-classic
+detection:
+    selection:
+        EventID:
             - 400
         ContextInfo: '*'
-    filter:
-        - ContextInfo: 'powershell.exe'
-        - Message: 'powershell.exe'
-        # Both fields contain key=value pairs where the key HostApplication is relevant but
-        # can't be referred directly as event field.
-    condition: selection and not filter
-falsepositives:
-    - Programs using PowerShell directly without invocation of a dedicated interpreter
-    - MSP Detection Searcher
-    - Citrix ConfigSync.ps1
-level: medium

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -35,6 +35,16 @@ logsources:
     service: sysmon
     conditions:
       winlog.channel: 'Microsoft-Windows-Sysmon/Operational'
+  windows-powershell:
+    product: windows
+    service: powershell
+    conditions:
+      winlog.channel: 'Microsoft-Windows-PowerShell/Operational'
+  windows-classicpowershell:
+    product: windows
+    service: powershell-classic
+    conditions:
+      winlog.channel: 'Windows PowerShell'
   windows-dns-server:
     product: windows
     service: dns-server

--- a/tools/config/winlogbeat-old.yml
+++ b/tools/config/winlogbeat-old.yml
@@ -34,6 +34,16 @@ logsources:
     service: sysmon
     conditions:
       log_name: 'Microsoft-Windows-Sysmon/Operational'
+  windows-powershell:
+    product: windows
+    service: powershell
+    conditions:
+      winlog.channel: 'Microsoft-Windows-PowerShell/Operational'
+  windows-classicpowershell:
+    product: windows
+    service: powershell-classic
+    conditions:
+      winlog.channel: 'Windows PowerShell'
   windows-dns-server:
     product: windows
     service: dns-server

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -34,6 +34,16 @@ logsources:
     service: sysmon
     conditions:
       winlog.channel: 'Microsoft-Windows-Sysmon/Operational'
+  windows-powershell:
+    product: windows
+    service: powershell
+    conditions:
+      winlog.channel: 'Microsoft-Windows-PowerShell/Operational'
+  windows-classicpowershell:
+    product: windows
+    service: powershell-classic
+    conditions:
+      winlog.channel: 'Windows PowerShell'
   windows-dns-server:
     product: windows
     service: dns-server


### PR DESCRIPTION
Hi,
Add some fix to make more accurate the detection
### Fix

- Add powershell channel mapping to tools/config/winlogbeat-modules-enabled.yml
- Add powershell channel mapping to tools/config/winlogbeat-old.yml
- Add powershell channel mapping to tools/config/winlogbeat.yml
- Split powershell_alternate_powershell_hosts.yml to get the correct channel <-> EventId

### Before
```
D:\FrackSigma\Sigma\tools>python sigmac -t es-qs -c .\config\winlogbeat-modules-enabled.yml D:\FrackSigma\Sigma\rules\windows\powershell\powershell_alternate_powershell_hosts.yml
((winlog.event_id:("4103" OR "400") AND ContextInfo.keyword:*) AND (NOT (ContextInfo:"powershell.exe" OR Message:"powershell.exe")))
```
### After
```
D:\FrackSigma\Sigma\tools>python sigmac -t es-qs -c .\config\winlogbeat-modules-enabled.yml D:\FrackSigma\Sigma\rules\windows\powershell\powershell_alternate_powershell_hosts.yml
(winlog.channel:"Microsoft\-Windows\-PowerShell\/Operational" AND (winlog.event_id:("4103") AND ContextInfo.keyword:*) AND (NOT (ContextInfo:"powershell.exe" OR Message:"powershell.exe")))
(winlog.channel:"Windows\ PowerShell" AND (winlog.event_id:("400") AND ContextInfo.keyword:*) AND (NOT (ContextInfo:"powershell.exe" OR Message:"powershell.exe")))
```