### PR TITLE
Updated rules with modifiers instead of '*', removed trailing '\\', removed drive letter before "Users"

### DIFF
--- a/rules/windows/builtin/win_impacket_secretdump.yml
+++ b/rules/windows/builtin/win_impacket_secretdump.yml
@@ -1,8 +1,9 @@
 title: Possible Impacket SecretDump Remote Activity
 id: 252902e3-5830-4cf6-bf21-c22083dfd5cf
 description: Detect AD credential dumping using impacket secretdump HKTL
-author: Samir Bousseaden
+author: Samir Bousseaden, wagga
 date: 2019/04/03
+modified: 2021/06/27
 references:
     - https://blog.menasec.net/2019/02/threat-huting-10-impacketsecretdump.html
 tags:
@@ -19,7 +20,9 @@ detection:
     selection:
         EventID: 5145
         ShareName: \\*\ADMIN$
-        RelativeTargetName: 'SYSTEM32\\*.tmp'
+        RelativeTargetName|contains|all: 
+            - 'SYSTEM32\'
+            - '.tmp'
     condition: selection
 falsepositives:
     - pentesting

--- a/rules/windows/builtin/win_net_ntlm_downgrade.yml
+++ b/rules/windows/builtin/win_net_ntlm_downgrade.yml
@@ -4,9 +4,9 @@ id: d67572a0-e2ec-45d6-b8db-c100d14b8ef2
 description: Detects NetNTLM downgrade attack
 references:
     - https://www.optiv.com/blog/post-exploitation-using-netntlm-downgrade-attacks
-author: Florian Roth
+author: Florian Roth, wagga
 date: 2018/03/20
-modified: 2021/02/24
+modified: 2021/06/27
 tags:
     - attack.defense_evasion
     - attack.t1089          # an old one
@@ -41,7 +41,10 @@ logsource:
 detection:
     selection:
         EventID: 4657
-        ObjectName|startswith: '\REGISTRY\MACHINE\SYSTEM\\*ControlSet*\Control\Lsa'
+        ObjectName|contains|all: 
+            - '\REGISTRY\MACHINE\SYSTEM'
+            - 'ControlSet'
+            - '\Control\Lsa'
         ObjectValueName: 
             - 'LmCompatibilityLevel'
             - 'NtlmMinClientSec'

--- a/rules/windows/builtin/win_net_use_admin_share.yml
+++ b/rules/windows/builtin/win_net_use_admin_share.yml
@@ -4,8 +4,9 @@ status: experimental
 description: Detects when an admin share is mounted using net.exe
 references:
     - https://drive.google.com/file/d/1lKya3_mLnR3UQuCoiYruO3qgu052_iS_/view
-author: 'oscd.community, Teymur Kheirkhabarov @HeirhabarovT, Zach Stanford @svch0st'
+author: 'oscd.community, Teymur Kheirkhabarov @HeirhabarovT, Zach Stanford @svch0st, wagga'
 date: 2020/10/05
+modified: 2021/06/27
 tags:
     - attack.lateral_movement
     - attack.t1021.002
@@ -19,7 +20,7 @@ detection:
             - '\net1.exe'
         CommandLine|contains|all:
             - ' use '
-            - '\\\\*\*$*'
+            - '\\\*\\*$*' # (Specs) If some wildcard after a backslash should be searched, the backslash has to be escaped: \\*
     condition: selection
 falsepositives:
     - Administrators

--- a/rules/windows/builtin/win_net_use_admin_share.yml
+++ b/rules/windows/builtin/win_net_use_admin_share.yml
@@ -20,7 +20,7 @@ detection:
             - '\net1.exe'
         CommandLine|contains|all:
             - ' use '
-            - '\\\*\\*$*' # (Specs) If some wildcard after a backslash should be searched, the backslash has to be escaped: \\*
+            - '\\\*\\*$' # (Specs) If some wildcard after a backslash should be searched, the backslash has to be escaped: \\*
     condition: selection
 falsepositives:
     - Administrators

--- a/rules/windows/builtin/win_vul_cve_2020_0688.yml
+++ b/rules/windows/builtin/win_vul_cve_2020_0688.yml
@@ -4,8 +4,10 @@ status: experimental
 description: Detects the exploitation of Microsoft Exchange vulnerability as described in CVE-2020-0688 
 references:
     - https://www.trustedsec.com/blog/detecting-cve-20200688-remote-code-execution-vulnerability-on-microsoft-exchange-server/
