### PR TITLE
Create zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml

### DIFF
--- a/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
+++ b/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
@@ -1,5 +1,5 @@
 title: Potential PetitPotam Attack via EFS RPC Calls 
-id: bae2865c-5565-470d-b505-9496c87d0c30
+id: 4096842a-8f9f-4d36-92b4-d0b2a62f9b2a
 Description: 'Detects usage of the windows RPC library Encrypting File System Remote Protocol (MS-EFSRPC). Variations of this RPC are used within the attack refereed to as PetitPotam. The usage of this RPC function should be rare if ever used at all. Thus usage of this function is uncommon enough that any usage of this RPC function should warrant further investigation to determine if it is legitimate. View surrounding logs (within a few minutes before and after) from the Source IP to. Logs from from the Source IP would include dce_rpc, smb_mapping, smb_files, rdp, ntlm, kerberos, etc..'
 author: '@neu5ron, @Antonlovesdnb, Mike Remen'
 date: 2021/08/17

--- a/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
+++ b/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
@@ -1,4 +1,48 @@
-title: Potential PetitPotam Attack via Usage of Encrypting File System RPC Calls. 
+title: Potential PetitPotam Attack via EFS RPC Call
+id: bae2865c-5565-470d-b505-9496c87d0c30
+Description: 'Detects usage of the windows RPC library Encrypting File System Remote Protocol (MS-EFSRPC). Variations of this RPC are used within the attack refereed to as PetitPotam. The usage of this RPC function should be rare if ever used at all. Thus usage of this function is uncommon enough that any usage of this RPC function should warrant further investigation to determine if it is legitimate. View surrounding logs (within a few minutes before and after) from the Source IP to. Logs from from the Source IP would include dce_rpc, smb_mapping, smb_files, rdp, ntlm, kerberos, etc..'
+author: '@neu5ron, @Antonlovesdnb, Mike Remen'
+date: 2021/08/17
+references:
+    - 'https://github.com/topotam/PetitPotam/blob/main/PetitPotam/PetitPotam.cpp'
+    - 'https://msrc.microsoft.com/update-guide/vulnerability/ADV210003'
+    - 'https://vx-underground.org/archive/Symantec/windows-vista-network-attack-07-en.pdf'
+    - 'https://threatpost.com/microsoft-petitpotam-poc/168163/'
+tags:
+    - attack.t1557.001
+    - attack.t1187
+logsource:
+    product: zeek
+    service: dce_rpc
+detection:
+    efs_operation:
+        endpoint|startswith:
+        - 'Efs'
+        - 'efs'
+        # EfsDecryptFileSrv'
+        # EfsRpcAddUsersToFile'
+        # EfsRpcAddUsersToFileEx'
+        # EfsRpcCloseRaw'
+        # EfsRpcDuplicateEncryptionInfoFile'
+        # EfsRpcEncryptFileExServ'
+        # EfsRpcEncryptFileSrv'
+        # EfsRpcFileKeyInfo'
+        # EfsRpcFileKeyInfoEx'
+        # EfsRpcFlushEfsCache'
+        # EfsRpcGetEncryptedFileMetadata'
+        # EfsRpcNotSupported'
+        # EfsRpcOpenFileRaw'
+        # EfsRpcQueryProtectors'
+        # EfsRpcQueryRecoveryAgents'
+        # EfsRpcQueryUsersOnFile'
+        # EfsRpcReadFileRaw'
+        # EfsRpcRemoveUsersFromFile'
+        # EfsRpcSetEncryptedFileMetadata'
+        # EfsRpcWriteFileRaw'
+    condition: efs_operation
+falsepositives:
+    - 'Uncommon but legitimate windows administrator or software tasks that make use of the Encrypting File System RPC Calls. Verify if this is common activity (see description).'
+level: medium
 id: bae2865c-5565-470d-b505-9496c87d0c30
 Description: 'Detects usage of the windows RPC library Encrypting File System Remote Protocol (MS-EFSRPC). Variations of this RPC are used within the attack refereed to as PetitPotam. The usage of this RPC function should be rare if ever used at all. Thus usage of this function is uncommon enough that any usage of this RPC function should warrant further investigation to determine if it is legitimate. View surrounding logs (within a few minutes before and after) from the Source IP to. Logs from from the Source IP would include dce_rpc, smb_mapping, smb_files, rdp, ntlm, kerberos, etc..'
 author: '@neu5ron, @Antonlovesdnb, Mike Remen'

