### PR TITLE
Fix config banckends name

### DIFF
--- a/tools/config/carbon-black-eedr.yml
+++ b/tools/config/carbon-black-eedr.yml
@@ -2,7 +2,6 @@ title: CarbonBlack Enterprise EDR
 order: 20
 backends:
   - carbonblack
-  - cb
 fieldmappings:
   AccountName:
     - process_username

--- a/tools/config/carbon-black.yml
+++ b/tools/config/carbon-black.yml
@@ -2,7 +2,6 @@ title: CarbonBlack field mapping
 order: 20
 backends:
   - carbonblack
-  - cb
 fieldmappings:
   AccountName: username
   CommandLine: cmdline

--- a/tools/config/ecs-auditd.yml
+++ b/tools/config/ecs-auditd.yml
@@ -11,7 +11,6 @@ backends:
   - xpack-watcher
   - elastalert
   - elastalert-dsl
-  - elasticsearch-rule
   - ee-outliers
 
 logsources:

--- a/tools/config/ecs-dns.yml
+++ b/tools/config/ecs-dns.yml
@@ -3,7 +3,7 @@ order: 20
 backends:
   - es-qs
   - es-dsl
-  - elasticsearch-rule
+  - es-rule
   - kibana
   - kibana-ndjson
   - xpack-watcher

--- a/tools/config/ecs-filebeat.yml
+++ b/tools/config/ecs-filebeat.yml
@@ -11,7 +11,6 @@ backends:
   - xpack-watcher
   - elastalert
   - elastalert-dsl
-  - elasticsearch-rule
   - ee-outliers
 
 defaultindex: filebeat-*

--- a/tools/config/ecs-zeek-corelight.yml
+++ b/tools/config/ecs-zeek-corelight.yml
@@ -5,7 +5,7 @@ backends:
   - es-qs
   - corelight_es-qs
   - es-dsl
-  - elasticsearch-rule
+  - es-rule
   - corelight_elasticsearch-rule
   - kibana
   - kibana-ndjson

--- a/tools/config/ecs-zeek-elastic-beats-implementation.yml
+++ b/tools/config/ecs-zeek-elastic-beats-implementation.yml
@@ -4,7 +4,6 @@ backends:
   - es-qs
   - es-dsl
   - es-rule
-  - elasticsearch-rule
   - kibana
   - kibana-ndjson
   - xpack-watcher

--- a/tools/config/logstash-zeek-default-json.yml
+++ b/tools/config/logstash-zeek-default-json.yml
@@ -3,7 +3,7 @@ order: 20
 backends:
   - es-qs
   - es-dsl
-  - elasticsearch-rule
+  - es-rule
   - kibana
   - kibana-ndjson
   - xpack-watcher

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -11,7 +11,6 @@ backends:
   - xpack-watcher
   - elastalert
   - elastalert-dsl
-  - elasticsearch-rule
   - ee-outliers
 logsources:
   windows:

--- a/tools/sigma/sigma_configurations_check.py
+++ b/tools/sigma/sigma_configurations_check.py
@@ -18,39 +18,72 @@
 import sigma.backends.discovery as backends
 import ruamel.yaml
 from pathlib import Path
-
+from argparse import ArgumentParser
+import sys
+import csv
+    
 def main():
+    argparser = ArgumentParser(description="A simple Sigma Configurations checker")
+    argparser.add_argument("--verify", "-V", action="store_true", help="Verify if configuration file have valid backend name")
+    argparser.add_argument("--sumary", "-s", action="store_true", help="Give some information.")
+    argparser.add_argument("--error", "-e", action="store_true", help="Exit with error code 10 on verification failures.")
+    argparser.add_argument("--output", "-o", default=None, help="Output csv file")
+    args = argparser.parse_args()
+    
+    passed = True
+    
     list_backend =[]
     for backend in sorted(backends.getBackendList(), key=lambda backend: backend.identifier):
         list_backend.append(backend.identifier)
 
-    print(f"Valid backend name are {list_backend}")
-    print('result tab:')
-    print('|Name file|Backend|check')
-    print('|---|---|---')
+    if args.sumary: 
+        print(f"Backend found :\n{list_backend}\n")
 
