### PR TITLE
refactor: Mimikatz keyword rule refactoring

### DIFF
--- a/rules/windows/builtin/win_alert_mimikatz_keywords.yml
+++ b/rules/windows/builtin/win_alert_mimikatz_keywords.yml
@@ -3,7 +3,7 @@ id: 06d71506-7beb-4f22-8888-e2e5e2ca7fd8
 description: This method detects mimikatz keywords in different Eventlogs (some of them only appear in older Mimikatz version that are however still used by different threat groups)
 author: Florian Roth
 date: 2017/01/10
-modified: 2019/10/11
+modified: 2021/08/26
 tags:
     - attack.s0002
     - attack.t1003          # an old one
@@ -19,18 +19,23 @@ logsource:
     product: windows
 detection:
     keywords:
-        - "mimikatz"
-        - "mimilib"
-        - "<3 eo.oe"
-        - "eo.oe.kiwi"
-        - "privilege::debug"
-        - "sekurlsa::logonpasswords"
-        - "lsadump::sam"
-        - "mimidrv.sys"
-        - " p::d "
-        - " s::l "
+        - '\mimikatz'
+        - 'mimikatz.exe'
+        - '\mimilib.dll'
+        - '<3 eo.oe'
+        - 'eo.oe.kiwi'
+        - 'privilege::debug'
+        - 'sekurlsa::logonpasswords'
+        - 'lsadump::sam'
+        - 'mimidrv.sys'
+        - ' p::d '
+        - ' s::l '
+        - 'gentilkiwi.com'
+        - 'Kiwi Legit Printer'
     condition: keywords
 falsepositives:
     - Naughty administrators
     - Penetration test
+    - AV Signature updates
+    - Files with Mimikatz in their filename
 level: critical


### PR DESCRIPTION
- trying to avoid false positives with the mimikatz keyword somewhere in the log line like `our_mimikatz_signature.xml` or `new AV signature Win32/MIMIKATZ.MAL installed`