### PR TITLE
Added ability to define free-text searches in the logsource mapping

### DIFF
--- a/tools/config/splunk-windows.yml
+++ b/tools/config/splunk-windows.yml
@@ -24,6 +24,13 @@ logsources:
     service: sysmon
     conditions:
       source: 'WinEventLog:Microsoft-Windows-Sysmon/Operational'
+  windows-process-creation:
+    product: windows
+    service: sysmon
+    category: process_creation
+    # Optimized search for process creation, being dramatically faster than EventCode=1 search, as 'ParentProcessGuid' is more unique than '1' in the raw data.
+    # This also supports custom splunk macros.
+    search: '`example_splunk_macro_for_sysmon` ParentProcessGuid'
   windows-powershell:
     product: windows
     service: powershell

--- a/tools/config/splunk-windows.yml
+++ b/tools/config/splunk-windows.yml
@@ -28,9 +28,14 @@ logsources:
     product: windows
     service: sysmon
     category: process_creation
-    # Optimized search for process creation, being dramatically faster than EventCode=1 search, as 'ParentProcessGuid' is more unique than '1' in the raw data.
-    # This also supports custom splunk macros.
-    search: '`example_splunk_macro_for_sysmon` ParentProcessGuid'
+    # Optimized search for process creation, being dramatically faster in Lispy than just EventCode=1 search, as 'ParentProcessGuid' is more unique than '1' in the raw data.
+    # This also supports custom splunk macros, just like they are written in splunk (i.e. as `macro`), minding that it has to be written inside the string quotes here.
+    search: 'ParentProcessGuid EventCode=1'
+  windows-process-creation:
+    product: windows
+    service: sysmon
+    category: file_creation
+    search: 'TargetFilename EventCode=11'
   windows-powershell:
     product: windows
     service: powershell

--- a/tools/sigma/backends/base.py
+++ b/tools/sigma/backends/base.py
@@ -169,6 +169,8 @@ class BaseBackend:
             return self.applyOverrides(self.generateNotNULLValueNode(node))
         elif type(node) == sigma.parser.condition.NodeSubexpression:
             return self.applyOverrides(self.generateSubexpressionNode(node))
+        elif type(node) == sigma.parser.condition.SigmaSearchValueAsIs:
+            return self.generateValueAsIsNode(node)
         elif type(node) == tuple:
             return self.applyOverrides(self.generateMapItemNode(node))
         elif type(node) in (str, int):
@@ -179,6 +181,9 @@ class BaseBackend:
             return self.applyOverrides(self.generateTypedValueNode(node))
         else:
             raise TypeError("Node type %s was not expected in Sigma parse tree" % (str(type(node))))
+
+    def generateValueAsIsNode(self, node):
+        raise NotImplementedError("Node type not implemented for this backend")
 
     def generateANDNode(self, node):
         raise NotImplementedError("Node type not implemented for this backend")
@@ -247,6 +252,11 @@ class SingleTextQueryBackend(RulenameCommentMixin, BaseBackend, QuoteCharMixin):
     mapListValueExpression = None       # Syntax for field/value condititons where map value is a list
 
     sort_condition_lists = False        # Sort condition items for AND and OR conditions
+
+    def generateValueAsIsNode(self, node):
+        if type(node.value) is list:
+            return self.listExpression % (self.listSeparator.join(node.value))
+        return self.listExpression % node.value
 
     def generateANDNode(self, node):
         generated = [ self.generateNode(val) for val in node ]

--- a/tools/sigma/configuration.py
+++ b/tools/sigma/configuration.py
@@ -160,6 +160,7 @@ class SigmaConfiguration:
 class SigmaLogsourceConfiguration:
     """Contains the definition of a log source"""
     def __init__(self, logsource=None, defaultindex=None):
+        self.search = []
         if logsource == None:               # create empty object
             self.merged = False
             self.category = None
@@ -210,6 +211,8 @@ class SigmaLogsourceConfiguration:
                 else:
                     raise TypeError("Default index must be string or list of strings")
 
+            self.search = [ ls.search for ls in logsource if ls.search ]
+
             self.conditions = [ ls.conditions for ls in logsource if ls.conditions ]        # build list of list of (field, value) tuples as base for merged query condition.
         elif type(logsource) == dict:       # create logsource configuration from parsed yaml
             self.merged = False
@@ -259,6 +262,13 @@ class SigmaLogsourceConfiguration:
                 # config and these must not necessarily contain an index definition. A valid index may later be result
                 # from a merge, where default index handling applies.
                 self.index = []
+
+            # free-form text search as-is. Instead of key=value, the value of 'search' is directly the value itself. Appended to conditions.
+            search = logsource.get('search', None)
+            if search not in [None, '']:
+                if type(search) != str:
+                    raise SigmaConfigParseError("search field must be a string: " + repr(search))
+                self.search.append(logsource.get('search', ''))
 
             try:
                 if type(logsource['conditions']) != dict:

--- a/tools/sigma/parser/condition.py
+++ b/tools/sigma/parser/condition.py
@@ -260,6 +260,12 @@ class NodeSubexpression(ParseTreeNode):
         self.items = subexpr
 
 
+class SigmaSearchValueAsIs:
+    """The contained value is used as-is in the output."""
+    def __init__(self, value):
+        self.value = value
+
+
 # Parse tree generators: generate parse tree nodes from extended conditions
 def generateXOf(sigma, val, condclass):
     """

--- a/tools/sigma/parser/rule.py
+++ b/tools/sigma/parser/rule.py
@@ -16,7 +16,7 @@
 
 import re
 from .exceptions import SigmaParseError
-from .condition import SigmaConditionTokenizer, SigmaConditionParser, ConditionAND, ConditionOR, ConditionNULLValue
+from .condition import SigmaConditionTokenizer, SigmaConditionParser, ConditionAND, ConditionOR, ConditionNULLValue, SigmaSearchValueAsIs
 from .modifiers import apply_modifiers
 
 class SigmaParser:
@@ -167,5 +167,10 @@ class SigmaParser:
                     cond.add(index_cond)
                 else:           # only one index, add directly to AND from above
                     cond.add((index_field, indices[0]))
+
+            # Add free-text search condition, expressed in the configuration as 'search' field.
+            if len(logsource.search) > 0:
+                for item in logsource.search:
+                    cond.add(SigmaSearchValueAsIs(item))
 
             return cond


### PR DESCRIPTION
The default logsource definition is limited to key=value filtering. This change adds support for "search" key that can contain a free-text search query to the remote SIEM, only the value being added to the generated search query.

This is needed to be able to use Splunk macros, for example. One might have a splunk macro `dns` that returns all DNS related log sources with all the optimizations and field transforms needed. 

The free-text field can also be used for search optimization. Splunk uses lispy engine for finding indexed words. "EventCode=1" search is incredible inefficient, because the string "1" is so short and common in the raw data across different data sources and event types (matching date and time fields etc.). It is much faster to find events that have "ParentProcessGuid" in them, as an example, because that does not commonly exist in other sysmon event types. The difference can be in the order of one magnitude on large clusters.
