### PR TITLE
Added new Print Spooler exploitation detection method

### DIFF
--- a/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler_Security.yml
+++ b/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler_Security.yml
@@ -1,6 +1,6 @@
-title: CVE-2021-1675 Print Spooler Exploitation
+title: CVE-2021-1675 Print Spooler Exploitation IPC Access
 id: 8fe1c584-ee61-444b-be21-e9054b229694
-description: Detects remote printer driver load from Detailed File Share in Security logs that are a sign of successful exploitation attempts against print spooler vulnerability CVE-2021-1675
+description: Detects remote printer driver load from Detailed File Share in Security logs that are a sign of successful exploitation attempts against print spooler vulnerability CVE-2021-1675 and CVE-2021-34527
 author: INIT_6
 status: experimental
 level: critical
@@ -10,13 +10,14 @@ date: 2021/07/02
 tags:
     - attack.execution
     - cve.2021-1675
+    - cve.2021-34527
 logsource:
     product: windows
     service: security
 detection:
     selection:
         EventID: '5145'
-        ShareName: \\*\IPC$
+        ShareName: '\\*\IPC$'
         RelativeTargetName: 'spoolss'
         AccessMask: '0x3'
         ObjectType: 'File'

--- a/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler_Security.yml
+++ b/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler_Security.yml
@@ -1,0 +1,25 @@
+title: CVE-2021-1675 Print Spooler Exploitation
+id: 8fe1c584-ee61-444b-be21-e9054b229694
+description: Detects remote printer driver load from Detailed File Share in Security logs that are a sign of successful exploitation attempts against print spooler vulnerability CVE-2021-1675
+author: INIT_6
+status: experimental
+level: critical
+references:
+    - https://twitter.com/INIT_3/status/1410662463641731075
+date: 2021/07/02
+tags:
+    - attack.execution
+    - cve.2021-1675
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: '5145'
+        ShareName: \\*\IPC$
+        RelativeTargetName: 'spoolss'
+        AccessMask: '0x3'
+        ObjectType: 'File'
+    condition: selection
+falsepositives:
+    - nothing observed so far


### PR DESCRIPTION
This is the first rule I've added; I think I followed the guidelines correctly.