### PR TITLE
Sigma Schema add new Attribute and test

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -281,7 +281,7 @@ class TestRules(unittest.TestCase):
                         faulty_rules.append(file)                       
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
-                         "There are rules with malformed optional 'related' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification)")            
+                         "There are rules with malformed optional 'related' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification#rule-identification)")            
     
     def test_sysmon_rule_without_eventid(self):
         faulty_rules = []
@@ -348,7 +348,7 @@ class TestRules(unittest.TestCase):
                     faulty_rules.append(file) 
         
         self.assertEqual(faulty_rules, [], Fore.RED +
-                         "There are rules with malformed 'status' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification)")
+                         "There are rules with malformed 'status' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification#status-optional)")
 
     def test_level(self):
         faulty_rules = []
@@ -369,7 +369,7 @@ class TestRules(unittest.TestCase):
                     faulty_rules.append(file) 
         
         self.assertEqual(faulty_rules, [], Fore.RED +
-                         "There are rules with missing or malformed 'level' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification)")
+                         "There are rules with missing or malformed 'level' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification#level)")
 
     def test_optional_fields(self):
         faulty_rules = []
@@ -495,7 +495,7 @@ class TestRules(unittest.TestCase):
                 faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
-                         "There are rules with non-conform 'title' fields. Please check: https://github.com/Neo23x0/sigma/wiki/Rule-Creation-Guide#title")
+                         "There are rules with non-conform 'title' fields. Please check: https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide#title")
 
     def test_invalid_logsource_attributes(self):
         faulty_rules = []
@@ -516,7 +516,7 @@ class TestRules(unittest.TestCase):
                faulty_rules.append(file)
         
         self.assertEqual(faulty_rules, [], Fore.RED + 
-                         "There are rules with non-conform 'logsource' fields. Please check: https://github.com/Neo23x0/sigma/wiki/Rule-Creation-Guide#logsource")
+                         "There are rules with non-conform 'logsource' fields. Please check: https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide#log-source")
 
     def test_selection_list_one_value(self):
         faulty_rules = []
@@ -528,15 +528,15 @@ class TestRules(unittest.TestCase):
                     if isinstance(detection[key],list):
                         if len(detection[key]) == 1 and not isinstance(detection[key][0],str): #rule with only list of Keywords term
                            print(Fore.RED + "Rule {} has the selection ({}) with a list of only 1 value in detection".format(file, key))
-                           valid = False
+                           #valid = False
                     if isinstance(detection[key],dict):
                         for sub_key in detection[key]:
                             if isinstance(detection[key][sub_key],list): #split in 2 if as get a error "int has not len()"
                                 if len(detection[key][sub_key]) == 1:
                                     print (Fore.RED + "Rule {} has the selection ({}/{}) with a list of only 1 value in detection".format(file, key, sub_key))
-                                    valid = False
-                #if not valid:
-                #   faulty_rules.append(file)
+                                    #valid = False
+                if not valid:
+                  faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED + "There are rules using list with only 1 value")                  
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -251,7 +251,7 @@ class TestRules(unittest.TestCase):
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
                          "There are rules with missing or malformed 'id' fields. Create an id (e.g. here: https://www.uuidgenerator.net/version4) and add it to the reported rule(s).")
-    
+
     def test_optional_related(self):
         faulty_rules = []
         valid_type = [
@@ -278,11 +278,11 @@ class TestRules(unittest.TestCase):
                     #Only add one time if many bad type in the same file
                     if type_ok == False:
                         print(Fore.YELLOW + "Rule {} has a 'related/type' invalid value.".format(file))
-                        faulty_rules.append(file)                       
+                        faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
-                         "There are rules with malformed optional 'related' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification#rule-identification)")            
-    
+                         "There are rules with malformed optional 'related' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification)")
+
     def test_sysmon_rule_without_eventid(self):
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):
@@ -296,7 +296,7 @@ class TestRules(unittest.TestCase):
                             found = True
                             break
                     if not found:
-                        faulty_rules.append(file)      
+                        faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
                          "There are rules using sysmon events but with no EventID specified")
@@ -310,10 +310,10 @@ class TestRules(unittest.TestCase):
                 faulty_rules.append(file)
             elif not isinstance(datefield, str):
                 print(Fore.YELLOW + "Rule {} has a malformed 'date' (should be YYYY/MM/DD).".format(file))
