### PR TITLE
Import Iterable from collections.abc

### DIFF
--- a/tools/sigma/config/collection.py
+++ b/tools/sigma/config/collection.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import Iterable
+from collections.abc import Iterable
 from pathlib import Path
 import sys
 import re


### PR DESCRIPTION
Importing Iterable directly from collections has been deprecated since python3.3, but has been removed as of python3.10. This change has been tested on both 3.8.10 and 3.10 and works correctly on both. 

I wasn't sure if this warranted opening an issue prior to the PR, so if that's a requirement I'd be happy to retroactively open an issue. 