### PR TITLE
Unsupported rules now possible with Sysmonv13.30

### DIFF
--- a/rules/windows/process_creation/win_susp_child_process_as_system_.yml
+++ b/rules/windows/process_creation/win_susp_child_process_as_system_.yml
@@ -17,11 +17,13 @@ modified: 2020/10/26
 logsource:
     category: process_creation
     product: windows
+    definition: ParentUser field needs sysmon >= 13.30
 detection:
     selection:
         ParentUser:
             - 'NT AUTHORITY\NETWORK SERVICE'
             - 'NT AUTHORITY\LOCAL SERVICE'
+            - 'AUTORITE NT\' # French language settings
         User:
             - 'NT AUTHORITY\SYSTEM'
             - 'AUTORITE NT\Sys' # French language settings


### PR DESCRIPTION
A pull request to aggregate a few rules that can be possible now after the release of Sysmon v13.30

* https://github.com/SigmaHQ/sigma/blob/master/rules-unsupported/win_possible_privilege_escalation_using_rotten_potato.yml