### PR TITLE
Update win_nltest_query.yml

### DIFF
--- a/rules/windows/process_creation/win_nltest_query.yml
+++ b/rules/windows/process_creation/win_nltest_query.yml
@@ -1,24 +1,41 @@
-title: Nltest Credential Hash Theft
-id: 5cc90652-4cbd-4241-aa3b-4b462fa5a248
-description: Detects nltest query commands which may leak credential hashes
+title: Nltest Usage
+description: Detects nltest commands that can be used for information discovery
 references:
-    - https://twitter.com/sysopfb/status/986799053668139009
-    - https://github.com/LOLBAS-Project/LOLBAS/blob/94368c1e69a6ce5ce812f2b331c99b89a63791b9/yml/LOLUtilz/OSBinaries/Nltest.yml
-date: 2018/04/18
-modified: 2021/01/05
-tags:
-    - attack.credential_access
-    - attack.t1003
+- https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731935(v=ws.11)
+- https://thedfirreport.com/2021/08/16/trickbot-leads-up-to-fake-1password-installation/
+- https://attack.mitre.org/techniques/T1482/
+- https://attack.mitre.org/techniques/T1016/
+- https://book.hacktricks.xyz/windows/basic-cmd-for-pentesters
 status: experimental
-author: Craig Young, oscd.community
+author: Craig Young, oscd.community, Georg Lauenstein
+date: 2021/07/24
+modified: 2021/08/17
+tags:
+  - attack.discovery
+  - attack.T1016
+  - attack.T1482
 logsource:
-    category: process_creation
-    product: windows
+  category: process_creation
+  product: windows
 detection:
-    selection:
+    selection_nltest:
         Image|endswith: '\nltest.exe'
-        CommandLine|contains: '\query'
-    condition: selection
+    selection_recon1:
+        CommandLine|contains|all:
+            - '/server'
+            - '/query'
+    selection_recon2:
+        CommandLine|startswith:
+            - '/dclist:'
+            - '/parentdomain'
+            - '/domain_trusts'
+            - '/user'
+    condition: selection_nltest AND (selection_recon1 OR selection_recon2)
 falsepositives:
-    - Legitimate administration
+    - To be determined
 level: medium
+fields:
+    - Image
+    - User
+    - CommandLine
+    - ParentCommandLine

--- a/rules/windows/process_creation/win_nltest_recon.yml
+++ b/rules/windows/process_creation/win_nltest_recon.yml
@@ -1,4 +1,5 @@
-title: Nltest Usage
+title: Detect Recon Activity with nltest
+id: 5cc90652-4cbd-4241-aa3b-4b462fa5a248
 description: Detects nltest commands that can be used for information discovery
 references:
 - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731935(v=ws.11)
@@ -9,7 +10,7 @@ references:
 status: experimental
 author: Craig Young, oscd.community, Georg Lauenstein
 date: 2021/07/24
-modified: 2021/08/17
+modified: 2021/08/19
 tags:
   - attack.discovery
   - attack.T1016
@@ -32,7 +33,7 @@ detection:
             - '/user'
     condition: selection_nltest AND (selection_recon1 OR selection_recon2)
 falsepositives:
-    - To be determined
+    - Legitimate administration use but user must be check out
 level: medium
 fields:
     - Image

--- a/rules/windows/process_creation/win_nltest_recon.yml
+++ b/rules/windows/process_creation/win_nltest_recon.yml
@@ -2,19 +2,19 @@ title: Recon Activity with NLTEST
 id: 5cc90652-4cbd-4241-aa3b-4b462fa5a248
 description: Detects nltest commands that can be used for information discovery
 references:
-- https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731935(v=ws.11)
-- https://thedfirreport.com/2021/08/16/trickbot-leads-up-to-fake-1password-installation/
-- https://attack.mitre.org/techniques/T1482/
-- https://attack.mitre.org/techniques/T1016/
-- https://book.hacktricks.xyz/windows/basic-cmd-for-pentesters
+  - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731935(v=ws.11)
+  - https://thedfirreport.com/2021/08/16/trickbot-leads-up-to-fake-1password-installation/
+  - https://attack.mitre.org/techniques/T1482/
+  - https://attack.mitre.org/techniques/T1016/
+  - https://book.hacktricks.xyz/windows/basic-cmd-for-pentesters
 status: experimental
 author: Craig Young, oscd.community, Georg Lauenstein
 date: 2021/07/24
 modified: 2021/08/19
 tags:
   - attack.discovery
-  - attack.T1016
-  - attack.T1482
+  - attack.t1016
+  - attack.t1482
 logsource:
   category: process_creation
   product: windows

--- a/rules/windows/process_creation/win_nltest_recon.yml
+++ b/rules/windows/process_creation/win_nltest_recon.yml
@@ -1,4 +1,4 @@
-title: Detect Recon Activity with nltest
+title: Recon Activity with NLTEST
 id: 5cc90652-4cbd-4241-aa3b-4b462fa5a248
 description: Detects nltest commands that can be used for information discovery
 references:

--- a/rules/windows/process_creation/win_nltest_recon.yml
+++ b/rules/windows/process_creation/win_nltest_recon.yml
@@ -26,7 +26,7 @@ detection:
             - '/server'
             - '/query'
     selection_recon2:
-        CommandLine|startswith:
+        CommandLine|contains:
             - '/dclist:'
             - '/parentdomain'
             - '/domain_trusts'


### PR DESCRIPTION
modification based on new reports

1.https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731935(v=ws.11) 
-> for (selection_recon1 and seletion_recon2")
2.https://book.hacktricks.xyz/windows/basic-cmd-for-pentesters -> nltest example
3.MITRE reference just for reference to MITRE to gain more insights
4.https://thedfirreport.com/2021/08/16/trickbot-leads-up-to-fake-1password-installation/ 
-> new Report about Trickbot with reference and usage of "nltest" therefore I included the option in this rule