-author: Florian Roth
+    - https://cyberpolygon.com/materials/okhota-na-ataki-ms-exchange-chast-2-cve-2020-0688-cve-2020-16875-cve-2021-24085/
+author: Florian Roth, wagga
 date: 2020/02/29
+modified: 2021/06/27
 tags:
     - attack.initial_access
     - attack.t1190
@@ -18,7 +20,8 @@ detection:
         Source: MSExchange Control Panel
         Level: Error
     selection2:
-        - '*&__VIEWSTATE=*'
+        Message|contains:
+            - '&__VIEWSTATE='
     condition: selection1 and selection2
 falsepositives:
     - Unknown

--- a/rules/windows/create_remote_thread/sysmon_suspicious_remote_thread.yml
+++ b/rules/windows/create_remote_thread/sysmon_suspicious_remote_thread.yml
@@ -7,7 +7,7 @@ notes:
     - MonitoringHost.exe is a process that loads .NET CLR by default and thus a favorite for process injection for .NET in-memory offensive tools.
 status: experimental
 date: 2019/10/27
-modified: 2020/08/28
+modified: 2021/06/27
 author: Perez Diego (@darkquassar), oscd.community
 references:
     - Personal research, statistical analysis
@@ -64,7 +64,7 @@ detection:
             - '\userinit.exe'
             - '\vssadmin.exe'
             - '\vssvc.exe'
-            - '\w3wp.exe*'       
+            - '\w3wp.exe'       
             - '\winlogon.exe'
             - '\winscp.exe'
             - '\wmic.exe'

--- a/rules/windows/file_event/win_rclone_exec_file.yml
+++ b/rules/windows/file_event/win_rclone_exec_file.yml
@@ -3,6 +3,7 @@ id: 34986307-b7f4-49be-92f3-e7a4d01ac5db
 description: Detects Rclone config file being created
 status: experimental
 date: 2021/05/26
+modified: 2021/06/27
 author: Aaron Greetham (@beardofbinary) - NCC Group
 references:
     - https://research.nccgroup.com/2021/05/27/detecting-rclone-an-effective-tool-for-exfiltration/
@@ -19,6 +20,6 @@ detection:
     file_selection:
         EventID: 11
         TargetFilename|contains|all:
-            - 'C:\Users\'
+            - ':\Users\'
             - '\.config\rclone\'
     condition: file_selection

--- a/rules/windows/file_event/win_rclone_exec_file.yml
+++ b/rules/windows/file_event/win_rclone_exec_file.yml
@@ -18,6 +18,7 @@ logsource:
 detection:
     file_selection:
         EventID: 11
-        TargetFilename:
-            - 'C:\Users\*\.config\rclone\*'
+        TargetFilename|contains|all:
+            - 'C:\Users\'
+            - '\.config\rclone\'
     condition: file_selection

--- a/rules/windows/process_access/sysmon_cmstp_execution.yml
+++ b/rules/windows/process_access/sysmon_cmstp_execution.yml
@@ -14,7 +14,7 @@ tags:
     - car.2019-04-001
 author: Nik Seetharaman
 date: 2018/07/16
-modified: 2020/12/23
+modified: 2021/06/27
 references:
     - https://web.archive.org/web/20190720093911/http://www.endurant.io/cmstp/detecting-cmstp-enabled-code-execution-and-uac-bypass-with-sysmon/
 fields:
@@ -30,5 +30,5 @@ logsource:
 detection:
     # Process Access Call Trace
     selection:
-        CallTrace|contains: 'cmlua.dll*'
+        CallTrace|contains: 'cmlua.dll'
     condition: selection

--- a/rules/windows/process_creation/win_apt_lazarus_activity_apr21.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_activity_apr21.yml
@@ -23,8 +23,8 @@ detection:
         Image:
             - 'C:\Windows\System32\mshta.exe'
     selection3:
-        ParentImage|startswith:
-            - 'C:\Users\Public\'
+        ParentImage|contains:
+            - ':\Users\Public\'
         Image:
             - 'C:\Windows\System32\rundll32.exe'
     condition: 1 of them

