### PR TITLE
Fix bad category in possible_privilege_escalation_via_service_registry_permissions

### DIFF
--- a/rules/windows/process_creation/process_creation_possible_privilege_escalation_via_service_registry_permissions.yml
+++ b/rules/windows/process_creation/process_creation_possible_privilege_escalation_via_service_registry_permissions.yml
@@ -14,16 +14,17 @@ date: 2019/10/26
 modified: 2020/09/06
 logsource:
     product: windows
-    category: registry_event
+    category: process_creation
 detection:
     selection:
-        
         IntegrityLevel: 'Medium'
-        TargetObject|contains: '\services\'
-        TargetObject|endswith:
-            - '\ImagePath'
-            - '\FailureCommand'
-            - '\Parameters\ServiceDll'
+        CommandLine|contains|all:
+            - ControlSet
+            - services
+        CommandLine|contains:
+            - \ImagePath
+            - \FailureCommand
+            - \ServiceDll
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/process_creation_possible_privilege_escalation_via_service_registry_permissions.yml
+++ b/rules/windows/process_creation/process_creation_possible_privilege_escalation_via_service_registry_permissions.yml
@@ -11,7 +11,7 @@ tags:
 status: experimental
 author: Teymur Kheirkhabarov
 date: 2019/10/26
-modified: 2020/09/06
+modified: 2021/09/15
 logsource:
     product: windows
     category: process_creation


### PR DESCRIPTION
Hello
 
IntegrityLevel is in process creation and  in the references it is sysmon 1.
So this rule was broke.