### PR TITLE
Update test  adding  logsource to duplicate logic test 

### DIFF
--- a/rules/windows/file_event/win_rclone_exec_file.yml
+++ b/rules/windows/file_event/win_rclone_exec_file.yml
@@ -3,7 +3,7 @@ id: 34986307-b7f4-49be-92f3-e7a4d01ac5db
 description: Detects Rclone config file being created
 status: experimental
 date: 2021/05/26
-modified: 2021/06/27
+modified: 2021/10/04
 author: Aaron Greetham (@beardofbinary) - NCC Group
 references:
     - https://research.nccgroup.com/2021/05/27/detecting-rclone-an-effective-tool-for-exfiltration/
@@ -18,7 +18,6 @@ logsource:
     category: file_event
 detection:
     file_selection:
-        EventID: 11
         TargetFilename|contains|all:
             - ':\Users\'
             - '\.config\rclone\'

--- a/rules/windows/image_load/image_load_silenttrinity_stage_use.yml
+++ b/rules/windows/image_load/image_load_silenttrinity_stage_use.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/byt3bl33d3r/SILENTTRINITY
 author: Aleksey Potapov, oscd.community
 date: 2019/10/22
-modified: 2021/09/19
+modified: 2021/10/04
 tags:
     - attack.command_and_control
 logsource:
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventID: 11 # to pass the test otherwise block as same detection that 75c505b1-711d-4f68-a357-8c3fe37dbf2d
         Description|contains: 'st2stager'
     condition: selection
 falsepositives:

--- a/rules/windows/network_connection/sysmon_regsvr32_network_activity.yml
+++ b/rules/windows/network_connection/sysmon_regsvr32_network_activity.yml
@@ -21,7 +21,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventID: 3 # need to pass the test "There are rule files with exactly the same detection logic"
         Image|endswith: '\regsvr32.exe'
     condition: selection
 fields:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -219,6 +219,8 @@ class TestRules(unittest.TestCase):
 
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             detection = self.get_rule_part(file_path = file, part_name = "detection")
+            logsource = self.get_rule_part(file_path = file, part_name = "logsource")
+            detection.update(logsource)
             yaml = self.get_rule_yaml(file_path = file)
 
             is_multipart_yaml_file = len(yaml) != 1


### PR DESCRIPTION
With the removal of the global rules I had to add eventid to pass the tests.
So I update the test by adding the logsource to detection.
Now same detection logic  with  different logsource are not equal.