### PR TITLE
Fixing exception caused by incorrect type of passed 'path' parameter

### DIFF
--- a/tools/sigma/config/collection.py
+++ b/tools/sigma/config/collection.py
@@ -51,7 +51,7 @@ class SigmaConfigurationManager(object):
                         if path.exists()
                     ]
         elif isinstance(paths, Iterable) and all([type(path) is str for path in paths]):
-            self.paths = paths
+            self.paths = [Path(path) for path in paths]
         else:
             raise TypeError("None or iterable of strings expected as paths")
 


### PR DESCRIPTION
`self.paths` is supposed to be an iterable of `Path` objects, if you pass it using the `path=` parameter it can only be an iterable of strings (see line 53).

This patch converts the list of strings to Path objects to fix the issue and maximise backwards compatibility. 