### PR TITLE
Create sysmon_svchost_cred_dump.yml

### DIFF
--- a/rules/windows/process_access/sysmon_svchost_cred_dump.yml
+++ b/rules/windows/process_access/sysmon_svchost_cred_dump.yml
@@ -1,4 +1,4 @@
-title: SVCHOST Credential dump
+title: SVCHOST Credential Dump
 description: Detect when process, such as mimikatz access the memory of svchost to dump the credentials
 date: 2021/04/30
 author: Florent Labouyrie
@@ -19,4 +19,4 @@ falsepositives:
     - Non identified legit exectubale
 level: critical
 tags:
-    - attack.T1548
+    - attack.t1548

--- a/rules/windows/process_access/sysmon_svchost_cred_dump.yml
+++ b/rules/windows/process_access/sysmon_svchost_cred_dump.yml
@@ -1,22 +1,23 @@
 title: SVCHOST Credential Dump
-description: Detect when process, such as mimikatz access the memory of svchost to dump the credentials
+id: 174afcfa-6e40-4ae9-af64-496546389294
+description: Detects when a process, such as mimikatz, accesses the memory of svchost to dump credentials
 date: 2021/04/30
 author: Florent Labouyrie
 logsource:
     product: windows
     category: process_access
+tags:
+    - attack.t1548
 detection:
     selection_process:
-        TargetImage: "svchost.exe"
+        TargetImage|endswith: '\svchost.exe'
     selection_memory:
-        GrantedAccess: "0x143a"
+        GrantedAccess: '0x143a'
     filter_trusted_process_access:
-        SourceImage: 
-          - "services.exe"
-          - "msiexec.exe"
+        SourceImage|endswith: 
+          - '*\services.exe'
+          - '*\msiexec.exe'
     condition: selection_process and selection_memory and not filter_trusted_process_access
 falsepositives:
     - Non identified legit exectubale
 level: critical
-tags:
-    - attack.t1548

--- a/rules/windows/process_access/sysmon_svchost_cred_dump.yml
+++ b/rules/windows/process_access/sysmon_svchost_cred_dump.yml
@@ -4,16 +4,14 @@ date: 2021/04/30
 author: Florent Labouyrie
 logsource:
     product: windows
-    category: Sysmon
+    category: process_access
 detection:
     selection_process:
-        EventID: 10
-        destination_process_name: "svchost.exe"
+        TargetImage: "svchost.exe"
     selection_memory:
-        EventID: 10
-        ProcessAccess: "0x143a"
+        GrantedAccess: "0x143a"
     filter_trusted_process_access:
-        source_process_name: 
+        SourceImage: 
           - "services.exe"
           - "msiexec.exe"
     condition: selection_process and selection_memory and not filter_trusted_process_access

--- a/rules/windows/process_access/sysmon_svchost_cred_dump.yml
+++ b/rules/windows/process_access/sysmon_svchost_cred_dump.yml
@@ -1,0 +1,24 @@
+title: SVCHOST Credential dump
+description: Detect when process, such as mimikatz access the memory of svchost to dump the credentials
+date: 2021/04/30
+author: Florent Labouyrie
+logsource:
+    product: windows
+    category: Sysmon
+detection:
+    selection_process:
+        EventID: 10
+        destination_process_name: "svchost.exe"
+    selection_memory:
+        EventID: 10
+        ProcessAccess: "0x143a"
+    filter_trusted_process_access:
+        source_process_name: 
+          - "services.exe"
+          - "msiexec.exe"
+    condition: selection_process and selection_memory and not filter_trusted_process_access
+falsepositives:
+    - Non identified legit exectubale
+level: critical
+tags:
+    - attack.T1548


### PR DESCRIPTION
Rule to detect when credentials are dump from svchost through a soft, as mimikatz or reviewed by a soft such as process hacker