### PR TITLE
Corrected Technique

### DIFF
--- a/rules/windows/process_creation/process_mailboxexport_share.yml
+++ b/rules/windows/process_creation/process_mailboxexport_share.yml
@@ -25,5 +25,5 @@ fields:
     - CommandLine
     - ParentCommandLine
 tags:
-   - attack.collection  
-   - attack.t1114 
+   - attack.persistence  
+   - attack.t1505.003

--- a/rules/windows/process_creation/process_mailboxexport_share.yml
+++ b/rules/windows/process_creation/process_mailboxexport_share.yml
@@ -27,3 +27,5 @@ fields:
 tags:
    - attack.persistence  
    - attack.t1505.003
+   - attack.resource_development
+   - attack.t1584.006


### PR DESCRIPTION
Probably a nitpick but it bugged me enough to create a pull request.

In the WebProxy exploit chain, the mailbox is used to upload the webshell, either using CVE-2021-31207 or a simple SMTP. Either way, the mailbox contains the webshell, which is then extracted using a command like the one below:

`New-MailBoxExportRequest – Mailbox john.doe@enterprise.corp -FilePath \\127.0.0.1\C$\path\to\webshell.aspx`

As such, this is establishing Persistence through Webshell. It is not Collection through email.

Refenece:
https://www.fireeye.com/blog/threat-research/2021/09/proxyshell-exploiting-microsoft-exchange-servers.html