### PR TITLE
fix(backend): add remediation for lacework policy

### DIFF
--- a/tools/sigma/backends/lacework.py
+++ b/tools/sigma/backends/lacework.py
@@ -554,7 +554,7 @@ class LaceworkPolicy:
         self.description = safe_get(rule, 'description', str)
 
         # 14. Get Remediation
-        self.remediation = ""
+        self.remediation = 'Remediation steps are not represented in Sigma rule specification'
 
     def __iter__(self):
         for key, attr in {


### PR DESCRIPTION
The Lacework Policy API requires that we have something populated for `remediation`.  Adding some placeholder text to satisfy this requirement.