--- a/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
+++ b/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
@@ -1,4 +1,4 @@
-title: Potential PetitPotam Attack via EFS RPC Call
+title: Potential PetitPotam Attack via EFS RPC Calls 
 id: bae2865c-5565-470d-b505-9496c87d0c30
 Description: 'Detects usage of the windows RPC library Encrypting File System Remote Protocol (MS-EFSRPC). Variations of this RPC are used within the attack refereed to as PetitPotam. The usage of this RPC function should be rare if ever used at all. Thus usage of this function is uncommon enough that any usage of this RPC function should warrant further investigation to determine if it is legitimate. View surrounding logs (within a few minutes before and after) from the Source IP to. Logs from from the Source IP would include dce_rpc, smb_mapping, smb_files, rdp, ntlm, kerberos, etc..'
 author: '@neu5ron, @Antonlovesdnb, Mike Remen'
@@ -17,74 +17,9 @@ logsource:
 detection:
     efs_operation:
         endpoint|startswith:
-        - 'Efs'
-        - 'efs'
-        # EfsDecryptFileSrv'
-        # EfsRpcAddUsersToFile'
-        # EfsRpcAddUsersToFileEx'
-        # EfsRpcCloseRaw'
-        # EfsRpcDuplicateEncryptionInfoFile'
-        # EfsRpcEncryptFileExServ'
-        # EfsRpcEncryptFileSrv'
-        # EfsRpcFileKeyInfo'
-        # EfsRpcFileKeyInfoEx'
-        # EfsRpcFlushEfsCache'
-        # EfsRpcGetEncryptedFileMetadata'
-        # EfsRpcNotSupported'
-        # EfsRpcOpenFileRaw'
-        # EfsRpcQueryProtectors'
-        # EfsRpcQueryRecoveryAgents'
-        # EfsRpcQueryUsersOnFile'
-        # EfsRpcReadFileRaw'
-        # EfsRpcRemoveUsersFromFile'
-        # EfsRpcSetEncryptedFileMetadata'
-        # EfsRpcWriteFileRaw'
+          - 'Efs'
+          - 'efs'
     condition: efs_operation
 falsepositives:
     - 'Uncommon but legitimate windows administrator or software tasks that make use of the Encrypting File System RPC Calls. Verify if this is common activity (see description).'
 level: medium
-id: bae2865c-5565-470d-b505-9496c87d0c30
-Description: 'Detects usage of the windows RPC library Encrypting File System Remote Protocol (MS-EFSRPC). Variations of this RPC are used within the attack refereed to as PetitPotam. The usage of this RPC function should be rare if ever used at all. Thus usage of this function is uncommon enough that any usage of this RPC function should warrant further investigation to determine if it is legitimate. View surrounding logs (within a few minutes before and after) from the Source IP to. Logs from from the Source IP would include dce_rpc, smb_mapping, smb_files, rdp, ntlm, kerberos, etc..'
-author: '@neu5ron, @Antonlovesdnb, Mike Remen'
-date: 2021/08/17
-references:
-    - 'https://github.com/topotam/PetitPotam/blob/main/PetitPotam/PetitPotam.cpp'
-    - 'https://msrc.microsoft.com/update-guide/vulnerability/ADV210003'
-    - 'https://vx-underground.org/archive/Symantec/windows-vista-network-attack-07-en.pdf'
-    - 'https://threatpost.com/microsoft-petitpotam-poc/168163/'
-tags:
-    - attack.t1557.001
-    - attack.t1187
-logsource:
-    product: zeek
-    service: dce_rpc
-detection:
-    efs_operation:
-        endpoint|startswith:
-        - 'Efs'
-        - 'efs'
-        # EfsDecryptFileSrv'
-        # EfsRpcAddUsersToFile'
-        # EfsRpcAddUsersToFileEx'
-        # EfsRpcCloseRaw'
-        # EfsRpcDuplicateEncryptionInfoFile'
-        # EfsRpcEncryptFileExServ'
-        # EfsRpcEncryptFileSrv'
-        # EfsRpcFileKeyInfo'
-        # EfsRpcFileKeyInfoEx'
-        # EfsRpcFlushEfsCache'
-        # EfsRpcGetEncryptedFileMetadata'
-        # EfsRpcNotSupported'
-        # EfsRpcOpenFileRaw'
-        # EfsRpcQueryProtectors'
-        # EfsRpcQueryRecoveryAgents'
-        # EfsRpcQueryUsersOnFile'
-        # EfsRpcReadFileRaw'
-        # EfsRpcRemoveUsersFromFile'
-        # EfsRpcSetEncryptedFileMetadata'
-        # EfsRpcWriteFileRaw'
-    condition: efs_operation
-falsepositives:
-    - 'Uncommon but legitimate windows administrator or software tasks that make use of the Encrypting File System RPC Calls. Verify if this is common activity (see description).'
-level: medium
-status: stable

