### PR TITLE
Update and rename to av_printernightmare_cve_2021_34527.yml

### DIFF
--- a/rules/windows/malware/av_printernightmare_cve_2021_34527.yml
+++ b/rules/windows/malware/av_printernightmare_cve_2021_34527.yml
@@ -1,10 +1,13 @@
-title: Antivirus PrinterNightmare CVE-2021-1675 Exploit Detection
+title: Antivirus PrinterNightmare CVE-2021-34527 Exploit Detection
 id: 6fe1719e-ecdf-4caf-bffe-4f501cb0a561
 status: stable
 description: Detects the suspicius file that is created from PoC code against print spooler vulnerability CVE-2021-1675 (PrinterNightmare).
 references:
     - https://twitter.com/mvelazco/status/1410291741241102338
     - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1675
+    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
+Windows Print Spooler Remote Code Execution Vulnerability
+CVE-2021-34527
 author: Sittikorn S, Nuttakorn T
 date: 2021/07/01
 tag:

--- a/rules/windows/malware/av_printernightmare_cve_2021_34527.yml
+++ b/rules/windows/malware/av_printernightmare_cve_2021_34527.yml
@@ -1,13 +1,10 @@
 title: Antivirus PrinterNightmare CVE-2021-34527 Exploit Detection
 id: 6fe1719e-ecdf-4caf-bffe-4f501cb0a561
 status: stable
-description: Detects the suspicius file that is created from PoC code against print spooler vulnerability CVE-2021-1675 (PrinterNightmare).
+description: Detects the suspicius file that is created from PoC code against Windows Print Spooler Remote Code Execution Vulnerability CVE-2021-34527 (PrinterNightmare).
 references:
     - https://twitter.com/mvelazco/status/1410291741241102338
-    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1675
     - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
-Windows Print Spooler Remote Code Execution Vulnerability
-CVE-2021-34527
 author: Sittikorn S, Nuttakorn T
 date: 2021/07/01
 tag:

--- a/rules/windows/malware/av_printernightmare_cve_2021_34527.yml
+++ b/rules/windows/malware/av_printernightmare_cve_2021_34527.yml
@@ -1,9 +1,10 @@
 title: Antivirus PrinterNightmare CVE-2021-34527 Exploit Detection
 id: 6fe1719e-ecdf-4caf-bffe-4f501cb0a561
 status: stable
-description: Detects the suspicius file that is created from PoC code against Windows Print Spooler Remote Code Execution Vulnerability CVE-2021-34527 (PrinterNightmare).
+description: Detects the suspicius file that is created from PoC code against Windows Print Spooler Remote Code Execution Vulnerability CVE-2021-34527 (PrinterNightmare), CVE-2021-1675 .
 references:
     - https://twitter.com/mvelazco/status/1410291741241102338
+    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1675
     - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
 author: Sittikorn S, Nuttakorn T
 date: 2021/07/01


### PR DESCRIPTION
Assign CVE-2021-34527 Windows Print Spooler Remote Code Execution Vulnerability