### PR TITLE
Add missing sysmon EventID

### DIFF
--- a/tools/config/generic/sysmon.yml
+++ b/tools/config/generic/sysmon.yml
@@ -9,11 +9,29 @@ logsources:
         rewrite:
             product: windows
             service: sysmon
+    file_change:
+        category: file_change
+        product: windows
+        conditions:
+            EventID: 2
+        rewrite:
+            product: windows
+            service: sysmon
     network_connection:
         category: network_connection
         product: windows
         conditions:
             EventID: 3
+        rewrite:
+            product: windows
+            service: sysmon
+    sysmon_status:
+        category: sysmon_status
+        product: windows
+        conditions:
+            EventID: 
+                - 4
+                - 16
         rewrite:
             product: windows
             service: sysmon
@@ -129,3 +147,24 @@ logsources:
         rewrite:
             product: windows
             service: sysmon
+    clipboard_capture:
+        category: clipboard_capture
+        product: windows
+        conditions:
+            EventID: 24
+        rewrite:
+            product: windows
+            service: sysmon
+    process_tampering:
+        category: process_tampering
+        product: windows
+        conditions:
+            EventID: 25
+        rewrite:
+            product: windows
+            service: sysmon
+    sysmon_error:
+        category: sysmon_error
+        product: windows
+        conditions:
+            EventID: 255   


### PR DESCRIPTION
### Purpose
Add missing sysmon event ID to the Sigma Category.
from my https://github.com/SigmaHQ/sigma/issues/1525# I've create sysmon_error as it is not a status change

### Synthesis
EventID | Sysmon name | Sigma category
-------- | --------- | ---------
2 | SYSMON_FILE_TIME | [file_change](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/file-create-time-change.md)
4 | SYSMON_SERVICE_STATE_CHANGE | [sysmon_status](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/operational-events.md)
16 | SYSMONEVENT_SERVICE_CONFIGURATION_CHANGE | [sysmon_status](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/operational-events.md)
24 | SYSMON_CLIPBOARD | [clipboard_capture](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/clipboard-capture.md)
25 | SYSMON_PROCESS_IMAGE_TAMPERING | [process_tampering](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/process-tampering.md)
255 | SYSMON_ERROR | [sysmon_error](https://github.com/trustedsec/SysmonCommunityGuide/blob/master/operational-events.md)
