### PR TITLE
Correcting regex in win_modif_of_services_for_via_commandline.yml

### DIFF
--- a/rules/windows/process_creation/win_modif_of_services_for_via_commandline.yml
+++ b/rules/windows/process_creation/win_modif_of_services_for_via_commandline.yml
@@ -20,7 +20,7 @@ detection:
     selection_cmdline_2: 
         CommandLine|re: '(?i)sc failure.*command=.*'
     selection_cmdline_3:
-        CommandLine|re: '(?i).*reg add.*(FailureCommand|ImagePath).*(\.sh|\.exe|\.dll|\.bin^|\.bat|\.cmd|\.js|\.msh^|\.reg^|\.scr|\.ps|\.vb|\.jar|\.pl).*'
+        CommandLine|re: '(?i).*reg add.*(FailureCommand|ImagePath).*(\.sh|\.exe|\.dll|\.bin$|\.bat|\.cmd|\.js|\.msh$|\.reg$|\.scr|\.ps|\.vb|\.jar|\.pl).*'
     condition: selection_cmdline_1 or selection_cmdline_2 or selection_cmdline_3
 falsepositives:
     - unknown

--- a/rules/windows/process_creation/win_modif_of_services_for_via_commandline.yml
+++ b/rules/windows/process_creation/win_modif_of_services_for_via_commandline.yml
@@ -10,7 +10,7 @@ tags:
     - attack.t1058
 author: Sreeman
 date: 2020/09/29
-modified: 2021/06/11
+modified: 2021/08/10
 logsource:
     category: process_creation
     product: windows


### PR DESCRIPTION
The ^ symbol designates the beginning of the string, but in this rule it is clearly intended to be the end of the string.