### PR TITLE
improve rule logic zeek_default_cobalt_strike_certificate.yml

### DIFF
--- a/rules/network/zeek/zeek_default_cobalt_strike_certificate.yml
+++ b/rules/network/zeek/zeek_default_cobalt_strike_certificate.yml
@@ -2,7 +2,8 @@ title: Default Cobalt Strike Certificate
 id: 7100f7e3-92ce-4584-b7b7-01b40d3d4118
 description: Detects the presence of default Cobalt Strike certificate in the HTTPS traffic
 author: Bhabesh Raj
-date: 2021/08/26
+date: 2021/06/23
+modified: 2021/08/24
 references: 
   - https://sergiusechel.medium.com/improving-the-network-based-detection-of-cobalt-strike-c2-servers-in-the-wild-while-reducing-the-6964205f6468
 tags:

--- a/rules/network/zeek/zeek_default_cobalt_strike_certificate.yml
+++ b/rules/network/zeek/zeek_default_cobalt_strike_certificate.yml
@@ -2,7 +2,7 @@ title: Default Cobalt Strike Certificate
 id: 7100f7e3-92ce-4584-b7b7-01b40d3d4118
 description: Detects the presence of default Cobalt Strike certificate in the HTTPS traffic
 author: Bhabesh Raj
-date: 2021/06/23
+date: 2021/08/26
 references: 
   - https://sergiusechel.medium.com/improving-the-network-based-detection-of-cobalt-strike-c2-servers-in-the-wild-while-reducing-the-6964205f6468
 tags:
@@ -13,7 +13,7 @@ logsource:
   service: x509
 detection:
   selection:
-    certificate.serial: 8bb00ee
+    certificate.serial: 8BB00EE
   condition: selection
 fields:
     - san.dns


### PR DESCRIPTION
zeek logging for `certificate.serial` is all letters are capitalized