--- a/rules/windows/process_creation/win_apt_lazarus_activity_apr21.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_activity_apr21.yml
@@ -8,6 +8,7 @@ tags:
     - attack.g0032
 author: Bhabesh Raj
 date: 2021/04/20
+modified: 2021/06/27
 logsource:
     category: process_creation
     product: windows
@@ -22,8 +23,8 @@ detection:
         Image:
             - 'C:\Windows\System32\mshta.exe'
     selection3:
-        ParentImage:
-            - 'C:\Users\Public\*'
+        ParentImage|startswith:
+            - 'C:\Users\Public\'
         Image:
             - 'C:\Windows\System32\rundll32.exe'
     condition: 1 of them

--- a/rules/windows/process_creation/win_apt_lazarus_activity_dec20.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_activity_dec20.yml
@@ -30,7 +30,7 @@ detection:
     # Network share discovery
     selection4:
         CommandLine|contains:
-            - '.255 10 C:\ProgramData\\'
+            - '.255 10 C:\ProgramData\'
     condition: 1 of them
 falsepositives:
     - Overlap with legitimate process activity in some cases (especially selection 3 and 4)

--- a/rules/windows/process_creation/win_apt_lazarus_activity_dec20.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_activity_dec20.yml
@@ -9,6 +9,7 @@ tags:
     - attack.g0032
 author: Florian Roth
 date: 2020/12/23
+modified: 2021/06/27
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_apt_lazarus_loader.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_loader.yml
@@ -7,8 +7,9 @@ references:
     - https://securelist.com/lazarus-covets-covid-19-related-intelligence/99906/
 tags:
     - attack.g0032
-author: Florian Roth
+author: Florian Roth, wagga
 date: 2020/12/23
+modified: 2021/06/27
 logsource:
     category: process_creation
     product: windows
@@ -19,12 +20,12 @@ detection:
             - ' -p 0x'
     selection_cmd2:
         CommandLine|contains:
-            - 'C:\ProgramData\\'
-            - 'C:\RECYCLER\\'
+            - 'C:\ProgramData\'
+            - 'C:\RECYCLER\'
     selection_rundll1:
         CommandLine|contains|all: 
             - 'rundll32.exe '
-            - 'C:\ProgramData\\'
+            - 'C:\ProgramData\'
     selection_rundll2:
         CommandLine|contains:
             - '.bin,'

--- a/rules/windows/process_creation/win_apt_unc2452_cmds.yml
+++ b/rules/windows/process_creation/win_apt_unc2452_cmds.yml
@@ -11,6 +11,7 @@ tags:
     - unc2452
 author: Florian Roth
 date: 2021/01/22
+date: 2021/06/27
 logsource:
     category: process_creation
     product: windows
@@ -32,7 +33,7 @@ detection:
         CommandLine|contains: 'cmd.exe /C '
     selection4:
         CommandLine|contains|all: 
-            - 'rundll32 c:\windows\\'
+            - 'rundll32 c:\windows\'
             - '.dll '
     specific1:
         ParentImage|endswith: '\rundll32.exe'

--- a/rules/windows/process_creation/win_apt_unc2452_cmds.yml
+++ b/rules/windows/process_creation/win_apt_unc2452_cmds.yml
@@ -11,7 +11,7 @@ tags:
     - unc2452
 author: Florian Roth
 date: 2021/01/22
-date: 2021/06/27
+modified: 2021/06/27
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_crime_maze_ransomware.yml
+++ b/rules/windows/process_creation/win_crime_maze_ransomware.yml
@@ -8,7 +8,7 @@ references:
     - https://app.any.run/tasks/65a79440-373a-4725-8d74-77db9f2abda4/
 author: Florian Roth
 date: 2020/05/08
-modified: 2020/08/29
+modified: 2021/06/27
 tags:
     - attack.execution
     - attack.t1204.002
@@ -25,7 +25,7 @@ detection:
         ParentImage|endswith:
             - '\WINWORD.exe'
         Image|endswith:
-            - '*.tmp'
+            - '.tmp'
     # Binary Execution
     selection2:
         Image|endswith: '\wmic.exe'

