### PR TITLE
Adding CVE's Exploitation attempt detection: Year - 2010

### DIFF
--- a/rules/web/web_cve_CVE-2010-0943.yaml
+++ b/rules/web/web_cve_CVE-2010-0943.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-0943:Joomla! Component com_jashowcase - Directory Traversal
+id: a7b7151c-99e5-444b-89db-df927d1055ed
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the JA Showcase (com_jashowcase)
+  component for Joomla! allows remote attackers to read arbitrary files via a .. (dot
+  dot) in the controller parameter in a jashowcase action to index.php.
+references:
+- https://www.exploit-db.com/exploits/11090
+- https://www.cvedetails.com/cve/CVE-2010-0943
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_jashowcase&view=jashowcase&controller=../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-0944.yaml
+++ b/rules/web/web_cve_CVE-2010-0944.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-0944:Joomla! Component com_jcollection - Directory Traversal
+id: c3a5750d-210b-4a15-b1f7-17444d634a6a
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the JCollection (com_jcollection)
+  component for Joomla! allows remote attackers to read arbitrary files via a .. (dot
+  dot) in the controller parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/11088
+- https://www.cvedetails.com/cve/CVE-2010-0944
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_jcollection&controller=../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1314.yaml
+++ b/rules/web/web_cve_CVE-2010-1314.yaml
@@ -1,0 +1,23 @@
+title: CVE-2010-1314:Joomla! Component Highslide 1.5 - Local File Inclusion
+id: 226602ff-06ce-4173-9b87-7c2d62b4b3a4
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Highslide JS (com_hsconfig)
+  component 1.5 and 2.0.9 for Joomla! allows remote attackers to read arbitrary files
+  via a .. (dot dot) in the controller parameter to index.php.
+references:
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_hsconfig&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1345.yaml
+++ b/rules/web/web_cve_CVE-2010-1345.yaml
@@ -1,0 +1,23 @@
+title: CVE-2010-1345:Joomla! Component Cookex Agency CKForms - Local File Inclusion
+id: ff1015cf-e991-458c-a999-67e30fd34f9a
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Cookex Agency CKForms (com_ckforms)
+  component 1.3.3 for Joomla! allows remote attackers to read arbitrary files via
+  a .. (dot dot) in the controller parameter to index.php.
+references:
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_ckforms&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1353.yaml
+++ b/rules/web/web_cve_CVE-2010-1353.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-1353:Joomla! Component LoginBox - Local File Inclusion
+id: dee9b22f-1e7c-44ec-ad34-555ea35c0a6e
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the LoginBox Pro (com_loginbox)
+  component for Joomla! allows remote attackers to read arbitrary files via a .. (dot
+  dot) in the view parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/12068
+- https://www.cvedetails.com/cve/CVE-2010-1353
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_loginbox&view=../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1474.yaml
+++ b/rules/web/web_cve_CVE-2010-1474.yaml
@@ -1,0 +1,26 @@
+title: CVE-2010-1474:Joomla! Component Sweetykeeper 1.5 - Local File Inclusion
+id: b2a1a114-6d92-4cce-8b53-b82518abf56c
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Sweety Keeper (com_sweetykeeper)
+  component 1.5.x for Joomla! allows remote attackers to read arbitrary files and
+  possibly have unspecified other impact via a .. (dot dot) in the controller parameter
+  to index.php.
+references:
+- https://www.exploit-db.com/exploits/12182
+- https://www.cvedetails.com/cve/CVE-2010-1474
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_sweetykeeper&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1475.yaml
+++ b/rules/web/web_cve_CVE-2010-1475.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-1475:Joomla! Component Preventive And Reservation 1.0.5 - Local File
+  Inclusion
+id: 6d1e0e6f-4e68-4f1c-8f60-467521d0c25b
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Preventive & Reservation (com_preventive)
+  component 1.0.5 for Joomla! allows remote attackers to read arbitrary files and
+  possibly have unspecified other impact via a .. (dot dot) in the controller parameter
+  to index.php.
+references:
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_preventive&controller==../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1495.yaml
+++ b/rules/web/web_cve_CVE-2010-1495.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-1495:Joomla! Component Matamko 1.01 - Local File Inclusion
+id: 6edfc22e-9b33-43c4-8872-eb41d6cfb5bd
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Matamko (com_matamko) component
+  1.01 for Joomla! allows remote attackers to read arbitrary files via a .. (dot dot)
+  in the controller parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/12286
+- https://www.cvedetails.com/cve/CVE-2010-1495
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_matamko&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1532.yaml
+++ b/rules/web/web_cve_CVE-2010-1532.yaml
@@ -1,0 +1,24 @@
+title: CVE-2010-1532:Joomla! Component PowerMail Pro 1.5.3 - Local File Inclusion
+id: d1890f8a-ef82-4d0c-a686-bace99bd54f2
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the givesight PowerMail Pro (com_powermail)
+  component 1.5.3 for Joomla! allows remote attackers to read arbitrary files and
+  possibly have unspecified other impact via a .. (dot dot) in the controller parameter
+  to index.php.
+references:
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_powermail&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1533.yaml
+++ b/rules/web/web_cve_CVE-2010-1533.yaml
@@ -1,0 +1,23 @@
+title: CVE-2010-1533:Joomla! Component TweetLA 1.0.1 - Local File Inclusion
+id: 432ecccc-dfd6-4c0f-8173-0f57f8eafe46
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the TweetLA (com_tweetla) component
+  1.0.1 for Joomla! allows remote attackers to read arbitrary files via a .. (dot
+  dot) in the controller parameter to index.php.
+references:
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_tweetla&controller=../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1535.yaml
+++ b/rules/web/web_cve_CVE-2010-1535.yaml
@@ -1,0 +1,24 @@
+title: CVE-2010-1535:Joomla! Component TRAVELbook 1.0.1 - Local File Inclusion
+id: 36a64564-5ba1-40ff-a85f-6a0a11215c35
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the TRAVELbook (com_travelbook)
+  component 1.0.1 for Joomla! allows remote attackers to read arbitrary files and
+  possibly have unspecified other impact via a .. (dot dot) in the controller parameter
+  to index.php.
+references:
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_travelbook&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1602.yaml
+++ b/rules/web/web_cve_CVE-2010-1602.yaml
@@ -1,0 +1,26 @@
+title: CVE-2010-1602:Joomla! Component ZiMB Comment 0.8.1 - Local File Inclusion
+id: e9519f69-b3b8-4695-88bb-5bf2d34e40aa
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the ZiMB Comment (com_zimbcomment)
+  component 0.8.1 for Joomla! allows remote attackers to read arbitrary files and
+  possibly have unspecified other impact via a .. (dot dot) in the controller parameter
+  to index.php.
+references:
+- https://www.exploit-db.com/exploits/12283
+- https://www.cvedetails.com/cve/CVE-2010-1602
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_zimbcomment&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1657.yaml
+++ b/rules/web/web_cve_CVE-2010-1657.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-1657:Joomla! Component SmartSite 1.0.0 - Local File Inclusion
+id: b32928f2-521b-4e3b-b34c-cb49617727ca
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the SmartSite (com_smartsite) component
+  1.0.0 for Joomla! allows remote attackers to read arbitrary files via a .. (dot
+  dot) in the controller parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/12428
+- https://www.cvedetails.com/cve/CVE-2010-1657
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_smartsite&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1718.yaml
+++ b/rules/web/web_cve_CVE-2010-1718.yaml
@@ -1,0 +1,24 @@
+title: CVE-2010-1718:Joomla! Component Archery Scores 1.0.6 - Local File Inclusion
+id: 60f6f1f4-0312-4416-bb31-fd376a59ce7b
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in archeryscores.php in the Archery
+  Scores (com_archeryscores) component 1.0.6 for Joomla! allows remote attackers to
+  include and execute arbitrary local files via a .. (dot dot) in the controller parameter
+  to index.php.
+references:
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_archeryscores&controller=../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1722.yaml
+++ b/rules/web/web_cve_CVE-2010-1722.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-1722:Joomla! Component Online Market 2.x - Local File Inclusion
+id: e33e435a-51b1-416d-b0f3-0965a0b73af9
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Online Market (com_market) component
+  2.x for Joomla! allows remote attackers to read arbitrary files and possibly have
+  unspecified other impact via a .. (dot dot) in the controller parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/12177
+- https://www.cvedetails.com/cve/CVE-2010-1722
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_market&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1875.yaml
+++ b/rules/web/web_cve_CVE-2010-1875.yaml
@@ -1,0 +1,26 @@
+title: CVE-2010-1875:Joomla! Component Property - Local File Inclusion
+id: d989a93e-8f69-4419-876d-12bd5f9bfc19
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Real Estate Property (com_properties)
+  component 3.1.22-03 for Joomla! allows remote attackers to read arbitrary files
+  and possibly have unspecified other impact via a .. (dot dot) in the controller
+  parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/11851
+- https://www.cvedetails.com/cve/CVE-2010-1875
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_properties&controller=../../../../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1953.yaml
+++ b/rules/web/web_cve_CVE-2010-1953.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-1953:Joomla! Component iNetLanka Multiple Map 1.0 - Local File Inclusion
+id: 88a112bd-6581-4492-8d76-5c984d738c09
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the iNetLanka Multiple Map (com_multimap)
+  component 1.0 for Joomla! allows remote attackers to read arbitrary files via a
+  .. (dot dot) in the controller parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/12288
+- https://www.cvedetails.com/cve/CVE-2010-1953
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_multimap&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1955.yaml
+++ b/rules/web/web_cve_CVE-2010-1955.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-1955:Joomla! Component Deluxe Blog Factory 1.1.2 - Local File Inclusion
+id: 5eeaa5a1-e6d1-46f8-9bf3-ef141d6733f9
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Deluxe Blog Factory (com_blogfactory)
+  component 1.1.2 for Joomla! allows remote attackers to read arbitrary files via
+  a .. (dot dot) in the controller parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/12238
+- https://www.cvedetails.com/cve/CVE-2010-1955
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_blogfactory&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1979.yaml
+++ b/rules/web/web_cve_CVE-2010-1979.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-1979:Joomla! Component Affiliate Datafeeds 880 - Local File Inclusion
+id: 0221e773-afea-48bf-b3b2-dd60ed509720
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Affiliate Datafeeds (com_datafeeds)
+  component build 880 for Joomla! allows remote attackers to read arbitrary files
+  via a .. (dot dot) in the controller parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/12088
+- https://www.cvedetails.com/cve/CVE-2010-1979
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_datafeeds&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-1983.yaml
+++ b/rules/web/web_cve_CVE-2010-1983.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-1983:Joomla! Component redTWITTER 1.0 - Local File Inclusion
+id: b205e0d0-b61a-4a7a-a8db-45225cad643f
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the redTWITTER (com_redtwitter)
+  component 1.0.x including 1.0b11 for Joomla! allows remote attackers to read arbitrary
+  files via a .. (dot dot) in the view parameter to index.php
+references:
+- https://www.exploit-db.com/exploits/12055
+- https://www.cvedetails.com/cve/CVE-2010-1983
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_redtwitter&view=../../../../../../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-2033.yaml
+++ b/rules/web/web_cve_CVE-2010-2033.yaml
@@ -1,0 +1,26 @@
+title: CVE-2010-2033:Joomla Percha Categories Tree 0.6 - Local File Inclusion
+id: d61b5ebd-9dc8-4dc5-b377-5e7cabfde00e
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Percha Fields Attach (com_perchafieldsattach)
+  component 1.x for Joomla! allows remote attackers to read arbitrary files and possibly
+  have unspecified other impact via a .. (dot dot) in the controller parameter to
+  index.php.
+references:
+- https://packetstormsecurity.com/files/89654/Joomla-Percha-Categories-Tree-0.6-Local-File-Inclusion.html
+- https://www.cvedetails.com/cve/CVE-2010-2033
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_perchacategoriestree&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-2036.yaml
+++ b/rules/web/web_cve_CVE-2010-2036.yaml
@@ -1,0 +1,26 @@
+title: CVE-2010-2036:Joomla! Component Percha Fields Attach 1.0 - Directory Traversal
+id: 1859e4d6-2965-4bee-897f-bded883e7364
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Percha Fields Attach (com_perchafieldsattach)
+  component 1.x for Joomla! allows remote attackers to read arbitrary files and possibly
+  have unspecified other impact via a .. (dot dot) in the controller parameter to
+  index.php.
+references:
+- https://www.exploit-db.com/exploits/34004
+- https://www.cvedetails.com/cve/CVE-2010-2036
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_perchafieldsattach&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-2259.yaml
+++ b/rules/web/web_cve_CVE-2010-2259.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-2259:Joomla! Component com_bfsurvey - Local File Inclusion
+id: 0f74c630-3e11-41d3-8352-66961fc12085
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the BF Survey (com_bfsurvey) component
+  for Joomla! allows remote attackers to include and execute arbitrary local files
+  via a .. (dot dot) in the controller parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/10946
+- https://www.cvedetails.com/cve/CVE-2010-2259
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_bfsurvey&controller=../../../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-2307.yaml
+++ b/rules/web/web_cve_CVE-2010-2307.yaml
@@ -1,0 +1,27 @@
+title: CVE-2010-2307:Motorola SBV6120E SURFboard Digital Voice Modem SBV6X2X-1.0.0.5-SCM
+  - Directory Traversal
+id: f03488dd-2c62-4541-9f0e-a11e8a7e1750
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Multiple directory traversal vulnerabilities in the web server for Motorola
+  SURFBoard cable modem SBV6120E running firmware SBV6X2X-1.0.0.5-SCM-02-SHPC allow
+  remote attackers to read arbitrary files via (1) "//" (multiple leading slash),
+  (2) ../ (dot dot) sequences, and encoded dot dot sequences in a URL request.
+references:
+- https://www.securityfocus.com/bid/40550/info
+- https://nvd.nist.gov/vuln/detail/CVE-2010-2307
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /../../etc/passwd
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-2682.yaml
+++ b/rules/web/web_cve_CVE-2010-2682.yaml
@@ -1,0 +1,26 @@
+title: CVE-2010-2682:Joomla! Component Realtyna Translator 1.0.15 - Local File Inclusion
+id: 99824e58-3cce-4172-9970-04e0a6de5108
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the Realtyna Translator (com_realtyna)
+  component 1.0.15 for Joomla! allows remote attackers to read arbitrary files and
+  possibly have unspecified other impact via a .. (dot dot) in the controller parameter
+  to index.php.
+references:
+- https://www.exploit-db.com/exploits/14017
+- https://www.cvedetails.com/cve/CVE-2010-2682
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_realtyna&controller=../../../../../../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-2861.yaml
+++ b/rules/web/web_cve_CVE-2010-2861.yaml
@@ -1,0 +1,27 @@
+title: CVE-2010-2861:Adobe ColdFusion 8.0/8.0.1/9.0/9.0.1 LFI
+id: e22f6ee2-341a-44b8-a58b-33a0960fa8e0
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Multiple directory traversal vulnerabilities in the administrator console
+  in Adobe ColdFusion 9.0.1 and earlier allow remote attackers to read arbitrary files
+  via the locale parameter to (1) CFIDE/administrator/settings/mappings.cfm, (2) logging/settings.cfm,
+  (3) datasources/index.cfm, (4) j2eepackaging/editarchive.cfm, and (5) enter.cfm
+  in CFIDE/administrator/.
+references:
+- https://github.com/vulhub/vulhub/tree/master/coldfusion/CVE-2010-2861
+- http://www.adobe.com/support/security/bulletins/apsb10-18.html
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /CFIDE/administrator/enter.cfm?locale=../../../../../../../lib/password.properties%00en
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-3426.yaml
+++ b/rules/web/web_cve_CVE-2010-3426.yaml
@@ -1,0 +1,23 @@
+title: CVE-2010-3426:Joomla! Component Jphone 1.0 Alpha 3 - Local File Inclusion
+id: 8df31def-3d71-4f01-85ab-4891fa481a8c
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in jphone.php in the JPhone (com_jphone)
+  component 1.0 Alpha 3 for Joomla! allows remote attackers to include and execute
+  arbitrary local files via a .. (dot dot) in the controller parameter to index.php.
+references:
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_jphone&controller=../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-4231.yaml
+++ b/rules/web/web_cve_CVE-2010-4231.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-4231:Camtron CMNC-200 IP Camera - Directory Traversal
+id: e097e932-b39e-4e00-ac6f-1f03e43fc716
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: The CMNC-200 IP Camera has a built-in web server that is enabled by default.
+  The server is vulnerable to directory transversal attacks, allowing access to any
+  file on the camera file system.
+references:
+- https://nvd.nist.gov/vuln/detail/CVE-2010-4231
+- https://www.exploit-db.com/exploits/15505
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /../../../../../../../../../../../../../etc/passwd
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-4617.yaml
+++ b/rules/web/web_cve_CVE-2010-4617.yaml
@@ -1,0 +1,25 @@
+title: CVE-2010-4617:Joomla! Component JotLoader 2.2.1 - Local File Inclusion
+id: 3965e578-e509-41e2-a572-12522bbcf4fd
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in the JotLoader (com_jotloader) component
+  2.2.1 for Joomla! allows remote attackers to read arbitrary files via directory
+  traversal sequences in the section parameter to index.php.
+references:
+- https://www.exploit-db.com/exploits/15791
+- https://www.cvedetails.com/cve/CVE-2010-4617
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /index.php?option=com_jotloader&section=../../../../../../../../../../../../../../etc/passwd%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/web/web_cve_CVE-2010-5278.yaml
+++ b/rules/web/web_cve_CVE-2010-5278.yaml
@@ -1,0 +1,26 @@
+title: CVE-2010-5278:MODx manager - Local File Inclusion
+id: 5f6499cc-97a6-49ed-af28-00278c2c954e
+Author: Subhash Popuri (@pbssubhash)
+date: 25/08/2021
+status: experimental
+description: Directory traversal vulnerability in manager/controllers/default/resource/tvs.php
+  in MODx Revolution 2.0.2-pl, and possibly earlier, when magic_quotes_gpc is disabled,
+  allows remote attackers to read arbitrary files via a .. (dot dot) in the class_key
+  parameter.
+references:
+- https://www.exploit-db.com/exploits/34788
+- https://www.cvedetails.com/cve/CVE-2010-5278
+- https://github.com/projectdiscovery/nuclei-templates
+detection:
+  selection:
+    c-uri|contains:
+    - /manager/controllers/default/resource/tvs.php?class_key=../../../../../../../../../../windows/win.ini%00
+  condition: selection
+false_positives:
+- Scanning from Nuclei
+- Penetration Testing Activity
+- Unknown
+tags:
+- attack.initial_access
+- attack.t1190
+level: critical

--- a/rules/windows/file_event/sysmon_detect_powerup_dllhijacking.yml
+++ b/rules/windows/file_event/sysmon_detect_powerup_dllhijacking.yml
@@ -15,7 +15,7 @@ tags:
     - attack.defense_evasion
     - attack.t1574.001
 logsource:
-    category: file_event
+    service: sysmon
     product: windows
 detection:
     selection:


### PR DESCRIPTION
I've taken reference from Nuclei Templates - https://github.com/projectdiscovery/nuclei-templates. Nuclei is a tool used for automated scanning of web vulnerabilities. I built an automated tool to convert a Nuclei template to Sigma rule. Using this, we can identify exploitation attempts over external attack surface. 

Team, please review my PR. 🙏