### PR TITLE
Update AWS CloudTrail rules

### DIFF
--- a/rules/cloud/aws/aws_ec2_disable_encryption.yml
+++ b/rules/cloud/aws/aws_ec2_disable_encryption.yml
@@ -4,7 +4,7 @@ status: stable
 description: Identifies disabling of default Amazon Elastic Block Store (EBS) encryption in the current region. Disabling default encryption does not change the encryption status of your existing volumes.
 author: Sittikorn S
 date: 2021/06/29
-modified: 2021/08/09
+modified: 2021/08/20
 references:
     - https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DisableEbsEncryptionByDefault.html
 tags:
@@ -17,7 +17,6 @@ detection:
     selection:
         eventSource: ec2.amazonaws.com
         eventName: DisableEbsEncryptionByDefault
-        status: success
     condition: selection
 falsepositives:
     - System Administrator Activities

--- a/rules/cloud/aws/aws_ec2_download_userdata.yml
+++ b/rules/cloud/aws/aws_ec2_download_userdata.yml
@@ -4,9 +4,9 @@ status: experimental
 description: Detects bulk downloading of User Data associated with AWS EC2 instances. Instance User Data may include installation scripts and hard-coded secrets for deployment.
 author: faloker
 date: 2020/02/11
-modified: 2021/08/09
+modified: 2021/08/20
 references:
-    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__download_userdata/main.py#L24
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu/modules/ec2__download_userdata/main.py
 logsource:
     service: cloudtrail
 detection:

--- a/rules/cloud/aws/aws_ec2_vm_export_failure.yml
+++ b/rules/cloud/aws/aws_ec2_vm_export_failure.yml
@@ -4,6 +4,7 @@ status: experimental
 description: An attempt to export an AWS EC2 instance has been detected. A VM Export might indicate an attempt to extract information from an instance.     
 author: Diogo Braz
 date: 2020/04/16
+modified: 2021/08/20
 references: 
   - https://docs.aws.amazon.com/vm-import/latest/userguide/vmexport.html#export-instance
 logsource:
@@ -16,10 +17,7 @@ detection:
     errorMessage: '*'
   filter2:
     errorCode: '*'
-  filter3:
-    eventName: 'ConsoleLogin'
-    responseElements|contains: 'Failure'
-  condition: selection and (filter1 or filter2 or filter3)
+  condition: selection and (filter1 or filter2)
 level: low
 tags:
 - attack.collection    

--- a/rules/cloud/aws/aws_ec2_vm_export_failure.yml
+++ b/rules/cloud/aws/aws_ec2_vm_export_failure.yml
@@ -17,7 +17,9 @@ detection:
     errorMessage: '*'
   filter2:
     errorCode: '*'
-  condition: selection and (filter1 or filter2)
+  filter3:
+    responseElements|contains: 'Failure'
+  condition: selection and (filter1 or filter2 or filter3)
 level: low
 tags:
 - attack.collection    

--- a/rules/cloud/aws/aws_iam_backdoor_users_keys.yml
+++ b/rules/cloud/aws/aws_iam_backdoor_users_keys.yml
@@ -4,9 +4,9 @@ status: experimental
 description: Detects AWS API key creation for a user by another user. Backdoored users can be used to obtain persistence in the AWS environment. Also with this alert, you can detect a flow of AWS keys in your org.
 author: faloker
 date: 2020/02/12
-modified: 2021/08/09
+modified: 2021/08/20
 references:
-    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/iam__backdoor_users_keys/main.py#L6
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu/modules/iam__backdoor_users_keys/main.py
 logsource:
     service: cloudtrail
 detection:

--- a/rules/cloud/aws/aws_rds_change_master_password.yml
+++ b/rules/cloud/aws/aws_rds_change_master_password.yml
@@ -4,9 +4,9 @@ status: experimental
 description: Detects the change of database master password. It may be a part of data exfiltration.
 author: faloker
 date: 2020/02/12
-modified: 2021/08/09
+modified: 2021/08/20
 references:
-    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu/modules/rds__explore_snapshots/main.py
 logsource:
     service: cloudtrail
 detection:

--- a/rules/cloud/aws/aws_rds_public_db_restore.yml
+++ b/rules/cloud/aws/aws_rds_public_db_restore.yml
@@ -4,9 +4,9 @@ status: experimental
 description: Detects the recovery of a new public database instance from a snapshot. It may be a part of data exfiltration.
 author: faloker
 date: 2020/02/12
-modified: 2021/08/09
+modified: 2021/08/20
 references:
-    - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/rds__explore_snapshots/main.py#L10
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu/modules/rds__explore_snapshots/main.py
 logsource:
     service: cloudtrail
 detection:

--- a/rules/cloud/aws/aws_sts_assumerole_misuse.yml
+++ b/rules/cloud/aws/aws_sts_assumerole_misuse.yml
@@ -1,9 +1,10 @@
-title: AWS STS AssumedRole Misuse
+title: AWS STS AssumeRole Misuse
 id: 905d389b-b853-46d0-9d3d-dea0d3a3cd49
-description: Identifies the suspicious use of AssumedRole. Attackers could move laterally and escalate privileges.
+description: Identifies the suspicious use of AssumeRole. Attackers could move laterally and escalate privileges.
 author: Austin Songer @austinsonger
 status: experimental
 date: 2021/07/24
+modified: 2021/08/20
 references:
     - https://github.com/elastic/detection-rules/pull/1214
     - https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
@@ -12,8 +13,8 @@ logsource:
 detection:
     selection:
         eventSource: sts.amazonaws.com
-        eventName: AssumedRole
-        userIdentity.sessionContext: Role
+        eventName: AssumeRole
+        userIdentity.sessionContext.sessionIssuer.type: Role
     condition: selection
 level: low
 tags:
@@ -23,5 +24,5 @@ tags:
     - attack.t1550
     - attack.t1550.001
 falsepositives:
-    - AssumedRole may be done by a system or network administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. AssumedRole from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+    - AssumeRole may be done by a system or network administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. AssumeRole from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     - Automated processes that uses Terraform may lead to false positives.

--- a/rules/cloud/aws/aws_sts_assumerole_misuse.yml
+++ b/rules/cloud/aws/aws_sts_assumerole_misuse.yml
@@ -24,5 +24,6 @@ tags:
     - attack.t1550
     - attack.t1550.001
 falsepositives:
-    - AssumeRole may be done by a system or network administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. AssumeRole from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+    - AssumeRole may be done by a system or network administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+    - AssumeRole from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     - Automated processes that uses Terraform may lead to false positives.


### PR DESCRIPTION
aws_ec2_disable_encryption.yml
Remove `status: success` from selection criteria, not required

aws_ec2_vm_export_failure.yml
Remove filter3:
```
eventName: 'ConsoleLogin'
responseElements|contains: 'Failure'
```
Incompatible with selection criteria `eventName: 'CreateInstanceExportTask'`

aws_ec2_download_userdata.yml, aws_iam_backdoor_users_keys.yml, aws_rds_change_master_password.yml, aws_rds_public_db_restore.yml
Update reference

aws_sts_assumedrole_misuse.yml
Rename to aws_sts_assumerole_misuse.yml
Update references to "AssumedRole" to "AssumeRole"
Update selection criteria of `userIdentity.sessionContext: Role` to `userIdentity.sessionContext.sessionIssuer.type: Role`