### PR TITLE
Fix double quotes escaping and values with commas in SQLite/SQL backends

### DIFF
--- a/tools/sigma/backends/sql.py
+++ b/tools/sigma/backends/sql.py
@@ -106,24 +106,25 @@ class SQLBackend(SingleTextQueryBackend):
     def generateMapItemNode(self, node):
         fieldname, value = node
         transformed_fieldname = self.fieldNameMapping(fieldname, value)
+        generated_value = self.generateNode(value)
 
-        has_wildcard = re.search(r"((\\(\*|\?|\\))|\*|\?|_|%)", self.generateNode(value))
+        has_wildcard = re.search(r"((\\(\*|\?|\\))|\*|\?|_|%)", generated_value)
 
-        if "," in self.generateNode(value) and not has_wildcard:
-            return self.mapMulti % (transformed_fieldname, self.generateNode(value))
+        if "," in generated_value  and generated_value[0]=="(" and generated_value[-1]==")" and not has_wildcard:
+            return self.mapMulti % (transformed_fieldname, generated_value)
         elif "LENGTH" in transformed_fieldname:
             return self.mapLength % (transformed_fieldname, value)
         elif type(value) == list:
             return self.generateMapItemListNode(transformed_fieldname, value)
         elif self.mapListsSpecialHandling == False and type(value) in (str, int, list) or self.mapListsSpecialHandling == True and type(value) in (str, int):
             if has_wildcard:
-                return self.mapWildcard % (transformed_fieldname, self.generateNode(value))
+                return self.mapWildcard % (transformed_fieldname, generated_value)
             else:
-                return self.mapExpression % (transformed_fieldname, self.generateNode(value))
+                return self.mapExpression % (transformed_fieldname, generated_value)
         elif "sourcetype" in transformed_fieldname:
-            return self.mapSource % (transformed_fieldname, self.generateNode(value))
+            return self.mapSource % (transformed_fieldname, generated_value)
         elif has_wildcard:
-            return self.mapWildcard % (transformed_fieldname, self.generateNode(value))
+            return self.mapWildcard % (transformed_fieldname, generated_value)
         else:
             raise TypeError("Backend does not support map values of type " + str(type(value)))
 


### PR DESCRIPTION
## Double quotes escaping : 

Some rules contain double quotes in their field values like this [one](https://github.com/SigmaHQ/sigma/blob/10b70edff055cfb12b16d934c77f9ccf4b97a529/rules/windows/process_creation/win_susp_winrm_awl_bypass.yml) : 

```yaml
detection:
    contains_format_pretty_arg:       
        CommandLine|contains:
            - 'format:pretty'
            - 'format:"pretty"'
```

In the current SQLite backend, the double quotes are not escaped so the resulting SQL query is not valid : 

```sql
AND (CommandLine LIKE "%format:pretty%" ESCAPE '\'
OR CommandLine LIKE "%format:"pretty"%" ESCAPE '\'
OR CommandLine LIKE "%format:"text"%" ESCAPE '\'
OR CommandLine LIKE "%format:text%" ESCAPE '\')
```

This PR solves the problem by escaping correctly the double quotes : 

```sql
AND (CommandLine LIKE "%format:pretty%" ESCAPE '\'
OR CommandLine LIKE "%format:""pretty""%" ESCAPE '\'
OR CommandLine LIKE "%format:""text""%" ESCAPE '\'
OR CommandLine LIKE "%format:text%" ESCAPE '\')
```

## Field values containing commas : 

Some rules have commas in field values like this [one](https://github.com/SigmaHQ/sigma/blob/08ca62cc8860f4660e945805d0dd615ce75258c1/rules/windows/process_creation/sysmon_susp_plink_remote_forward.yml) : 

```yaml
detection:
    selection:
        Description: 'Command-line SSH, Telnet, and Rlogin client'
        CommandLine|contains: ' -R '
    condition: selection
```

The current SQL and SQLite backends work in such a way that if you have commas in field values it would generate a SQL query with the `IN` keyword even if it there is only one value. For example, the above rule was converted into : 

```sql
SELECT *
FROM logs
WHERE (EventID = "1"
        AND Channel = "Microsoft-Windows-Sysmon/Operational"
        AND Description IN "Command-line SSH, Telnet, and Rlogin client"
        AND CommandLine LIKE "% -R %" ESCAPE '\') 
```
In this case, the SQL query is not valid because the `IN` keyword must be followed by `(`.

This PR solves the problem by restricting even more when the keyword IN is used : 

```sql
SELECT *
FROM logs
WHERE (EventID = "1"
        AND Channel = "Microsoft-Windows-Sysmon/Operational"
        AND Description = "Command-line SSH, Telnet, and Rlogin client"
        AND CommandLine LIKE "% -R %" ESCAPE '\') 
```
