### PR TITLE
Adding two more process, additional references, information about Cob…

### DIFF
--- a/rules/windows/file_event/sysmon_susp_clr_logs.yml
+++ b/rules/windows/file_event/sysmon_susp_clr_logs.yml
@@ -1,17 +1,23 @@
 title: Suspcious CLR Logs Creation
 id: e4b63079-6198-405c-abd7-3fe8b0ce3263
-description: Detects suspicious .NET assembly executions 
+description: Detects suspicious .NET assembly executions. Could detect using Cobalt Strike's command execute-assembly. 
 references:
     - https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
+    - https://bohops.com/2021/03/16/investigating-net-clr-usage-log-tampering-techniques-for-edr-evasion/
+    - https://github.com/olafhartong/sysmon-modular/blob/master/11_file_create/include_dotnet.xml
 date: 2020/10/12
+modified: 2021/11/17
 tags:
     - attack.execution
+    - attack.defense_evasion
     - attack.t1059.001
+    - attack.t1218
 status: experimental
-author: omkar72, oscd.community
+author: omkar72, oscd.community, Wojciech Lesicki
 logsource:
     category: file_event
     product: windows
+    definition: Check your sysmon configuration for monitoring UsageLogs folder. In SwiftOnSecurity configuration we have that thanks @SBousseaden
 detection:
     selection:
         TargetFilename|contains|all:
@@ -23,7 +29,9 @@ detection:
           - 'wscript'
           - 'regsvr32'
           - 'wmic'
+          - 'rundll32'
+          - 'svchost'
     condition: selection
 falsepositives:
-  - Unknown
+  - https://twitter.com/SBousseaden/status/1388064061087260675 - rundll32.exe with zzzzInvokeManagedCustomActionOutOfProc in command line and msiexec.exe as parent process
 level: high


### PR DESCRIPTION
…alt Strike etc.

Base on information from https://bohops.com/2021/03/16/investigating-net-clr-usage-log-tampering-techniques-for-edr-evasion/ we can detect by this rule also Cobalt Strike using command execute-assembly.

I added rundll32 as default CS process and also svchost (according https://github.com/olafhartong/sysmon-modular/blob/master/11_file_create/include_dotnet.xml)