### PR TITLE
Update winlogbeat.yml - Imphash Field

### DIFF
--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -133,7 +133,7 @@ fieldmappings:
     Image: winlog.event_data.Image
     ImageLoaded: winlog.event_data.ImageLoaded
     ImagePath: winlog.event_data.ImagePath
-    Imphash: winlog.event_data.Imphash
+    Imphash: winlog.event_data.Hashes
     IpAddress: winlog.event_data.IpAddress
     KeyLength: winlog.event_data.KeyLength
     LogonProcessName: winlog.event_data.LogonProcessName


### PR DESCRIPTION
Change Imphash's value as current value only exists with the Sysmon processor module under Winlogbeat (which is seen in `winlogbeat-modules-enabled.yml`).

For more clarity regarding the same field (where Winlogbeat's Sysmon module is enabled), see #1667.