--- a/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
+++ b/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
@@ -1,0 +1,46 @@
+title: Potential PetitPotam Attack via Usage of Encrypting File System RPC Calls. 
+id: bae2865c-5565-470d-b505-9496c87d0c30
+Description: 'Detects usage of the windows RPC library Encrypting File System Remote Protocol (MS-EFSRPC). Variations of this RPC are used within the attack refereed to as PetitPotam. The usage of this RPC function should be rare if ever used at all. Thus usage of this function is uncommon enough that any usage of this RPC function should warrant further investigation to determine if it is legitimate. View surrounding logs (within a few minutes before and after) from the Source IP to. Logs from from the Source IP would include dce_rpc, smb_mapping, smb_files, rdp, ntlm, kerberos, etc..'
+author: '@neu5ron, @Antonlovesdnb, Mike Remen'
+date: 2021/08/17
+references:
+    - 'https://github.com/topotam/PetitPotam/blob/main/PetitPotam/PetitPotam.cpp'
+    - 'https://msrc.microsoft.com/update-guide/vulnerability/ADV210003'
+    - 'https://vx-underground.org/archive/Symantec/windows-vista-network-attack-07-en.pdf'
+    - 'https://threatpost.com/microsoft-petitpotam-poc/168163/'
+tags:
+    - attack.t1557.001
+    - attack.t1187
+logsource:
+    product: zeek
+    service: dce_rpc
+detection:
+    efs_operation:
+        endpoint|startswith:
+        - 'Efs'
+        - 'efs'
+        # EfsDecryptFileSrv'
+        # EfsRpcAddUsersToFile'
+        # EfsRpcAddUsersToFileEx'
+        # EfsRpcCloseRaw'
+        # EfsRpcDuplicateEncryptionInfoFile'
+        # EfsRpcEncryptFileExServ'
+        # EfsRpcEncryptFileSrv'
+        # EfsRpcFileKeyInfo'
+        # EfsRpcFileKeyInfoEx'
+        # EfsRpcFlushEfsCache'
+        # EfsRpcGetEncryptedFileMetadata'
+        # EfsRpcNotSupported'
+        # EfsRpcOpenFileRaw'
+        # EfsRpcQueryProtectors'
+        # EfsRpcQueryRecoveryAgents'
+        # EfsRpcQueryUsersOnFile'
+        # EfsRpcReadFileRaw'
+        # EfsRpcRemoveUsersFromFile'
+        # EfsRpcSetEncryptedFileMetadata'
+        # EfsRpcWriteFileRaw'
+    condition: efs_operation
+falsepositives:
+    - 'Uncommon but legitimate windows administrator or software tasks that make use of the Encrypting File System RPC Calls. Verify if this is common activity (see description).'
+level: medium
+status: stable

