### PR TITLE
T1562.001 Atomic Test #18 - Disable Microsoft Office Security Features

### DIFF
--- a/rules/windows/registry_event/sysmon_disable_microsoft_office_security_features.yml
+++ b/rules/windows/registry_event/sysmon_disable_microsoft_office_security_features.yml
@@ -1,0 +1,37 @@
+title: Disable Microsoft Office Security Features
+id: 7c637634-c95d-4bbf-b26c-a82510874b34
+description: Disable Microsoft Office Security Features by registry
+status: experimental
+date: 2021/06/08
+author: frack113
+tags:
+    - attack.defense_evasion
+    - attack.t1562.001
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1562.001/T1562.001.md
+    - https://unit42.paloaltonetworks.com/unit42-gorgon-group-slithering-nation-state-cybercrime/
+    - https://yoroi.company/research/cyber-criminal-espionage-operation-insists-on-italian-manufacturing/
+
+logsource:
+    product: windows
+    category: registry_event
+    definition: key must be add to the sysmon configuration to works
+                    # Sysmon
+                    # <TargetObject name="T1562,office" condition="end with">\VBAWarnings</TargetObject> 
+                    # <TargetObject name="T1562,office" condition="end with">\DisableInternetFilesInPV</TargetObject>
+                    # <TargetObject name="T1562,office" condition="end with">\DisableUnsafeLocationsInPV</TargetObject> 
+                    # <TargetObject name="T1562,office" condition="end with">\DisableAttachementsInPV</TargetObject>   
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains: '\SOFTWARE\Microsoft\Office\'
+        TargetObject|endswith:
+            - VBAWarnings
+            - DisableInternetFilesInPV
+            - DisableUnsafeLocationsInPV
+            - DisableAttachementsInPV
+        Details: 'DWORD (0x00000001)'
+    condition: selection
+falsepositives:
+    - unknown
+level: high


### PR DESCRIPTION
### Propose:
If registry is set to 1 an external document will not show any warning before editing the document

### Detection:
Not the same as sysmon_reg_office_security.yml detect registry with changes to Office macro settings

To make to work with all version of office.
`TargetObject: HKU\S-1-5-21-56616125-1371661524-2852374103-1001\SOFTWARE\Microsoft\Office\16.0\Excel\Security\VBAWarnings`
so Split to :
- \SOFTWARE\Microsoft\Office\
- \VBAWarnings

the re can be `HKU\\\S+\\SOFTWARE\\Microsoft\\Office\\\d+\.0\\\w+\\Security\\VBAWarnings` but not all backend support it