### PR TITLE
Added detection for .pri files

### DIFF
--- a/rules/windows/image_load/sysmon_foggyweb_nobelium.yml
+++ b/rules/windows/image_load/sysmon_foggyweb_nobelium.yml
@@ -1,18 +1,22 @@
 title: FoggyWeb Backdoor DLL Loading
 id: 640dc51c-7713-4faa-8a0e-e7c0d9d4654c
 status: experimental
-description: Detects DLL image load activity as used by FoggyWeb backdoor loader
+description: Detects DLL image load events as seen in FoggyWeb infections
 references:
     - https://www.microsoft.com/security/blog/2021/09/27/foggyweb-targeted-nobelium-malware-leads-to-persistent-backdoor/
-author: Florian Roth
-date: 2021/09/27
+author: Florian Roth & Guus Verbeek
+date: 2021/09/29
 logsource:
     category: image_load
     product: windows
 detection:
-    selection:
-        Image: C:\Windows\ADFS\version.dll
-    condition: selection
+    selection1:
+        Image|contains: '\Windows\ADFS\version.dll'
+    selection2:
+        Image|endswith: '.pri'
+    filepath:
+        Image|contains: '\SystemResources\Windows.Data.TimeZones\pris\'
+    condition: selection1 or (selection2 and filepath)
 falsepositives:
-    - Unlikely
+    - Possible, requires further testing.
 level: critical


### PR DESCRIPTION
"FoggyWeb is stored in the encrypted file Windows.Data.TimeZones.zh-PH.pri, while the malicious file version.dll can be described as its loader."