### PR TITLE
Fix sysmon in memory assembly execution

### DIFF
--- a/rules/windows/process_access/sysmon_in_memory_assembly_execution.yml
+++ b/rules/windows/process_access/sysmon_in_memory_assembly_execution.yml
@@ -23,8 +23,8 @@ logsource:
 detection:
     selection1:
         CallTrace|contains|all:
-              - 'C:\Windows\SYSTEM32\ntdll.dll+'
-              - '|C:\Windows\System32\KERNELBASE.dll+'
+              - 'C:\WINDOWS\SYSTEM32\ntdll.dll+'
+              - '|C:\WINDOWS\System32\KERNELBASE.dll+'
               - '|UNKNOWN('
               - ')'
     selection2:


### PR DESCRIPTION
HI,

change : 
- "\\\\" to "\\" in the contains
-  CallTrace "windows" cast
-  optimize condition

example of event
```
Process accessed:
RuleName: -
UtcTime: 2021-10-21 07:16:42.087
SourceProcessGUID: {f3880333-12ca-6171-1100-000000004500}
SourceProcessId: 960
SourceThreadId: 1160
SourceImage: C:\WINDOWS\system32\svchost.exe
TargetProcessGUID: {f3880333-12ca-6171-0c00-000000004500}
TargetProcessId: 684
TargetImage: C:\WINDOWS\system32\lsass.exe
GrantedAccess: 0x1000
CallTrace: C:\WINDOWS\SYSTEM32\ntdll.dll+9d234|C:\WINDOWS\System32\KERNELBASE.dll+32e66|c:\windows\system32\lsm.dll+ea38|c:\windows\system32\lsm.dll+11b58|C:\WINDOWS\System32\RPCRT4.dll+78e33|C:\WINDOWS\System32\RPCRT4.dll+e11cb|C:\WINDOWS\System32\RPCRT4.dll+5cd6c|C:\WINDOWS\System32\RPCRT4.dll+57838|C:\WINDOWS\System32\RPCRT4.dll+39e06|C:\WINDOWS\System32\RPCRT4.dll+39758|C:\WINDOWS\System32\RPCRT4.dll+47f6f|C:\WINDOWS\System32\RPCRT4.dll+47378|C:\WINDOWS\System32\RPCRT4.dll+46961|C:\WINDOWS\System32\RPCRT4.dll+463ce|C:\WINDOWS\System32\RPCRT4.dll+4a9d2|C:\WINDOWS\SYSTEM32\ntdll.dll+20330|C:\WINDOWS\SYSTEM32\ntdll.dll+52f26|C:\WINDOWS\System32\KERNEL32.DLL+17034|C:\WINDOWS\SYSTEM32\ntdll.dll+52651
```