### PR TITLE
feat(backend): introducing lacework backend

### DIFF
--- a/tools/sigma/backends/lacework.py
+++ b/tools/sigma/backends/lacework.py
@@ -1,6 +1,8 @@
 # Output backends for sigmac
 # Copyright 2021 Lacework, Inc.
-# Author: 
+# Authors:
+# David Hazekamp (david.hazekamp@lacework.net)
+# Rachel Rice (rachel.rice@lacework.net)
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -26,7 +28,6 @@ from sigma.parser.modifiers.base import SigmaTypeModifier
 
 
 LACEWORK_CONFIG = yaml.load(
-    # TODO: build this out to support all the default aws sigma rules
     textwrap.dedent('''
     ---
     version: 0.1


### PR DESCRIPTION
# Sigma Rules For Lacework

* [Background](#background)  
* [Sigma](#sigma)  
    * [Sigmac](#sigmac)  
* [Objective](#objective)
    * [Example](#example)
* [Considerations](#considerations)  
    * [Config Driven Approach](#config-driven-approach)  
    * [Queries vs. Policies](#queries-vs-policies)  
    * [Conditions](#conditions)  
    * [Output](#output)  
* [Query Anatomy](#query-anatomy)
    * [Title](#title)  
    * [Logsource](#logsource)  
    * [Timeframe](#timeframe)  
* [Policy Anatomy](#policy-anatomy)
* [Configuration](#configuration)  
* [Usage](#usage)  

## Background
Some organizations want to (or have already) taken a vendor agnostic approach to rule authoring.  While Lacework remains “rules optional” interoperability is an important principal for successful security platforms.

## Sigma
> Sigma is a generic and open signature format that allows you to describe relevant log events in a straightforward manner.

https://github.com/SigmaHQ/sigma

### Sigmac
[Sigmac](https://github.com/SigmaHQ/sigma#sigma-tools) is a tool for converting Sigma rules into queries or inputs of supported targets.

## Objectives
1. Create a Lacework backend for Sigma to facilitate the conversion of Sigma rules into Lacework queries and policies.
2. Integrate directly with the Lacework CLI via standard input

## Considerations
### Config Driven Approach
Sigmac allows consumers to specify a configuration option to influence the conversion process.  For the Lacework Sigma backend I am recommending that we:
1. Embed a configuration object within the script such that users aren’t required to pass a configuration
2. If a configuration is passed allow this to be leveraged instead of the embedded configuration object
```
    --config CONFIG, -c CONFIG
                          Configurations with field name and index mapping for
                          target environment. Multiple configurations are merged
                          into one. Last config is authoritative in case of
                          conflicts.
```

### Conditions
At the present Lacework query language does not support aggregates.  We will need to gracefully degrade for such rules:  
```
    condition: selection_source | count() > 10
```

## Query Anatomy
### Title
`title` seems to map nicely to queryId.
```
    title: AWS CloudTrail Important Change
```
Recommend replacing spaces with underscores and prepending with `Sigma`
```
    queryId: Sigma_AWS_Cloudtrail_Important_Change
```

### Logsource
`logsource.service` seems to map nicely to evaluatorId/source:
```
    logsource:
        service: cloudtrail
```
### Timeframe
We don’t have a good way of representing relative time frames in `queryText` at the moment.
```
    timeframe: 30m
```
## Policy Anatomy
The mapping of Sigma rule context into a Lacework policy is pretty straightforward.  The `alertProfile` attribute within the policy schema is something specific to Lacework and must be supplied as part of the service configuration.

## Configuration
The current configuration is relatively straightforward:
```
---
version: 0.1
services:
  cloudtrail:
    evaluatorId: Cloudtrail
    source: CloudTrailRawEvents
    fieldMap:
      - sigmaField: eventName
        laceworkField: EVENT_NAME
        matchType: exact
        continue: false
      - sigmaField: eventSource
        laceworkField: EVENT_SOURCE
        matchType: exact
        continue: false
      - sigmaField: "^(.*)$"
        laceworkField: EVENT:$1
        matchType: regex
        continue: true
      - sigmaField: "^(.*?)\\\\.type$"
        laceworkField: '$1."type"'
        matchType: regex
        continue: true
    returns:
      - INSERT_ID
      - INSERT_TIME
      - EVENT_TIME
      - EVENT
    alertProfile: LW_CloudTrail_Alerts
```

The idea is that we create a block for each service which maps to an evaluatorId, source, field mappings, etc.  This allows us to dynamically influence the rule translation without having to build a bunch more code each time.  We are also validating against this config, so if you attempt to convert/translate a Sigma rule that doesn’t have a specification we will gracefully degrade with an error message.

The most complex part of the Lacework backend is the mapping of fields.  We have opted to do this on a per-service basis as well as provide facilities for different matchTypes (exact, startswith, regex).  The regex type allows for substitution based on capture groups!

### Embedded vs. Passed
The default Lacework configuration is embedded in the backend.  If a customized configuration is needed it can be passed via file using:
```
 --backend-config BACKEND_CONFIG, -C BACKEND_CONFIG
                        Configuration file (YAML format) containing options to
                        pass to the backend
```

## Options
Lacework’s policy platform is comprised of both queries and policies.  A Sigmac consumer may want to convert a Sigma rule into the Lacework query portion, Lacework policy portion, or both.

```
    --backend-option BACKEND_OPTION, -O BACKEND_OPTION
                          Options and switches that are passed to the backend
```

### Query vs. Policy
1. By default create both query and policy.
2. When specifying `-O query` create just a query
3. When specifying `-O policy` create just a policy
4. When specifying `-O query -O policy` create both query and policy.

### Yaml vs. Json
The sigmac `--output-format` argument does not behave as one might expect.  It has to do with `--output-fields` and is not meant to
communicate that you want a query in a specific format.

As such Lacework will leverage a backend option to communicate query output format.
1. By default output in YAML format.
2. When specifying `-O json` output in JSON format.

## Usage
1. Generate and run a query using the Lacework CLI
```
    ❯ tools/sigmac -t lacework rules/cloud/aws/aws_iam_backdoor_users_keys.yml -O query | lacework query run
    [
      {
        "EVENT": {
          "awsRegion": "us-east-1",
          "eventCategory": "Management",
          ...
```
2. Generate a query via stdout
```
    ❯ tools/sigmac -t lacework rules/cloud/aws/aws_ec2_startup_script_change.yml -O query
    ---
    evaluatorId: Cloudtrail
    queryId: Sigma_AWS_EC2_Startup_Shell_Script_Change
    queryText: |-
      Sigma_AWS_EC2_Startup_Shell_Script_Change {
          source {
              CloudTrailRawEvents
          }
          filter {
              (EVENT_SOURCE = 'ec2.amazonaws.com' AND EVENT:requestParameters.userData = '*' AND EVENT_NAME = 'ModifyInstanceAttribute')
          }
          return distinct {
              INSERT_ID,
              INSERT_TIME,
              EVENT_TIME,
              EVENT
          }
      }
```
3. Generate a query in JSON format via specified config
```
❯ tools/sigmac -t lacework rules/cloud/aws/aws_iam_backdoor_users_keys.yml -O json -C /foo/bar/baz.yaml            
```
4. Generate a query and policy in a single file prefixed by `dhaze` with `lacework` extension
```
    ❯ tools/sigmac -t lacework rules/cloud/aws/aws_cloudtrail_disable_logging.yml -o dhaze_ -e lacework
    ❯ ls dhaze_aws_cloudtrail_disable_logging.lacework
    dhaze_aws_cloudtrail_disable_logging.lacework
```
5. Generate a query in a single file specified as `my_query.lacework`
```
    ❯ tools/sigmac -t lacework rules/cloud/aws/aws_cloudtrail_disable_logging.yml -O query -o my_query.lacework
    ❯ ls my_query.lacework
    my_query.lacework
```
6. Generate a query and policy for rule with unsupported service
```
    ❯ tools/sigmac -t lacework rules/linux/at_command.yml
    Error: Backend error in rules/linux/at_command.yml: Service unknown is not supported by the Lacework backend
```
7. Generate a query and policy for rule with aggregation
```
    ❯ tools/sigmac -t lacework rules/cloud/aws/aws_ec2_download_userdata.yml -O query    
    An unsupported feature is required for this Sigma rule (rules/cloud/aws/aws_ec2_download_userdata.yml): Aggregations not implemented for this backend
```