--- a/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
+++ b/rules/network/zeek/zeek_dce_rpc_potential_petit_potam_efs_rpc_call.yml
@@ -1,13 +1,17 @@
-title: Potential PetitPotam Attack via EFS RPC Calls 
+title: Potential PetitPotam Attack Via EFS RPC Calls 
 id: 4096842a-8f9f-4d36-92b4-d0b2a62f9b2a
-Description: 'Detects usage of the windows RPC library Encrypting File System Remote Protocol (MS-EFSRPC). Variations of this RPC are used within the attack refereed to as PetitPotam. The usage of this RPC function should be rare if ever used at all. Thus usage of this function is uncommon enough that any usage of this RPC function should warrant further investigation to determine if it is legitimate. View surrounding logs (within a few minutes before and after) from the Source IP to. Logs from from the Source IP would include dce_rpc, smb_mapping, smb_files, rdp, ntlm, kerberos, etc..'
+description: |
+    Detects usage of the windows RPC library Encrypting File System Remote Protocol (MS-EFSRPC). Variations of this RPC are used within the attack refereed to as PetitPotam.
+    The usage of this RPC function should be rare if ever used at all.
+    Thus usage of this function is uncommon enough that any usage of this RPC function should warrant further investigation to determine if it is legitimate.
+     View surrounding logs (within a few minutes before and after) from the Source IP to. Logs from from the Source IP would include dce_rpc, smb_mapping, smb_files, rdp, ntlm, kerberos, etc..'
 author: '@neu5ron, @Antonlovesdnb, Mike Remen'
 date: 2021/08/17
 references:
-    - 'https://github.com/topotam/PetitPotam/blob/main/PetitPotam/PetitPotam.cpp'
-    - 'https://msrc.microsoft.com/update-guide/vulnerability/ADV210003'
-    - 'https://vx-underground.org/archive/Symantec/windows-vista-network-attack-07-en.pdf'
-    - 'https://threatpost.com/microsoft-petitpotam-poc/168163/'
+    - https://github.com/topotam/PetitPotam/blob/main/PetitPotam/PetitPotam.cpp
+    - https://msrc.microsoft.com/update-guide/vulnerability/ADV210003
+    - https://vx-underground.org/archive/Symantec/windows-vista-network-attack-07-en.pdf
+    - https://threatpost.com/microsoft-petitpotam-poc/168163/
 tags:
     - attack.t1557.001
     - attack.t1187
@@ -17,9 +21,9 @@ logsource:
 detection:
     efs_operation:
         endpoint|startswith:
-          - 'Efs'
-          - 'efs'
+            - 'Efs'
+            - 'efs'
     condition: efs_operation
 falsepositives:
-    - 'Uncommon but legitimate windows administrator or software tasks that make use of the Encrypting File System RPC Calls. Verify if this is common activity (see description).'
+    - Uncommon but legitimate windows administrator or software tasks that make use of the Encrypting File System RPC Calls. Verify if this is common activity (see description).
 level: medium


### PR DESCRIPTION
Detects usage of the windows RPC library Encrypting File System Remote Protocol (MS-EFSRPC). Variations of this RPC are used within the attack refereed to as PetitPotam.
Should cover the multiple variations of this RPC, many of which are "yet" to be used within public PoC,  such as:
```
EfsDecryptFileSrv'
EfsRpcAddUsersToFile'
EfsRpcAddUsersToFileEx'
EfsRpcCloseRaw'
EfsRpcDuplicateEncryptionInfoFile'
EfsRpcEncryptFileExServ'
EfsRpcEncryptFileSrv'
EfsRpcFileKeyInfo'
EfsRpcFileKeyInfoEx'
EfsRpcFlushEfsCache'
EfsRpcGetEncryptedFileMetadata'
EfsRpcNotSupported'
EfsRpcOpenFileRaw'
EfsRpcQueryProtectors'
EfsRpcQueryRecoveryAgents'
EfsRpcQueryUsersOnFile'
EfsRpcReadFileRaw'
EfsRpcRemoveUsersFromFile'
EfsRpcSetEncryptedFileMetadata'
EfsRpcWriteFileRaw'
```