### PR TITLE
Support for VMware Carbon Black Cloud EEDR

### DIFF
--- a/tools/config/carbon-black-eedr.yml
+++ b/tools/config/carbon-black-eedr.yml
@@ -1,0 +1,141 @@
+title: CarbonBlack Enterprise EDR
+order: 20
+backends:
+  - carbonblack
+  - cb
+fieldmappings:
+  AccountName:
+    - process_username
+    - childproc_username
+  CallingProcessName: process_name
+  CommandLine: process_cmdline
+  ComputerName: device_name
+  Company: process_publisher
+  Description:
+    - process_product_name
+    - process_product_version
+    - process_publisher
+    - process_file_description
+  DestPort:
+    - netconn_port
+    - netconn_remote_port
+  Destination:
+    - netconn_domain
+  DestinationAddress:
+    - netconn_domain
+    - netconn_ipv4
+    - netconn_ipv6
+    - netconn_remote_ipv4
+    - netconn_remote_ipv6
+  DestinationHostname: 
+    - netconn_domain
+    - netconn_proxy_domain
+  DestinationIp:
+    - netconn_ipv4
+    - netconn_ipv6
+    - netconn_remote_ipv4
+    - netconn_remote_ipv6
+  DestinationPort:
+    - netconn_port
+    - netconn_remote_port
+  Device: device_name
+  FileName:
+    - process_internal_name
+    - process_name
+    - process_original_filename
+  FileVersion: process_product_version
+  Image:
+    - process_name
+    - process_internal_name
+  IntegrityLevel: process_integrity_level
+  IpAddress:
+    - netconn_ipv4
+    - netconn_ipv6
+    - netconn_local_ipv4
+    - netconn_local_ipv6
+    - netconn_remote_ipv4
+    - netconn_remote_ipv6
+  LogonId:
+    - childproc_username
+    - process_username
+  md5: hash
+  NewName: regmod_new_name
+  OriginalFileName: process_original_filename
+  ParentCommandLine: parent_cmdline
+  ParentImage: parent_name
+  ParentIntegrityLevel: process_integrity_level
+  ProcessCommandLine: process_cmdline
+  ProcessName: process_name
+  Product: 
+    - process_product_name
+    - process_file_description
+  RelativeTargetName: childproc_name
+  ScriptBlockText: 
+    - childproc_cmdline
+    - crossproc_cmdline
+    - process_cmdline
+  ServiceFileName: process_service_name
+  ServiceName: process_service_name
+  sha256: hash
+  Signature: 
+    - childproc_publisher
+    - filemod_publisher
+    - modload_publisher
+    - parent_publisher
+    - process_publisher
+  Signed:
+    - childproc_publisher_state
+    - filemod_publisher_state
+    - modload_publisher_state
+    - parent_publisher_state
+    - process_publisher_state
+    - scriptload_publisher_state
+  SourceImage: parent_name
+  SourceNetworkAddress:
+    - netconn_local_ipv4
+    - netconn_local_ipv6
+  SourcePort:
+    - netconn_local_port
+    - netconn_port
+  SourceWorkstation: device_name
+  TargetFilename: 
+    - filemod_name
+    - crossproc_name
+  TargetImage:
+    - filemod_name
+    - crossproc_name
+  TargetName:
+    - filemod_name
+    - crossproc_name
+  TargetUserName:
+    - childproc_username
+    - process_username
+  TargetObject: 
+    - regmod_name
+    - regmod_new_name
+  User:
+    - childproc_username
+    - process_username
+  Value:
+    - regmod_name
+    - regmod_new_name
+  Workstation: device_name
+  WorkstationName: device_name
+
+  dst_ip:
+    - netconn_ipv4
+    - netconn_ipv6
+    - netconn_local_ipv4
+    - netconn_local_ipv6
+    - netconn_remote_ipv4
+    - netconn_remote_ipv6
+  dst_port:
+    - netconn_port
+    - netconn_remote_port
+  src_ip:
+    - netconn_ipv4
+    - netconn_ipv6
+    - netconn_local_ipv4
+    - netconn_local_ipv6
+    - netconn_remote_ipv4
+    - netconn_remote_ipv6


### PR DESCRIPTION
Add support for VMware Carbon Black Cloud EEDR. Field mappings derived from https://developer.carbonblack.com/reference/carbon-black-cloud/cb-threathunter/latest/process-search-fields/