### PR TITLE
cover evasions from unicode substitutions

### DIFF
--- a/rules/windows/process_creation/win_grabbing_sensitive_hives_via_reg.yml
+++ b/rules/windows/process_creation/win_grabbing_sensitive_hives_via_reg.yml
@@ -7,6 +7,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
     - https://eqllib.readthedocs.io/en/latest/analytics/aed95fc6-5e3f-49dc-8b35-06508613f979.html
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1003/T1003.md
+    - https://www.wietzebeukema.nl/blog/windows-command-line-obfuscation
 tags:
     - attack.credential_access
     - attack.t1003.002
@@ -23,15 +24,25 @@ detection:
         CommandLine|contains:
             - 'save'
             - 'export'
+            - 'ˢave'
+            - 'eˣport'
     selection_2:
         CommandLine|contains:
             - 'hklm'
             - 'hkey_local_machine'
+            - 'hkey_˪ocal_machine'
+            - 'hkey_loca˪_machine'
+            - 'hkey_˪oca˪_machine'
     selection_3:
         CommandLine|endswith:
             - '\system'
             - '\sam'
             - '\security'
+            - '\ˢystem'
+            - '\syˢtem'
+            - '\ˢyˢtem'
+            - '\ˢam'
+            - '\ˢecurity'
     condition: selection_1 and selection_2 and selection_3
 falsepositives:
     - Dumping hives for legitimate purpouse i.e. backup or forensic investigation

--- a/rules/windows/process_creation/win_grabbing_sensitive_hives_via_reg.yml
+++ b/rules/windows/process_creation/win_grabbing_sensitive_hives_via_reg.yml
@@ -29,6 +29,7 @@ detection:
     selection_2:
         CommandLine|contains:
             - 'hklm'
+            - 'hk˪m'
             - 'hkey_local_machine'
             - 'hkey_˪ocal_machine'
             - 'hkey_loca˪_machine'


### PR DESCRIPTION
Add variations to cover unicode substitutions to avoid evasion.

> Unicode contains a range for Spacing Modifier Letters (0x02B0 - 0x02FF) [4], which includes characters such as ˪, ˣ and ˢ. Some command-line parsers recognise these as letters and convert them back to l, x and s respectively. 

See (https://www.wietzebeukema.nl/blog/windows-command-line-obfuscation) by @Wietze