### PR TITLE
Adding Petitpotam/ADCS attack vector detections

### DIFF
--- a/rules/windows/builtin/win_petitpotam_network_share.yml
+++ b/rules/windows/builtin/win_petitpotam_network_share.yml
@@ -16,9 +16,10 @@ logsource:
 detection:
     selection:
         EventID: 5145
-        Share_Name: \\*\IPC$
-        Relative_Target_Name: lsarpc
-        Account_Name: ANONYMOUS LOGON
+        ShareName|startswith: '\\'
+        ShareName|endswith: '\IPC$'
+        RelativeTargetName: lsarpc
+        SubjectUserName: ANONYMOUS LOGON
     condition: selection
 falsepositives:
     - Unknown. Feedback welcomed.

--- a/rules/windows/builtin/win_petitpotam_network_share.yml
+++ b/rules/windows/builtin/win_petitpotam_network_share.yml
@@ -1,0 +1,25 @@
+title: Possible PetitPotam Coerce Authentication Attempt
+id: 1ce8c8a3-2723-48ed-8246-906ac91061a6
+description: Detect PetitPotam coerced authentication activity.
+author: Mauricio Velazco, Michael Haag
+date: 2021/09/02
+references:
+    - https://github.com/topotam/PetitPotam
+    - https://github.com/splunk/security_content/blob/0dd6de32de2118b2818550df9e65255f4109a56d/detections/endpoint/petitpotam_network_share_access_request.yml
+tags:
+    - attack.credential_access
+    - attack.t1187
+logsource:
+    product: windows
+    service: security
+    definition: 'The advanced audit policy setting "Object Access > Detailed File Share" must be configured for Success/Failure'
+detection:
+    selection:
+        EventID: 5145
+        Share_Name: \\*\IPC$
+        Relative_Target_Name: lsarpc
+        Account_Name: ANONYMOUS LOGON
+    condition: selection
+falsepositives:
+    - Unknown. Feedback welcomed.
+level: high

--- a/rules/windows/builtin/win_petitpotam_susp_tgt_request.yml
+++ b/rules/windows/builtin/win_petitpotam_susp_tgt_request.yml
@@ -23,11 +23,10 @@ logsource:
 detection:
     selection:
         EventID: 4768
-        Account_Name|endswith: '$'
-        Certificate_Thumbprint: '*'
+        TargetUserName|endswith: '$'
+        CertThumbprint: '*'
     filter_local:
-        Client_Address: '::1'
-        
+        IpAddress: '::1'
     condition: selection and not filter_local
 falsepositives:
     - False positives are possible if the environment is using certificates for authentication. We recommend filtering Account_Name to the Domain Controller computer accounts.

--- a/rules/windows/builtin/win_petitpotam_susp_tgt_request.yml
+++ b/rules/windows/builtin/win_petitpotam_susp_tgt_request.yml
@@ -1,0 +1,34 @@
+title: PetitPotam Suspicious Kerberos TGT Request
+id: 6a53d871-682d-40b6-83e0-b7c1a6c4e3a5
+description: Detect suspicious Kerberos TGT requests. Once an attacer obtains a computer
+  certificate by abusing Active Directory Certificate Services in combination with
+  PetitPotam, the next step would be to leverage the certificate for malicious purposes.
+  One way of doing this is to request a Kerberos Ticket Granting Ticket using a tool
+  like Rubeus. This request will generate a 4768 event with some unusual fields depending
+  on the environment. This analytic will require tuning, we recommend filtering Account_Name
+  to the Domain Controller computer accounts.
+author: Mauricio Velazco, Michael Haag
+date: 2021/09/02
+references:
+    - https://github.com/topotam/PetitPotam
+    - https://isc.sans.edu/forums/diary/Active+Directory+Certificate+Services+ADCS+PKI+domain+admin+vulnerability/27668/
+    - https://github.com/splunk/security_content/blob/develop/detections/endpoint/petitpotam_suspicious_kerberos_tgt_request.yml
+tags:
+    - attack.credential_access
+    - attack.t1187
+logsource:
+    product: windows
+    service: security
+    definition: 'The advanced audit policy setting "Account Logon > Kerberos Authentication Service" must be configured for Success/Failure'
+detection:
+    selection:
+        EventID: 4768
+        Account_Name|endswith: '$'
+        Certificate_Thumbprint: '*'
+    filter_local:
+        Client_Address: '::1'
+        
+    condition: selection and not filter_local
+falsepositives:
+    - False positives are possible if the environment is using certificates for authentication. We recommend filtering Account_Name to the Domain Controller computer accounts.
+level: high


### PR DESCRIPTION
This PR adds two host detections for PetitPotam

### Possible PetitPotam Coerce Authentication Attempt

Although the PetitPotam coerced authentication attempt does not generate 4624/4625 events, our testing shows it does generate a 5145 event with specific values. We tested in environments with 90K 5145 events with zero false positives. Feedback welcomed!

![image](https://user-images.githubusercontent.com/4950700/131949859-6bbc9b4a-bbc0-433a-b903-dbefd800cd7e.png)

Tested with Sigmac on a lab Splunk environment:

$ sigmac -t splunk rules/windows/builtin/win_petitpotam_network_share.yml -c tools/config/splunk-windows-index.yml

(index="windows" EventCode="5145" Share_Name="\\*\\IPC$" Relative_Target_Name="lsarpc" Account_Name="ANONYMOUS LOGON")
(base)

$ sigmac -t splunk rules/windows/builtin/win_petitpotam_network_share.yml -c tools/config/splunk-windows.yml

(source="WinEventLog:Security" EventCode="5145" Share_Name="\\*\\IPC$" Relative_Target_Name="lsarpc" Account_Name="ANONYMOUS LOGON")

### PetitPotam Suspicious Kerberos TGT Request

Once an attacer obtains a computer   certificate by abusing Active Directory Certificate Services in combination with
  PetitPotam, the next step would be to leverage the certificate for malicious purposes.   One way of doing this is to request a Kerberos Ticket Granting Ticket using a tool   like Rubeus. This request will generate a 4768 event with some unusual fields depending   on the environment. This analytic will require tuning, we recommend filtering Account_Name   to the Domain Controller computer accounts.

![image](https://user-images.githubusercontent.com/4950700/131950136-12867dfe-220d-4bbe-a3d8-0687aed3a7f6.png)

Tested with Sigmac on a lab Splunk environment:

$ sigmac -t splunk rules/windows/builtin/win_petitpotam_susp_tgt_request.yml -c tools/config/splunk-windows-index.yml

(index="windows" (EventCode="4768" Account_Name="*$" Certificate_Thumbprint="*") NOT (Client_Address="::1"))

$sigmac -t splunk rules/windows/builtin/win_petitpotam_susp_tgt_request.yml -c tools/config/splunk-windows.yml

(source="WinEventLog:Security" (EventCode="4768" Account_Name="*$" Certificate_Thumbprint="*") NOT (Client_Address="::1"))