### PR TITLE
Update test_missing_id message

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -234,7 +234,7 @@ class TestRules(unittest.TestCase):
 
     def test_missing_id(self):
         faulty_rules = []
-        list_id = []
+        dict_id = {}
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             id = self.get_rule_part(file_path=file, part_name="id")
             if not id:
@@ -243,11 +243,11 @@ class TestRules(unittest.TestCase):
             elif len(id) != 36:
                 print(Fore.YELLOW + "Rule {} has a malformed 'id' (not 36 chars).".format(file))
                 faulty_rules.append(file)                
-            elif id in list_id:
-                print(Fore.YELLOW + "Rule {} has a duplicate 'id'.".format(file))
+            elif id in dict_id.keys():
+                print(Fore.YELLOW + "Rule {} has the same 'id' than {} must be unique.".format(file,dict_id[id]))
                 faulty_rules.append(file)
             else:
-                list_id.append(id)
+                dict_id[id] = file
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
                          "There are rules with missing or malformed 'id' fields. Create an id (e.g. here: https://www.uuidgenerator.net/version4) and add it to the reported rule(s).")


### PR DESCRIPTION
Hello,
to help when there is a duplicate id ,I change the error message.
"Rule {rulename} has the same 'id' than {first_rulename} must be unique."

Example: 
```bash
frack113@frack113-virtual-machine:~/sigma$ pipenv run make test
rm -f .coverage
yamllint rules
tests/test_rules.py
[taxii2client.v20] [WARNING ] [2021-08-16 18:08:46,490] TAXII Server Response did not include 'Content-Range' header - results could be incomplete.
[taxii2client.v20] [WARNING ] [2021-08-16 18:08:46,531] TAXII Server Response with different amount of objects! Setting per_request=692
[taxii2client.v20] [WARNING ] [2021-08-16 18:08:47,235] TAXII Server Response did not include 'Content-Range' header - results could be incomplete.
[taxii2client.v20] [WARNING ] [2021-08-16 18:08:47,236] TAXII Server Response with different amount of objects! Setting per_request=70
[taxii2client.v20] [WARNING ] [2021-08-16 18:08:47,677] TAXII Server Response did not include 'Content-Range' header - results could be incomplete.
[taxii2client.v20] [WARNING ] [2021-08-16 18:08:47,682] TAXII Server Response with different amount of objects! Setting per_request=424
[taxii2client.v20] [WARNING ] [2021-08-16 18:08:48,249] TAXII Server Response did not include 'Content-Range' header - results could be incomplete.
[taxii2client.v20] [WARNING ] [2021-08-16 18:08:48,251] TAXII Server Response with different amount of objects! Setting per_request=124
....E.......Rule rules/application/appframework_django_exceptions.yml has the same 'id' than rules/application/appframework_django_exceptions (copy).yml must be unique.
F...............
======================================================================
ERROR: test_duplicate_titles (__main__.TestRules)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_rules.py", line 204, in test_duplicate_titles
    if compare_detections(detection, files_and_their_detections[key]):
  File "tests/test_rules.py", line 184, in compare_detections
    condition_value1 = detection1[named_condition][condition]
TypeError: list indices must be integers or slices, not str

======================================================================
FAIL: test_missing_id (__main__.TestRules)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_rules.py", line 252, in test_missing_id
    self.assertEqual(faulty_rules, [], Fore.RED +
AssertionError: Lists differ: ['rules/application/appframework_django_exceptions.yml'] != []

First list contains 1 additional elements.
First extra element 0:
'rules/application/appframework_django_exceptions.yml'

- ['rules/application/appframework_django_exceptions.yml']
+ [] : There are rules with missing or malformed 'id' fields. Create an id (e.g. here: https://www.uuidgenerator.net/version4) and add it to the reported rule(s).

----------------------------------------------------------------------
Ran 28 tests in 82.254s

FAILED (failures=1, errors=1)
make: *** [Makefile:16: test-rules] Error 1

```