### PR TITLE
Updated PrintNightmare Sysmon Imageload based rule with modifiers

### DIFF
--- a/rules/windows/image_load/sysmon_cve_2021_1675_print_nightmare.yml
+++ b/rules/windows/image_load/sysmon_cve_2021_1675_print_nightmare.yml
@@ -20,9 +20,11 @@ detection:
     selection:
         Image|endswith:
             - 'spoolsv.exe'
-        ImageLoaded:
-            - 'C:\Windows\System32\spool\drivers\x64\3\old\*.dll'
-            - 'C:\Windows\System32\spool\drivers\x64\3\*.dll'
+        ImageLoaded|startswith:
+            - 'C:\Windows\System32\spool\drivers\x64\3\old\'
+            - 'C:\Windows\System32\spool\drivers\x64\3\'
+        ImageLoaded|endswith:
+            - '.dll'
     condition: selection
 falsepositives:
     - Possible. Requires further testing.


### PR DESCRIPTION
This PR change : 
-  Paths used in the PrintNightmare Sysmon Image load based rule with modifiers instead of wildcard `*`