### PR TITLE
Fix elastalert multi output file

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -1321,6 +1321,7 @@ class ElastalertBackend(DeepFieldMappingMixin, MultiRuleOutputMixin):
             self.elastalert_alerts[rule_object['name']] = rule_object
             #Clear fields
             self.fields = []
+            return str(yaml.dump(rule_object, default_flow_style=False, width=10000))
 
     def generateNode(self, node):
         #Save fields for adding them in query_key
@@ -1369,11 +1370,12 @@ class ElastalertBackend(DeepFieldMappingMixin, MultiRuleOutputMixin):
         }.get(level, 2)
 
     def finalize(self):
-        result = ""
-        for rulename, rule in self.elastalert_alerts.items():
-            result += yaml.dump(rule, default_flow_style=False, width=10000)
-            result += '\n'
-        return result
+        pass
+        # result = ""
+        # for rulename, rule in self.elastalert_alerts.items():
+            # result += yaml.dump(rule, default_flow_style=False, width=10000)
+            # result += '\n'
+        # return result
 
 class ElastalertBackendDsl(ElastalertBackend, ElasticsearchDSLBackend):
     """Elastalert backend"""

--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -277,7 +277,7 @@ def main():
             if nb_result == 0: # backend get only 1 output
                 if not fileprefix == None: # want a prefix anyway
                     try:
-                        filename = "%s%s_nono_output%s" % (fileprefix,cmdargs.target,filename_ext)
+                        filename = "%s%s_mono_output%s" % (fileprefix,cmdargs.target,filename_ext)
                         out = open(filename, "w", encoding='utf-8')
                         fileprefix = None  # no need to open the same file many time
                     except (IOError, OSError) as e:

--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -252,7 +252,6 @@ def main():
             
             nb_result = len(list(copy.deepcopy(results)))
             inc_filenane = None if nb_result < 2 else 0
-
             
             newline_separator = '\0' if cmdargs.print0 else '\n'
             for result in results:
@@ -275,21 +274,12 @@ def main():
                         exit(ERR_OUTPUT)
                 print(result, file=out, end=newline_separator)
             
-            if nb_result == 0: # elastalert return "results=[]" so get a error with out not def
-                if not fileprefix == None and not inc_filenane == None: #yml action
+            if nb_result == 0: # backend get only 1 output
+                if not fileprefix == None: # want a prefix anyway
                     try:
-                        filename = fileprefix + str(sigmafile.name)
-                        filename = filename.replace('.yml','_' + str(inc_filenane) + filename_ext)
-                        inc_filenane += 1
+                        filename = "%s%s_nono_output%s" % (fileprefix,cmdargs.target,filename_ext)
                         out = open(filename, "w", encoding='utf-8')
-                    except (IOError, OSError) as e:
-                        print("Failed to open output file '%s': %s" % (filename, str(e)), file=sys.stderr)
-                        exit(ERR_OUTPUT)
-                elif  not fileprefix == None and inc_filenane == None: # a simple yml
-                    try:
-                        filename = fileprefix + str(sigmafile.name)
-                        filename = filename.replace('.yml',filename_ext) 
-                        out = open(filename, "w", encoding='utf-8')
+                        fileprefix = None  # no need to open the same file many time
                     except (IOError, OSError) as e:
                         print("Failed to open output file '%s': %s" % (filename, str(e)), file=sys.stderr)
                         exit(ERR_OUTPUT) 


### PR DESCRIPTION
Hi,
to satisfy my co-workers fix the multi output file for elastalert.
Test with recursive option
```yaml
python sigmac -t elastalert -c .\config\generic\sysmon.yml -rI ..\rules\windows\sysmon
```
get all the alert in the screen 👍 

```winbatch
python sigmac -t elastalert -c .\config\generic\sysmon.yml -rI ..\rules\windows\sysmon -o bigfile.txt
```
get bigfile.txt with 14 alerts 👍 

```winbatch
python sigmac -t elastalert -c .\config\generic\sysmon.yml -rI ..\rules\windows\sysmon -o elast_
```
get 14 files with 1 alert / file 👍 

```winbatch
python sigmac -t kibana -c .\config\generic\sysmon.yml -rI ..\rules\windows\sysmon -o kiban_
```
As kibana backend produce only 1 file get `kiban_kibana_mono_output.rule`
If the backend do not support multi output get only 1 file : 
prefix  + backend name + '_mono_ouput' +extention (.rule if missing)

If you think about other tests I will validate the result