### PR TITLE
Update date and modified test

### DIFF
--- a/rules/windows/builtin/win_susp_sdelete.yml
+++ b/rules/windows/builtin/win_susp_sdelete.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects renaming of file while deletion with SDelete tool.
 author: Thomas Patzke
 date: 2017/06/14
-modified: 2020/08/2
+modified: 2020/08/02
 references:
     - https://jpcertcc.github.io/ToolAnalysisResultSheet/details/sdelete.htm
     - https://www.jpcert.or.jp/english/pub/sr/ir_research.html

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -277,12 +277,30 @@ class TestRules(unittest.TestCase):
             if not datefield:
                 print(Fore.YELLOW + "Rule {} has no field 'date'.".format(file))
                 faulty_rules.append(file)
+            elif not isinstance(datefield, str):
+                print(Fore.YELLOW + "Rule {} has a malformed 'date' (should be YYYY/MM/DD).".format(file))
+                faulty_rules.append(file)                
             elif len(datefield) != 10:
                 print(Fore.YELLOW + "Rule {} has a malformed 'date' (not 10 chars, should be YYYY/MM/DD).".format(file))
                 faulty_rules.append(file)                
 
         self.assertEqual(faulty_rules, [], Fore.RED +
                          "There are rules with missing or malformed 'date' fields. (create one, e.g. date: 2019/01/14)")
+
+    def test_date_modified(self):
+        faulty_rules = []
+        for file in self.yield_next_rule_file_path(self.path_to_rules):
+            modifiedfield = self.get_rule_part(file_path=file, part_name="modified")
+            if modifiedfield:
+                if not isinstance(modifiedfield, str):
+                    print(Fore.YELLOW + "Rule {} has a malformed 'modified' (should be YYYY/MM/DD).".format(file))
+                    faulty_rules.append(file)                
+                elif len(modifiedfield) != 10:
+                    print(Fore.YELLOW + "Rule {} has a malformed 'modified' (not 10 chars, should be YYYY/MM/DD).".format(file))
+                    faulty_rules.append(file)                
+
+        self.assertEqual(faulty_rules, [], Fore.RED +
+                         "There are rules with malformed 'modified' fields. (create one, e.g. date: 2019/01/14)")
 
     def test_references(self):
         faulty_rules = []


### PR DESCRIPTION
Hi,
In tests/test_rules.py add: 

- check if  `modified` is good
- check if `date` and  `modified` are string  (for 2021-07-21 get a data type error for len() )

And of course fix `modified` in rules/windows/builtin/win_susp_sdelete.yml  :smile:

Test on Unbuntu 20.04
![image](https://user-images.githubusercontent.com/62423083/126592188-8660a934-5c92-4e34-af26-dd0170941cf0.png)
