### PR TITLE
Escape spaces in graylog backend

### DIFF
--- a/tools/sigma/backends/graylog.py
+++ b/tools/sigma/backends/graylog.py
@@ -23,5 +23,5 @@ class GraylogQuerystringBackend(ElasticsearchQuerystringBackend):
     active = True
     config_required = False
 
-    reEscape = re.compile("([+\\-!(){}\\[\\]^\"~:/]|(?<!\\\\)\\\\(?![*?\\\\])|&&|\\|\\|)")
+    reEscape = re.compile("([\s+\\-!(){}\\[\\]^\"~:/]|(?<!\\\\)\\\\(?![*?\\\\])|&&|\\|\\|)")
     listSeparator = " "


### PR DESCRIPTION
Search queries generated by Graylog backend don't escape spaces in field values.