### PR TITLE
Fix Regsvr32 Command Line Without DLL detection logic

### DIFF
--- a/rules/windows/process_creation/win_susp_regsvr32_no_dll.yml
+++ b/rules/windows/process_creation/win_susp_regsvr32_no_dll.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects a regsvr.exe execution that doesn't contain a DLL in the command line
 author: Florian Roth
 date: 2019/07/17
-modified: 2021/07/20
+modified: 2021/10/07
 references:
     - https://app.any.run/tasks/34221348-072d-4b70-93f3-aa71f6ebecad/
 tags:


### PR DESCRIPTION
Changed ` ParentImage ` to ` Image ` so it detects when Regsvr32.exe is executed with any other filetype that the ones in the filter.

Closes #2126