### PR TITLE
Clean-up Powershell EventID 4104

### DIFF
--- a/rules/windows/powershell/powershell_CL_Invocation_LOLScript.yml
+++ b/rules/windows/powershell/powershell_CL_Invocation_LOLScript.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection:
         EventID: 4104

--- a/rules/windows/powershell/powershell_CL_Invocation_LOLScript_v2.yml
+++ b/rules/windows/powershell/powershell_CL_Invocation_LOLScript_v2.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection2:
         EventID: 4104

--- a/rules/windows/powershell/powershell_CL_Mutexverifiers_LOLScript.yml
+++ b/rules/windows/powershell/powershell_CL_Mutexverifiers_LOLScript.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection:
         EventID: 4104

--- a/rules/windows/powershell/powershell_CL_Mutexverifiers_LOLScript_v2.yml
+++ b/rules/windows/powershell/powershell_CL_Mutexverifiers_LOLScript_v2.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection2:
         EventID: 4104

--- a/rules/windows/powershell/powershell_accessing_win_api.yml
+++ b/rules/windows/powershell/powershell_accessing_win_api.yml
@@ -4,6 +4,7 @@ status: experimental
 description: Detecting use WinAPI Functions in PowerShell
 author: Nikita Nazarov, oscd.community
 date: 2020/10/06
+modified: 2021/08/04
 references:
     - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse
 tags:
@@ -13,11 +14,11 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection:
-        EventID:
-            - 4104
-        Message|contains:
+        EventID: 4104
+        ScriptBlockText|contains:
             - 'WaitForSingleObject'
             - 'QueueUserApc'
             - 'RtlCreateUserThread'

--- a/rules/windows/powershell/powershell_automated_collection.yml
+++ b/rules/windows/powershell/powershell_automated_collection.yml
@@ -32,7 +32,6 @@ detection:
             - 'Get-ChildItem'
             - ' -Recurse '
             - ' -Include '
-
     condition: all of them
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_clear_powershell_history.yml
+++ b/rules/windows/powershell/powershell_clear_powershell_history.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_create_local_user.yml
+++ b/rules/windows/powershell/powershell_create_local_user.yml
@@ -13,15 +13,15 @@ tags:
     - attack.t1136  # an old one    
 author: '@ROxPinTeddy'
 date: 2020/04/11
-modified: 2020/08/24
+modified: 2021/08/04
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection:
         EventID: 4104
-        Message|contains:
-            - 'New-LocalUser'
+        ScriptBlockText|contains: 'New-LocalUser'
     condition: selection
 falsepositives:
     - Legitimate user creation

--- a/rules/windows/powershell/powershell_decompress_commands.yml
+++ b/rules/windows/powershell/powershell_decompress_commands.yml
@@ -13,6 +13,7 @@ references:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_dnscat_execution.yml
+++ b/rules/windows/powershell/powershell_dnscat_execution.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection:
         EventID: 4104

--- a/rules/windows/powershell/powershell_get_clipboard.yml
+++ b/rules/windows/powershell/powershell_get_clipboard.yml
@@ -13,6 +13,7 @@ references:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_icmp_exfiltration.yml
+++ b/rules/windows/powershell/powershell_icmp_exfiltration.yml
@@ -12,6 +12,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_clip+.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_clip+.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_obfuscated_iex.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_obfuscated_iex.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_stdin+.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_stdin+.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_var+.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_var+.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_compress.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_compress.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_rundll.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_rundll.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_stdin.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_stdin.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_use_clip.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_use_clip.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_use_mhsta.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_use_mhsta.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_use_rundll32.yml
@@ -14,6 +14,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_invoke_obfuscation_via_var++.yml
+++ b/rules/windows/powershell/powershell_invoke_obfuscation_via_var++.yml
@@ -15,6 +15,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection_1:
         EventID: 4104

--- a/rules/windows/powershell/powershell_prompt_credentials.yml
+++ b/rules/windows/powershell/powershell_prompt_credentials.yml
@@ -12,6 +12,7 @@ tags:
     - attack.t1086  # an old one
 author: John Lambert (idea), Florian Roth (rule)
 date: 2017/04/09
+modified: 2021/08/04
 logsource:
     product: windows
     service: powershell
@@ -20,8 +21,7 @@ detection:
     selection:
         EventID: 4104
     keyword:
-        Message|contains:
-            - 'PromptForCredential'
+        ScriptBlockText|contains: 'PromptForCredential'
     condition: all of them
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_suspicious_export_pfxcertificate.yml
+++ b/rules/windows/powershell/powershell_suspicious_export_pfxcertificate.yml
@@ -10,6 +10,7 @@ tags:
     - attack.t1552.004
 author: Florian Roth
 date: 2021/04/23
+modified: 2021/08/04
 logsource:
     product: windows
     service: powershell
@@ -17,8 +18,7 @@ logsource:
 detection:
     keywords:
         EventID: 4104
-        ScriptBlockText|contains:
-            - "Export-PfxCertificate"
+        ScriptBlockText|contains: "Export-PfxCertificate"
     condition: keywords
 falsepositives:
     - Legitimate certificate exports invoked by administrators or users (depends on processes in the environment - filter if unusable)

--- a/rules/windows/powershell/powershell_suspicious_getprocess_lsass.yml
+++ b/rules/windows/powershell/powershell_suspicious_getprocess_lsass.yml
@@ -9,6 +9,7 @@ tags:
     - attack.t1003.001
 author: Florian Roth
 date: 2021/04/23
+modified: 2021/08/04
 logsource:
     product: windows
     service: powershell
@@ -16,8 +17,7 @@ logsource:
 detection:
     keywords:
         EventID: 4104
-        ScriptBlockText|contains:
-            - 'Get-Process lsass'
+        ScriptBlockText|contains: 'Get-Process lsass'
     condition: keywords
 falsepositives:
     - Legitimate certificate exports invoked by administrators or users (depends on processes in the environment - filter if unusable)

--- a/rules/windows/powershell/powershell_suspicious_mounted_share_deletion.yml
+++ b/rules/windows/powershell/powershell_suspicious_mounted_share_deletion.yml
@@ -12,6 +12,7 @@ tags:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection:
         EventID: 4104

--- a/rules/windows/powershell/win_powershell_web_request.yml
+++ b/rules/windows/powershell/win_powershell_web_request.yml
@@ -35,6 +35,7 @@ detection:
 logsource:
     product: windows
     service: powershell
+    definition: 'Script block logging must be enabled'
 detection:
     selection:
         EventID: 4104


### PR DESCRIPTION
Hi,
For PowerShell EventID 4104 :

1. Add `definition: 'Script block logging must be enabled'` if missing
2. `ScriptBlockText` is the correct field name
3. Remove list with only 1 value ( exclude filter)