### PR TITLE
Added rule for default cobalt strike certificate

### DIFF
--- a/rules/network/zeek/zeek_default_cobalt_strike_certificate.yml
+++ b/rules/network/zeek/zeek_default_cobalt_strike_certificate.yml
@@ -13,12 +13,12 @@ logsource:
   service: x509
 detection:
   selection:
-    certificate_serial: 8bb00ee
+    certificate.serial: 8bb00ee
   condition: selection
 fields:
-    - san_dns
-    - certificate_subject
-    - certificate_issuer
+    - san.dns
+    - certificate.subject
+    - certificate.issuer
 falsepositives:
     - none
 level: high

--- a/rules/network/zeek/zeek_default_cobalt_strike_certificate.yml
+++ b/rules/network/zeek/zeek_default_cobalt_strike_certificate.yml
@@ -1,0 +1,24 @@
+title: Default Cobalt Strike Certificate
+id: 7100f7e3-92ce-4584-b7b7-01b40d3d4118
+description: Detects the presense of default Cobalt Strike certificate in the HTTPS traffic
+author: Bhabesh Raj
+date: 2021/06/23
+references: 
+  - https://sergiusechel.medium.com/improving-the-network-based-detection-of-cobalt-strike-c2-servers-in-the-wild-while-reducing-the-6964205f6468
+tags:
+  - attack.command_and_control
+  - attack.s0154
+logsource:
+  product: zeek
+  service: x509
+detection:
+  selection:
+    certificate_serial: 8bb00ee
+  condition: selection
+fields:
+    - san_dns
+    - certificate_subject
+    - certificate_issuer
+falsepositives:
+    - none
+level: high


### PR DESCRIPTION
Remark: I have replaced the dot in the fields to underscore.

<img width="1406" alt="Screen Shot 2021-06-23 at 10 19 22" src="https://user-images.githubusercontent.com/61026070/123036278-84582f80-d40c-11eb-8dca-c7b488f70fb2.png">

### Log:
```#fields	ts	id	certificate.version	certificate.serial	certificate.subject	certificate.issuer	certificate.not_valid_before	certificate.not_valid_after	certificate.key_alg	certificate.sig_alg	certificate.key_type	certificate.key_length	certificate.exponent	certificate.curve	san.dns	san.uri	san.email	san.ip	basic_constraints.ca	basic_constraints.path_len```

```1620943055.563566	FebYNp2042PTwLAlOf	3	08BB00EE	CN=,OU=,O=,L=,ST=,C=	CN=,OU=,O=,L=,ST=,C=	1432125684.000000	1747485684.000000	rsaEncryption	sha256WithRSAEncryption	rsa	2048	65537	-	-	-	-	-	-	-```
