### PR TITLE
Fix errors introduced at commit 58d9e41

### DIFF
--- a/tools/sigma/backends/carbonblack.py
+++ b/tools/sigma/backends/carbonblack.py
@@ -166,7 +166,6 @@ class CarbonBlackQueryBackend(CarbonBlackWildcardHandlingMixin, SingleTextQueryB
 
     def generateMapItemNode(self, node):
         fieldname, value = node
-        value = str(value)
         if fieldname == "EventID" and (type(value) is str or type(value) is int):
             fieldname = self.generateEventKey(value)
             value = self.generateEventValue(value)

--- a/tools/sigma/backends/carbonblack.py
+++ b/tools/sigma/backends/carbonblack.py
@@ -167,6 +167,7 @@ class CarbonBlackQueryBackend(CarbonBlackWildcardHandlingMixin, SingleTextQueryB
     def generateMapItemNode(self, node):
         fieldname, value = node
         if fieldname == "EventID" and (type(value) is str or type(value) is int):
+            value = str(value)
             fieldname = self.generateEventKey(value)
             value = self.generateEventValue(value)
         if fieldname.lower() in self.excluded_fields:


### PR DESCRIPTION
Commit #2029 introduced the problem described in issue #2176. Line 160 from tools/sigma/backends/carbonblack.py makes every value a string. Because of this, some lists are interpreted as strings resulting in the problem described in #2176 as shown below.
```
$ ./sigmac -t carbonblack -c carbon-black-eedr win_apt_dragonfly.yml 
process_name:\[\' AND \\\\crackmapexec.exe\'\]

$ ./sigmac -t carbonblack -c carbon-black-eedr win_susp_control_cve_2021_40444.yml 
((process_name:control.exe AND parent_name:\[\' AND "\\winword.exe', '" AND "\\powerpnt.exe', '" AND \\\\excel.exe\'\]) AND ( -(process_cmdline:"\control.exe input.dll")))
```
Without `value = str(value)` at line 160 these rules are translated to the correct Carbon Black EEDR format.
```
$ ./sigmac -t carbonblack -c carbon-black-eedr win_apt_dragonfly.yml
process_name:crackmapexec.exe

$ ./sigmac -t carbonblack -c carbon-black-eedr win_susp_control_cve_2021_40444.yml
((process_name:control.exe AND (parent_name:winword.exe OR parent_name:powerpnt.exe OR parent_name:excel.exe)) AND ( -(process_cmdline:"\control.exe input.dll")))
```
