### PR TITLE
Fix some false positives in  renamed powershell

### DIFF
--- a/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
@@ -2,9 +2,9 @@ action: global
 title: Alternate PowerShell Hosts
 id: 64e8e417-c19a-475a-8d19-98ea705394cc
 description: Detects alternate PowerShell hosts potentially bypassing detections looking for powershell.exe
-status: experimental
+status: test
 date: 2019/08/11
-modified: 2021/08/16
+modified: 2021/08/18
 author: Roberto Rodriguez @Cyb3rWard0g
 references:
     - https://threathunterplaybook.com/notebooks/windows/02_execution/WIN-190815181010.html
@@ -26,7 +26,7 @@ detection:
         EventID: 4103
         ContextInfo: '*'
     filter:
-        ContextInfo: 'powershell.exe'
+        ContextInfo|endswith: 'powershell.exe'
     condition: selection and not filter        
 ---
 logsource:
@@ -38,5 +38,5 @@ detection:
         EventID: 400
         HostApplication: '*'
     filter:
-        HostApplication: 'powershell.exe'
+        HostApplication|endswith: 'powershell.exe'
     condition: selection and not filter        

--- a/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_alternate_powershell_hosts.yml
@@ -21,12 +21,13 @@ level: medium
 logsource:
     product: windows
     service: powershell
+    definition: ModuleLogging must be enable
 detection:
     selection:
         EventID: 4103
         ContextInfo: '*'
     filter:
-        ContextInfo|endswith: 'powershell.exe'
+        ContextInfo|contains: 'powershell.exe' # Host Application=...powershell.exe or Application hote=...powershell.exe in French Win10 event
     condition: selection and not filter        
 ---
 logsource:

--- a/rules/windows/powershell/powershell_renamed_powershell.yml
+++ b/rules/windows/powershell/powershell_renamed_powershell.yml
@@ -1,12 +1,12 @@
-title: Renamed Powershell
+title: Renamed Powershell Under Powershell Channel
 id: 30a8cb77-8eb3-4cfb-8e79-ad457c5a4592
 description: Detects renamed powershell
-status: experimental
+status: test
 references:
     - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse
 author: Harish Segar, frack113
 date: 2020/06/29
-modified: 2021/07/04
+modified: 2021/08/18
 tags:
     - attack.execution
     - attack.t1086
@@ -17,10 +17,11 @@ logsource:
 detection:
     selection:
         EventID: 400
-        HostName: "ConsoleHost"
+        HostName: ConsoleHost
     filter:
         HostApplication|startswith:
-            - "powershell"
+            - powershell.exe
+            - C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe
     condition: selection and not filter
 falsepositives:
     - unknown


### PR DESCRIPTION
Hi,
find some FP:
1. ContextInfo can never be 'powershell.exe'
2. HostApplication have:
- powershell.exe
- C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe

with `HostName: ConsoleHost` HostApplication is the full command so use `|startswith`
