### PR TITLE
fixing cb path wildcards that don't work

### DIFF
--- a/tools/sigma/backends/carbonblack.py
+++ b/tools/sigma/backends/carbonblack.py
@@ -116,6 +116,14 @@ class CarbonBlackQueryBackend(CarbonBlackWildcardHandlingMixin, SingleTextQueryB
                     strUnescapeMatch = self.unescapeCharacter(strMatch)
                     val = val.replace(strMatch, '"{}"'.format(strUnescapeMatch))
         return val.strip()
+    
+    def fixWildcards(self, val):
+        # prob a better way to do this with SigmaStartswithModifier/SigmaEndswithModifier? idk, fail fast!
+        if val.endswith("\\\\"):
+            val = val[:-1] + "*"
+        if val.startswith("\\\\") and not val.startswith("\\\\\\\\"):
+            val = val[2:]
+        return val
 
     def cleanValue(self, val):
         if "[1 to *]" in val:
@@ -129,6 +137,7 @@ class CarbonBlackQueryBackend(CarbonBlackWildcardHandlingMixin, SingleTextQueryB
             val = self.cleanLeading(val)
             val = self.escapeCharacter(val)
             val = self.cleanWhitespace(val)
+            val = self.fixWildcards(val)
         return val
 
     def cleanIPRange(self, value):


### PR DESCRIPTION
Fix for path tokenization per [search guide](https://docs.vmware.com/en/VMware-Carbon-Black-EDR/7.5/VMware%20Carbon%20Black%20EDR%207.5%20User%20Guide.pdf).

Probably a better way to do this with SigmaStartswithModifier/SigmaEndswithModifier? Just want to show this end to end with my team tomorrow without this issue tbh. 