### PR TITLE
fix TargetUserName and TargetUserSid for detection

### DIFF
--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -468,12 +468,8 @@ fieldmappings:
     TargetOutboundUserName: winlog.event_data.TargetOutboundUserName
     TargetServerName: winlog.event_data.TargetServerName
     TargetSid: winlog.event_data.TargetSid
-    TargetUserName:
-        service=security: user.name
-        default: winlog.event_data.TargetUserName
-    TargetUserSid:
-        service=security: user.id
-        default: winlog.event_data.TargetUserSid
+    TargetUserName: winlog.event_data.TargetUserName
+    TargetUserSid: winlog.event_data.TargetUserSid
     TaskContent: winlog.event_data.TaskContent
     TaskName: winlog.event_data.TaskName
     TicketEncryptionType: winlog.event_data.TicketEncryptionType


### PR DESCRIPTION
Hi,
Find in [winlogbeat-security.js](https://github.com/elastic/beats/blob/master/x-pack/winlogbeat/module/security/config/winlogbeat-security.js) some trouble with the mapping
```javascript
 var copyTargetUser = function(evt) {
        var targetUserId = evt.Get("winlog.event_data.TargetUserSid");
        if (targetUserId) {
            if (evt.Get("user.id")) evt.Put("user.target.id", targetUserId);
            else evt.Put("user.id", targetUserId);
        }

        var targetUserName = evt.Get("winlog.event_data.TargetUserName");
        if (targetUserName) {
            if (/.@*/.test(targetUserName)) {
                targetUserName = targetUserName.split('@')[0];
            }

            evt.AppendTo("related.user", targetUserName);
            if (evt.Get("user.name")) evt.Put("user.target.name", targetUserName);
            else evt.Put("user.name", targetUserName);
        }

        var targetUserDomain = evt.Get("winlog.event_data.TargetDomainName");
        if (targetUserDomain) {
            if (evt.Get("user.domain")) evt.Put("user.target.domain", targetUserDomain);
            else evt.Put("user.domain", targetUserDomain);
        }
    }
```

So keep only the original field name