### PR TITLE
Fix test_rules.py

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -230,7 +230,6 @@ class TestRules(unittest.TestCase):
         files_and_their_detections = {}
 
         for file in self.yield_next_rule_file_path(self.path_to_rules):
-            print(file)
             detection = self.get_rule_part(file_path = file, part_name = "detection")
             logsource = self.get_rule_part(file_path = file, part_name = "logsource")
             detection["logsource"] = {}


### PR DESCRIPTION
Hi
from #2198 fix the test_duplicate_detections.

My previous PR for checking logsource was not correct.
logsource is now correctly view as a condition "logsource"  to compare.

