### PR TITLE
Zeek DCE_RPC PrintNightmare

### DIFF
--- a/rules/network/zeek/zeek_dce_rpc_printnightmare_print_driver_install.yml
+++ b/rules/network/zeek/zeek_dce_rpc_printnightmare_print_driver_install.yml
@@ -13,7 +13,6 @@ references:
     - https://github.com/SigmaHQ/sigma/blob/master/rules/network/zeek/zeek_dce_rpc_mitre_bzar_persistence.yml
     - https://old.zeek.org/zeekweek2019/slides/bzar.pdf
     - https://www.crowdstrike.com/blog/cve-2021-1678-printer-spooler-relay-security-advisory/
-    - 
 tags:
     - attack.execution
     - cve.2021-1675

--- a/rules/network/zeek/zeek_dce_rpc_printnightmare_print_driver_install.yml
+++ b/rules/network/zeek/zeek_dce_rpc_printnightmare_print_driver_install.yml
@@ -1,0 +1,45 @@
+title: Possible PrintNightmare Print Driver Install
+id: 7b33baef-2a75-4ca3-9da4-34f9a15382d8
+description: |
+    Detects the remote installation of a print driver which is possible indication of the exploitation of PrintNightmare (CVE-2021-1675).
+    The occurrence of print drivers being installed remotely via RPC functions should be rare, as print drivers are normally installed locally and or through group policy.
+author: '@neu5ron (Nate Guagenti)'
+date: 2021/08/23
+references:
+    - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-par/93d1915d-4d9f-4ceb-90a7-e8f2a59adc29
+    - https://github.com/zeek/zeek/blob/master/scripts/base/protocols/dce-rpc/consts.zeek
+    - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527
+    - https://github.com/corelight/CVE-2021-1675
+    - https://github.com/SigmaHQ/sigma/blob/master/rules/network/zeek/zeek_dce_rpc_mitre_bzar_persistence.yml
+    - https://old.zeek.org/zeekweek2019/slides/bzar.pdf
+    - https://www.crowdstrike.com/blog/cve-2021-1678-printer-spooler-relay-security-advisory/
+    - 
+tags:
+    - attack.execution
+    - cve.2021-1675
+    - cve.2021-1678
+logsource:
+    product: zeek
+    service: dce_rpc
+detection:
+    printer_operation:
+        operation:
+            - "RpcAsyncInstallPrinterDriverFromPackage" # "76f03f96-cdfd-44fc-a22c-64950a001209",0x3e
+            - "RpcAsyncAddPrintProcessor" # "76f03f96-cdfd-44fc-a22c-64950a001209",0x2c
+            - "RpcAddPrintProcessor" # "12345678-1234-abcd-ef00-0123456789ab",0x0e
+            - "RpcAddPrinterDriverEx" # "12345678-1234-abcd-ef00-0123456789ab",0x59
+            - "RpcAddPrinterDriver" # "12345678-1234-abcd-ef00-0123456789ab",0x09
+            - "RpcAsyncAddPrinterDriver" # "76f03f96-cdfd-44fc-a22c-64950a001209",0x27
+    condition: printer_operation
+falsepositives:
+    - Legitimate remote alteration of a printer driver.
+level: medium
+fields:
+    - id.orig_h
+    - id.resp_h
+    - id.resp_p
+    - operation
+    - endpoint
+    - named_pipe
+    - uid
+status: stable


### PR DESCRIPTION
Zeek dce_rpc.log Detection of print driver installs over RPC (ie: possible PrintNightmare) using the three existing known RPC functions, as well as few others "discussed" but not directly related to PrintNightmare PoC or public post-compromise write-ups.