### PR TITLE
Remove Field Value Wildcard in ALA Backend

### DIFF
--- a/tools/sigma/backends/ala.py
+++ b/tools/sigma/backends/ala.py
@@ -124,7 +124,7 @@ class AzureLogAnalyticsBackend(SingleTextQueryBackend):
                 elif val.endswith("*"):
                     op = "startswith"
                 val = re.sub('([".^$]|(?![*?]))', '\g<1>', val)
-                val = re.sub('(\\\\\*|\*)', '.*', val)
+                val = re.sub('(\\\\\*|\*)', '', val)
                 val = re.sub('\\?', '.', val)
                 if "\\" in val:
                     return "%s @'%s'" % (op, self.cleanValue(val))


### PR DESCRIPTION
When using the contains modifier on sigma, the ala backend converts it to `where field contains ".*keyword.*"`, which causes it not to match the desired events.

The contains, startswith and endswith keyword on ala seems to exclude the need of using these kind of wildcards.