### PR TITLE
rule: add port proxy registry rule and further references

### DIFF
--- a/rules/windows/process_creation/win_netsh_port_fwd.yml
+++ b/rules/windows/process_creation/win_netsh_port_fwd.yml
@@ -1,10 +1,12 @@
 title: Netsh Port Forwarding
 id: 322ed9ec-fcab-4f67-9a34-e7c6aef43614
-description: Detects netsh commands that configure a port forwarding
+description: Detects netsh commands that configure a port forwarding (PortProxy)
 references:
     - https://www.fireeye.com/blog/threat-research/2019/01/bypassing-network-restrictions-through-rdp-tunneling.html
+    - https://adepts.of0x.cc/netsh-portproxy-code/
+    - https://www.dfirnotes.net/portproxy_detection/
 date: 2019/01/29
-modified: 2021/01/06
+modified: 2021/06/22
 tags:
     - attack.lateral_movement
     - attack.defense_evasion

--- a/rules/windows/registry_event/win_portproxy_registry_key.yml
+++ b/rules/windows/registry_event/win_portproxy_registry_key.yml
@@ -1,0 +1,26 @@
+title: PortProxy Registry Key
+id: a54f842a-3713-4b45-8c84-5f136fdebd3c
+status: experimental
+description: Detects the modification of PortProxy registry key which is used for port forwarding. For command execution see rule win_netsh_port_fwd.yml.
+references:
+    - https://www.fireeye.com/blog/threat-research/2019/01/bypassing-network-restrictions-through-rdp-tunneling.html
+    - https://adepts.of0x.cc/netsh-portproxy-code/
+    - https://www.dfirnotes.net/portproxy_detection/
+date: 2021/06/22
+tags:
+    - attack.lateral_movement
+    - attack.defense_evasion
+    - attack.command_and_control
+    - attack.t1090
+status: experimental
+author: Andreas Hunkeler (@Karneades)
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    selection_registry:
+        TargetObject: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PortProxy\v4tov4\tcp'
+    condition: selection_registry
+falsepositives:
+    - Unlikely
+level: medium

--- a/rules/windows/registry_event/win_portproxy_registry_key.yml
+++ b/rules/windows/registry_event/win_portproxy_registry_key.yml
@@ -12,7 +12,6 @@ tags:
     - attack.defense_evasion
     - attack.command_and_control
     - attack.t1090
-status: experimental
 author: Andreas Hunkeler (@Karneades)
 logsource:
     category: registry_event


### PR DESCRIPTION
Add new port proxy registry rule and add two further references to the rules:
- https://adepts.of0x.cc/netsh-portproxy-code/
- https://www.dfirnotes.net/portproxy_detection/