### PR TITLE
Fix a missing var reset in SQLite backend

### DIFF
--- a/tools/sigma/backends/sqlite.py
+++ b/tools/sigma/backends/sqlite.py
@@ -109,6 +109,7 @@ class SQLiteBackend(SQLBackend):
             return self.generateFTS(self.cleanValue(str(node)))
 
     def generateQuery(self, parsed):
+        self.countFTS = 0
         return self._generateQueryWithFields(parsed, list("*"))
 
     def checkFTS(self, parsed, result):


### PR DESCRIPTION
Since the last commit in SQLite backend, the countFTS variable is not reset for each query, so using `sigmac` in directory mode produce only some rules : 

```shell
$ sigmac -t sqlite -c ../../SIGMA/Zircolite/tools/genRules/config/sysmon.yml rules/windows/ -d \
--backend-option table=logs -r | wc -l
      12
```

Instead of : 

```shell
$ sigmac -t sqlite -c ../../SIGMA/Zircolite/tools/genRules/config/sysmon.yml rules/windows/ -d \
--backend-option table=logs -r | wc -l
      956
```