-                faulty_rules.append(file)                
+                faulty_rules.append(file)
             elif len(datefield) != 10:
                 print(Fore.YELLOW + "Rule {} has a malformed 'date' (not 10 chars, should be YYYY/MM/DD).".format(file))
-                faulty_rules.append(file)                
+                faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED +
                          "There are rules with missing or malformed 'date' fields. (create one, e.g. date: 2019/01/14)")
@@ -325,10 +325,10 @@ class TestRules(unittest.TestCase):
             if modifiedfield:
                 if not isinstance(modifiedfield, str):
                     print(Fore.YELLOW + "Rule {} has a malformed 'modified' (should be YYYY/MM/DD).".format(file))
-                    faulty_rules.append(file)                
+                    faulty_rules.append(file)
                 elif len(modifiedfield) != 10:
                     print(Fore.YELLOW + "Rule {} has a malformed 'modified' (not 10 chars, should be YYYY/MM/DD).".format(file))
-                    faulty_rules.append(file)                
+                    faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED +
                          "There are rules with malformed 'modified' fields. (create one, e.g. date: 2019/01/14)")
@@ -346,9 +346,9 @@ class TestRules(unittest.TestCase):
                 if not status_str in valid_status:
                     print(Fore.YELLOW + "Rule {} has a invalide 'status' (check wiki).".format(file))
                     faulty_rules.append(file) 
-        
+
         self.assertEqual(faulty_rules, [], Fore.RED +
-                         "There are rules with malformed 'status' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification#status-optional)")
+                         "There are rules with malformed 'status' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification)")
 
     def test_level(self):
         faulty_rules = []
@@ -363,13 +363,13 @@ class TestRules(unittest.TestCase):
             level_str = self.get_rule_part(file_path=file, part_name="level")
             if not level_str:
                 print(Fore.YELLOW + "Rule {} has no field 'level'.".format(file))
-                faulty_rules.append(file)            
+                faulty_rules.append(file)
             elif not level_str in valid_level:
                     print(Fore.YELLOW + "Rule {} has a invalide 'level' (check wiki).".format(file))
-                    faulty_rules.append(file) 
-        
+                    faulty_rules.append(file)
+
         self.assertEqual(faulty_rules, [], Fore.RED +
-                         "There are rules with missing or malformed 'level' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification#level)")
+                         "There are rules with missing or malformed 'level' fields. (check https://github.com/SigmaHQ/sigma/wiki/Specification)")
 
     def test_optional_fields(self):
         faulty_rules = []
@@ -410,6 +410,41 @@ class TestRules(unittest.TestCase):
         self.assertEqual(faulty_rules, [], Fore.RED + 
                          "There are rules with malformed optional 'author' fields. (has to be a string even if it contains many author)")
 
+    def test_optional_tlp(self):
+        faulty_rules = []
+        valid_tlp = [
+            "WHITE",
+            "GREEN",
+            "AMBER",
+            "RED",
+            ]
+        for file in self.yield_next_rule_file_path(self.path_to_rules):
+            tlp_str = self.get_rule_part(file_path=file, part_name="tlp")
+            if tlp_str:
+                # it exists but isn't a string
+                if not isinstance(tlp_str, str):
+                    print(Fore.YELLOW + "Rule {} has a 'tlp' field that isn't a string.".format(file))
+                    faulty_rules.append(file)
+                elif not tlp_str.upper() in valid_tlp:
+                    print(Fore.YELLOW + "Rule {} has a 'tlp' field with not valid value.".format(file))
+                    faulty_rules.append(file)
+
+        self.assertEqual(faulty_rules, [], Fore.RED + 
+                         "There are rules with malformed optional 'tlp' fields. (https://www.cisa.gov/tlp)")
+
+    def test_optional_target(self):
+        faulty_rules = []
+        for file in self.yield_next_rule_file_path(self.path_to_rules):
+            target = self.get_rule_part(file_path=file, part_name="target")
+            if target:
+                # it exists but isn't a list
+                if not isinstance(target, list):
+                    print(Fore.YELLOW + "Rule {} has a 'target' field that isn't a list.".format(file))
+                    faulty_rules.append(file)
+
+        self.assertEqual(faulty_rules, [], Fore.RED + 
+                         "There are rules with malformed 'target' fields. (has to be a list of values even if it contains only a single value)")
+
     def test_references(self):
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):
@@ -445,7 +480,7 @@ class TestRules(unittest.TestCase):
             filename = os.path.basename(file)
             if not filename_pattern.match(filename) and not '_' in filename:
                 print(Fore.YELLOW + "Rule {} has a file name that doesn't match our standard.".format(file))
