### PR TITLE
Fix process command line

### DIFF
--- a/rules/windows/process_creation/process_creation_office_from_proxy_executing_regsvr32_payload.yml
+++ b/rules/windows/process_creation/process_creation_office_from_proxy_executing_regsvr32_payload.yml
@@ -13,6 +13,7 @@ tags:
     - attack.defense_evasion
 status: experimental
 date: 2021/08/23
+modified: 2021/11/09
 logsource:
   product: windows
   category: process_creation
@@ -20,7 +21,7 @@ detection:
   #useful_information: add more LOLBins to the rules logic of your choice.
   selection1:
     - Image|endswith: '\wbem\WMIC.exe'
-    - ProcessCommandLine|contains: 'wmic '
+    - ParentCommandLine|contains: 'wmic '
     - OriginalFileName: 'wmic.exe'
     - Description: 'WMI Commandline Utility'
   selection2:
@@ -32,11 +33,11 @@ detection:
       - 'verclsid'
   selection3:
     ParentImage|endswith:
-    - winword.exe
-    - excel.exe
-    - powerpnt.exe
+      - winword.exe
+      - excel.exe
+      - powerpnt.exe
   selection4:
-    processCommandLine|contains|all: 
+    ParentCommandLine|contains|all: 
       - 'process'
       - 'create'
       - 'call'

--- a/rules/windows/process_creation/process_creation_office_from_proxy_executing_regsvr32_payload2.yml
+++ b/rules/windows/process_creation/process_creation_office_from_proxy_executing_regsvr32_payload2.yml
@@ -13,13 +13,14 @@ tags:
     - attack.defense_evasion
 status: experimental
 date: 2021/08/23
+modified: 2021/11/09
 logsource:
   product: windows
   category: process_creation
 detection:
   #useful_information: add more LOLBins to the rules logic of your choice.
   selection1:
-    ProcessCommandLine:
+    ParentCommandLine:
       - '*regsvr32*'
       - '*rundll32*'
       - '*msiexec*'
@@ -27,14 +28,14 @@ detection:
       - '*verclsid*'
   selection2:
     - Image|endswith: '\wbem\WMIC.exe'
-    - ProcessCommandLine|contains: 'wmic '
+    - ParentCommandLine|contains: 'wmic '
   selection3:
     ParentImage|endswith:
-    - winword.exe
-    - excel.exe
-    - powerpnt.exe
+      - winword.exe
+      - excel.exe
+      - powerpnt.exe
   selection4:
-    processCommandLine|contains|all: 
+    ParentCommandLine|contains|all: 
       - 'process'
       - 'create'
       - 'call' 

--- a/rules/windows/process_creation/process_creation_office_spawning_wmi_commandline.yml
+++ b/rules/windows/process_creation/process_creation_office_spawning_wmi_commandline.yml
@@ -13,19 +13,20 @@ tags:
     - attack.defense_evasion
 status: experimental
 date: 2021/08/23
+modified: 2021/11/09
 logsource:
   product: windows
   category: process_creation
 detection:
  #useful_information: Add more office applications to the rule logic of choice
   selection1:
-  - Image|endswith: '\wbem\WMIC.exe'
-  - ProcessCommandLine|contains: 'wmic '
+    - Image|endswith: '\wbem\WMIC.exe'
+    - ParentCommandLine|contains: 'wmic '
   selection2:
-   ParentImage:
-    - winword.exe
-    - excel.exe
-    - powerpnt.exe
+    ParentImage:
+      - winword.exe
+      - excel.exe
+      - powerpnt.exe
   condition: selection1 and selection2
 falsepositives:
 - Unknown

--- a/rules/windows/process_creation/win_susp_wuauclt.yml
+++ b/rules/windows/process_creation/win_susp_wuauclt.yml
@@ -20,7 +20,7 @@ detection:
         ParentCommandLine|contains|all: 
             - '/UpdateDeploymentProvider'
             - '/RunHandlerComServer'
-        Image|endswith: 
+        ParentImage|endswith: 
             - '\wuauclt.exe'
     condition: selection
 falsepositives:

--- a/rules/windows/process_creation/win_susp_wuauclt.yml
+++ b/rules/windows/process_creation/win_susp_wuauclt.yml
@@ -6,7 +6,7 @@ references:
     - https://dtm.uk/wuauclt/
 author: FPT.EagleEye Team
 date: 2020/10/17
-modified: 2021/05/12
+modified: 2021/11/09
 tags:
     - attack.command_and_control
     - attack.execution
@@ -17,7 +17,7 @@ logsource:
     category: process_creation
 detection:
     selection:
-        ProcessCommandLine|contains|all: 
+        ParentCommandLine|contains|all: 
             - '/UpdateDeploymentProvider'
             - '/RunHandlerComServer'
         Image|endswith: 

--- a/rules/windows/process_creation/win_susp_wuauclt.yml
+++ b/rules/windows/process_creation/win_susp_wuauclt.yml
@@ -17,10 +17,10 @@ logsource:
     category: process_creation
 detection:
     selection:
-        ParentCommandLine|contains|all: 
+        CommandLine|contains|all: 
             - '/UpdateDeploymentProvider'
             - '/RunHandlerComServer'
-        ParentImage|endswith: 
+        Image|endswith: 
             - '\wuauclt.exe'
     condition: selection
 falsepositives:

--- a/tools/config/generic/windows-audit.yml
+++ b/tools/config/generic/windows-audit.yml
@@ -24,3 +24,4 @@ fieldmappings:
     Image: NewProcessName
     ParentImage: ParentProcessName
     Details: NewValue
+    ParentCommandLine: ProcessCommandLine


### PR DESCRIPTION
ProcessCommandLine is from eventid 4688.
In all the other process_creation rule we use the sysmon name `ParentCommandLine`.

- fix ParentCommandLine to ParentCommandLine
- add ParentCommandLine to tools/config/generic/windows-audit.yml
- fix the detection of the rule `win_susp_wuauclt.yml` after try the payload in a VM