### PR TITLE
fix: prevent possible FPs ...

### DIFF
--- a/rules/windows/process_creation/win_bad_opsec_sacrificial_processes.yml
+++ b/rules/windows/process_creation/win_bad_opsec_sacrificial_processes.yml
@@ -4,6 +4,7 @@ status: experimental
 description: 'Detects attackers using tooling with bad opsec defaults e.g. spawning a sacrificial process to inject a capability into the process without taking into account how the process is normally run, one trivial example of this is using rundll32.exe without arguments as a sacrificial process (default in CS, now highlighted by c2lint), running WerFault without arguments (Kraken - credit am0nsec), and other examples.'
 author: 'Oleg Kolesnikov @securonix invrep_de, oscd.community'
 date: 2020/10/23
+modified: 2021/09/01
 references:
     - https://blog.malwarebytes.com/malwarebytes-news/2020/10/kraken-attack-abuses-wer-service/
     - https://www.cobaltstrike.com/help-opsec
@@ -16,6 +17,9 @@ logsource:
     product: windows
 detection:
     selection:
+        Image|endswith:
+            - '\WerFault.exe'
+            - '\rundll32.exe'
         CommandLine|endswith:
             - '\WerFault.exe'
             - '\rundll32.exe'

--- a/rules/windows/process_creation/win_susp_procs_req_dlls.yml
+++ b/rules/windows/process_creation/win_susp_procs_req_dlls.yml
@@ -10,11 +10,17 @@ references:
     - https://docs.microsoft.com/en-us/dotnet/framework/tools/regsvcs-exe-net-services-installation-tool#feedback
 author: Florian Roth
 date: 2021/05/27
+modified: 2021/09/01
 logsource:
     category: process_creation
     product: windows
 detection:
     selection:
+        Image|endswith:
+            - '\rundll32.exe'
+            - '\regsvcs.exe'
+            - '\regasm.exe'
+            - '\regsvr32.exe'
         CommandLine|endswith: 
             - '\rundll32.exe'
             - '\regsvcs.exe'


### PR DESCRIPTION
... with the respective command only used as the last parameter

Example FP:
Running: 'cacls C:\Windows\System32\rundll32.exe'