### PR TITLE
Generic remapping for PowerShell backend

### DIFF
--- a/tools/sigma/backends/powershell.py
+++ b/tools/sigma/backends/powershell.py
@@ -44,6 +44,11 @@ class PowerShellBackend(SingleTextQueryBackend):
     mapListsSpecialHandling = True
 
     logname = None
+    fieldMappings = {
+        "EventID": "ID",
+        "ID": "ID",
+        "ServiceFileName": "Service File Name"
+    }
 
     def generate(self, sigmaparser):
         """Method is called for each sigma rule and receives the parsed rule (SigmaParser)"""
@@ -112,9 +117,8 @@ class PowerShellBackend(SingleTextQueryBackend):
         if self.mapListsSpecialHandling == False and type(value) in (str, int, list) or self.mapListsSpecialHandling == True and type(value) in (str, int):
             if key in ("LogName","source"):
                 self.logname = value
-            elif key in ("ID", "EventID"):
-                if key == "EventID":
-                    key = "ID"
+            elif key in self.fieldMappings.keys():
+                key = self.fieldMappings[key]
                 return self.mapExpression % (key, self.generateValueNode(value, True))
             elif type(value) == str and "*" in value:
                 value = value.replace("*", ".*")
@@ -136,9 +140,8 @@ class PowerShellBackend(SingleTextQueryBackend):
     def generateMapItemListNode(self, key, value):
         itemslist = list()
         for item in value:
-            if key in ("ID", "EventID"):
-                if key == "EventID":
-                    key = "ID"
+            if key in self.fieldMappings.keys():
+                key = self.fieldMappings[key]
                 itemslist.append(self.mapExpression % (key, self.generateValueNode(item, True)))
             elif type(item) == str and "*" in item:
                 item = item.replace("*", ".*")


### PR DESCRIPTION
After seeing #1564, I reviewed the PowerShell backend and noticed there was already remapping for the `EventID` field. I changed it to use a mapping dictionary instead of a simple check due to the likelyhood of another one of these inconsistencies showing up in the future, which can then simply be added to the dictionary with no additional logic required.