### PR TITLE
New Rule - Linux-Audio-Capture

### DIFF
--- a/rules/linux/auditd/lnx_auditd_audio_capture.yml
+++ b/rules/linux/auditd/lnx_auditd_audio_capture.yml
@@ -1,0 +1,28 @@
+title: Audio Capture
+id: a7af2487-9c2f-42e4-9bb9-ff961f0561d5
+description: Detects attempts to record audio with arecord utility
+    #the actual binary that arecord is using and that has to be monitored is /usr/bin/aplay 
+author: 'Pawel Mazur'
+status: experimental
+date: 2021/09/04
+references:
+   - https://attack.mitre.org/techniques/T1123/
+logsource:
+   product: linux
+   service: auditd
+detection:
+   selection:
+       type: EXECVE
+       a0:
+           - arecord
+       a1:
+           - '-vv'
+       a2:
+           - '-fdat'
+   condition: selection
+tags:
+   - attack.collection
+   - attack.t1123
+falsepositives:
+   - None
+level: low

--- a/rules/linux/auditd/lnx_auditd_audio_capture.yml
+++ b/rules/linux/auditd/lnx_auditd_audio_capture.yml
@@ -6,6 +6,8 @@ author: 'Pawel Mazur'
 status: experimental
 date: 2021/09/04
 references:
+   - https://linux.die.net/man/1/arecord
+   - https://linuxconfig.org/how-to-test-microphone-with-audio-linux-sound-architecture-alsa
    - https://attack.mitre.org/techniques/T1123/
 logsource:
    product: linux


### PR DESCRIPTION
Linux auditd rule for Audio Capture detection with arecord. Arecord utility is actually using /usr/bin/aplay, thus this is the binary that needs to be monitored with auditd rule