### PR TITLE
[OSCD] sysmon_netcat_execution.yml T1095

### DIFF
--- a/rules/windows/process_creation/sysmon_netcat_execution.yml
+++ b/rules/windows/process_creation/sysmon_netcat_execution.yml
@@ -28,4 +28,4 @@ detection:
     condition: selection or selection_cmdline
 falsepositives:
     - Legitimate ncat use
-level: medium
+level: high

--- a/rules/windows/process_creation/sysmon_netcat_execution.yml
+++ b/rules/windows/process_creation/sysmon_netcat_execution.yml
@@ -1,0 +1,24 @@
+title: Ncat Execution
+id: e31033fc-33f0-4020-9a16-faf9b31cbf08
+status: experimental
+author: frack113
+date: 2021/07/21
+description: Adversaries may use a non-application layer protocol for communication between host and C2 server or among infected hosts within a network
+references:
+    - https://nmap.org/ncat/   
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1095/T1095.md
+tags:
+    - attack.command_and_control
+    - attack.t1095
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        # can not use OriginalFileName as is empty
+        Image|endswith:
+            - '\ncat.exe'
+    condition: selection 
+falsepositives:
+    - Legitimate ncat use
+level: medium

--- a/rules/windows/process_creation/sysmon_netcat_execution.yml
+++ b/rules/windows/process_creation/sysmon_netcat_execution.yml
@@ -18,7 +18,14 @@ detection:
         # can not use OriginalFileName as is empty
         Image|endswith:
             - '\ncat.exe'
-    condition: selection 
+    selection_cmdline:
+        # Typical command lines
+        CommandLine|contains:
+            - ' -lvp '
+            - ' -l --proxy-type http '
+            - ' --exec cmd.exe '
+            - ' -vnl --exec '
+    condition: selection or selection_cmdline
 falsepositives:
     - Legitimate ncat use
 level: medium


### PR DESCRIPTION
Hi,
Check use of [ncat.exe](https://nmap.org/ncat/).
I can not use OriginalFileName as is empty so it is easy to bypass the detection.😔
```
Ncat is a feature-packed networking utility which reads and writes data across networks from the command line.
Ncat was written for the Nmap Project as a much-improved reimplementation of the venerable Netcat.
It uses both TCP and UDP for communication and is designed to be a reliable back-end tool to instantly provide network connectivity to other applications and users.
Ncat will not only work with IPv4 and IPv6 but provides the user with a virtually limitless number of potential uses
```
Test 8  of #1013