### PR TITLE
New Rule - Linux Auditd Hidden Files - Steganography

### DIFF
--- a/rules/linux/auditd/lnx_auditd_hidden_files_steganography.yml
+++ b/rules/linux/auditd/lnx_auditd_hidden_files_steganography.yml
@@ -18,21 +18,19 @@ logsource:
 detection:
    commands:
        type: EXECVE
-       a0:
-           - cat
+       a0: cat
    a1:
        - a1|endswith: '.jpg'
        - a1|endswith: '.png'
    a2:
-       - a2|endswith: '.zip'
+       a2|endswith: '.zip'
    condition: commands and a1 and a2
 ---
 id: edd595d7-7895-4fa7-acb3-85a18a8772ca
 detection:
    commands:
        type: EXECVE
-       a0:
-           - unzip
+       a0: unzip
    a1:
        - a1|endswith: '.jpg'
        - a1|endswith: '.png'

--- a/rules/linux/auditd/lnx_auditd_hidden_files_steganography.yml
+++ b/rules/linux/auditd/lnx_auditd_hidden_files_steganography.yml
@@ -1,0 +1,39 @@
+title: Obfuscated Files or Information - Steganography
+id: 45810b50-7edc-42ca-813b-bdac02fb946b
+description: Detects appending of zip file to image
+author: 'Pawel Mazur'
+status: experimental
+date: 2021/09/09
+references:
+   - https://attack.mitre.org/techniques/T1027/003/
+tags:
+   - attack.defense_evasion
+   - attack.t1027.003
+falsepositives:
+   - None
+level: low
+logsource:
+   product: linux
+   service: auditd
+detection:
+   commands:
+       type: EXECVE
+       a0:
+           - cat
+   a1:
+       - a1|endswith: '.jpg'
+       - a1|endswith: '.png'
+   a2:
+       - a2|endswith: '.zip'
+   condition: commands and a1 and a2
+---
+id: edd595d7-7895-4fa7-acb3-85a18a8772ca
+detection:
+   commands:
+       type: EXECVE
+       a0:
+           - unzip
+   a1:
+       - a1|endswith: '.jpg'
+       - a1|endswith: '.png'
+   condition: commands and a1

--- a/rules/linux/auditd/lnx_auditd_hidden_files_steganography.yml
+++ b/rules/linux/auditd/lnx_auditd_hidden_files_steganography.yml
@@ -1,3 +1,4 @@
+action: global
 title: Obfuscated Files or Information - Steganography
 description: Detects appending of zip file to image
 author: 'Pawel Mazur'

--- a/rules/linux/auditd/lnx_auditd_hidden_files_steganography.yml
+++ b/rules/linux/auditd/lnx_auditd_hidden_files_steganography.yml
@@ -1,5 +1,4 @@
 title: Obfuscated Files or Information - Steganography
-id: 45810b50-7edc-42ca-813b-bdac02fb946b
 description: Detects appending of zip file to image
 author: 'Pawel Mazur'
 status: experimental
@@ -15,6 +14,8 @@ level: low
 logsource:
    product: linux
    service: auditd
+---
+id: 45810b50-7edc-42ca-813b-bdac02fb946b
 detection:
    commands:
        type: EXECVE

--- a/rules/linux/auditd/lnx_auditd_hidden_zip_files_steganography.yml
+++ b/rules/linux/auditd/lnx_auditd_hidden_zip_files_steganography.yml
@@ -21,8 +21,9 @@ detection:
        type: EXECVE
        a0: cat
    a1:
-       - a1|endswith: '.jpg'
-       - a1|endswith: '.png'
+       a1|endswith:
+          - '.jpg'
+          - '.png'
    a2:
        a2|endswith: '.zip'
    condition: commands and a1 and a2

--- a/rules/linux/auditd/lnx_auditd_hidden_zip_files_steganography.yml
+++ b/rules/linux/auditd/lnx_auditd_hidden_zip_files_steganography.yml
@@ -1,11 +1,12 @@
-action: global
-title: Obfuscated Files or Information - Steganography
+title: Steganography Hide Zip Information in Picture File
+id: 45810b50-7edc-42ca-813b-bdac02fb946b
 description: Detects appending of zip file to image
 author: 'Pawel Mazur'
 status: experimental
 date: 2021/09/09
 references:
    - https://attack.mitre.org/techniques/T1027/003/
+   - https://zerotoroot.me/steganography-hiding-a-zip-in-a-jpeg-file/
 tags:
    - attack.defense_evasion
    - attack.t1027.003
@@ -15,8 +16,6 @@ level: low
 logsource:
    product: linux
    service: auditd
----
-id: 45810b50-7edc-42ca-813b-bdac02fb946b
 detection:
    commands:
        type: EXECVE
@@ -27,13 +26,3 @@ detection:
    a2:
        a2|endswith: '.zip'
    condition: commands and a1 and a2
----
-id: edd595d7-7895-4fa7-acb3-85a18a8772ca
-detection:
-   commands:
-       type: EXECVE
-       a0: unzip
-   a1:
-       - a1|endswith: '.jpg'
-       - a1|endswith: '.png'
-   condition: commands and a1

--- a/rules/linux/auditd/lnx_auditd_unzip_hidden_zip_files_steganography.yml
+++ b/rules/linux/auditd/lnx_auditd_unzip_hidden_zip_files_steganography.yml
@@ -1,0 +1,27 @@
+title: Steganography Unzip Hidden Information From Picture File
+id: edd595d7-7895-4fa7-acb3-85a18a8772ca
+description: Detects extracting of zip file from image file
+author: 'Pawel Mazur'
+status: experimental
+date: 2021/09/09
+references:
+   - https://attack.mitre.org/techniques/T1027/003/
+   - https://zerotoroot.me/steganography-hiding-a-zip-in-a-jpeg-file/
+tags:
+   - attack.defense_evasion
+   - attack.t1027.003
+falsepositives:
+   - None
+level: low
+logsource:
+   product: linux
+   service: auditd
+detection:
+   commands:
+       type: EXECVE
+       a0:
+           - unzip
+   a1:
+       - a1|endswith: '.jpg'
+       - a1|endswith: '.png'
+   condition: commands and a1

--- a/rules/linux/auditd/lnx_auditd_unzip_hidden_zip_files_steganography.yml
+++ b/rules/linux/auditd/lnx_auditd_unzip_hidden_zip_files_steganography.yml
@@ -22,6 +22,7 @@ detection:
        a0:
            - unzip
    a1:
-       - a1|endswith: '.jpg'
-       - a1|endswith: '.png'
+       a1|endswith:
+           - '.jpg'
+           - '.png'
    condition: commands and a1


### PR DESCRIPTION
Rule for hidding zip files in images, was considering also logging for steghide - will try to do that later as it is not installed by default in linux