### PR TITLE
Added rule for zero day CVE-2021-22123 in Fortinet WAFs

### DIFF
--- a/rules/web/web_fortinet_cve_2021_22123_exploit.yml
+++ b/rules/web/web_fortinet_cve_2021_22123_exploit.yml
@@ -1,10 +1,11 @@
 title: Fortinet CVE-2021-22123 Exploitation
 description: Detects CVE-2021-22123 exploitation attempt against Fortinet WAFs
 id: f425637f-891c-4191-a6c4-3bb1b70513b4
+status: experimental
 references:
     - https://www.rapid7.com/blog/post/2021/08/17/fortinet-fortiweb-os-command-injection
-author: Bhabesh Raj
-date: 2021/08/18
+author: Bhabesh Raj, Florian Roth
+date: 2021/08/19
 tags:
     - attack.initial_access
     - attack.t1190
@@ -16,11 +17,12 @@ detection:
             - '/api/v2.0/user/remoteserver.saml'
         cs-method:
             - POST
-        content-type|startswith:
-            - 'multipart/form-data;'
-        content-disposition|contains:
-            - '`'
-    condition: selection
+    filter1:
+        cs-referer|contains: '/root/user/remote-user/saml-user/'
+    filter2:
+        cs-referer:
+            - null
+    condition: selection and not filter1 and not filter2
 fields:
     - client_ip
     - url

--- a/rules/web/web_fortinet_cve_2021_22123_exploit.yml
+++ b/rules/web/web_fortinet_cve_2021_22123_exploit.yml
@@ -1,0 +1,30 @@
+title: Fortinet CVE-2021-22123 Exploitation
+description: Detects CVE-2021-22123 exploitation attempt against Fortinet WAFs
+id: f425637f-891c-4191-a6c4-3bb1b70513b4
+references:
+    - https://www.rapid7.com/blog/post/2021/08/17/fortinet-fortiweb-os-command-injection
+author: Bhabesh Raj
+date: 2021/08/18
+tags:
+    - attack.initial_access
+    - attack.t1190
+logsource:
+    category: webserver
+detection:
+    selection:
+        c-uri|contains: 
+            - '/api/v2.0/user/remoteserver.saml'
+        cs-method:
+            - POST
+        content-type|startswith:
+            - 'multipart/form-data;'
+        content-disposition|contains:
+            - '`'
+    condition: selection
+fields:
+    - client_ip
+    - url
+    - response
+falsepositives:
+    - Unknown
+level: critical


### PR DESCRIPTION
May need taxonomy fixing for _content-type_ and _content-disposition_.