### PR TITLE
manage start end regex for Elastic

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -153,6 +153,15 @@ class ElasticsearchWildcardHandlingMixin(object):
         elif type(value) == list:
             return self.generateMapItemListNode(transformed_fieldname, value)
         elif isinstance(value, SigmaTypeModifier):
+            #On elastic can not use ^ or $ re is full match 
+            if isinstance(value,sigma.parser.modifiers.type.SigmaRegularExpressionModifier):
+                the_regex = value.value
+                if the_regex[0]=="^" and the_regex[-1]=="$":
+                    value.value = the_regex[1:-1]
+                elif the_regex[0]=="^":
+                    value.value = the_regex[1:] if the_regex[-2:] == ".*" else the_regex[1:] + ".*"
+                elif the_regex[-1]=="$":
+                    value.value = the_regex[:-1] if the_regex[:2] == ".*" else  ".*" +the_regex[:-1] 
             return self.generateMapItemTypedNode(transformed_fieldname, value)
         elif value is None:
             return self.nullExpression % (transformed_fieldname, )


### PR DESCRIPTION
Hi,
Elastic can not deal with "^" or "$" and make a full match
- if regex ^+$ -> remove no need
- if regex ^ -> remove and add ".*" at the end
- if regex $ -> remove ans ans ".*" at the star
- otherwise do nothing 

test with es-qs backend