--- a/rules/windows/process_creation/win_mal_adwind.yml
+++ b/rules/windows/process_creation/win_mal_adwind.yml
@@ -8,7 +8,7 @@ references:
     - https://www.first.org/resources/papers/conf2017/Advanced-Incident-Detection-and-Threat-Hunting-using-Sysmon-and-Splunk.pdf
 author: Florian Roth, Tom Ueltschi, Jonhnathan Ribeiro, oscd.community
 date: 2017/11/10
-modified: 2020/09/01
+modified: 2021/06/27
 tags:
     - attack.execution
     - attack.t1059.005
@@ -50,4 +50,4 @@ logsource:
 detection:
     selection:
         TargetObject|startswith: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run
-        Details|startswith: '%AppData%\Roaming\Oracle\bin\\'
+        Details|startswith: '%AppData%\Roaming\Oracle\bin\'

--- a/rules/windows/process_creation/win_powershell_reverse_shell_connection.yml
+++ b/rules/windows/process_creation/win_powershell_reverse_shell_connection.yml
@@ -2,11 +2,12 @@ title: Powershell Reverse Shell Connection
 id: edc2f8ae-2412-4dfd-b9d5-0c57727e70be
 status: experimental
 description: Detects the Nishang Invoke-PowerShellTcpOneLine reverse shell
-author: FPT.EagleEye 
+author: FPT.EagleEye, wagga
 references:
     - https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities/
     - https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers/
 date: 2021/03/03
+modified: 2021/06/27
 tags:
     - attack.execution
     - attack.t1086
@@ -16,9 +17,9 @@ logsource:
     product: windows
 detection:
     selection:
-        Image: '*\powershell.exe'
-        CommandLine:
-            - '*new-object system.net.sockets.tcpclient*'
+        Image|endswith: '\powershell.exe'
+        CommandLine|contains:
+            - 'new-object system.net.sockets.tcpclient'
     condition: selection
 fields:
     - CommandLine

--- a/rules/windows/process_creation/win_susp_conhost.yml
+++ b/rules/windows/process_creation/win_susp_conhost.yml
@@ -6,6 +6,7 @@ references:
     - http://www.hexacorn.com/blog/2020/05/25/how-to-con-your-host/
 author: omkar72
 date: 2020/10/25
+modified: 2021/06/27
 tags:
     - attack.defense_evasion
     - attack.t1202
@@ -14,7 +15,7 @@ logsource:
     product: windows
 detection:
     selection:
-        ParentImage: '*\conhost.exe'
+        ParentImage|endswith: '\conhost.exe'
     condition: selection
 fields:
     - Image

--- a/rules/windows/process_creation/win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/win_susp_file_characteristics.yml
@@ -7,7 +7,7 @@ references:
     - https://www.virustotal.com/#/file/276a765a10f98cda1a38d3a31e7483585ca3722ecad19d784441293acf1b7beb/detection
 author: Markus Neis, Sander Wiebing
 date: 2018/11/22
-modified: 2020/05/26
+modified: 2021/06/27
 tags:
     - attack.execution
     - attack.t1059.006
@@ -27,7 +27,7 @@ detection:
         Description: '\?'
         Company: '\?'
     folder:
-        Image|contains: '\Downloads\\'
+        Image|contains: '\Downloads\'
     condition: (selection1 or selection2 or selection3) and folder
 fields:
     - CommandLine

--- a/rules/windows/process_creation/win_susp_outlook_temp.yml
+++ b/rules/windows/process_creation/win_susp_outlook_temp.yml
@@ -4,6 +4,7 @@ status: experimental
 description: Detects a suspicious program execution in Outlook temp folder
 author: Florian Roth
 date: 2019/10/01
+modified: 2021/06/27
 tags:
     - attack.initial_access
     - attack.t1566.001
@@ -13,7 +14,7 @@ logsource:
     product: windows
 detection:
     selection:
-        Image|contains: '\Temporary Internet Files\Content.Outlook\\'
+        Image|contains: '\Temporary Internet Files\Content.Outlook\'
     condition: selection
 fields:
     - CommandLine

--- a/rules/windows/process_creation/win_susp_shell_spawn_from_mssql.yml
+++ b/rules/windows/process_creation/win_susp_shell_spawn_from_mssql.yml
@@ -2,8 +2,9 @@ title: Suspicious Shells Spawn by SQL Server
 id: 869b9ca7-9ea2-4a5a-8325-e80e62f75445
 description: Detects suspicious shell spawn from MSSQL process, this might be sight of RCE or SQL Injection
 status: experimental
