### PR TITLE
Create win_lolbas_execution_of_nltest.exe.yaml

### DIFF
--- a/rules/windows/process_creation/win_lolbas_execution_of_nltest.exe
+++ b/rules/windows/process_creation/win_lolbas_execution_of_nltest.exe
@@ -1,0 +1,28 @@
+title: windows lolbas execution of nltest.exe
+id: eeb66bbb-3dde-4582-815a-584aee9fe6d1 # https://www.uuidgenerator.net/version4
+status: experimental
+author: Arun Chauhan
+date: 2021/08/24
+description: The attacker might use LOLBAS nltest.exe for discovery of domain controllers, domain trusts, parent domain and the current user permissions.
+references:
+  - https://jpcertcc.github.io/ToolAnalysisResultSheet/details/nltest.htm
+  - https://attack.mitre.org/software/S0359/
+tags: 
+  - attack.discovery
+  - attack.t1482 # enumerate trusted domains by using commands such as nltest /domain_trusts
+  - attack.t1018 # enumerate remote domain controllers using options such as /dclist and /dsgetdc
+  - attack.1016  # enumerate the parent domain of a local machine using /parentdomain
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4689
+    Image|contains: "nltest.exe" 
+    ExitStatus: "0x0"
+  condition: selection
+fields:
+  - "SubjectUserName"
+falsepositives:
+  - "Red team activity"
+level: high

--- a/rules/windows/process_creation/win_lolbas_execution_of_nltest.exe
+++ b/rules/windows/process_creation/win_lolbas_execution_of_nltest.exe
@@ -1,5 +1,5 @@
-title: windows lolbas execution of nltest.exe
-id: eeb66bbb-3dde-4582-815a-584aee9fe6d1 # https://www.uuidgenerator.net/version4
+title: Correct Execution of Nltest.exe
+id: eeb66bbb-3dde-4582-815a-584aee9fe6d1
 status: experimental
 author: Arun Chauhan
 date: 2021/08/24
@@ -25,5 +25,6 @@ fields:
   - "SubjectUserName"
   - "SubjectDomainName"
 falsepositives:
-  - "Red team activity"
+  - Red team activity
+  - rare legitimate use by an administrator
 level: high

--- a/rules/windows/process_creation/win_lolbas_execution_of_nltest.exe
+++ b/rules/windows/process_creation/win_lolbas_execution_of_nltest.exe
@@ -18,11 +18,12 @@ logsource:
 detection:
   selection:
     EventID: 4689
-    Image|contains: "nltest.exe" 
-    ExitStatus: "0x0"
+    ProcessName|endswith: nltest.exe
+    Status: "0x0"
   condition: selection
 fields:
   - "SubjectUserName"
+  - "SubjectDomainName"
 falsepositives:
   - "Red team activity"
 level: high

--- a/rules/windows/process_creation/win_lolbas_execution_of_nltest.yml
+++ b/rules/windows/process_creation/win_lolbas_execution_of_nltest.yml
@@ -11,7 +11,7 @@ tags:
   - attack.discovery
   - attack.t1482 # enumerate trusted domains by using commands such as nltest /domain_trusts
   - attack.t1018 # enumerate remote domain controllers using options such as /dclist and /dsgetdc
-  - attack.1016  # enumerate the parent domain of a local machine using /parentdomain
+  - attack.t1016 # enumerate the parent domain of a local machine using /parentdomain
 logsource:
   product: windows
   service: security

--- a/rules/windows/process_creation/win_lolbas_execution_of_nltest.yml
+++ b/rules/windows/process_creation/win_lolbas_execution_of_nltest.yml
@@ -2,7 +2,7 @@ title: Correct Execution of Nltest.exe
 id: eeb66bbb-3dde-4582-815a-584aee9fe6d1
 status: experimental
 author: Arun Chauhan
-date: 2021/08/24
+date: 2021/10/04
 description: The attacker might use LOLBAS nltest.exe for discovery of domain controllers, domain trusts, parent domain and the current user permissions.
 references:
   - https://jpcertcc.github.io/ToolAnalysisResultSheet/details/nltest.htm


### PR DESCRIPTION
The attacker might use LOLBAS nltest.exe for the discovery of domain controllers, domain trusts, parent domain, and the current user permissions. This event can be detected in the Windows Security Log by looking for event id 4689 indicating that nltest.exe was executed and has exited with the execution result of "0x0".