### PR TITLE
Update shell open key rule

### DIFF
--- a/rules/windows/registry_event/win_registry_shell_open_keys_manipulation.yml
+++ b/rules/windows/registry_event/win_registry_shell_open_keys_manipulation.yml
@@ -1,6 +1,6 @@
-title: UAC Bypass Using Registry Shell Open Keys
+title: Shell Open Registry Keys Manipulation
 id: 152f3630-77c1-4284-bcc0-4cc68ab2f6e7
-description: Detects the pattern of UAC Bypass using fodhelper.exe, computerdefaults.exe, slui.exe via registry keys (e.g. UACMe 33 or 62)
+description: Detects the shell open key manipulation (exefile and ms-settings) and the pattern of UAC Bypass using fodhelper.exe, computerdefaults.exe, slui.exe via registry keys (e.g. UACMe 33 or 62)
 author: Christian Burkard
 date: 2021/08/30
 modified: 2021/09/17
@@ -9,10 +9,12 @@ references:
     - https://github.com/hfiref0x/UACME
     - https://winscripting.blog/2017/05/12/first-entry-welcome-and-uac-bypass/
     - https://github.com/RhinoSecurityLabs/Aggressor-Scripts/tree/master/UACBypass
+    - https://tria.ge/211119-gs7rtshcfr/behavioral2 [Lokibot sample from Nov 2021]
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
     - attack.t1548.002
+    - attack.t1546.001
 logsource:
     category: registry_event
     product: windows

--- a/rules/windows/registry_event/win_registry_shell_open_keys_manipulation.yml
+++ b/rules/windows/registry_event/win_registry_shell_open_keys_manipulation.yml
@@ -3,7 +3,7 @@ id: 152f3630-77c1-4284-bcc0-4cc68ab2f6e7
 description: Detects the shell open key manipulation (exefile and ms-settings) and the pattern of UAC Bypass using fodhelper.exe, computerdefaults.exe, slui.exe via registry keys (e.g. UACMe 33 or 62)
 author: Christian Burkard
 date: 2021/08/30
-modified: 2021/09/17
+modified: 2021/11/19
 status: experimental
 references:
     - https://github.com/hfiref0x/UACME

--- a/rules/windows/registry_event/win_registry_shell_open_keys_manipulation.yml
+++ b/rules/windows/registry_event/win_registry_shell_open_keys_manipulation.yml
@@ -1,6 +1,6 @@
 title: Shell Open Registry Keys Manipulation
 id: 152f3630-77c1-4284-bcc0-4cc68ab2f6e7
-description: Detects the shell open key manipulation (exefile and ms-settings) and the pattern of UAC Bypass using fodhelper.exe, computerdefaults.exe, slui.exe via registry keys (e.g. UACMe 33 or 62)
+description: Detects the shell open key manipulation (exefile and ms-settings) used for persistence and the pattern of UAC Bypass using fodhelper.exe, computerdefaults.exe, slui.exe via registry keys (e.g. UACMe 33 or 62)
 author: Christian Burkard
 date: 2021/08/30
 modified: 2021/11/19


### PR DESCRIPTION
Make rule more generic regarding the included exefile detection instead of only naming it "uac bypass". Add further references and attack tags. There is also an other rule regarding asep reg key manipulation which also includes exefile: https://github.com/SigmaHQ/sigma/blob/master/rules/windows/registry_event/sysmon_asep_reg_keys_modification.yml.