### PR TITLE
Fix title process_creation_powershell_web_request

### DIFF
--- a/rules/windows/process_creation/process_creation_susp_web_request_cmd.yml
+++ b/rules/windows/process_creation/process_creation_susp_web_request_cmd.yml
@@ -1,7 +1,7 @@
-title: Windows PowerShell Web Request
+title: Windows Suspicious Use Of Web Request in CommandLine
 id: 9fc51a3c-81b3-4fa7-b35f-7c02cf10fd2d
 status: experimental
-description: Detects the use of various web request methods (including aliases) via Windows PowerShell command
+description: Detects the use of various web request with commandline tools or Windows PowerShell command,methods (including aliases)
 references:
     - https://4sysops.com/archives/use-powershell-to-download-a-file-with-http-https-and-ftp/
     - https://blog.jourdant.me/post/3-ways-to-download-files-with-powershell


### PR DESCRIPTION
hi
fix title because  in the [rapport](https://www.joesandbox.com/analysis/509162/0/html) the rule trigger "Windows PowerShell Web Request" when it is a wget CommandLine (Sysmon 1)

Soc operator may think of a FP .
