### PR TITLE
Modify event.provider to event.module

### DIFF
--- a/tools/config/ecs-auditbeat-modules-enabled.yml
+++ b/tools/config/ecs-auditbeat-modules-enabled.yml
@@ -18,7 +18,7 @@ logsources:
     product: linux
     service: auditd
     conditions:
-      event.provider: auditd
+      event.module: auditd
 
 defaultindex: auditbeat-*
 


### PR DESCRIPTION
I modify the field mapping for having event.module instead event.provider .
I have tested with AuditBeat 7.15.1 and directly connected to Elasticsearch.

The ECS version is 1.11.0