### PR TITLE
Correct lists with only 1 value in cloud rules

### DIFF
--- a/rules/cloud/aws_cloudtrail_disable_logging.yml
+++ b/rules/cloud/aws_cloudtrail_disable_logging.yml
@@ -4,19 +4,19 @@ status: experimental
 description: Detects disabling, deleting and updating of a Trail
 author: vitaliy0x1
 date: 2020/01/21
+modified: 2021/08/09
 references:
     - https://docs.aws.amazon.com/awscloudtrail/latest/userguide/best-practices-security.html
 logsource:
     service: cloudtrail
 detection:
     selection_source:
-        - eventSource: cloudtrail.amazonaws.com
-    events:
-        - eventName:
+        eventSource: cloudtrail.amazonaws.com
+        eventName:
             - StopLogging
             - UpdateTrail
             - DeleteTrail
-    condition: selection_source AND events
+    condition: selection_source
 falsepositives:
     - Valid change in a Trail
 level: medium

--- a/rules/cloud/aws_config_disable_recording.yml
+++ b/rules/cloud/aws_config_disable_recording.yml
@@ -4,16 +4,16 @@ status: experimental
 description: Detects AWS Config Service disabling
 author: vitaliy0x1
 date: 2020/01/21
+modified: 2021/08/09
 logsource:
     service: cloudtrail
 detection:
     selection_source:
-        - eventSource: config.amazonaws.com
-    events:
-        - eventName:
+        eventSource: config.amazonaws.com
+        eventName:
             - DeleteDeliveryChannel
             - StopConfigurationRecorder
-    condition: selection_source AND events
+    condition: selection_source
 falsepositives:
     - Valid change in AWS Config Service
 level: high

--- a/rules/cloud/aws_ec2_disable_encryption.yml
+++ b/rules/cloud/aws_ec2_disable_encryption.yml
@@ -4,6 +4,7 @@ status: stable
 description: Identifies disabling of default Amazon Elastic Block Store (EBS) encryption in the current region. Disabling default encryption does not change the encryption status of your existing volumes.
 author: Sittikorn S
 date: 2021/06/29
+modified: 2021/08/09
 references:
     - https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DisableEbsEncryptionByDefault.html
 tags:
@@ -15,8 +16,7 @@ logsource:
 detection:
     selection:
         eventSource: ec2.amazonaws.com
-        eventName:
-          - DisableEbsEncryptionByDefault
+        eventName: DisableEbsEncryptionByDefault
         status: success
     condition: selection
 falsepositives:

--- a/rules/cloud/aws_ec2_download_userdata.yml
+++ b/rules/cloud/aws_ec2_download_userdata.yml
@@ -4,20 +4,18 @@ status: experimental
 description: Detects bulk downloading of User Data associated with AWS EC2 instances. Instance User Data may include installation scripts and hard-coded secrets for deployment.
 author: faloker
 date: 2020/02/11
-modified: 2020/09/01
+modified: 2021/08/09
 references:
     - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__download_userdata/main.py#L24
 logsource:
     service: cloudtrail
 detection:
     selection_source:
-        - eventSource: ec2.amazonaws.com
-    selection_requesttype:
-        - requestParameters.attribute: userData
-    selection_eventname:
-        - eventName: DescribeInstanceAttribute
+        eventSource: ec2.amazonaws.com
+        requestParameters.attribute: userData
+        eventName: DescribeInstanceAttribute
     timeframe: 30m
-    condition: all of them | count() > 10
+    condition: selection_source | count() > 10
 falsepositives:
     - Assets management software like device42
 level: medium

--- a/rules/cloud/aws_ec2_startup_script_change.yml
+++ b/rules/cloud/aws_ec2_startup_script_change.yml
@@ -4,19 +4,17 @@ status: experimental
 description: Detects changes to the EC2 instance startup script. The shell script will be executed as root/SYSTEM every time the specific instances are booted up.
 author: faloker
 date: 2020/02/12
-modified: 2020/09/01
+modified: 2021/08/09
 references:
     - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__startup_shell_script/main.py#L9
 logsource:
     service: cloudtrail
 detection:
     selection_source:
