### PR TITLE
Change getRuleName() to get 'id-title' instead of ('id' or 'title')

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -1171,7 +1171,7 @@ class ElastalertBackend(DeepFieldMappingMixin, MultiRuleOutputMixin):
         for parsed in sigmaparser.condparsed:
             #Static data
             rule_object = {
-                "name": rulename + "_" + str(rule_number),
+                "name": rulename,
                 "description": description,
                 "index": index,
                 "priority": self.convertLevel(level),

--- a/tools/sigma/backends/mixins.py
+++ b/tools/sigma/backends/mixins.py
@@ -68,9 +68,16 @@ class MultiRuleOutputMixin:
 
         """
         try:
-            rulename = sigmaparser.parsedyaml["id"]
+            yaml_id = sigmaparser.parsedyaml["id"]
         except KeyError:
-            rulename = sigmaparser.parsedyaml["title"].replace(" ", "-").replace("(", "").replace(")", "")
+            yaml_id = "00000000-0000-0000-0000-000000000000"
+        try:
+            yaml_title = sigmaparser.parsedyaml["title"]
+        except KeyError:
+            yaml_title = "No Title"
+        yaml_title = yaml_title.replace(" ", "-").replace("(", "").replace(")", "")
+        
+        rulename = "%s-%s" % (yaml_id, yaml_title)
         if rulename in self.rulenames:   # add counter if name collides
             cnt = 2
             while "%s-%d" % (rulename, cnt) in self.rulenames:


### PR DESCRIPTION
Hi,
getRuleName() return `uuid` or if missing `title`.
The uuid does not allow a easy following in elastalert or SIEM.
So I changed it to `id-title`.
the function already handles duplicates natively

close #1618 
close #666 