### PR TITLE
adding additional allow for dns service (domain controllers)

### DIFF
--- a/rules/windows/network_connection/sysmon_susp_rdp.yml
+++ b/rules/windows/network_connection/sysmon_susp_rdp.yml
@@ -38,9 +38,11 @@ detection:
             - '\FSAssessment.exe'
             - '\MobaRTE.exe'
             - '\chrome.exe'
+            - '\System32\dns.exe'
             - '\thor.exe'
             - '\thor64.exe'
     condition: selection and not filter 
 falsepositives:
     - Other Remote Desktop RDP tools
+    - domain controller using dns.exe
 level: high


### PR DESCRIPTION
Adding an additional allow for dns.exe requests . False positive found in our production cloud:

Example:

2021-11-10 16:41:44 VMDC1.company.pvt Sysmon: 3: Network connection detected | RuleName=technique_id=T1021,technique_name=Remote Services | UtcTime=2021-11-10 16:40:50.180 | ProcessGuid={8BB9D839-F8F1-6174-1E00-00000000AC00} | ProcessId=1988 | Image=C:\Windows\System32\dns.exe | User=NT AUTHORITY\SYSTEM | Protocol=udp | Initiated=true | SourceIsIpv6=false | SourceIp=172.16.1.251 | SourceHostname=VMDC1.company.pvt | SourcePort=53 | SourcePortName=domain | DestinationIsIpv6=false | DestinationIp=172.16.1.202 | DestinationHostname=vmprod1.company.pvt | DestinationPort=3389 | DestinationPortName=ms-wbt-server | pid=2564 | level=0 | sys_version=5 | category=Network connection detected (rule: NetworkConnect) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=27522889 | app="sysmon64.exe" | tid=3204 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) .... (omitted)