### PR TITLE
Add `ipcidrv4` modifiers to manage CIDR

### DIFF
--- a/tools/sigma/backends/tools.py
+++ b/tools/sigma/backends/tools.py
@@ -88,12 +88,12 @@ def flatten(l):
 
 def generatelistforcidrv4 (fieldname : str,ip_str : str, Separator_str : str, explose : bool):
     """ the network CIDR brain """
-    
+
     if ',' in ip_str:
         list_ip_str = ip_str.split(',')
     else:
         list_ip_str = [ip_str]
-  
+
     list_field_ip = []    
     for cidr in list_ip_str:
         if explose :
@@ -118,9 +118,8 @@ def generatelistforcidrv4 (fieldname : str,ip_str : str, Separator_str : str, ex
             list_ip = [str(ip_sub).replace(remp_old,remp_new) for ip_sub in ip_range]
         else:
             list_ip = [cidr]
-            
+
         for term in list_ip:
             list_field_ip.append(str(fieldname+': '+ term))
     str_ip = Separator_str.join(list_field_ip)
-    return str_ip
-    
+    return str_ip 

--- a/tools/sigma/backends/tools.py
+++ b/tools/sigma/backends/tools.py
@@ -121,7 +121,6 @@ def generatelistforcidrv4 (fieldname : str,ip_str : str, Separator_str : str, ex
             
         for term in list_ip:
             list_field_ip.append(str(fieldname+': '+ term))
-            print
     str_ip = Separator_str.join(list_field_ip)
     return str_ip
     

--- a/tools/sigma/backends/tools.py
+++ b/tools/sigma/backends/tools.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .base import BaseBackend
+from ipaddress import ip_network
 
 ### Backends for developement purposes
 
@@ -84,3 +85,43 @@ def flatten(l):
           yield from flatten(i)
       else:
           yield i
+
+def generatelistforcidrv4 (fieldname : str,ip_str : str, Separator_str : str, explose : bool):
+    """ the network CIDR brain """
+    
+    if ',' in ip_str:
+        list_ip_str = ip_str.split(',')
+    else:
+        list_ip_str = [ip_str]
+  
+    list_field_ip = []    
+    for cidr in list_ip_str:
+        if explose :
+            subnet = int (str(cidr).split('/')[1])
+            if subnet <= 8 :
+                new_sub = 8
+                remp_old = '0/8'
+                remp_new = '*'
+            elif subnet <= 16:
+                new_sub = 16
+                remp_old = '0/16'
+                remp_new = '*'
+            elif subnet <= 24:
+                new_sub = 24
+                remp_old = '0/24'
+                remp_new = '*'
+            elif subnet <= 32:
+                new_sub = 32
+                remp_old = '/32'
+                remp_new = ''
+            ip_range = list(ip_network(str(cidr)).subnets(new_prefix=new_sub))
+            list_ip = [str(ip_sub).replace(remp_old,remp_new) for ip_sub in ip_range]
+        else:
+            list_ip = [cidr]
+            
+        for term in list_ip:
+            list_field_ip.append(str(fieldname+': '+ term))
+            print
+    str_ip = Separator_str.join(list_field_ip)
+    return str_ip
+    

--- a/tools/sigma/parser/modifiers/transform.py
+++ b/tools/sigma/parser/modifiers/transform.py
@@ -18,8 +18,7 @@ from .base import SigmaTransformModifier
 from .mixins import ListOrStringModifierMixin
 from sigma.parser.condition import ConditionAND
 from base64 import b64encode
-from ipaddress import ip_network
-import re
+
 
 class SigmaContainsModifier(ListOrStringModifierMixin, SigmaTransformModifier):
     """Add *-wildcard before and after all string(s)"""
@@ -139,39 +138,3 @@ class SigmaEncodeUTF16BEModifier(SigmaEncodingBaseModifier):
     active = True
     encoding = "utf-16be"
 
-class SigmaIpCIDRV4hModifier(ListOrStringModifierMixin, SigmaTransformModifier):
-    """Convert ip CIDR to x.x.x.* """
-    identifier = "ipcidrv4"
-    active = True
-    
-    def CidrV4_to_list(self,ip_str : str):
-        """ the network CIDR brain """
-
-        subnet = int (ip_str.split('/')[1])
-       
-        if subnet <= 8 :
-            new_sub = 8
-            remp_old = '0/8'
-            remp_new = '*'
-        elif subnet <= 16:
-            new_sub = 16
-            remp_old = '0/16'
-            remp_new = '*'
-        elif subnet <= 24:
-            new_sub = 24
-            remp_old = '0/24'
-            remp_new = '*'
-        elif subnet <= 32:
-            new_sub = 32
-            remp_old = '/32'
-            remp_new = ''
-        
-        ip_range = list(ip_network(ip_str).subnets(new_prefix=new_sub))
-        list_ip = [str(ip_sub).replace(remp_old,remp_new) for ip_sub in ip_range]
-        return (list_ip)
-        
-    def apply_str(self, val : str):
-        if type(val) == str:
-            if re.match('\d+\.\d+\.\d+\.\d+/\d+',val):
-                val = self.CidrV4_to_list(val)
-        return val

--- a/tools/sigma/parser/modifiers/transform.py
+++ b/tools/sigma/parser/modifiers/transform.py
@@ -19,6 +19,7 @@ from .mixins import ListOrStringModifierMixin
 from sigma.parser.condition import ConditionAND
 from base64 import b64encode
 from ipaddress import ip_network
+import re
 
 class SigmaContainsModifier(ListOrStringModifierMixin, SigmaTransformModifier):
     """Add *-wildcard before and after all string(s)"""
@@ -143,7 +144,7 @@ class SigmaIpCIDRV4hModifier(ListOrStringModifierMixin, SigmaTransformModifier):
     identifier = "ipcidrv4"
     active = True
     
-    def convert_ipv4(self,ip_str : str):
+    def CidrV4_to_list(self,ip_str : str):
         """ the network CIDR brain """
 
         subnet = int (ip_str.split('/')[1])
@@ -170,6 +171,7 @@ class SigmaIpCIDRV4hModifier(ListOrStringModifierMixin, SigmaTransformModifier):
         return (list_ip)
         
     def apply_str(self, val : str):
-        if type(val) == str and '/' in val:
-            val = self.convert_ipv4(val)
+        if type(val) == str:
+            if re.match('\d+\.\d+\.\d+\.\d+/\d+',val):
+                val = self.CidrV4_to_list(val)
         return val

--- a/tools/sigma/parser/modifiers/type.py
+++ b/tools/sigma/parser/modifiers/type.py
@@ -23,7 +23,7 @@ class SigmaRegularExpressionModifier(SigmaTypeModifier):
     valid_input_types = (str,)
 
 class SigmaIpCIDRV4Modifier(SigmaTypeModifier):
-    """Convert ip CIDR to x.x.x.* """
+    """Treat value as CIDR expression"""
     identifier = "ipcidrv4"
     active = True
     valid_input_types = (str,)

--- a/tools/sigma/parser/modifiers/type.py
+++ b/tools/sigma/parser/modifiers/type.py
@@ -21,3 +21,9 @@ class SigmaRegularExpressionModifier(SigmaTypeModifier):
     identifier = "re"
     active = True
     valid_input_types = (str,)
+
+class SigmaIpCIDRV4Modifier(SigmaTypeModifier):
+    """Convert ip CIDR to x.x.x.* """
+    identifier = "ipcidrv4"
+    active = True
+    valid_input_types = (str,)


### PR DESCRIPTION
HI,
My first try to make a modifiers `ipcidrv4`.

The rule 
```
title: Test ip range
description: test convert ip CIDR to string , detect nothing 
status: experimental
author: frack113
logsource:
    product: windows
    service: system
detection:
    selection:
        srcip|ipcidrv4:
            - 192.168.10.0/26
            - 10.10.0.0/16
            - 172.154.52.6/32
            - 'a string lol'
    condition: selection
falsepositives:
    - Unknown
level: critical
```
The output:
```
python sigmac -t es-qs -c .\config\winlogbeat.yml ..\test_ip.yml
srcip.keyword:(192.168.10.0 OR 192.168.10.1 OR 192.168.10.2 OR 192.168.10.3 OR 192.168.10.4 OR 192.168.10.5 OR 192.168.10.6 OR 192.168.10.7 OR 192.168.10.8 OR 192.168.10.9 OR 192.168.10.10 OR 192.168.10.11 OR 192.168.10.12 OR 192.168.10.13 OR 192.168.10.14 OR 192.168.10.15 OR 192.168.10.16 OR 192.168.10.17 OR 192.168.10.18 OR 192.168.10.19 OR 192.168.10.20 OR 192.168.10.21 OR 192.168.10.22 OR 192.168.10.23 OR 192.168.10.24 OR 192.168.10.25 OR 192.168.10.26 OR 192.168.10.27 OR 192.168.10.28 OR 192.168.10.29 OR 192.168.10.30 OR 192.168.10.31 OR 192.168.10.32 OR 192.168.10.33 OR 192.168.10.34 OR 192.168.10.35 OR 192.168.10.36 OR 192.168.10.37 OR 192.168.10.38 OR 192.168.10.39 OR 192.168.10.40 OR 192.168.10.41 OR 192.168.10.42 OR 192.168.10.43 OR 192.168.10.44 OR 192.168.10.45 OR 192.168.10.46 OR 192.168.10.47 OR 192.168.10.48 OR 192.168.10.49 OR 192.168.10.50 OR 192.168.10.51 OR 192.168.10.52 OR 192.168.10.53 OR 192.168.10.54 OR 192.168.10.55 OR 192.168.10.56 OR 192.168.10.57 OR 192.168.10.58 OR 192.168.10.59 OR 192.168.10.60 OR 192.168.10.61 OR 192.168.10.62 OR 192.168.10.63 OR 10.10.0.* OR 172.154.52.6 OR a\ string\ lol)
```
Please feel free to try, correct make better