### PR TITLE
Added rule for rundll32 launch of default F-Secure C3 Relay

### DIFF
--- a/rules/windows/process_creation/process_creation_c3_load_by_rundll32.yml
+++ b/rules/windows/process_creation/process_creation_c3_load_by_rundll32.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/FSecureLABS/C3/blob/master/Src/NodeRelayDll/NodeRelayDll.cpp#L12
 tags:
     - attack.defense_evasion
-    - attack. t1218.011
+    - attack.t1218.011
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/process_creation_c3_load_by_rundll32.yml
+++ b/rules/windows/process_creation/process_creation_c3_load_by_rundll32.yml
@@ -1,0 +1,24 @@
+title: F-Secure C3 Load by Rundll32
+status: experimental
+id: b18c9d4c-fac9-4708-bd06-dd5bfacf200f
+author: Alfie Champion (ajpc500)
+date: 2021/06/02
+description: F-Secure C3 produces DLLs with a default exported StartNodeRelay function.
+references:
+    - https://github.com/FSecureLABS/C3/blob/master/Src/NodeRelayDll/NodeRelayDll.cpp#L12
+tags:
+    - attack.defense_evasion
+    - attack. t1218.011
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains|all:
+            - 'rundll32.exe'
+            - '.dll'
+            - 'StartNodeRelay'
+    condition: selection
+falsepositives:
+    - Unknown
+level: critical


### PR DESCRIPTION
This rule targets DLLs created with the default version of F-Secure's C3. These DLLs include the export function `StartNodeRelay`

![image](https://user-images.githubusercontent.com/62765165/120537529-4eabc200-c3dd-11eb-8080-02e52277598d.png)
