### PR TITLE
Added alternative nltest command parameter

### DIFF
--- a/rules/windows/process_creation/win_trust_discovery.yml
+++ b/rules/windows/process_creation/win_trust_discovery.yml
@@ -13,6 +13,7 @@ references:
     - https://eqllib.readthedocs.io/en/latest/analytics/03e231a6-74bc-467a-acb1-e5676b0fb55e.html
     - https://thedfirreport.com/2020/10/18/ryuk-in-5-hours/
     - https://redcanary.com/blog/how-one-hospital-thwarted-a-ryuk-ransomware-outbreak/
+    - https://www.harmj0y.net/blog/redteaming/a-guide-to-attacking-domain-trusts/
 tags:
     - attack.discovery
     - attack.t1482

--- a/rules/windows/process_creation/win_trust_discovery.yml
+++ b/rules/windows/process_creation/win_trust_discovery.yml
@@ -25,6 +25,7 @@ detection:
         CommandLine|contains: 
             - 'domain_trusts'
             - 'all_trusts'
+            - '/trusted_domains'
             - '/dclist'
     selection_dsquery_v1:
         Image|endswith: '\dsquery.exe'


### PR DESCRIPTION
Same as recent change to "Recon Activity with NLTEST" (see commit a2418e4d2cadeefa3b6a7bb639a92ff0872b89ca)
Added the command parameter '/trusted_domains' for nltest which can be used as an alternative to '/domain_trusts' to bypass detection. 
Tested on Windows 10.0.19042
Reference: https://www.harmj0y.net/blog/redteaming/a-guide-to-attacking-domain-trusts/