### PR TITLE
win-apt-greenbug-fix small change to B64encoded value of '/server='

### DIFF
--- a/rules/windows/process_creation/win_apt_greenbug_may20.yml
+++ b/rules/windows/process_creation/win_apt_greenbug_may20.yml
@@ -39,7 +39,7 @@ detection:
             - ' -nop -w hidden -c $m=new-object net.webclient;$m'
             - '-noninteractive -executionpolicy bypass whoami'
             - '-noninteractive -executionpolicy bypass netstat -a'
-            - 'L3NlcnZlc'  # base64 encoded '/server='
+            - 'L3NlcnZlcj0='  # base64 encoded '/server='
     selection4:
         Image|endswith:
             - '\adobe\Adobe.exe'

--- a/rules/windows/process_creation/win_apt_greenbug_may20.yml
+++ b/rules/windows/process_creation/win_apt_greenbug_may20.yml
@@ -39,7 +39,7 @@ detection:
             - ' -nop -w hidden -c $m=new-object net.webclient;$m'
             - '-noninteractive -executionpolicy bypass whoami'
             - '-noninteractive -executionpolicy bypass netstat -a'
-            - 'L3NlcnZlcj0='  # base64 encoded '/server='
+            - 'L3NlcnZlcj1'  # base64 encoded '/server='
     selection4:
         Image|endswith:
             - '\adobe\Adobe.exe'

--- a/rules/windows/process_creation/win_apt_greenbug_may20.yml
+++ b/rules/windows/process_creation/win_apt_greenbug_may20.yml
@@ -6,7 +6,7 @@ references:
     - https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/greenbug-espionage-telco-south-asia
 author: Florian Roth
 date: 2020/05/20
-modified: 2020/08/27
+modified: 2021/09/21
 tags:
     - attack.g0049
     - attack.execution


### PR DESCRIPTION
### Summary
- The intended value for the this B64 criteria was /server= but the current string does not EXACTLY match this causing unnecessary false positives.
- This PR amends this to 'L3NlcnZlcj0=' which should be the correct encoding