### PR TITLE
Added alternative command parameter

### DIFF
--- a/rules/windows/process_creation/win_nltest_recon.yml
+++ b/rules/windows/process_creation/win_nltest_recon.yml
@@ -30,6 +30,7 @@ detection:
             - '/dclist:'
             - '/parentdomain'
             - '/domain_trusts'
+            - '/trusted_domains'
             - '/user'
     condition: selection_nltest and (selection_recon1 or selection_recon2)
 falsepositives:


### PR DESCRIPTION
Added the command parameter '/trusted_domains' for nltest which can be used as an alternative to '/domain_trusts' to bypass detection. 
Tested on Windows 10.0.19042
Reference: https://www.harmj0y.net/blog/redteaming/a-guide-to-attacking-domain-trusts/