### PR TITLE
Typo on Find-DomainObjectPropertyOutlier

### DIFF
--- a/rules/windows/powershell/powershell_powerview_malicious_commandlets.yml
+++ b/rules/windows/powershell/powershell_powerview_malicious_commandlets.yml
@@ -38,7 +38,7 @@ detection:
         - Get-Forest
         - Get-ForestDomain
         - Get-ForestGlobalCatalog
-        - Find-DomainObjectPropertyOutlier-
+        - Find-DomainObjectPropertyOutlier
         - Get-DomainUser
         - New-DomainUser
         - Set-DomainUserPassword


### PR DESCRIPTION
Hello,

I am not very familiar with SIGMA but it seems that there is a typo on a cmdlet.
I'm not sure what I'm saying so don't hesitate to tell me if I'm wrong.

Thanks