### PR TITLE
mispelled 'mshta.exe' in selection_base

### DIFF
--- a/rules/windows/process_creation/win_susp_mshta_pattern.yml
+++ b/rules/windows/process_creation/win_susp_mshta_pattern.yml
@@ -16,7 +16,7 @@ logsource:
 detection:
     # Binary Selector
     selection_base:
-        Image|endswith: '\mhsta.exe'
+        Image|endswith: '\mshta.exe'
     # Suspicious parents
     selection1:
         ParentImage|endswith:


### PR DESCRIPTION
it said 'mhsta.exe' and it should say 'mshta.exe'