### PR TITLE
fix detection in sysmon_susp_mic_cam_access

### DIFF
--- a/rules/windows/registry_event/sysmon_susp_mic_cam_access.yml
+++ b/rules/windows/registry_event/sysmon_susp_mic_cam_access.yml
@@ -3,6 +3,7 @@ id: 62120148-6b7a-42be-8b91-271c04e281a3
 description: Detects Processes accessing the camera and microphone from suspicious folder
 author: Den Iuzvyk
 date: 2020/06/07
+modified: 2021/09/17
 references:
     - https://medium.com/@7a616368/can-you-track-processes-accessing-the-camera-and-microphone-7e6885b37072
 tags:
@@ -23,12 +24,12 @@ detection:
             - webcam
     selection_3:
         TargetObject|contains:
-            - '#C:#Windows#Temp#'
-            - '#C:#$Recycle.bin#'
-            - '#C:#Temp#'
-            - '#C:#Users#Public#'
-            - '#C:#Users#Default#'
-            - '#C:#Users#Desktop#'
+            - ':#Windows#Temp#'
+            - ':#$Recycle.bin#'
+            - ':#Temp#'
+            - ':#Users#Public#'
+            - ':#Users#Default#'
+            - ':#Users#Desktop#'
     condition: all of selection_*
 falsepositives:
     - Unlikely, there could be conferencing software running from a Temp folder accessing the devices


### PR DESCRIPTION
hello,
in the doc
```
Within the NonPackaged directory, you can see that the name of the keys are the full path of an executable with # replacing \.
```

So can not be `#C:#` , I have change to `:#` to match c:\ or d:\ ...