-        - eventSource: ec2.amazonaws.com
-    selection_userdata:
-        - requestParameters.userData: "*"
-    selection_eventname:
-        - eventName: ModifyInstanceAttribute
-    condition: all of them
+        eventSource: ec2.amazonaws.com
+        requestParameters.userData: "*"
+        eventName: ModifyInstanceAttribute
+    condition: selection_source
 falsepositives:
     - Valid changes to the startup script
 level: high

--- a/rules/cloud/aws_enum_listing.yml
+++ b/rules/cloud/aws_enum_listing.yml
@@ -4,13 +4,14 @@ status: experimental
 description: Detects enumeration of accounts configuration via api call to list different instances and services within a short period of time.  
 author: toffeebr33k
 date: 2020/11/21
+modified: 2021/08/09
 logsource:
     service: cloudtrail
 detection:
     selection_eventname:
-        - eventName: list*
+        eventName: list*
     timeframe: 10m
-    condition: all of them | count() > 50
+    condition: selection_eventname | count() > 50
 fields:
     - userIdentity.arn
 falsepositives:

--- a/rules/cloud/aws_guardduty_disruption.yml
+++ b/rules/cloud/aws_guardduty_disruption.yml
@@ -4,16 +4,16 @@ status: experimental
 description: Detects updates of the GuardDuty list of trusted IPs, perhaps to disable security alerts against malicious IPs.
 author: faloker
 date: 2020/02/11
+modified: 2021/08/09
 references:
     - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/guardduty__whitelist_ip/main.py#L9
 logsource:
     service: cloudtrail
 detection:
     selection_source:
-        - eventSource: guardduty.amazonaws.com
-    selection_eventName:
-        - eventName: CreateIPSet
-    condition: all of them
+        eventSource: guardduty.amazonaws.com
+        eventName: CreateIPSet
+    condition: selection_source
 falsepositives:
     - Valid change in the GuardDuty (e.g. to ignore internal scanners)
 level: high

--- a/rules/cloud/aws_iam_backdoor_users_keys.yml
+++ b/rules/cloud/aws_iam_backdoor_users_keys.yml
@@ -4,19 +4,18 @@ status: experimental
 description: Detects AWS API key creation for a user by another user. Backdoored users can be used to obtain persistence in the AWS environment. Also with this alert, you can detect a flow of AWS keys in your org.
 author: faloker
 date: 2020/02/12
-modified: 2020/09/01
+modified: 2021/08/09
 references:
     - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/iam__backdoor_users_keys/main.py#L6
 logsource:
     service: cloudtrail
 detection:
     selection_source:
-        - eventSource: iam.amazonaws.com
-    selection_eventname:
-        - eventName: CreateAccessKey
+        eventSource: iam.amazonaws.com
+        eventName: CreateAccessKey
     filter:
         userIdentity.arn|contains: responseElements.accessKey.userName
-    condition: all of selection* and not filter
+    condition: selection_source and not filter
 fields:
     - userIdentity.arn
     - responseElements.accessKey.userName

--- a/rules/cloud/aws_rds_change_master_password.yml
+++ b/rules/cloud/aws_rds_change_master_password.yml
@@ -4,19 +4,17 @@ status: experimental
 description: Detects the change of database master password. It may be a part of data exfiltration.
 author: faloker
 date: 2020/02/12
-modified: 2020/09/01
+modified: 2021/08/09
 references:
     - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
 logsource:
     service: cloudtrail
 detection:
     selection_source:
-        - eventSource: rds.amazonaws.com
-    selection_modified_values:
-        - responseElements.pendingModifiedValues.masterUserPassword: "*"
-    selection_eventname:
-        - eventName: ModifyDBInstance
-    condition: all of them
+        eventSource: rds.amazonaws.com
+        responseElements.pendingModifiedValues.masterUserPassword: "*"
+        eventName: ModifyDBInstance
+    condition: selection_source
 falsepositives:
     - Benign changes to a db instance
 level: medium

--- a/rules/cloud/aws_rds_public_db_restore.yml
+++ b/rules/cloud/aws_rds_public_db_restore.yml
@@ -4,19 +4,17 @@ status: experimental
 description: Detects the recovery of a new public database instance from a snapshot. It may be a part of data exfiltration.
 author: faloker
 date: 2020/02/12
