### PR TITLE
Correct lists with only 1 value in network rules

### DIFF
--- a/rules/network/net_susp_dns_b64_queries.yml
+++ b/rules/network/net_susp_dns_b64_queries.yml
@@ -4,15 +4,14 @@ status: experimental
 description: Detects suspicious DNS queries using base64 encoding
 author: Florian Roth
 date: 2018/05/10
-modified: 2020/08/27
+modified: 2021/08/09
 references:
     - https://github.com/krmaxwell/dns-exfiltration
 logsource:
     category: dns
 detection:
     selection:
-        query|contains:
-            - '==.'
+        query|contains: '==.'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/network/net_susp_telegram_api.yml
+++ b/rules/network/net_susp_telegram_api.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects suspicious DNS queries to api.telegram.org used by Telegram Bots of any kind
 author: Florian Roth
 date: 2018/06/05
-modified: 2020/08/27
+modified: 2021/08/09
 references:
     - https://core.telegram.org/bots/faq
     - https://researchcenter.paloaltonetworks.com/2018/03/unit42-telerat-another-android-trojan-leveraging-telegrams-bot-api-to-target-iranian-users/
@@ -14,8 +14,7 @@ logsource:
     category: dns
 detection:
     selection:
-        query:
-            - 'api.telegram.org'   # Telegram Bot API Request https://core.telegram.org/bots/faq
+        query: 'api.telegram.org'   # Telegram Bot API Request https://core.telegram.org/bots/faq
     condition: selection
 falsepositives:
     - Legitimate use of Telegram bots in the company

--- a/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
+++ b/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
@@ -4,13 +4,12 @@ status: experimental
 description: Detects Bitsadmin connections to domains with uncommon TLDs - https://twitter.com/jhencinski/status/1102695118455349248 - https://isc.sans.edu/forums/diary/Investigating+Microsoft+BITS+Activity/23281/
 author: Florian Roth
 date: 2019/03/07
-modified: 2020/09/03
+modified: 2021/08/09
 logsource:
     category: proxy
 detection:
     selection:
-        c-useragent|startswith:
-            - 'Microsoft BITS/'
+        c-useragent|startswith: 'Microsoft BITS/'
     falsepositives:
         r-dns|endswith:
             - '.com' 

--- a/rules/proxy/proxy_ua_suspicious.yml
+++ b/rules/proxy/proxy_ua_suspicious.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects suspicious malformed user agent strings in proxy logs
 author: Florian Roth
 date: 2017/07/08
-modified: 2020/09/03
+modified: 2021/08/09
 references:
     - https://github.com/fastly/waf_testbed/blob/master/templates/default/scanners-user-agents.data.erb
 logsource:
@@ -32,8 +32,7 @@ detection:
         - 'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:28.0) Gecko/20100101 Firefox/28.0'  # used by APT28 malware https://threatvector.cylance.com/en_us/home/inside-the-apt28-dll-backdoor-blitz.html
         - 'HTTPS'  # https://twitter.com/stvemillertime/status/1204437531632250880
     falsepositives:
-        c-useragent:
-            - 'Mozilla/3.0 * Acrobat *'  # Acrobat with linked content
+        c-useragent: 'Mozilla/3.0 * Acrobat *'  # Acrobat with linked content
     condition: ( selection1 or selection2 or selection3 ) and not falsepositives
 fields:
     - ClientIP

--- a/rules/proxy/proxy_ursnif_malware_c2_url.yml
+++ b/rules/proxy/proxy_ursnif_malware_c2_url.yml
@@ -1,29 +1,3 @@
-title: Ursnif Malware Download URL Pattern
-id: a36ce77e-30db-4ea0-8795-644d7af5dfb4
-status: stable
-description: Detects download of Ursnif malware done by dropper documents.
-author: Thomas Patzke
-date: 2019/12/19
-modified: 2020/11/28
-logsource:
-  category: proxy
-detection:
-  selection:
-    c-uri|contains|all: 
-      - '/'
-      - '.php?l='
-    c-uri|endswith: '.cab'
-    sc-status: 200
-  condition: selection
-fields:
-  - c-ip
-  - c-uri
-  - sc-bytes
-  - c-ua
-falsepositives:
-    - Unknown
-level: critical
----
 title: Ursnif Malware C2 URL Pattern
 id: 932ac737-33ca-4afd-9869-0d48b391fcc9
 status: stable
@@ -31,6 +5,8 @@ description: Detects Ursnif C2 traffic.
 references:
   - https://www.fortinet.com/blog/threat-research/ursnif-variant-spreading-word-document.html
 author: Thomas Patzke
+date: 2019/12/19
+modified: 2021/08/09
 logsource:
   category: proxy
 detection:

