### PR TITLE
fix: FPs with whoami rule and 4688 event IDs without parent info

### DIFF
--- a/rules/windows/process_creation/win_susp_whoami_anomaly.yml
+++ b/rules/windows/process_creation/win_susp_whoami_anomaly.yml
@@ -26,14 +26,15 @@ detection:
         ParentImage:
             - 'C:\Program Files\Microsoft Monitoring Agent\Agent\MonitoringHost.exe'
             - ''
-            - null
+    filter3:
+        ParentImage: null
     selection_special:
         CommandLine|contains:
             - 'whoami -all'
             - 'whoami /all'
             - 'whoami.exe -all'
             - 'whoami.exe /all'
-    condition: ( selection and not filter1 and not filter2 ) or selection_special
+    condition: ( selection and not filter1 and not filter2 and not filter3 ) or selection_special
 falsepositives:
     - Admin activity
     - Scripts and administrative tools used in the monitored environment


### PR DESCRIPTION
THOR FPs on Security Eventlog with 4688 event IDs

```
THOR: Warning: 
MODULE: Eventlog
MESSAGE: high Sigma match on Eventlog record 
SCANID: S-dwV1ypzGyUY 
EVENT_ID: 4688 
EVENT_LEVEL: Information 
EVENT_CHANNEL: Security 
EVENT_TIME: Fri Aug 20 01:19:14 2021 
ENTRY: SubjectUserSid: S-1-5-18 
SubjectUserName: XXXX11111$ 
SubjectDomainName: XXX 
SubjectLogonId: 0x3e7 
NewProcessId: 0x1a3c 
NewProcessName: C:\Windows\System32\whoami.exe 
TokenElevationType: %%1936 
ProcessId: 0x11ec 
CommandLine: 
TargetUserSid: S-1-0-0 
TargetUserName: - 
TargetDomainName: - 
TargetLogonId: 0x0 
SCORE: 70 
REASON_1: Whoami Execution Anomaly 
DESC_1: Detects the execution of whoami with suspicious parents or parameters 
SCORE_1: 70 
MATCHED_1: $EventID: '4688', $NewProcessName: 'C:\Windows\System32\whoami.exe', $ParentProcessName: null 
FALSEPOSITIVES_1: Admin activity, Scripts and administrative tools used in the monitored environment, Monitoring activity 
REF_1: https://brica.de/alerts/alert/public/1247926/agent-tesla-keylogger-delivered-inside-a-power-iso-daa-archive/, https://app.any.run/tasks/7eaba74e-c1ea-400f-9c17-5e30eee89906/ 
AUTHOR_1: Florian Roth
```