-                faulty_rules.append(file)     
+                faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
                          "There are rules with malformed file names (too short, too long, uppercase letters, a minus sign etc.). Please see the file names used in our repository and adjust your file names accordingly. The pattern for a valid file name is '[a-z0-9_]{10,70}\.yml' and it has to contain at least an underline character.")
@@ -495,7 +530,7 @@ class TestRules(unittest.TestCase):
                 faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
-                         "There are rules with non-conform 'title' fields. Please check: https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide#title")
+                         "There are rules with non-conform 'title' fields. Please check: https://github.com/SimaHQ/sigma/wiki/Rule-Creation-Guide#title")
 
     def test_invalid_logsource_attributes(self):
         faulty_rules = []
@@ -514,32 +549,32 @@ class TestRules(unittest.TestCase):
                     valide = False
             if not valid:
                faulty_rules.append(file)
-        
+
         self.assertEqual(faulty_rules, [], Fore.RED + 
                          "There are rules with non-conform 'logsource' fields. Please check: https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide#log-source")
-
-    def test_selection_list_one_value(self):
-        faulty_rules = []
-        for file in self.yield_next_rule_file_path(self.path_to_rules):
-            detection = self.get_rule_part(file_path=file, part_name="detection")
-            if detection:
-                valid = True
-                for key in detection:
-                    if isinstance(detection[key],list):
-                        if len(detection[key]) == 1 and not isinstance(detection[key][0],str): #rule with only list of Keywords term
-                           print(Fore.RED + "Rule {} has the selection ({}) with a list of only 1 value in detection".format(file, key))
-                           #valid = False
-                    if isinstance(detection[key],dict):
-                        for sub_key in detection[key]:
-                            if isinstance(detection[key][sub_key],list): #split in 2 if as get a error "int has not len()"
-                                if len(detection[key][sub_key]) == 1:
-                                    print (Fore.RED + "Rule {} has the selection ({}/{}) with a list of only 1 value in detection".format(file, key, sub_key))
-                                    #valid = False
-                if not valid:
-                  faulty_rules.append(file)
-
-        self.assertEqual(faulty_rules, [], Fore.RED + "There are rules using list with only 1 value")                  
-
+  
+  #deactivate because more than 170 rules have been corrected
+  #  def test_selection_list_one_value(self):
+  #      faulty_rules = []
+  #      for file in self.yield_next_rule_file_path(self.path_to_rules):
+  #          detection = self.get_rule_part(file_path=file, part_name="detection")
+  #          if detection:
+  #              valid = True
+  #              for key in detection:
+  #                  if isinstance(detection[key],list):
+  #                      if len(detection[key]) == 1 and not isinstance(detection[key][0],str): #rule with only list of Keywords term
+  #                         print(Fore.RED + "Rule {} has the selection ({}) with a list of only 1 value in detection".format(file, key))
+  #                         #valid = False
+  #                  if isinstance(detection[key],dict):
+  #                      for sub_key in detection[key]:
+  #                          if isinstance(detection[key][sub_key],list): #split in 2 if as get a error "int has not len()"
+  #                              if len(detection[key][sub_key]) == 1:
+  #                                  print (Fore.RED + "Rule {} has the selection ({}/{}) with a list of only 1 value in detection".format(file, key, sub_key))
+  #                                  #valid = False
+  #              if not valid:
+  #                faulty_rules.append(file)
+  #
+  #      self.assertEqual(faulty_rules, [], Fore.RED + "There are rules using list with only 1 value")
 
 def get_mitre_data():
     """


### PR DESCRIPTION
Hi,

As my first PR #1802 has too many rules , I've close it.

Add new Attribute:
- tlp from https://www.cisa.gov/tlp  for internal organisation use
- target  a free optional list ('server','workstation','iot',..) 

Add new test:
- test_optional_tlp
- test_optional_target
- test_selection_list_one_value (deactivate because more than 170 rules to fix before but it is ready)

Add new filter :
- tlp=  (if rule have no tlp it is convert to "WHITE")
- target=

Check #1804 for more information