### PR TITLE
Added a new rule about loading dll CS via rundll32 and also some chan…

### DIFF
--- a/rules/windows/builtin/win_cobaltstrike_service_installs.yml
+++ b/rules/windows/builtin/win_cobaltstrike_service_installs.yml
@@ -4,7 +4,8 @@ description: Detects known malicious service installs that appear in cases in wh
 author: Florian Roth, Wojciech Lesicki
 references:
     - https://www.sans.org/webcasts/119395
-date: 2021/06/01
+date: 2021/05/26
+modified: 2021/06/01
 tags:
     - attack.execution
     - attack.privilege_escalation

--- a/rules/windows/builtin/win_cobaltstrike_service_installs.yml
+++ b/rules/windows/builtin/win_cobaltstrike_service_installs.yml
@@ -1,25 +1,33 @@
 title: CobaltStrike Service Installations
 id: 5a105d34-05fc-401e-8553-272b45c1522d
-description: Detects known malicious service installs that appear in cases in which a Cobalt Strike beacon elevates privileges
-author: Florian Roth
+description: Detects known malicious service installs that appear in cases in which a Cobalt Strike beacon elevates privileges or lateral movement
+author: Florian Roth, Wojciech Lesicki
 references:
     - https://www.sans.org/webcasts/119395
-date: 2021/05/26
+date: 2021/06/01
 tags:
     - attack.execution
     - attack.privilege_escalation
+    - attack.lateral_movement 
+    - attack.t1021.002
     - attack.t1543.003
     - attack.t1569.002
 logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection1:
         EventID: 7045
-        ImagePath|contains|all: 
-            - '\\127.0.0.1\ADMIN$'
+    selection2:
+        Service File Name|contains|all: 
+            - 'ADMIN$'
             - '.exe'
-    condition: selection
+    selection3:
+        Service File Name|contains|all: 
+            - '%COMSPEC%'
+            - 'start'
+            - 'powershell'
+    condition: selection1 and (selection2 or selection3)
 falsepositives:
     - Unknown
 level: critical

--- a/rules/windows/process_creation/process_creation_cobaltstrike_load_by_rundll32.yml
+++ b/rules/windows/process_creation/process_creation_cobaltstrike_load_by_rundll32.yml
@@ -1,4 +1,4 @@
-title: Cobalt Strike load by rundll32
+title: CobaltStrike load by rundll32
 status: experimental
 id: ae9c6a7c-9521-42a6-915e-5aaa8689d529
 author: Wojciech Lesicki

--- a/rules/windows/process_creation/process_creation_cobaltstrike_load_by_rundll32.yml
+++ b/rules/windows/process_creation/process_creation_cobaltstrike_load_by_rundll32.yml
@@ -1,4 +1,4 @@
-title: CobaltStrike load by rundll32
+title: CobaltStrike Load by Rundll32
 status: experimental
 id: ae9c6a7c-9521-42a6-915e-5aaa8689d529
 author: Wojciech Lesicki

--- a/rules/windows/process_creation/process_creation_cobaltstrike_load_by_rundll32.yml
+++ b/rules/windows/process_creation/process_creation_cobaltstrike_load_by_rundll32.yml
@@ -9,7 +9,7 @@ references:
     - https://redcanary.com/threat-detection-report/
     - https://thedfirreport.com/2020/10/18/ryuk-in-5-hours/
 tags:
-    - attack.defense evasion
+    - attack.defense_evasion
     - attack.t1218.011
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/process_creation_cobaltstrike_load_by_rundll32.yml
+++ b/rules/windows/process_creation/process_creation_cobaltstrike_load_by_rundll32.yml
@@ -1,0 +1,26 @@
+title: Cobalt Strike load by rundll32
+status: experimental
+id: ae9c6a7c-9521-42a6-915e-5aaa8689d529
+author: Wojciech Lesicki
+date: 2021/06/01
+description: Rundll32 can be use by Cobalt Strike with StartW function to load DLLs from the command line.
+references:
+    - https://www.cobaltstrike.com/help-windows-executable
+    - https://redcanary.com/threat-detection-report/
+    - https://thedfirreport.com/2020/10/18/ryuk-in-5-hours/
+tags:
+    - attack.defense evasion
+    - attack.t1218.011
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains|all:
+            - 'rundll32.exe'
+            - '.dll'
+            - 'StartW'
+    condition: selection
+falsepositives:
+    - Unknown
+level: critical


### PR DESCRIPTION
Cobalt Strike dll could be load by rundll32 with StartW function from the command line.
From Cobalt Strike documentation: 
“The x86 and x64 DLL options export a StartW function that is compatible with rundll32.exe. Use the architecture-appropriate rundll32.exe to load your DLL from the command line.
rundll32 foo.dll,StartW”

This is mentioned in those reports: 
https://redcanary.com/threat-detection-report/
https://thedfirreport.com/2020/10/18/ryuk-in-5-hours/

------

Cobalt Strike generates a 7045 log in several different ways:
By sc-evelate during privilege escalation - we have then `\\127.0.0.1\ADMIN$\[0-9, a-z].exe` in “Service File Name” field
By psexec module during laterment movement - we have then `\\<hostname>\ADMIN$\[0-9, a-z]`.exe in “Service File Name” field
By psexec_psh during within laterment movement - we have then  `%COMSPEC% /b /c start /b /min powershell -nop -w hidden -encodedcommand <powershell encoded command>` in “Service File Name” field

Base on my tests we need looking on “Service File Name” field.