--- a/rules/proxy/proxy_ursnif_malware_download_url.yml
+++ b/rules/proxy/proxy_ursnif_malware_download_url.yml
@@ -1,0 +1,25 @@
+title: Ursnif Malware Download URL Pattern
+id: a36ce77e-30db-4ea0-8795-644d7af5dfb4
+status: stable
+description: Detects download of Ursnif malware done by dropper documents.
+author: Thomas Patzke
+date: 2019/12/19
+modified: 2021/08/09
+logsource:
+  category: proxy
+detection:
+  selection:
+    c-uri|contains|all: 
+      - '/'
+      - '.php?l='
+    c-uri|endswith: '.cab'
+    sc-status: 200
+  condition: selection
+fields:
+  - c-ip
+  - c-uri
+  - sc-bytes
+  - c-ua
+falsepositives:
+    - Unknown
+level: critical

--- a/rules/web/web_citrix_cve_2020_8193_8195_exploit.yml
+++ b/rules/web/web_citrix_cve_2020_8193_8195_exploit.yml
@@ -4,6 +4,7 @@ id: 0d0d9a8a-a49e-4e27-b061-7ce4b936cfb7
 author: Florian Roth
 status: experimental
 date: 2020/07/10
+modified: 2021/08/09
 references:
     - https://support.citrix.com/article/CTX276688
     - https://research.nccgroup.com/2020/07/10/rift-citrix-adc-vulnerabilities-cve-2020-8193-cve-2020-8195-and-cve-2020-8196-intelligence/
@@ -12,8 +13,7 @@ logsource:
     category: webserver
 detection:
     selection1:
-        c-uri|contains: 
-            - '/rapi/filedownload?filter=path:%2F'
+        c-uri|contains: '/rapi/filedownload?filter=path:%2F'
     selection2:
         c-uri|contains|all:
             - '/pcidss/report'

--- a/rules/web/web_cve_2018_2894_weblogic_exploit.yml
+++ b/rules/web/web_cve_2018_2894_weblogic_exploit.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects access to a webshell dropped into a keystore folder on the WebLogic server
 author: Florian Roth
 date: 2018/07/22
-modified: 2020/09/03
+modified: 2021/08/09
 references:
     - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-2894
     - https://twitter.com/pyn3rd/status/1020620932967223296
@@ -13,8 +13,7 @@ logsource:
     category: webserver
 detection:
     selection:
-        c-uri:
-            - '*/config/keystore/*.js*'
+        c-uri: '*/config/keystore/*.js*'
     condition: selection
 fields:
     - c-ip

--- a/rules/web/web_solarwinds_supernova_webshell.yml
+++ b/rules/web/web_solarwinds_supernova_webshell.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects access to SUPERNOVA webshell as described in Guidepoint report
 author: Florian Roth
 date: 2020/12/17
-modified: 2020/12/22
+modified: 2021/08/09
 references:
     - https://www.guidepointsecurity.com/supernova-solarwinds-net-webshell-analysis/
     - https://www.anquanke.com/post/id/226029
@@ -19,8 +19,7 @@ detection:
             - 'logoimagehandler.ashx'
             - 'clazz'
     selection2:
-        c-uri|contains:
-            - 'logoimagehandler.ashx'
+        c-uri|contains: 'logoimagehandler.ashx'
         sc-status: 500
     condition: selection1 or selection2
 fields:

--- a/rules/web/web_vsphere_cve_2021_21972_unauth_rce_exploit.yml
+++ b/rules/web/web_vsphere_cve_2021_21972_unauth_rce_exploit.yml
@@ -4,6 +4,7 @@ status: experimental
 description: Detects the exploitation of VSphere Remote Code Execution vulnerability as described in CVE-2021-21972
 author: Bhabesh Raj
 date: 2021/02/24
+modified: 2021/08/09
 references:
     - https://www.vmware.com/security/advisories/VMSA-2021-0002.html
     - https://f5.pm/go-59627.html
@@ -13,8 +14,7 @@ logsource:
 detection:
     selection:
         cs-method: 'POST'
-        c-uri:
-            - '/ui/vropspluginui/rest/services/uploadova'
+        c-uri: '/ui/vropspluginui/rest/services/uploadova'
     condition: selection
 fields:
     - c-ip

--- a/rules/web/win_powershell_snapins_hafnium.yml
+++ b/rules/web/win_powershell_snapins_hafnium.yml
@@ -7,6 +7,7 @@ references:
     - https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities/
     - https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers/
 date: 2021/03/03
+modified: 2021/08/09
 tags:
     - attack.execution
     - attack.t1086
@@ -19,8 +20,7 @@ logsource:
 detection:
     selection:
         Image: '*\powershell.exe'
-        CommandLine:
-            - '*add-pssnapin microsoft.exchange.powershell.snapin*'
+        CommandLine: '*add-pssnapin microsoft.exchange.powershell.snapin*'
     condition: selection
 fields:
     - CommandLine


### PR DESCRIPTION
Hello
As my #1802 is to big to be check , I've make a split PR for "network" rules more humain.

So FIX :

  -  selection with a list of only 1 field
  -  field with list of only 1 value
  - split `proxy_ursnif_malware` into 2 files proxy_ursnif_malware_c2_url.yml  and proxy_ursnif_malware_download_url.yml
