### PR TITLE
Update AWS STS AssumeRole Misuse rule

### DIFF
--- a/rules/cloud/aws/aws_sts_assumerole_misuse.yml
+++ b/rules/cloud/aws/aws_sts_assumerole_misuse.yml
@@ -12,8 +12,7 @@ logsource:
     service: cloudtrail
 detection:
     selection:
-        eventSource: sts.amazonaws.com
-        eventName: AssumeRole
+        userIdentity.type: AssumedRole
         userIdentity.sessionContext.sessionIssuer.type: Role
     condition: selection
 level: low


### PR DESCRIPTION
Update selection criteria for AWS STS AssumeRole Misuse rule for any event by an AssumedRole userIdentity.
Closes SigmaHQ/sigma#1963.