### PR TITLE
Fix logsource  not a string

### DIFF
--- a/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
+++ b/rules/windows/builtin/win_susp_logon_explicit_credentials.yml
@@ -13,7 +13,6 @@ tags:
 logsource:
     product: windows
     service: security
-    definition: 
 detection:
     selection:
         EventID: 4648

--- a/rules/windows/other/win_lateral_movement_condrv.yml
+++ b/rules/windows/other/win_lateral_movement_condrv.yml
@@ -15,7 +15,6 @@ tags:
 logsource:
     product: windows
     service: security
-    definition: 
 detection:
     selection:
           EventID: 4674

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -613,6 +613,9 @@ class TestRules(unittest.TestCase):
                 if key.lower() not in valid_logsource:
                     print(Fore.RED + "Rule {} has a logsource with an invalid field ({})".format(file, key))
                     valid = False
+                elif not isinstance(logsource[key],str):
+                    print(Fore.RED + "Rule {} has a logsource with an invalid field type ({})".format(file, key))
+                    valid = False
             if not valid:
                faulty_rules.append(file)
 

--- a/tools/sigma/backends/sysmon.py
+++ b/tools/sigma/backends/sysmon.py
@@ -217,7 +217,7 @@ class SysmonConfigBackend(SingleTextQueryBackend, MultiRuleOutputMixin):
             raise NotSupportedError(
                 "Not supported logsource. Should be product `windows`.")
         for item in self.logsource.values():
-            if item.lower() in self.allowedSource.keys():
+             if str(item).lower() in self.allowedSource.keys():
                 self.table = self.allowedSource.get(item.lower())
                 break
         else:

--- a/tools/sigma/backends/sysmon.py
+++ b/tools/sigma/backends/sysmon.py
@@ -217,7 +217,7 @@ class SysmonConfigBackend(SingleTextQueryBackend, MultiRuleOutputMixin):
             raise NotSupportedError(
                 "Not supported logsource. Should be product `windows`.")
         for item in self.logsource.values():
-             if str(item).lower() in self.allowedSource.keys():
+            if str(item).lower() in self.allowedSource.keys():
                 self.table = self.allowedSource.get(item.lower())
                 break
         else:


### PR DESCRIPTION
With contrib/sigmacover.py find a error with sysmon backend.
If logsource is not a string then signac exit with 'NoneType' object has no attribute 'lower'

- add a conversion to string in sysmon backend 
- add a check in test_rules.py
- fix the rules with invalid definition