-modified: 2020/09/01
+modified: 2021/08/09
 references:
     - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
 logsource:
     service: cloudtrail
 detection:
     selection_source:
-        - eventSource: rds.amazonaws.com
-    selection_ispublic:
-        - responseElements.publiclyAccessible: "true"
-    selection_eventname:
-        - eventName: RestoreDBInstanceFromDBSnapshot
-    condition: all of them
+        eventSource: rds.amazonaws.com
+        responseElements.publiclyAccessible: "true"
+        eventName: RestoreDBInstanceFromDBSnapshot
+    condition: selection_source
 falsepositives:
     - unknown
 level: high

--- a/rules/cloud/aws_root_account_usage.yml
+++ b/rules/cloud/aws_root_account_usage.yml
@@ -4,16 +4,16 @@ status: experimental
 description: Detects AWS root account usage
 author: vitaliy0x1
 date: 2020/01/21
-modified: 2020/09/01
+modified: 2021/08/09
 references:
   - https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html
 logsource:
   service: cloudtrail
 detection:
   selection_usertype:
-    - userIdentity.type: Root
+    userIdentity.type: Root
   selection_eventtype:
-    - eventType: AwsServiceEvent
+    eventType: AwsServiceEvent
   condition: selection_usertype AND NOT selection_eventtype
 falsepositives:
   - AWS Tasks That Require AWS Account Root User Credentials https://docs.aws.amazon.com/general/latest/gr/aws_tasks-that-require-root.html

--- a/rules/cloud/aws_snapshot_backup_exfiltration.yml
+++ b/rules/cloud/aws_snapshot_backup_exfiltration.yml
@@ -4,6 +4,7 @@ status: test
 description: Detects the modification of an EC2 snapshot's permissions to enable access from another account
 author: Darin Smith
 date: 2021/05/17
+modified: 2021/08/09
 references:
   - https://www.justice.gov/file/1080281/download
   - https://attack.mitre.org/techniques/T1537/
@@ -11,11 +12,9 @@ logsource:
   service: cloudtrail
 detection:
   selection_source:
-    - eventSource: cloudtrail.amazonaws.com
-  events:
-    - eventName:
-      - ModifySnapshotAttribute
-  condition: selection_source AND events
+    eventSource: cloudtrail.amazonaws.com
+    eventName: ModifySnapshotAttribute
+  condition: selection_source
 falsepositives:
   - Valid change to a snapshot's permissions
 level: medium

--- a/rules/cloud/aws_update_login_profile.yml
+++ b/rules/cloud/aws_update_login_profile.yml
@@ -1,21 +1,22 @@
 title: AWS User Login Profile Was Modified
 id: 055fb148-60f8-462d-ad16-26926ce050f1 
 status: experimental
-description: An attacker with the iam:UpdateLoginProfile permission on other users can change the password used to login to the AWS console on any user that already has a login profile setup. With this alert, it is used to detect anyone is changing password on behalf of other users.
+description: | 
+ An attacker with the iam:UpdateLoginProfile permission on other users can change the password used to login to the AWS console on any user that already has a login profile setup.
+ With this alert, it is used to detect anyone is changing password on behalf of other users.
 author: toffeebr33k
-date: 2020/11/21
+date: 2021/08/09
 references:
     - https://github.com/RhinoSecurityLabs/AWS-IAM-Privilege-Escalation
 logsource:
     service: cloudtrail
 detection:
     selection_source:
-        - eventSource: iam.amazonaws.com
-    selection_eventname:
-        - eventName: UpdateLoginProfile
+        eventSource: iam.amazonaws.com
+        eventName: UpdateLoginProfile
     filter:
         userIdentity.arn|contains: responseElements.accessKey.userName
-    condition: all of selection* and not filter
+    condition: selection_source and not filter
 fields:
     - userIdentity.arn
     - responseElements.accessKey.userName


### PR DESCRIPTION
Hello
As my #1802 is to big to be check , I've make a split PR for rules/cloud/ more humain. 

So FIX : 
- selection  with a list of only 1 field
- field with list of only 1 value
- cleanup "sel1 and sel2 and selx..." when need 