-author: FPT.EagleEye Team 
+author: FPT.EagleEye Team, wagga
 date: 2020/12/11
+modified: 2021/06/27
 tags:
     - attack.t1100
     - attack.t1190
@@ -15,12 +16,12 @@ logsource:
     product: windows
 detection:
     selection:
-        ParentImage: '*\sqlservr.exe'
-        Image:
-            - '*\cmd.exe'
-            - '*\sh.exe'
-            - '*\bash.exe'
-            - '*\powershell.exe'
-            - '*\bitsadmin.exe'
+        ParentImage|endswith: '\sqlservr.exe'
+        Image|endswith:
+            - '\cmd.exe'
+            - '\sh.exe'
+            - '\bash.exe'
+            - '\powershell.exe'
+            - '\bitsadmin.exe'
     condition: selection
 level: critical

--- a/rules/windows/process_creation/win_susp_userinit_child.yml
+++ b/rules/windows/process_creation/win_susp_userinit_child.yml
@@ -13,7 +13,7 @@ detection:
     selection:
         ParentImage|endswith: '\userinit.exe'
     filter1:
-        CommandLine|contains: '\\netlogon\\'
+        CommandLine|contains: '\netlogon\'
     filter2:
         Image|endswith: '\explorer.exe'
     condition: selection and not filter1 and not filter2

--- a/rules/windows/process_creation/win_susp_userinit_child.yml
+++ b/rules/windows/process_creation/win_susp_userinit_child.yml
@@ -6,6 +6,7 @@ references:
     - https://twitter.com/SBousseaden/status/1139811587760562176
 author: Florian Roth (rule), Samir Bousseaden (idea)
 date: 2019/06/17
+modified: 2021/06/27
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/sysmon/sysmon_dcom_iertutil_dll_hijack.yml
+++ b/rules/windows/sysmon/sysmon_dcom_iertutil_dll_hijack.yml
@@ -3,7 +3,8 @@ id: e554f142-5cf3-4e55-ace9-a1b59e0def65
 description: Detects a threat actor creating a file named `iertutil.dll` in the `C:\Program Files\Internet Explorer\` directory over the network and loading it for a DCOM InternetExplorer DLL Hijack scenario.
 status: experimental
 date: 2020/10/12
-author: Roberto Rodriguez @Cyb3rWard0g, Open Threat Research (OTR)
+modified: 2021/06/27
+author: Roberto Rodriguez @Cyb3rWard0g, Open Threat Research (OTR), wagga
 tags:
     - attack.lateral_movement
     - attack.t1021.002
@@ -17,11 +18,11 @@ detection:
     selection_one: 
         EventID: 11
         Image: System
-        TargetFilename: '*\Internet Explorer\iertutil.dll'
+        TargetFilename|endswith: '\Internet Explorer\iertutil.dll'
     selection_two: 
         EventID: 7
-        Image: '*\Internet Explorer\iexplore.exe'
-        ImageLoaded: '*\Internet Explorer\iertutil.dll'
+        Image|endswith: '\Internet Explorer\iexplore.exe'
+        ImageLoaded|endswith: '\Internet Explorer\iertutil.dll'
     condition: selection_one or selection_two
 falsepositives:
     - Unknown


### PR DESCRIPTION
Changes in this PR : 
- Some backends (SQL, SQLite) don't like the '*' wildcard, so when it was possible the rules have been rewritten with modifiers (contains etc.)
- During the rewrite, I came across a lot of double backlashes in the rules. But according the [specs](https://github.com/SigmaHQ/sigma/wiki/Specification#general) : *"You don't have to escape characters except the string quotation marks `'`"* and *"Wildcards can be escaped with `\`, e.g. `\*`. If some wildcard after a backslash should be searched, the backslash has to be escaped: `\\*`"*. So, I removed a lot of trailing double backslashes, this changes are not very important for some backends (like Splunk) but it corrects some bad rules conversion for SQL/SQLite backends
- When I came across `CommandLine` field values with "C:\Users", I removed the drive letter `C` as some admin put the user profiles on another drive
