### PR TITLE
Create process_creation_mal_netwire_registry.yml

### DIFF
--- a/rules/windows/malware/process_creation_mal_netwire_registry.yml
+++ b/rules/windows/malware/process_creation_mal_netwire_registry.yml
@@ -1,6 +1,6 @@
 title: NetWire RAT Configuration Registry Key
 id: de44568a-64b7-4e7a-a2f8-e0372e865796
-description: Attempts to detect reg.exe writing to HKCU\Software\NetWire. This is where NetWire commonly stores configureation information.
+description: Attempts to detect reg.exe writing to HKCU\Software\NetWire. This is where NetWire commonly stores configuration information.
 status: experimental
 references:
     - https://redcanary.com/blog/netwire-remote-access-trojan-on-linux/


### PR DESCRIPTION
This rule seeks to detect writes to the hkcu\software\netwire, where NetWire commonly stores configuration data. Due to being in HKCU most sysmon configurations, such as the one from Swift On Security, do not see the registry event.