### PR TITLE
[Ready] SQL & SQLite rule fields selection

### DIFF
--- a/tools/sigma/backends/sql.py
+++ b/tools/sigma/backends/sql.py
@@ -45,19 +45,21 @@ class SQLBackend(SingleTextQueryBackend):
     mapLength = "(%s %s)"
 
     options = SingleTextQueryBackend.options + (
-        ("table", False, "Use this option to specify table name, default is \"eventlog\"", None),
+        ("table", "eventlog", "Use this option to specify table name.", None),
+        ("select", "*", "Use this option to specify fields you want to select. Example: \"--backend-option select=xxx,yyy\"", None),
     )
 
     
 
     def __init__(self, sigmaconfig, options):
         super().__init__(sigmaconfig)
+        
         if "table" in options:
             self.table = options["table"]
         else:
             self.table = "eventlog"
 
-        if "select" in options:
+        if "select" in options and options["select"]:
             self.select_fields = options["select"].split(',')
         else:
             self.select_fields = list()

--- a/tools/sigma/backends/sql.py
+++ b/tools/sigma/backends/sql.py
@@ -48,7 +48,6 @@ class SQLBackend(SingleTextQueryBackend):
         ("table", "eventlog", "Use this option to specify table name.", None),
         ("select", "*", "Use this option to specify fields you want to select. Example: \"--backend-option select=xxx,yyy\"", None),
     )
-
     
 
     def __init__(self, sigmaconfig, options):
@@ -62,7 +61,7 @@ class SQLBackend(SingleTextQueryBackend):
         if "select" in options and options["select"]:
             self.select_fields = options["select"].split(',')
         else:
-            self.select_fields = list()
+            self.select_fields = list("*")
 
     def generateANDNode(self, node):
         generated = [ self.generateNode(val) for val in node ]
@@ -197,10 +196,7 @@ class SQLBackend(SingleTextQueryBackend):
         if self._recursiveFtsSearch(parsed.parsedSearch):
             raise NotImplementedError("FullTextSearch not implemented for SQL Backend.")
         result = self.generateNode(parsed.parsedSearch)
-        select = "*"
-
-        if self.select_fields:
-            select = ", ".join(self.select_fields)
+        select = ", ".join(self.select_fields)
 
         if parsed.parsedAgg:
             #Handle aggregation


### PR DESCRIPTION
This PR is following #1785 .

It's adding asked things like help for select option and if select empty use '*' you now get `SELECT * FROM xxx WHERE ...`

But most important, this PR is adding field selection from Sigma rules to SQL and SQLite backend.
If the rule is using `fields : ['xxx', 'yyy']` (or any other yaml format), it will replace the `SELECT * ...` by `SELECT xxx, yyy ...`.

If you use both fields from rule and backend options, it will concatenate them.
When rule is using `fields : ['xxx', 'yyy']`, and using `sigmac -t sql ... --backend-option select=zzz`, it will replace the `SELECT * ...` by `SELECT xxx, yyy, zzz ...`.

Of course, if the rule and the backend option are not using fields at all, it keeps using the default `SELECT * ...`.
