### PR TITLE
Added new possible ErrorCode

### DIFF
--- a/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler.yml
+++ b/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler.yml
@@ -17,11 +17,13 @@ logsource:
     service: printservice-admin
 detection:
     selection:
-        EventID: 
+        EventID:
             - 808   # old id
             - 4909  # new id
-        ErrorCode: '0x45A'
-    keywords: 
+        ErrorCode:
+            - '0x45A'
+            - '0x7e'
+    keywords:
         - 'The print spooler failed to load a plug-in module'
         # default file names used in PoC codes
         - 'MyExploit.dll'


### PR DESCRIPTION
XML of the event showing different ErrorCode on Windows 10 Host. 
```
- <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
- <System>
  <Provider Name="Microsoft-Windows-PrintService" Guid="{747ef6fd-e535-4d16-b510-42c90f6873a1}" /> 
  <EventID>808</EventID> 
  <Version>0</Version> 
  <Level>2</Level> 
  <Task>36</Task> 
  <Opcode>12</Opcode> 
  <Keywords>0x8000000000020000</Keywords> 
  <TimeCreated SystemTime="2021-07-01T17:33:51.505479000Z" /> 
  <EventRecordID>1</EventRecordID> 
  <Correlation /> 
  <Execution ProcessID="2616" ThreadID="5176" /> 
  <Channel>Microsoft-Windows-PrintService/Admin</Channel> 
  <Computer>DESKTOP-GB8KT3V.hawkio.local</Computer> 
  <Security UserID="S-1-5-18" /> 
  </System>
- <UserData>
- <LoadPluginFailed xmlns="http://manifests.microsoft.com/win/2005/08/windows/printing/spooler/core/events">
  <PluginDllName>C:\Windows\system32\spool\DRIVERS\x64\3\HAWKBadDll.dll</PluginDllName> 
  <ErrorCode>0x7e</ErrorCode> 
  <Context>112</Context> 
  </LoadPluginFailed>
  </UserData>
  </Event>
```