### PR TITLE
Update AWS Update Login Profile Rule fields

### DIFF
--- a/rules/cloud/aws/aws_update_login_profile.yml
+++ b/rules/cloud/aws/aws_update_login_profile.yml
@@ -5,7 +5,7 @@ description: |
  An attacker with the iam:UpdateLoginProfile permission on other users can change the password used to login to the AWS console on any user that already has a login profile setup.
  With this alert, it is used to detect anyone is changing password on behalf of other users.
 author: toffeebr33k
-date: 2021/09/07
+date: 2021/08/09
 references:
     - https://github.com/RhinoSecurityLabs/AWS-IAM-Privilege-Escalation
 logsource:

--- a/rules/cloud/aws/aws_update_login_profile.yml
+++ b/rules/cloud/aws/aws_update_login_profile.yml
@@ -5,7 +5,7 @@ description: |
  An attacker with the iam:UpdateLoginProfile permission on other users can change the password used to login to the AWS console on any user that already has a login profile setup.
  With this alert, it is used to detect anyone is changing password on behalf of other users.
 author: toffeebr33k
-date: 2021/08/09
+date: 2021/09/07
 references:
     - https://github.com/RhinoSecurityLabs/AWS-IAM-Privilege-Escalation
 logsource:
@@ -19,7 +19,7 @@ detection:
     condition: selection_source and not filter
 fields:
     - userIdentity.arn
-    - responseElements.accessKey.userName
+    - requestParameters.userName
     - errorCode
     - errorMessage
 falsepositives:


### PR DESCRIPTION
Missed updating field from `responseElements.accessKey.userName` to `requestParameters.userName` on last update.