### PR TITLE
Rule Edits and 'TaskCache Entry' Rule

### DIFF
--- a/rules/windows/process_creation/win_susp_bcdedit.yml
+++ b/rules/windows/process_creation/win_susp_bcdedit.yml
@@ -4,8 +4,10 @@ status: experimental
 description: Detects, possibly, malicious unauthorized usage of bcdedit.exe
 references:
     - https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/bcdedit--set
+    - https://twitter.com/malwrhunterteam/status/1372536434125512712/photo/2
 author: '@neu5ron'
 date: 2019/02/07
+modified: 2021/06/18
 tags:
     - attack.defense_evasion
     - attack.t1070
@@ -22,5 +24,7 @@ detection:
             - 'delete'
             - 'deletevalue'
             - 'import'
+            - 'safeboot'
+            - 'network'
     condition: selection
 level: medium

--- a/rules/windows/process_creation/win_susp_wmi_execution.yml
+++ b/rules/windows/process_creation/win_susp_wmi_execution.yml
@@ -17,7 +17,6 @@ detection:
         Image|endswith: '\wmic.exe'
     selection2:
         CommandLine|contains|all:
-            - '/NODE:'
             - 'process'
             - 'call'
             - 'create '

--- a/rules/windows/process_creation/win_susp_wmi_execution.yml
+++ b/rules/windows/process_creation/win_susp_wmi_execution.yml
@@ -29,8 +29,8 @@ detection:
         CommandLine|contains|all:
             - 'Product'
             - ' get '
-    condition: selection and selection2 or
-               selection and recon_part1 and recon_part2
+    condition: (selection and selection2) or
+               (selection and recon_part1 and recon_part2)
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/registry_event/sysmon_taskcache_entry.yml
+++ b/rules/windows/registry_event/sysmon_taskcache_entry.yml
@@ -1,6 +1,6 @@
 title: New TaskCache Entry
 id: 4720b7df-40c3-48fd-bbdf-fd4b3c464f0d
-description: Monitor the creation of a new GUID key under 'TaskCache' when a new scheduled task is registered
+description: Monitor the creation of a new key under 'TaskCache' when a new scheduled task is registered
 tags:
   - attack.persistence
   - attack..t1053

--- a/rules/windows/registry_event/sysmon_taskcache_entry.yml
+++ b/rules/windows/registry_event/sysmon_taskcache_entry.yml
@@ -17,5 +17,5 @@ logsource:
   product: windows
 detection:
   selection:
-    TargetObject|contains: '*SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree\*'
+    TargetObject|contains: 'SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree\'
   condition: selection

--- a/rules/windows/registry_event/sysmon_taskcache_entry.yml
+++ b/rules/windows/registry_event/sysmon_taskcache_entry.yml
@@ -1,0 +1,21 @@
+title: New TaskCache Entry
+id: 4720b7df-40c3-48fd-bbdf-fd4b3c464f0d
+description: Monitor the creation of a new GUID key under 'TaskCache' when a new scheduled task is registered
+tags:
+  - attack.persistence
+  - attack..t1053
+  - attack.t1053.005
+date: 2021/06/18
+references:
+  - https://thedfirreport.com/2021/03/29/sodinokibi-aka-revil-ransomware/
+author: Syed Hasan (@syedhasan009)
+falsepositives:
+  - Unknown
+level: medium
+logsource:
+  category: registry_event
+  product: windows
+detection:
+  selection:
+    TargetObject|contains: '*SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree\*'
+  condition: selection


### PR DESCRIPTION
Hi, I've modified two rules and added two new ones. Here's a short description to maybe justify this:

**Addition of Safemode Flags:**
BCDEDIT can be used with a few other parameters such as 'safemode' and 'network' to boot into safemode with networking enabled. Such was done in an older REvil campaign as I've added to the references. 

**Suspicious WMI Execution**
When we add the NODE parameter to the filter with 'ALL', commands run locally lose coverage. Either the filter should be a bit loose or it shouldn't be using NODE in the first place. Example, 'wmic process call create' is just as valid as me mentioning a node in there for remote coverage. Former covers more than the latter.

**TaskCache Entry**
If a new scheduled task is registered, these keys are populated by a new GUID or task name and can be used to monitor for new additions. 

Thanks. Feel free to comment or reject these if not fit for the repo. Do share your thoughts if possible! 