### PR TITLE
[CarbonBlack EEDR] Several updates to config file

### DIFF
--- a/tools/config/carbon-black-eedr.yml
+++ b/tools/config/carbon-black-eedr.yml
@@ -16,68 +16,56 @@ fieldmappings:
     - process_product_version
     - process_publisher
     - process_file_description
-  DestPort:
-    - netconn_port
-    - netconn_remote_port
+  DestPort: netconn_port
   Destination:
     - netconn_domain
   DestinationAddress:
     - netconn_domain
     - netconn_ipv4
     - netconn_ipv6
-    - netconn_remote_ipv4
-    - netconn_remote_ipv6
-  DestinationHostname: 
+  DestinationHostname:
     - netconn_domain
     - netconn_proxy_domain
   DestinationIp:
     - netconn_ipv4
     - netconn_ipv6
-    - netconn_remote_ipv4
-    - netconn_remote_ipv6
-  DestinationPort:
-    - netconn_port
-    - netconn_remote_port
+  DestinationPort: netconn_port
   Device: device_name
   FileName:
-    - process_internal_name
     - process_name
     - process_original_filename
   FileVersion: process_product_version
   Image:
     - process_name
-    - process_internal_name
   IntegrityLevel: process_integrity_level
   IpAddress:
     - netconn_ipv4
     - netconn_ipv6
     - netconn_local_ipv4
     - netconn_local_ipv6
-    - netconn_remote_ipv4
-    - netconn_remote_ipv6
   LogonId:
     - childproc_username
     - process_username
   md5: hash
-  NewName: regmod_new_name
+  NewName: regmod_name
   OriginalFileName: process_original_filename
   ParentCommandLine: parent_cmdline
   ParentImage: parent_name
   ParentIntegrityLevel: process_integrity_level
   ProcessCommandLine: process_cmdline
   ProcessName: process_name
-  Product: 
+  Product:
     - process_product_name
     - process_file_description
   RelativeTargetName: childproc_name
-  ScriptBlockText: 
+  ScriptBlockText:
     - childproc_cmdline
     - crossproc_cmdline
     - process_cmdline
   ServiceFileName: process_service_name
   ServiceName: process_service_name
   sha256: hash
-  Signature: 
+  Signature:
     - childproc_publisher
     - filemod_publisher
     - modload_publisher
@@ -98,27 +86,17 @@ fieldmappings:
     - netconn_local_port
     - netconn_port
   SourceWorkstation: device_name
-  TargetFilename: 
-    - filemod_name
-    - crossproc_name
-  TargetImage:
-    - filemod_name
-    - crossproc_name
-  TargetName:
-    - filemod_name
-    - crossproc_name
+  TargetFilename: filemod_name
+  TargetImage: filemod_name
+  TargetName: filemod_name
   TargetUserName:
     - childproc_username
     - process_username
-  TargetObject: 
-    - regmod_name
-    - regmod_new_name
+  TargetObject: regmod_name
   User:
     - childproc_username
     - process_username
-  Value:
-    - regmod_name
-    - regmod_new_name
+  Value: regmod_name
   Workstation: device_name
   WorkstationName: device_name
 
@@ -127,15 +105,9 @@ fieldmappings:
     - netconn_ipv6
     - netconn_local_ipv4
     - netconn_local_ipv6
-    - netconn_remote_ipv4
-    - netconn_remote_ipv6
-  dst_port:
-    - netconn_port
-    - netconn_remote_port
+  dst_port: netconn_port
   src_ip:
     - netconn_ipv4
     - netconn_ipv6
     - netconn_local_ipv4
     - netconn_local_ipv6
-    - netconn_remote_ipv4
-    - netconn_remote_ipv6


### PR DESCRIPTION
Couple of updates:

| Update | Comment | 
| --- | --- |
| Removed `netconn_remote_*` | Does not exist according to [the docs](https://developer.carbonblack.com/reference/carbon-black-cloud/cb-threathunter/latest/process-search-fields/). |
| Removed `process_internal_name` | Whilst a relevant and interesting field, this is inconsistent with other Sigma backends. <sub>(in my case, it caused FPs on Windows Update processes/files which use random filenames on disk but obviously keep the internal file name)</sub> |
| Renamed `regmod_new_name` | This field doesn't exist according to [the docs](https://developer.carbonblack.com/reference/carbon-black-cloud/cb-threathunter/latest/process-search-fields/), `regmod_name` does. |
| Removed `crossproc_name` | Removed from entries that also look for `filemod_name` as the scope is entirely different. |