### PR TITLE
Some Redcanary T1228

### DIFF
--- a/rules/windows/process_creation/process_creation_infdefaultinstall.yml
+++ b/rules/windows/process_creation/process_creation_infdefaultinstall.yml
@@ -1,4 +1,4 @@
-title:  InfDefaultInstall.exe .inf Execution
+title: InfDefaultInstall.exe .inf Execution
 id: ce7cf472-6fcc-490a-9481-3786840b5d9b
 status: experimental
 author: frack113

--- a/rules/windows/process_creation/process_creation_infdefaultinstall.yml
+++ b/rules/windows/process_creation/process_creation_infdefaultinstall.yml
@@ -1,0 +1,29 @@
+title:  InfDefaultInstall.exe .inf Execution
+id: ce7cf472-6fcc-490a-9481-3786840b5d9b
+status: experimental
+author: frack113
+date: 2021/07/13
+description: Executes SCT script using scrobj.dll from a command in entered into a specially prepared INF file.
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218/T1218.md
+    - https://github.com/LOLBAS-Project/LOLBAS/blob/master/yml/OSBinaries/Infdefaultinstall.yml
+tags:
+    - attack.defense_evasion
+    - attack.t1562.001
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains|all:
+            - 'InfDefaultInstall.exe '
+            - '.inf'
+    condition: selection 
+fields:
+    - ComputerName
+    - User
+    - CommandLine
+    - ParentCommandLine
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/process_creation/process_creation_syncappvpublishingserver_execute_arbitrary_powershell.yml
+++ b/rules/windows/process_creation/process_creation_syncappvpublishingserver_execute_arbitrary_powershell.yml
@@ -1,6 +1,6 @@
 title: SyncAppvPublishingServer Execute Arbitrary PowerShell Code
 id: fbd7c32d-db2a-4418-b92c-566eb8911133
-related :
+related:
     id: fde7929d-8beb-4a4c-b922-be9974671667
     type: obsoletes
 status: experimental

--- a/rules/windows/process_creation/process_creation_syncappvpublishingserver_execute_arbitrary_powershell.yml
+++ b/rules/windows/process_creation/process_creation_syncappvpublishingserver_execute_arbitrary_powershell.yml
@@ -1,9 +1,12 @@
 title: SyncAppvPublishingServer Execute Arbitrary PowerShell Code
 id: fbd7c32d-db2a-4418-b92c-566eb8911133
+related :
+    id: fde7929d-8beb-4a4c-b922-be9974671667
+    type: obsoletes
 status: experimental
 author: frack113
 date: 2021/07/12
-description: Executes arbitrary PowerShell code using SyncAppvPublishingServer.exe. Requires Windows 10.
+description: Executes arbitrary PowerShell code using SyncAppvPublishingServer.exe.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218/T1218.md
 tags:
@@ -25,5 +28,5 @@ fields:
     - CommandLine
     - ParentCommandLine
 falsepositives:
-    - Unknown
+    - App-V clients
 level: medium

--- a/rules/windows/process_creation/process_creation_syncappvpublishingserver_execute_arbitrary_powershell.yml
+++ b/rules/windows/process_creation/process_creation_syncappvpublishingserver_execute_arbitrary_powershell.yml
@@ -1,0 +1,29 @@
+title: SyncAppvPublishingServer Execute Arbitrary PowerShell Code
+id: fbd7c32d-db2a-4418-b92c-566eb8911133
+status: experimental
+author: frack113
+date: 2021/07/12
+description: Executes arbitrary PowerShell code using SyncAppvPublishingServer.exe. Requires Windows 10.
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218/T1218.md
+tags:
+    - attack.defense_evasion
+    - attack.t1218
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\SyncAppvPublishingServer.exe'
+        CommandLine|contains|all:
+            - '"n; '
+            - ' Start-Process '
+    condition: selection 
+fields:
+    - ComputerName
+    - User
+    - CommandLine
+    - ParentCommandLine
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/process_creation/sysmon_creation_mavinject_dll.yml
+++ b/rules/windows/process_creation/sysmon_creation_mavinject_dll.yml
@@ -1,0 +1,29 @@
+title: Mavinject Inject DLL Into Running Process
+id: 4f73421b-5a0b-4bbf-a892-5a7fb99bea66
+status: experimental
+author: frack113
+date: 2021/07/12
+description: Injects arbitrary DLL into running process specified by process ID. Requires Windows 10.
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218/T1218.md
+tags:
+    - attack.defense_evasion
+    - attack.t1218
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains|all: 
+            - ' /INJECTRUNNING'
+            - '.dll' # space some time in the end
+        OriginalFileName|contains: mavinject
+    condition: selection 
+fields:
+    - ComputerName
+    - User
+    - CommandLine
+    - ParentCommandLine
+falsepositives:
+    - Unknown
+level: medium


### PR DESCRIPTION
Hi,
I check rule for:
|Tactic|Technique|Technique Name|Test|Test Name|Rule|
|---|---|---|---|---|---|
|defense-evasion|T1218|Signed Binary Proxy Execution|1|mavinject - Inject DLL into running process|add|
|defense-evasion|T1218|Signed Binary Proxy Execution|2|SyncAppvPublishingServer - Execute arbitrary PowerShell code|new one|
|defense-evasion|T1218|Signed Binary Proxy Execution|3|Register-CimProvider - Execute evil dll|-|
|defense-evasion|T1218|Signed Binary Proxy Execution|4|InfDefaultInstall.exe .inf Execution|add

for SyncAppvPublishingServer  think to remove the `win_syncappvpublishingserver_exe.yml`