### PR TITLE
Rule Fix: Paths with Quotes

### DIFF
--- a/rules/windows/process_creation/win_susp_emotet_rundll32_execution.yml
+++ b/rules/windows/process_creation/win_susp_emotet_rundll32_execution.yml
@@ -23,7 +23,10 @@ detection:
             - ',Control_RunDLL'
             # - ',#1'  too generic - function load by ordinal is not Emotet specific
     filter_legitimate_dll:
-        CommandLine|endswith: '.dll,Control_RunDLL'
+        CommandLine|endswith:
+          - '.dll,Control_RunDLL'
+          - '.dll",Control_RunDLL'
+          - ".dll',Control_RunDLL"
     filter_ide:
         ParentImage|endswith:
             - '\tracker.exe' #When Visual Studio compile NodeJS program, it might use MSBuild to create tracker.exe and then, the tracker.exe fork rundll32.exe


### PR DESCRIPTION
Prevent possible FPs from non-windows native calls using paths surrounded by quotes which might happen by 3rd party calls to rundll32.exe