### PR TITLE
fix test_rules.py errors when no logsource

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -308,16 +308,17 @@ class TestRules(unittest.TestCase):
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             logsource = self.get_rule_part(file_path=file, part_name="logsource")
-            service = logsource.get('service', '')
-            if service.lower() == 'sysmon':
-                with open(file,encoding='utf-8') as f:
-                    found = False
-                    for line in f:
-                        if re.search(r'.*EventID:.*$', line):  # might be on a single line or in multiple lines
-                            found = True
-                            break
-                    if not found:
-                        faulty_rules.append(file)
+            if logsource:
+                service = logsource.get('service', '')
+                if service.lower() == 'sysmon':
+                    with open(file,encoding='utf-8') as f:
+                        found = False
+                        for line in f:
+                            if re.search(r'.*EventID:.*$', line):  # might be on a single line or in multiple lines
+                                found = True
+                                break
+                        if not found:
+                            faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED + 
                          "There are rules using sysmon events but with no EventID specified")

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -585,6 +585,10 @@ class TestRules(unittest.TestCase):
            ]
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             logsource = self.get_rule_part(file_path=file, part_name="logsource")
+            if not logsource:
+                print(Fore.RED + "Rule {} has no 'logsource'.".format(file))
+                faulty_rules.append(file)
+                continue           
             valid = True
             for key in logsource:
                 if key.lower() not in valid_logsource:


### PR DESCRIPTION
Hello,

old message
```bash
======================================================================
ERROR: test_invalid_logsource_attributes (__main__.TestRules)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_rules.py", line 589, in test_invalid_logsource_attributes
    for key in logsource:
TypeError: 'NoneType' object is not iterable

======================================================================
ERROR: test_sysmon_rule_without_eventid (__main__.TestRules)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_rules.py", line 311, in test_sysmon_rule_without_eventid
    service = logsource.get('service', '')
AttributeError: 'NoneType' object has no attribute 'get'
```

now
```bash
........Rule rules\application\testtttttttttttt.yml has no 'logsource'.
F.....................
======================================================================
FAIL: test_invalid_logsource_attributes (__main__.TestRules)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests\test_rules.py", line 601, in test_invalid_logsource_attributes
    self.assertEqual(faulty_rules, [], Fore.RED +
AssertionError: Lists differ: ['rules\\application\\testtttttttttttt.yml'] != []

First list contains 1 additional elements.
First extra element 0:
'rules\\application\\testtttttttttttt.yml'

- ['rules\\application\\testtttttttttttt.yml']
+ [] : There are rules with non-conform 'logsource' fields. Please check: https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide#log-source

----------------------------------------------------------------------
```