### PR TITLE
Fix match for wildcard after backslash

### DIFF
--- a/rules/windows/builtin/win_net_use_admin_share.yml
+++ b/rules/windows/builtin/win_net_use_admin_share.yml
@@ -20,7 +20,7 @@ detection:
             - '\net1.exe'
         CommandLine|contains|all:
             - ' use '
-            - '\\\*\\*$' # (Specs) If some wildcard after a backslash should be searched, the backslash has to be escaped: \\*
+            - '\\\\*\\*$' # (Specs) If some wildcard after a backslash should be searched, the backslash has to be escaped: \\*
     condition: selection
 falsepositives:
     - Administrators


### PR DESCRIPTION
Based on [the reference](https://drive.google.com/file/d/1lKya3_mLnR3UQuCoiYruO3qgu052_iS_/view) (see the slide with title: _Hunting - search for usage of net tool for mounting remote admin share_), I believe line 23 of this rule is intended to look for stuff like `\\10.10.10.10\C$`. Therefore, I think the first `*` should not be taken literally while the `?` at the end should be.