### PR TITLE
rule: ProxyLogon web_cve_2021_26858_iis_rce.yml

### DIFF
--- a/rules/web/web_cve_2021_26858_iis_rce.yml
+++ b/rules/web/web_cve_2021_26858_iis_rce.yml
@@ -9,16 +9,16 @@ date: 2021/08/10
 logsource:
     product: windows
     category: webserver
-    service: iis
+    definition: w3c-logging must be enable https://docs.microsoft.com/en-us/windows/win32/http/w3c-logging
 detection:
     selection:
-        http_method: 'POST'
-        http_code: 200
-        url_path: '/ecp/DDI/DDIService.svc/SetObject'
-        Message|contains|all:
+        cs-method: 'POST'
+        sc-status: 200
+        cs-uri-stem|startswith: '/ecp/DDI/DDIService.svc/SetObject'
+        cs-uri-stem|contains|all:
             - 'schema=Reset'
             - 'VirtualDirectory'
-        Username|endswith: '$'
+        cs-username|endswith: '$'
     condition: selection
 falsepositives:
     - Unlikely

--- a/rules/web/web_cve_2021_26858_iis_rce.yml
+++ b/rules/web/web_cve_2021_26858_iis_rce.yml
@@ -14,8 +14,8 @@ detection:
     selection:
         cs-method: 'POST'
         sc-status: 200
-        cs-uri-stem|startswith: '/ecp/DDI/DDIService.svc/SetObject'
-        cs-uri-stem|contains|all:
+        cs-uri-stem: '/ecp/DDI/DDIService.svc/SetObject'
+        cs-uri-query|contains|all:
             - 'schema=Reset'
             - 'VirtualDirectory'
         cs-username|endswith: '$'

--- a/rules/web/web_cve_2021_26858_iis_rce.yml
+++ b/rules/web/web_cve_2021_26858_iis_rce.yml
@@ -19,7 +19,14 @@ detection:
             - 'schema=Reset'
             - 'VirtualDirectory'
         cs-username|endswith: '$'
-    condition: selection
+    keywords:
+        - 'POST'
+        - '200'
+        - '/ecp/DDI/DDIService.svc/SetObject'
+        - 'schema=Reset'
+        - 'VirtualDirectory'
+        - '$'    
+    condition: selection or all of keywords
 falsepositives:
     - Unlikely
 level: critical 

--- a/rules/web/web_cve_2021_26858_iis_rce.yml
+++ b/rules/web/web_cve_2021_26858_iis_rce.yml
@@ -1,4 +1,4 @@
-title: ProxyLogon Reset Virtual Directories Based On IIS log
+title: ProxyLogon Reset Virtual Directories Based On IIS Log
 id: effee1f6-a932-4297-a81f-acb44064fa3a
 status: experimental
 description: When exploiting this vulnerability with CVE-2021–26858, an SSRF attack is used to manipulate virtual directories

--- a/rules/web/web_cve_2021_26858_iis_rce.yml
+++ b/rules/web/web_cve_2021_26858_iis_rce.yml
@@ -1,0 +1,25 @@
+title: ProxyLogon Reset Virtual Directories Based On IIS log
+id: effee1f6-a932-4297-a81f-acb44064fa3a
+status: experimental
+description: When exploiting this vulnerability with CVE-2021–26858, an SSRF attack is used to manipulate virtual directories
+references:
+    - https://bi-zone.medium.com/hunting-down-ms-exchange-attacks-part-1-proxylogon-cve-2021-26855-26858-27065-26857-6e885c5f197c
+author: frack113
+date: 2021/08/10
+logsource:
+    product: windows
+    category: webserver
+    service: iis
+detection:
+    selection:
+        http_method: 'POST'
+        http_code: 200
+        url_path: '/ecp/DDI/DDIService.svc/SetObject'
+        Message|contains|all:
+            - 'schema=Reset'
+            - 'VirtualDirectory'
+        Username|endswith: '$'
+    condition: selection
+falsepositives:
+    - Unlikely
+level: critical 


### PR DESCRIPTION
HI,
I don't the log to check if the rule is correct.
I use this part of the article in reference:
```
When exploiting this vulnerability with CVE-2021–26858, an SSRF attack is used to manipulate virtual directories.
For this reason, the Username field will contain the computer account, in our case lab.local\EXCHANGE$,
as the request is initiated by the Exchange server itself. Given this fact, another rule can be implemented:

   event_log_source:’IIS’ AND http_method:’POST’ AND http_code:'200' 
   AND url_path:'/ecp/DDI/DDIService.svc/SetObject' 
   AND (Message contains 'schema=Reset' AND Message contains 'VirtualDirectory')
   AND Username contains '$'
```