### PR TITLE
Update Mapping Winlogbeat modules enabled

### DIFF
--- a/rules/windows/other/win_defender_amsi_trigger.yml
+++ b/rules/windows/other/win_defender_amsi_trigger.yml
@@ -2,6 +2,7 @@ title: Windows Defender AMSI Trigger Detected
 id: ea9bf0fa-edec-4fb8-8b78-b119f2528186
 description: Detects triggering of AMSI by Windows Defender.
 date: 2020/09/14
+modified: 2021/08/06
 author: Bhabesh Raj
 references:
     - https://docs.microsoft.com/en-us/windows/win32/amsi/how-amsi-helps
@@ -12,7 +13,7 @@ logsource:
 detection:
     selection:
         EventID: 1116
-        DetectionSource: 'AMSI'
+        Source Name: 'AMSI'
     condition: selection
 falsepositives:
     - unlikely

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -116,7 +116,6 @@ fieldmappings:
     FailureCode: winlog.event_data.FailureCode
     FileName: file.path
     HiveName: winlog.event_data.HiveName
-    Path: winlog.event_data.Path
     ProcessCommandLine: winlog.event_data.ProcessCommandLine
     SecurityID: winlog.event_data.SecurityID
     Source: winlog.event_data.Source
@@ -506,3 +505,43 @@ fieldmappings:
     SourceLine: winlog.event_data.SourceLine
     SourceTag: winlog.event_data.SourceTag
     CallStack: winlog.event_data.CallStack
+    #
+    # Microsoft-Windows-Windows Defender/Operational
+    #
+    Action ID: winlog.event_data.Action ID
+    Action Name: winlog.event_data.Action Name
+    Additional Actions ID: winlog.event_data.Additional Actions ID
+    Additional Actions String: winlog.event_data.Additional Actions String
+    Category ID: winlog.event_data.Category ID
+    Category Name: winlog.event_data.Category Name
+    Detection ID: winlog.event_data.Detection ID
+    Detection Time: winlog.event_data.Detection Time
+    Detection User: winlog.event_data.Detection User
+    Engine Version: winlog.event_data.Engine Version
+    Error Code: winlog.event_data.Error Code
+    Error Description: winlog.event_data.Error Description
+    Execution ID: winlog.event_data.Execution ID
+    Execution Name: winlog.event_data.Execution Name
+    FWLink: winlog.event_data.FWLink
+    New Value: winlog.event_data.New Value
+    Old Value: winlog.event_data.Old Value
+    Origin ID: winlog.event_data.Origin ID
+    Origin Name: winlog.event_data.Origin Name
+    Path: winlog.event_data.Path
+    Post Clean Status: winlog.event_data.Post Clean Status
+    Pre Execution Status: winlog.event_data.Pre Execution Status
+    Process Name: winlog.event_data.Process Name
+    Product Name: winlog.event_data.Product Name
+    Product Version: winlog.event_data.Product Version
+    Remediation User: winlog.event_data.Remediation User
+    Security intelligence Version: winlog.event_data.Security intelligence Version
+    Severity ID: winlog.event_data.Severity ID
+    Severity Name: winlog.event_data.Severity Name
+    Source ID: winlog.event_data.Source ID
+    Source Name: winlog.event_data.Source Name
+    Status Code: winlog.event_data.Status Code
+    Status Description: winlog.event_data.Status Description
+    Threat ID: winlog.event_data.Threat ID
+    Threat Name: winlog.event_data.Threat Name
+    Type ID: winlog.event_data.Type ID
+    Type Name: winlog.event_data.Type Name

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -508,40 +508,40 @@ fieldmappings:
     #
     # Microsoft-Windows-Windows Defender/Operational
     #
-    Action ID: winlog.event_data.Action ID
-    Action Name: winlog.event_data.Action Name
-    Additional Actions ID: winlog.event_data.Additional Actions ID
-    Additional Actions String: winlog.event_data.Additional Actions String
-    Category ID: winlog.event_data.Category ID
-    Category Name: winlog.event_data.Category Name
-    Detection ID: winlog.event_data.Detection ID
-    Detection Time: winlog.event_data.Detection Time
-    Detection User: winlog.event_data.Detection User
-    Engine Version: winlog.event_data.Engine Version
-    Error Code: winlog.event_data.Error Code
-    Error Description: winlog.event_data.Error Description
-    Execution ID: winlog.event_data.Execution ID
-    Execution Name: winlog.event_data.Execution Name
+    Action ID: winlog.event_data.Action\ ID
+    Action Name: winlog.event_data.Action\ Name
+    Additional Actions ID: winlog.event_data.Additional\ Actions\ ID
+    Additional Actions String: winlog.event_data.Additional\ Actions\ String
+    Category ID: winlog.event_data.Category\ ID
+    Category Name: winlog.event_data.Category\ Name
+    Detection ID: winlog.event_data.Detection\ ID
+    Detection Time: winlog.event_data.Detection\ Time
+    Detection User: winlog.event_data.Detection\ User
+    Engine Version: winlog.event_data.Engine\ Version
+    Error Code: winlog.event_data.Error\ Code
+    Error Description: winlog.event_data.Error\ Description
+    Execution ID: winlog.event_data.Execution\ ID
+    Execution Name: winlog.event_data.Execution\ Name
     FWLink: winlog.event_data.FWLink
