### PR TITLE
Update winlogbeat-modules-enabled.yml - Imphash Field

### DIFF
--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -146,7 +146,7 @@ fieldmappings:
     Image: process.executable
     ImageLoaded: file.path
     ImagePath: winlog.event_data.ImagePath
-    Imphash: winlog.event_data.Imphash
+    Imphash: process.pe.imphash
     IpAddress: source.ip
     IpPort: source.port
     KeyLength: winlog.event_data.KeyLength


### PR DESCRIPTION
Replaced mapping for Imphash (based on Winlogbeat's Sysmon processor module).

* In https://www.elastic.co/guide/en/beats/winlogbeat/current/exported-fields-ecs.html, we see `process.pe.imphash`.
* In Winlogbeat's Sysmon processor module found at https://raw.githubusercontent.com/elastic/beats/master/x-pack/winlogbeat/module/sysmon/config/winlogbeat-sysmon.js, we see at line 400 that it is processed into `process.pe.imphash` via `return namespace + ".pe.imphash";`.