### PR TITLE
Update powershell-classic rule

### DIFF
--- a/rules/windows/builtin/win_susp_athremotefxvgpudisablementcommand.yml
+++ b/rules/windows/builtin/win_susp_athremotefxvgpudisablementcommand.yml
@@ -37,6 +37,7 @@ detection:
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     selection_cmd:
         HostApplication|contains: 'Invoke-ATHRemoteFXvGPUDisablementCommand '

--- a/rules/windows/builtin/win_susp_zip_compress.yml
+++ b/rules/windows/builtin/win_susp_zip_compress.yml
@@ -29,6 +29,7 @@ detection:
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     selection:
         HostApplication|contains|all:

--- a/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
@@ -37,7 +37,6 @@ detection:
     selection:
         EventID: 400
         HostApplication: '*'
-detection:
     filter:
         HostApplication: 'powershell.exe'
     condition: selection and not filter        

--- a/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
@@ -4,7 +4,7 @@ id: 64e8e417-c19a-475a-8d19-98ea705394cc
 description: Detects alternate PowerShell hosts potentially bypassing detections looking for powershell.exe
 status: experimental
 date: 2019/08/11
-modified: 2021/08/03
+modified: 2021/08/16
 author: Roberto Rodriguez @Cyb3rWard0g
 references:
     - https://threathunterplaybook.com/notebooks/windows/02_execution/WIN-190815181010.html
@@ -17,14 +17,6 @@ falsepositives:
     - MSP Detection Searcher
     - Citrix ConfigSync.ps1
 level: medium   
-detection:
-    filter:
-        - ContextInfo: 'powershell.exe'
-        - Message: 'powershell.exe'
-        # Both fields contain key=value pairs where the key HostApplication is relevant but
-        # can't be referred directly as event field.
-    condition: selection and not filter
- 
 ---
 logsource:
     product: windows
@@ -33,11 +25,19 @@ detection:
     selection:
         EventID: 4103
         ContextInfo: '*'
+    filter:
+        ContextInfo: 'powershell.exe'
+    condition: selection and not filter        
 ---
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     selection:
         EventID: 400
-        ContextInfo: '*'
+        HostApplication: '*'
+detection:
+    filter:
+        HostApplication: 'powershell.exe'
+    condition: selection and not filter        

--- a/rules/windows/powershell/powershell_delete_volume_shadow_copies.yml
+++ b/rules/windows/powershell/powershell_delete_volume_shadow_copies.yml
@@ -15,6 +15,7 @@ modified: 2021/08/03
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     selection_obj:
         CommandLine|contains|all:

--- a/rules/windows/powershell/powershell_downgrade_attack.yml
+++ b/rules/windows/powershell/powershell_downgrade_attack.yml
@@ -14,6 +14,7 @@ date: 2017/03/22
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     selection:
         EventID: 400

--- a/rules/windows/powershell/powershell_exe_calling_ps.yml
+++ b/rules/windows/powershell/powershell_exe_calling_ps.yml
@@ -14,6 +14,7 @@ date: 2017/03/05
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     selection1:
         EventID: 400

--- a/rules/windows/powershell/powershell_powercat.yml
+++ b/rules/windows/powershell/powershell_powercat.yml
@@ -19,6 +19,7 @@ level: medium
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     selection:
         EventID: 400
@@ -30,7 +31,6 @@ detection:
 logsource:
     product: windows
     service: powershell
-
 detection:
     selection:
         EventID: 4103

--- a/rules/windows/powershell/powershell_remote_powershell_session.yml
+++ b/rules/windows/powershell/powershell_remote_powershell_session.yml
@@ -32,6 +32,7 @@ detection:
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     selection:
         EventID: 400

--- a/rules/windows/powershell/powershell_renamed_powershell.yml
+++ b/rules/windows/powershell/powershell_renamed_powershell.yml
@@ -13,6 +13,7 @@ tags:
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     selection:
         EventID: 400

--- a/rules/windows/powershell/powershell_suspicious_download.yml
+++ b/rules/windows/powershell/powershell_suspicious_download.yml
@@ -28,6 +28,7 @@ detection:
 logsource:
     product: windows
     service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     downloadfile:
         EventID: 400 #  get 400 ,403 and 600 for 1 execution

--- a/rules/windows/powershell/powershell_tamper_with_windows_defender.yml
+++ b/rules/windows/powershell/powershell_tamper_with_windows_defender.yml
@@ -9,12 +9,14 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1562.001/T1562.001.md
 author: frack113
 date: 2021/06/07
+modified: 2021/08/16
 falsepositives:
     - Unknown
 level: high
 logsource:
     product: windows
-    category: powershell-classic
+    service: powershell-classic
+    definition: fields have to be extract from event
 detection:
     select_EventID:
         EventID: 600

--- a/rules/windows/powershell/powershell_xor_commandline.yml
+++ b/rules/windows/powershell/powershell_xor_commandline.yml
@@ -11,6 +11,7 @@ tags:
 logsource:
   product: windows
   service: powershell-classic
+  definition: fields have to be extract from event
 detection:
   selection:
     EventID: 400


### PR DESCRIPTION
Hello,
add `definition: fields have to be extract from event` 
fix bad category instead of service for powershell_tamper_with_windows_defender.yml
 
check #1843 