### PR TITLE
Added space in "Service File Name" field as it was in the previous ve…

### DIFF
--- a/rules/windows/builtin/win_cobaltstrike_service_installs.yml
+++ b/rules/windows/builtin/win_cobaltstrike_service_installs.yml
@@ -5,7 +5,7 @@ author: Florian Roth, Wojciech Lesicki
 references:
     - https://www.sans.org/webcasts/119395
 date: 2021/05/26
-modified: 2021/06/03
+modified: 2021/06/20
 tags:
     - attack.execution
     - attack.privilege_escalation

--- a/rules/windows/builtin/win_cobaltstrike_service_installs.yml
+++ b/rules/windows/builtin/win_cobaltstrike_service_installs.yml
@@ -20,11 +20,11 @@ detection:
     selection1:
         EventID: 7045
     selection2:
-        ServiceFileName|contains|all: 
+        Service File Name|contains|all: 
             - 'ADMIN$'
             - '.exe'
     selection3:
-        ServiceFileName|contains|all: 
+        Service File Name|contains|all: 
             - '%COMSPEC%'
             - 'start'
             - 'powershell'


### PR DESCRIPTION
I understand the need for consistency mentioned in https://github.com/SigmaHQ/sigma/pull/1533 by @SpeedyFireCyclone.
But this field in log 7045 itself is called "Service File Name"
Currently using sigmac to convert to powershell we are unable to detect these events in the logs.
