### PR TITLE
Update AWS SAML and Lambda rules

### DIFF
--- a/rules/cloud/aws/aws_attached_malicious_lambda_layer.yml
+++ b/rules/cloud/aws/aws_attached_malicious_lambda_layer.yml
@@ -11,8 +11,13 @@ logsource:
 detection:
     selection:
         eventSource: lambda.amazonaws.com
+    filter1:
         eventName: UpdateFunctionConfiguration
-    condition: selection
+    filter2:
+        eventName: UpdateFunctionConfiguration20150331
+    filter3:
+        eventName: UpdateFunctionConfiguration20150331v2
+    condition: selection and (filter1 or filter2 or filter3)
 level: medium
 tags:
     - attack.privilege_escalation

--- a/rules/cloud/aws/aws_attached_malicious_lambda_layer.yml
+++ b/rules/cloud/aws/aws_attached_malicious_lambda_layer.yml
@@ -11,13 +11,8 @@ logsource:
 detection:
     selection:
         eventSource: lambda.amazonaws.com
-    filter1:
-        eventName: UpdateFunctionConfiguration
-    filter2:
-        eventName: UpdateFunctionConfiguration20150331
-    filter3:
-        eventName: UpdateFunctionConfiguration20150331v2
-    condition: selection and (filter1 or filter2 or filter3)
+        eventName|startswith: UpdateFunctionConfiguration
+    condition: selection
 level: medium
 tags:
     - attack.privilege_escalation

--- a/rules/cloud/aws/aws_suspicious_saml_activity.yml
+++ b/rules/cloud/aws/aws_suspicious_saml_activity.yml
@@ -12,7 +12,7 @@ logsource:
 detection:
     selection1:
         eventSource: sts.amazonaws.com
-        eventName: Assumerolewithsaml
+        eventName: AssumeRoleWithSAML
     selection2:
         eventSource: iam.amazonaws.com
         eventName: UpdateSAMLProvider


### PR DESCRIPTION
Use correct case for `AssumeRoleWithSAML` event name.
`UpdateFunctionConfiguration`, `UpdateFunctionConfiguration20150331` and `UpdateFunctionConfiguration20150331v2` are all valid event names for updating Lambda function configuration, added selection condition for any of these.