### PR TITLE
Mapped OriginalFileName in DeviceProcessEvents

### DIFF
--- a/tools/sigma/backends/mdatp.py
+++ b/tools/sigma/backends/mdatp.py
@@ -83,6 +83,7 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
                 "ImageLoaded": ("FolderPath", self.default_value_mapping),
                 "LogonType": (self.id_mapping, self.logontype_mapping),
                 "NewProcessName": ("FolderPath", self.default_value_mapping),
+                "OriginalFileName": ("ProcessVersionInfoOriginalFileName", self.default_value_mapping),
                 "ParentCommandLine": ("InitiatingProcessCommandLine", self.default_value_mapping),
                 "ParentName": ("InitiatingProcessFileName", self.default_value_mapping),
                 "ParentProcessName": ("InitiatingProcessFileName", self.default_value_mapping),


### PR DESCRIPTION
Mapped OriginalFileName to ProcessVersionInfoOriginalFileName in DeviceProcessEvents. Tested and works for rules such as https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/win_renamed_binary.yml