### PR TITLE
add win_pc_susp_schtasks_user_temp

### DIFF
--- a/rules/windows/process_creation/win_pc_susp_schtasks_user_temp.yml
+++ b/rules/windows/process_creation/win_pc_susp_schtasks_user_temp.yml
@@ -17,7 +17,7 @@ detection:
     option:
         CommandLine|contains|all:
             - '/Create '
-            - '\AppData\Temp'
+            - '\AppData\Local\Temp'
     condition: schtasks and option
 falsepositives:
     - unknown

--- a/rules/windows/process_creation/win_pc_susp_schtasks_user_temp.yml
+++ b/rules/windows/process_creation/win_pc_susp_schtasks_user_temp.yml
@@ -1,0 +1,24 @@
+title: Suspicius Add Task From User AppData Temp 
+id: 43f487f0-755f-4c2a-bce7-d6d2eec2fcf8
+description: schtasks.exe create task from user AppData\Local\Temp
+references:
+    - malware analyse https://www.joesandbox.com/analysis/514608/0/html#324415FF7D8324231381BAD48A052F85DF04
+tags:
+    - attack.execution
+    - attack.t1053.005 
+author: frack113
+date: 2021/11/03
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    schtasks:
+        Image|endswith: 'schtasks.exe'
+    option:
+        CommandLine|contains|all:
+            - '/Create '
+            - '\AppData\Temp'
+    condition: schtasks and option
+falsepositives:
+    - unknown
+level: high


### PR DESCRIPTION
I view many time this kind of line `C:\Windows\System32\schtasks.exe" /Create /TN "Updates\QUQovKcaZRcNZ" /XML "C:\Users\user\AppData\Local\Temp\tmpD7D5.tmp`  in malware sandbox repport.

I put `level: high` as it come from malware but medium could be fine.

There is no reason to program a task from the temp directory