### PR TITLE
standardization m365

### DIFF
--- a/rules/cloud/m365/microsoft365_activity_by_terminated_user.yml
+++ b/rules/cloud/m365/microsoft365_activity_by_terminated_user.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: m365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_activity_from_anonymous_ip_addresses.yml
+++ b/rules/cloud/m365/microsoft365_activity_from_anonymous_ip_addresses.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: m365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_activity_from_infrequent_country.yml
+++ b/rules/cloud/m365/microsoft365_activity_from_infrequent_country.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: m365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_data_exfiltration_to_unsanctioned_app.yml
+++ b/rules/cloud/m365/microsoft365_data_exfiltration_to_unsanctioned_app.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: m365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_from_suspicious_ip_addresses.yml
+++ b/rules/cloud/m365/microsoft365_from_suspicious_ip_addresses.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatDetection
-    service: m365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_impossible_travel_activity.yml
+++ b/rules/cloud/m365/microsoft365_impossible_travel_activity.yml
@@ -10,7 +10,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: Office365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_logon_from_risky_ip_address.yml
+++ b/rules/cloud/m365/microsoft365_logon_from_risky_ip_address.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: m365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_potential_ransomware_activity.yml
+++ b/rules/cloud/m365/microsoft365_potential_ransomware_activity.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: Microsoft365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_suspicious_inbox_forwarding.yml
+++ b/rules/cloud/m365/microsoft365_suspicious_inbox_forwarding.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: m365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_suspicious_oauth_app_file_download_activities.yml
+++ b/rules/cloud/m365/microsoft365_suspicious_oauth_app_file_download_activities.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: m365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_unusual_volume_of_file_deletion.yml
+++ b/rules/cloud/m365/microsoft365_unusual_volume_of_file_deletion.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: Microsoft365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/rules/cloud/m365/microsoft365_user_restricted_from_sending_email.yml
+++ b/rules/cloud/m365/microsoft365_user_restricted_from_sending_email.yml
@@ -9,7 +9,7 @@ references:
     - https://docs.microsoft.com/en-us/cloud-app-security/policy-template-reference
 logsource:
     category: ThreatManagement
-    service: Microsoft365
+    product: m365
 detection:
     selection:
         eventSource: SecurityComplianceCenter

--- a/tools/config/generic/m365.yml
+++ b/tools/config/generic/m365.yml
@@ -1,32 +1,33 @@
 title: Microsoft 365 Rules
 order: 10
-ThreatManagement:
-   product: m365
-   category: ThreatManagement
-   conditions:
-       eventSource: SecurityComplianceCenter
-AccessGovernance:
-   product: m365
-   category: AccessGovernance
-   conditions:
-       eventSource: SecurityComplianceCenter
-CloudDiscovery:
-   product: m365
-   category: CloudDiscovery
-   conditions:
-       eventSource: SecurityComplianceCenter
-DataLossPrevention:
-   product: m365
-   category: DataLossPrevention
-   conditions:
-       eventSource: SecurityComplianceCenter
-ThreatDetection:
-   product: m365
-   category: ThreatDetection
-   conditions:
-       eventSource: SecurityComplianceCenter
-SharingControl:
-   product: m365
-   category: SharingControl
-   conditions:
-       eventSource: SecurityComplianceCenter
+logsources:
+    ThreatManagement:
+        product: m365
+        category: ThreatManagement
+        conditions:
+            eventSource: SecurityComplianceCenter
+    AccessGovernance:
+        product: m365
+        category: AccessGovernance
+        conditions:
+            eventSource: SecurityComplianceCenter
+    CloudDiscovery:
+        product: m365
+        category: CloudDiscovery
+        conditions:
+            eventSource: SecurityComplianceCenter
+    DataLossPrevention:
+        product: m365
+        category: DataLossPrevention
+        conditions:
+            eventSource: SecurityComplianceCenter
+    ThreatDetection:
+        product: m365
+        category: ThreatDetection
+        conditions:
+            eventSource: SecurityComplianceCenter
+    SharingControl:
+        product: m365
+        category: SharingControl
+        conditions:
+            eventSource: SecurityComplianceCenter


### PR DESCRIPTION
m365.yml and the rules. 
did not remove `eventSource` from rule even if it is not usefull when use `-c /config/generic/m365.yml` 