### PR TITLE
Detect suspicious named pipe connections to an AD FS WID

### DIFF
--- a/rules/windows/pipe_created/sysmon_susp_adfs_namedpipe_connection.yml
+++ b/rules/windows/pipe_created/sysmon_susp_adfs_namedpipe_connection.yml
@@ -1,0 +1,33 @@
+title: ADFS Database Named Pipe Connection
+id: 1ea13e8c-03ea-409b-877d-ce5c3d2c1cb3
+description: Detects suspicious local connections via a named pipe to the AD FS configuration database (Windows Internal Database). Used to access information such as the AD FS configuration settings which contains sensitive information used to sign SAML tokens.
+status: experimental
+date: 2021/10/08
+modified: 2021/10/08
+author: Roberto Rodriguez @Cyb3rWard0g
+references:
+    - https://github.com/Azure/Azure-Sentinel/blob/master/Detections/SecurityEvent/ADFSDBNamedPipeConnection.yaml
+    - https://o365blog.com/post/adfs/
+    - https://github.com/Azure/SimuLand
+tags:
+    - attack.collection
+    - attack.t1005
+logsource:
+    product: windows
+    service: pipe_connected
+detection:
+    selection:
+        PipeName: '\MICROSOFT##WID\tsql\query'
+    filter:
+        Image|endswith:
+            - 'Microsoft.IdentityServer.ServiceHost.exe'
+            - 'Microsoft.Identity.Health.Adfs.PshSurrogate.exe'
+            - 'AzureADConnect.exe'
+            - 'Microsoft.Tri.Sensor.exe'
+            - 'wsmprovhost.exe'
+            - 'mmc.exe'
+            - 'sqlservr.exe'
+    condition: selection and not filter
+falsepositives:
+    - Processes in the filter condition
+level: critical


### PR DESCRIPTION
Locally, the AD FS Windows Internal Database (WID) does not have its own management user interface (UI), but one could connect to it via a specific named pipe. The named pipe information can be obtained directly from the ConfigurationDatabaseConnectionString property of the SecurityTokenService class from the WMI ADFS namespace.

Open PowerShell and run the following commands:

```PowerShell
$ADFS = Get-WmiObject -Namespace root/ADFS -Class SecurityTokenService
$conn = $ADFS.ConfigurationDatabaseConnectionString
$conn
```
A threat actor can use this method to extract sensitive information from the AD FS WID. Information such as certificates used to, for example, sign a SAML token and impersonate a user.