-    New Value: winlog.event_data.New Value
-    Old Value: winlog.event_data.Old Value
-    Origin ID: winlog.event_data.Origin ID
-    Origin Name: winlog.event_data.Origin Name
+    New Value: winlog.event_data.New\ Value
+    Old Value: winlog.event_data.Old\ Value
+    Origin ID: winlog.event_data.Origin\ ID
+    Origin Name: winlog.event_data.Origin\ Name
     Path: winlog.event_data.Path
-    Post Clean Status: winlog.event_data.Post Clean Status
-    Pre Execution Status: winlog.event_data.Pre Execution Status
-    Process Name: winlog.event_data.Process Name
-    Product Name: winlog.event_data.Product Name
-    Product Version: winlog.event_data.Product Version
-    Remediation User: winlog.event_data.Remediation User
-    Security intelligence Version: winlog.event_data.Security intelligence Version
-    Severity ID: winlog.event_data.Severity ID
-    Severity Name: winlog.event_data.Severity Name
-    Source ID: winlog.event_data.Source ID
-    Source Name: winlog.event_data.Source Name
-    Status Code: winlog.event_data.Status Code
-    Status Description: winlog.event_data.Status Description
-    Threat ID: winlog.event_data.Threat ID
-    Threat Name: winlog.event_data.Threat Name
-    Type ID: winlog.event_data.Type ID
-    Type Name: winlog.event_data.Type Name
+    Post Clean Status: winlog.event_data.Post\ Clean\ Status
+    Pre Execution Status: winlog.event_data.Pre\ Execution\ Status
+    Process Name: winlog.event_data.Process\ Name
+    Product Name: winlog.event_data.Product\ Name
+    Product Version: winlog.event_data.Product\ Version
+    Remediation User: winlog.event_data.Remediation\ User
+    Security intelligence Version: winlog.event_data.Security\ intelligence\ Version
+    Severity ID: winlog.event_data.Severity\ ID
+    Severity Name: winlog.event_data.Severity\ Name
+    Source ID: winlog.event_data.Source\ ID
+    Source Name: winlog.event_data.Source\ Name
+    Status Code: winlog.event_data.Status\ Code
+    Status Description: winlog.event_data.Status\ Description
+    Threat ID: winlog.event_data.Threat\ ID
+    Threat Name: winlog.event_data.Threat\ Name
+    Type ID: winlog.event_data.Type\ ID
+    Type Name: winlog.event_data.Type\ Name

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -108,6 +108,8 @@ defaultindex: winlogbeat-*
 fieldmappings:
     EventID: event.code
     Channel: winlog.channel
+    #Keywords: from "<System><Keywords>Value</Keywords></System><EventData>" is lost with winlogbeat exist in nxlog
+    provider name: winlog.provider_name
     CallingProcessName: winlog.event_data.CallingProcessName
     ComputerName: winlog.ComputerName
     EventType: winlog.event_data.EventType
@@ -135,8 +137,6 @@ fieldmappings:
     ClassName: winlog.event_data.ClassName
     ClassId: winlog.event_data.ClassId
     DeviceDescription: winlog.event_data.DeviceDescription
-    # DeviceName =>  Microsoft-Windows-Ntfs  EventID: 98
-    DeviceName: winlog.event_data.DeviceName
     # ErrorCode =>  printservice-admin  EventID: 4909 or 808
     ErrorCode: winlog.event_data.ErrorCode 
     FilePath: winlog.event_data.FilePath
@@ -211,7 +211,10 @@ fieldmappings:
     SchemaVersion: winlog.event_data.SchemaVersion
     ImageLoaded: file.path
     Signed: file.code_signature.signed
-    Signature: file.code_signature.subject_name
+    Signature: 
+        category=driver_loaded: file.code_signature.subject_name
+        category=image_loaded: file.code_signature.subject_name
+        default: winlog.event_data.Signature
     SignatureStatus: file.code_signature.status
     SourceProcessGuid: process.entity_id
     SourceProcessId: process.pid
@@ -487,3 +490,19 @@ fieldmappings:
     VirtualAccount: winlog.event_data.VirtualAccount
     Workstation: winlog.event_data.Workstation
     WorkstationName: source.domain
+    #
+    # System
+    #
+    DriveName: winlog.event_data.DriveName
+    DeviceName: winlog.event_data.DeviceName
+    HeaderFlags: winlog.event_data.HeaderFlags
+    Severity: winlog.event_data.Severity
+    Origin: winlog.event_data.Origin
+    Verb: winlog.event_data.Verb
+    Outcome: winlog.event_data.Outcome
+    SampleLength: winlog.event_data.SampleLength
+    SampleData: winlog.event_data.SampleData
+    SourceFile: winlog.event_data.SourceFile
+    SourceLine: winlog.event_data.SourceLine
+    SourceTag: winlog.event_data.SourceTag
+    CallStack: winlog.event_data.CallStack


### PR DESCRIPTION
Hi 
add mising System and Microsoft-Windows-Windows Defender/Operational field.

Fix win_defender_amsi_trigger.yml with the correct field name (check with the xml event on windows 10).

Windows Defense use space in field name and winlogbeat keep it.
find the trick so now: 
```cmd
python sigmac -t es-qs -c .\config\generic\sysmon.yml -c .\config\winlogbeat-modules-enabled.yml C:\FrackSigma\sigma\rules\windows\other\win_defender_amsi_trigger.yml
(winlog.channel:"Microsoft\-Windows\-Windows\ Defender\/Operational" AND event.code:"1116" AND winlog.event_data.Source\ Name:"AMSI")
```
![image](https://user-images.githubusercontent.com/62423083/128902598-ef7bc32a-6ec7-4fbd-8aa6-6cc706e1ffad.png)
