### PR TITLE
Update AWS Update Login Profile rule

### DIFF
--- a/rules/cloud/aws/aws_update_login_profile.yml
+++ b/rules/cloud/aws/aws_update_login_profile.yml
@@ -15,7 +15,7 @@ detection:
         eventSource: iam.amazonaws.com
         eventName: UpdateLoginProfile
     filter:
-        userIdentity.arn|contains: responseElements.accessKey.userName
+        userIdentity.arn|contains: requestParameters.userName
     condition: selection_source and not filter
 fields:
     - userIdentity.arn


### PR DESCRIPTION
Update selection criteria for AWS Update Login Profile rule to check for mismatch between userIdentity.arn and requestParameters.userName.
Closes SigmaHQ/sigma#1966.