### PR TITLE
Revert "feat: OriginalFileName mapping in MDATP ImageLoad events"

### DIFF
--- a/tools/sigma/backends/mdatp.py
+++ b/tools/sigma/backends/mdatp.py
@@ -160,7 +160,6 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
                 "DeviceName": (self.id_mapping, self.default_value_mapping),
                 "EventType": ("ActionType", self.default_value_mapping),
                 "FileName": (self.id_mapping, self.default_value_mapping),
-                "OriginalFileName": ("OriginalFileName", self.default_value_mapping),
                 "Image": ("InitiatingProcessFolderPath", self.default_value_mapping),
                 "ImageLoaded": ("FolderPath", self.default_value_mapping),
                 "ParentCommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),


### PR DESCRIPTION
This reverts commit cdc434cfc485bfd7b0cfafbc7df7347c67d5eec1.