### PR TITLE
Update winlogbeat-modules-enabled.yml

### DIFF
--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -106,7 +106,7 @@ defaultindex: winlogbeat-*
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: winlog.event_data.\1/g'
 # Keep EventID! Clean up the list afterwards!
 fieldmappings:
-    EventID: winlog.event_id
+    EventID: event.code
     AccessMask: winlog.event_data.AccessMask
     AccountName: winlog.event_data.AccountName
     AllowedToDelegateTo: winlog.event_data.AllowedToDelegateTo
@@ -189,7 +189,7 @@ fieldmappings:
     SubjectUserSid: user.id
     TargetFilename: file.path
     TargetImage: winlog.event_data.TargetImage
-    TargetObject: winlog.event_data.TargetObject
+    TargetObject: registry.path
     TicketEncryptionType: winlog.event_data.TicketEncryptionType
     TicketOptions: winlog.event_data.TicketOptions
     TargetDomainName: user.domain


### PR DESCRIPTION
Update mapping for `EventID` and `TargetObject`.

Reference for `event.code` and `registry.path`: https://www.elastic.co/guide/en/beats/winlogbeat/current/exported-fields-ecs.html