### PR TITLE
[CarbonBlack] Adding extra escape character

### DIFF
--- a/tools/sigma/backends/carbonblack.py
+++ b/tools/sigma/backends/carbonblack.py
@@ -81,6 +81,7 @@ class CarbonBlackQueryBackend(CarbonBlackWildcardHandlingMixin, SingleTextQueryB
         '|',
         ';',
         ':',
+        '-'
     ]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
In CarbonBlack EEDR, leading hyphens (e.g. `process_cmdline:-create`) cause syntax errors - presumably because hyphens are also used to negate conditions.

Whilst leading hyphens seem to be accepted in Carbon Black Response, escaping them doesn't impact the query results. If anything, it probably makes the rules more readable. 

E.g.:
| Case | Product | Syntax | Accepted? |
| -- | -- | -- | -- |
|Case 1| **Carbon Black Response**|  `cmdline:hello-world` | ✔ |
|| **Carbon Black Cloud (EEDR)**|  `process_cmdline:hello-world` | ✔ |
|Case 2| **Carbon Black Response**|  `cmdline:-create` | ✔|
|| **Carbon Black Cloud (EEDR)**|  `process_cmdline:-create` | ❌ |
|Case 3| **Carbon Black Response**|  `cmdline:\-create` | ✔|
|| **Carbon Black Cloud (EEDR)**|  `process_cmdline:\-create` | ✔ |

Sigma currently generates 'case 2', this PR replaces the behaviour with 'case 3'. 