### PR TITLE
Fix duplicate output in elastalert Backend

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -300,6 +300,7 @@ class ElasticsearchQuerystringBackend(DeepFieldMappingMixin, ElasticsearchWildca
             return result
         else:
             return super().generateSubexpressionNode(node)
+
 class ElasticsearchQuerystringBackendLogRhythm(DeepFieldMappingMixin, ElasticsearchWildcardHandlingMixin, SingleTextQueryBackend):
     """Converts Sigma rule into Lucene query string for LogRhythm. Only searches, no aggregations."""
     identifier = "es-qs-lr"
@@ -365,8 +366,7 @@ class ElasticsearchQuerystringBackendLogRhythm(DeepFieldMappingMixin, Elasticsea
             return result
         else:
             return super().generateSubexpressionNode(node)
-        
-        
+
 class ElasticsearchEQLBackend(DeepFieldMappingMixin, ElasticsearchWildcardHandlingMixin, SingleTextQueryBackend):
     """Converts Sigma rule into EQL."""
     identifier = "es-eql"
@@ -1370,15 +1370,9 @@ class ElastalertBackend(DeepFieldMappingMixin, MultiRuleOutputMixin):
 
     def finalize(self):
         result = ""
-        rule_lst = []
         for rulename, rule in self.elastalert_alerts.items():
-            filter_data = rule['filter']
-            if filter_data in rule_lst:
-                pass
-            else:
-                result += yaml.dump(rule, default_flow_style=False, width=10000)
-                result += '\n'
-                rule_lst.append(filter_data)
+            result += yaml.dump(rule, default_flow_style=False, width=10000)
+            result += '\n'
         return result
 
 class ElastalertBackendDsl(ElastalertBackend, ElasticsearchDSLBackend):

--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -1370,9 +1370,15 @@ class ElastalertBackend(DeepFieldMappingMixin, MultiRuleOutputMixin):
 
     def finalize(self):
         result = ""
+        rule_lst = []
         for rulename, rule in self.elastalert_alerts.items():
-            result += yaml.dump(rule, default_flow_style=False, width=10000)
-            result += '\n'
+            filter_data = rule['filter']
+            if filter_data in rule_lst:
+                pass
+            else:
+                result += yaml.dump(rule, default_flow_style=False, width=10000)
+                result += '\n'
+                rule_lst.append(filter_data)
         return result
 
 class ElastalertBackendDsl(ElastalertBackend, ElasticsearchDSLBackend):


### PR DESCRIPTION
HI,
Find the bug and fix it.
close #1759

```yaml
C:\FrackSigma\sigma\tools>python sigmac -t elastalert -c .\config\winlogbeat.yml ..\rules\windows\builtin\win_account_backdoor_dcsync_rights.yml
alert:
- debug
description: backdooring domain object to grant the rights associated with DCSync to a regular user or machine account using Powerview\Add-DomainObjectAcl DCSync Extended Right cmdlet, will allow to re-obtain the pwd hashes of any user/computer
filter:
- query:
    query_string:
      query: (winlog.channel:"Security" AND winlog.event_id:"5136" AND winlog.event_data.AttributeLDAPDisplayName:"ntSecurityDescriptor" AND winlog.event_data.AttributeValue.keyword:(*1131f6ad\-9c07\-11d1\-f79f\-00c04fc2dcd2* OR *1131f6aa\-9c07\-11d1\-f79f\-00c04fc2dcd2* OR *89e95b76\-444d\-4c62\-991a\-0facbeda640c*))
index: winlogbeat-*
name: 2c99737c-585d-4431-b61a-c911d86ff32f-Powerview-Add-DomainObjectAcl-DCSync-AD-Extend-Right
priority: 1
realert:
  minutes: 0
type: any
```
`python sigmac -t elastalert -c .\config\winlogbeat.yml ..\rules\windows\builtin\win_account_backdoor_dcsync_rights.yml -o frack_ -e yml`
frack_win_account_backdoor_dcsync_rights.yml : 
```yaml
alert:
- debug
description: backdooring domain object to grant the rights associated with DCSync to a regular user or machine account using Powerview\Add-DomainObjectAcl DCSync Extended Right cmdlet, will allow to re-obtain the pwd hashes of any user/computer
filter:
- query:
    query_string:
      query: (winlog.channel:"Security" AND winlog.event_id:"5136" AND winlog.event_data.AttributeLDAPDisplayName:"ntSecurityDescriptor" AND winlog.event_data.AttributeValue.keyword:(*1131f6ad\-9c07\-11d1\-f79f\-00c04fc2dcd2* OR *1131f6aa\-9c07\-11d1\-f79f\-00c04fc2dcd2* OR *89e95b76\-444d\-4c62\-991a\-0facbeda640c*))
index: winlogbeat-*
name: 2c99737c-585d-4431-b61a-c911d86ff32f-Powerview-Add-DomainObjectAcl-DCSync-AD-Extend-Right
priority: 1
realert:
  minutes: 0
type: any
```