-    valid = 0
-    empty = 0
-    faulty = 0
-    yml_files =Path('config/').glob("*.yml")
-    for yml in yml_files:
-       with yml.open("r",encoding="UTF-8") as f:
-           data = ruamel.yaml.load(f,Loader=ruamel.yaml.RoundTripLoader)
-           if 'backends' in data:
-               for backend in data['backends']:
-                   if backend in list_backend:
-                       print(f"|{yml.name:45} | {backend:30} | OK ")
-                       valid += 1
-                   else:
-                       print(f"|{yml.name:45} | {backend:30} | NOK")
-                       faulty += 1
-           else:
-              msg = "no backend set"
-              print(f"|{yml.name:45} | {msg:30} | -  ")
-              empty += 1
+    if args.verify:
+        csv_lst = []
+        valid = 0
+        empty = 0
+        faulty = 0
+        yml_files =Path('config/').glob("*.yml")
+        for yml in yml_files:
+            print(f"Check configurations file : {yml.name}")
+            with yml.open("r",encoding="UTF-8") as f:
+                data = ruamel.yaml.load(f,Loader=ruamel.yaml.RoundTripLoader)
+                if 'backends' in data:
+                    for backend in data['backends']:
+                        if backend in list_backend:
+                            csv_lst.append([yml.name,backend,'OK'])
+                            valid += 1
+                        else:
+                            csv_lst.append([yml.name,backend,'NOK'])
+                            faulty += 1
+                            passed = False
+                else:
+                    csv_lst.append([yml.name,"no backends section",'-'])
+                    empty += 1
+                    #passed = False 
+                    #Should not be but not sure
+            
+        if args.sumary: 
+            print('-------')
+            print('Summary')
+            print(f'Valid backend name: {valid}\nInvalid backend name: {faulty}\nFile with no Backend: {empty}')
+            print('-------')
 
-    print('Summary')
-    print(f'Valid : {valid}  Invalid : {faulty} No Backend : {empty}')
+        if args.output:
+            with open(args.output, 'w', newline='') as csvfile:
+                spamwriter = csv.writer(csvfile, delimiter=';',quotechar='|', quoting=csv.QUOTE_MINIMAL)
+                spamwriter.writerow(['Configurations Name','Backend Name','Result'])
+                for row in csv_lst:
+                    spamwriter.writerow(row)
+                
+        if not passed:
+            print("**************************************")
+            print("Some Configurations file are not valid")
+            print("**************************************")
+            if args.error:
+                exit(10)
+                
 
 if __name__ == "__main__":
     main()

--- a/tools/sigma/sigma_configurations_check.py
+++ b/tools/sigma/sigma_configurations_check.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# A simple Sigma Configurations checker
+# Copyright frack113
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sigma.backends.discovery as backends
+import ruamel.yaml
+from pathlib import Path
+
+def main():
+    list_backend =[]
+    for backend in sorted(backends.getBackendList(), key=lambda backend: backend.identifier):
+        list_backend.append(backend.identifier)
+
+    print(f"Valid backend name are {list_backend}")
+    print('result tab:')
+    print('|Name file|Backend|check')
+    print('|---|---|---')
+
+    valid = 0
+    empty = 0
+    faulty = 0
+    yml_files =Path('config/').glob("*.yml")
+    for yml in yml_files:
+       with yml.open("r",encoding="UTF-8") as f:
+           data = ruamel.yaml.load(f,Loader=ruamel.yaml.RoundTripLoader)
+           if 'backends' in data:
+               for backend in data['backends']:
+                   if backend in list_backend:
+                       print(f"|{yml.name:45} | {backend:30} | OK ")
+                       valid += 1
+                   else:
+                       print(f"|{yml.name:45} | {backend:30} | NOK")
+                       faulty += 1
+           else:
+              msg = "no backend set"
+              print(f"|{yml.name:45} | {msg:30} | -  ")
+              empty += 1
+
+    print('Summary')
+    print(f'Valid : {valid}  Invalid : {faulty} No Backend : {empty}')
+
+if __name__ == "__main__":
+    main()

--- a/tools/sigma_configurations_check
+++ b/tools/sigma_configurations_check
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+from sigma.sigma_configurations_check import main
+
+main()


### PR DESCRIPTION
Some update for #2033

Invalid backend name :  
- corelight_elasticsearch-rule 
- corelight_es-qs 
- corelight_elasticsearch-rule
- corelight_xpack-watcher
- corelight_splunk
- thor  

File with no Backends section: 
- elk-defaultindex-filebeat.yml 
- elk-defaultindex-logstash.yml 
- elk-defaultindex.yml 
- elk-linux.yml   
- elk-windows.yml
- elk-winlogbeat-sp.yml   
- elk-winlogbeat.yml 

Script is not the best but do the job for this time