### PR TITLE
Update win_mal_service_installs.yml - Corrected logsource

### DIFF
--- a/rules/windows/builtin/win_mal_service_installs.yml
+++ b/rules/windows/builtin/win_mal_service_installs.yml
@@ -1,3 +1,4 @@
+action: global
 title: Malicious Service Installations
 id: 2cfe636e-317a-4bee-9f2c-1066d9f54d1a
 description: Detects known malicious service installs that only appear in cases of lateral movement, credential dumping, and other suspicious activities.
@@ -17,14 +18,18 @@ tags:
     - car.2013-09-005
     - attack.t1543.003
     - attack.t1569.002
+detection:
+    condition: selection and 1 of malsvc_*
+falsepositives:
+    - Penetration testing
+level: critical
+---
 logsource:
     product: windows
     service: system
 detection:
     selection:
-        EventID:
-            - 4697
-            - 7045
+        EventID: 7045
     malsvc_paexec:
         ServiceFileName|contains: '\PAExec'
     malsvc_wannacry:
@@ -32,8 +37,13 @@ detection:
     malsvc_persistence:
         ServiceFileName|contains: 'net user'
     malsvc_apt29:
+        ServiceName: 'Java(TM) Virtual Machine Support Service'
+---
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4697
+    malsvc_apt29:
         ServiceName: 'javamtsup'
-    condition: selection and 1 of malsvc_*
-falsepositives:
-    - Penetration testing
-level: critical


### PR DESCRIPTION
Fix mistake (incorrect logsource for event ID 4697) in PR #1629.

* Event ID 4697 belongs under `winlog.channel: Security`.
* Event ID 7045 belongs under `winlog.channel: System`.

Have tested that the latest changes result in rule detections - sorry for the mistake earlier.