### PR TITLE
Fix registry TargetObject

### DIFF
--- a/rules/windows/registry_event/sysmon_apt_leviathan.yml
+++ b/rules/windows/registry_event/sysmon_apt_leviathan.yml
@@ -10,12 +10,12 @@ tags:
     - attack.t1547.001
 author: Aidan Bracher
 date: 2020/07/07
-modified: 2020/09/06
+modified: 2021/09/13
 logsource:
     category: registry_event
     product: windows
 detection:
     selection:
-        TargetObject: 'HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run\ntkd'
+        TargetObject: 'HKCU\Software\Microsoft\Windows\CurrentVersion\Run\ntkd'
     condition: selection
 level: critical

--- a/rules/windows/registry_event/sysmon_apt_oceanlotus_registry.yml
+++ b/rules/windows/registry_event/sysmon_apt_oceanlotus_registry.yml
@@ -9,14 +9,14 @@ tags:
     - attack.t1112
 author: megan201296, Jonhnathan Ribeiro
 date: 2019/04/14
-modified: 2020/09/06
+modified: 2021/09/13
 logsource:
     category: registry_event
     product: windows
 detection:
     selection:       
         TargetObject: 
-            - 'HKCR\CLSID\{E08A0F4B-1F65-4D4D-9A09-BD4625B9C5A1}\Model'
+            - 'HKCU\CLSID\{E08A0F4B-1F65-4D4D-9A09-BD4625B9C5A1}\Model'
         TargetObject|endswith:
               # covers HKU\* and HKLM..
             - '\SOFTWARE\App\AppXbf13d4ea2945444d8b13e2121cb6b663\Application'
@@ -27,7 +27,7 @@ detection:
             - '\SOFTWARE\App\AppX37cc7fdccd644b4f85f4b22d5a3f105a\DefaultIcon'
     selection2:
         TargetObject|startswith:
-            - 'HKU\'
+            - 'HKCU\'
         TargetObject|contains:
             # HKCU\SOFTWARE\Classes\AppXc52346ec40fb4061ad96be0e6cb7d16a\
             - '_Classes\AppXc52346ec40fb4061ad96be0e6cb7d16a\'

--- a/rules/windows/registry_event/sysmon_office_test_regadd.yml
+++ b/rules/windows/registry_event/sysmon_office_test_regadd.yml
@@ -9,14 +9,15 @@ tags:
     - attack.persistence
     - attack.t1137.002
 date: 2020/10/25
+modified: 2021/09/13
 logsource:
     category: registry_event
     product: windows
 detection:
     selection_registry:
         TargetObject:
-            - 'HKEY_CURRENT_USER\Software\Microsoft\Office test\Special\Perf'
-            - 'HKEY_LOCAL_MACHINE\Software\Microsoft\Office test\Special\Perf'
+            - 'HKCU\Software\Microsoft\Office test\Special\Perf'
+            - 'HKLM\Software\Microsoft\Office test\Special\Perf'
     condition: selection_registry
 falsepositives:
     - Unlikely

--- a/rules/windows/registry_event/win_outlook_c2_registry_key.yml
+++ b/rules/windows/registry_event/win_outlook_c2_registry_key.yml
@@ -12,12 +12,13 @@ tags:
     - attack.t1008
     - attack.t1546
 date: 2021/04/05
+modified: 2021/09/13
 logsource:
     category: registry_event
     product: windows
 detection:
     selection_registry:
-        TargetObject: 'HKEY_CURRENT_USER\Software\Microsoft\Office\16.0\Outlook\Security\Level'
+        TargetObject: 'HKCU\Software\Microsoft\Office\16.0\Outlook\Security\Level'
         Details|contains: '0x00000001'
     condition: selection_registry
 falsepositives:

--- a/rules/windows/registry_event/win_portproxy_registry_key.yml
+++ b/rules/windows/registry_event/win_portproxy_registry_key.yml
@@ -7,6 +7,7 @@ references:
     - https://adepts.of0x.cc/netsh-portproxy-code/
     - https://www.dfirnotes.net/portproxy_detection/
 date: 2021/06/22
+modified: 2021/09/13
 tags:
     - attack.lateral_movement
     - attack.defense_evasion
@@ -18,7 +19,7 @@ logsource:
     product: windows
 detection:
     selection_registry:
-        TargetObject: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\PortProxy\v4tov4\tcp'
+        TargetObject: 'HKLM\SYSTEM\CurrentControlSet\Services\PortProxy\v4tov4\tcp'
     condition: selection_registry
 falsepositives:
     - WSL2 network bridge PowerShell script used for WSL/Kubernetes/Docker (e.g. https://github.com/microsoft/WSL/issues/4150#issuecomment-504209723)


### PR DESCRIPTION
Hello,
find some rule with a bad `TargetObject`.

sysmon_apt_oceanlotus_registry.yml should need a deeper check.