### PR TITLE
Add missing Mitre Techniques Tags for windows rules

### DIFF
--- a/rules/windows/builtin/win_apt_gallium.yml
+++ b/rules/windows/builtin/win_apt_gallium.yml
@@ -14,6 +14,7 @@ references:
 tags:
     - attack.credential_access
     - attack.command_and_control
+    - attack.t1071
 logsource:
     product: windows
     service: dns-server

--- a/rules/windows/builtin/win_apt_slingshot.yml
+++ b/rules/windows/builtin/win_apt_slingshot.yml
@@ -12,6 +12,7 @@ references:
     - https://securelist.com/apt-slingshot/84312/
 tags:
     - attack.persistence
+    - attack.t1053
     - attack.s0111
 logsource:
     product: windows

--- a/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler.yml
+++ b/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler.yml
@@ -12,6 +12,7 @@ date: 2021/06/30
 modified: 2021/07/08
 tags:
     - attack.execution
+    - attack.t1569    
     - cve.2021.1675
 logsource:
     product: windows

--- a/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler_operational.yml
+++ b/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler_operational.yml
@@ -9,6 +9,7 @@ references:
 date: 2021/07/01
 tags:
     - attack.execution
+    - attack.t1569
     - cve.2021.1675
 logsource:
     product: windows

--- a/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler_security.yml
+++ b/rules/windows/builtin/win_exploit_cve_2021_1675_printspooler_security.yml
@@ -9,6 +9,7 @@ references:
 date: 2021/07/02
 tags:
     - attack.execution
+    - attack.t1569    
     - cve.2021.1675
     - cve.2021.34527
 logsource:

--- a/rules/windows/builtin/win_hybridconnectionmgr_svc_installation.yml
+++ b/rules/windows/builtin/win_hybridconnectionmgr_svc_installation.yml
@@ -7,6 +7,7 @@ modified: 2021/08/09
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 tags:
     - attack.persistence
+    - attack.t1554 
 references:
     - https://twitter.com/Cyb3rWard0g/status/1381642789369286662
 logsource:

--- a/rules/windows/builtin/win_hybridconnectionmgr_svc_running.yml
+++ b/rules/windows/builtin/win_hybridconnectionmgr_svc_running.yml
@@ -6,6 +6,7 @@ date: 2021/04/12
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 tags:
     - attack.persistence
+    - attack.t1554 
 references:
     - https://twitter.com/Cyb3rWard0g/status/1381642789369286662
 logsource:

--- a/rules/windows/builtin/win_scm_database_handle_failure.yml
+++ b/rules/windows/builtin/win_scm_database_handle_failure.yml
@@ -9,6 +9,7 @@ references:
     - https://threathunterplaybook.com/notebooks/windows/07_discovery/WIN-190826010110.html
 tags:
     - attack.discovery
+    - attack.t1010
 logsource:
     product: windows
     service: security

--- a/rules/windows/builtin/win_susp_add_domain_trust.yml
+++ b/rules/windows/builtin/win_susp_add_domain_trust.yml
@@ -6,6 +6,7 @@ author: Thomas Patzke
 date: 2019/12/03
 tags:
     - attack.persistence
+    - attack.t1098
 logsource:
     product: windows
     service: security

--- a/rules/windows/builtin/win_vul_cve_2020_1472.yml
+++ b/rules/windows/builtin/win_vul_cve_2020_1472.yml
@@ -9,6 +9,7 @@ date: 2020/09/15
 modified: 2021/08/09
 tags:
     - attack.privilege_escalation
+    - attack.t1548
 logsource:
     product: windows
     service: system

--- a/rules/windows/dns_query/dns_query_hybridconnectionmgr_servicebus.yml
+++ b/rules/windows/dns_query/dns_query_hybridconnectionmgr_servicebus.yml
@@ -7,6 +7,7 @@ modified: 2021/06/10
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 tags:
     - attack.persistence
+    - attack.t1554 
 references:
     - https://twitter.com/Cyb3rWard0g/status/1381642789369286662
 logsource:

--- a/rules/windows/driver_load/driver_load_vuln_dell_driver.yml
+++ b/rules/windows/driver_load/driver_load_vuln_dell_driver.yml
@@ -27,3 +27,7 @@ detection:
 falsepositives:
     - legitimate BIOS driver updates (should be rare)
 level: high
+tags:
+    - attack.persistence
+    - attack.defense_evasion
+    - attack.t1542.001

--- a/rules/windows/driver_load/driver_load_vuln_dell_driver.yml
+++ b/rules/windows/driver_load/driver_load_vuln_dell_driver.yml
@@ -12,6 +12,7 @@ logsource:
 tags:
     - attack.privilege_escalation
     - cve.2021.21551
+    - attack.t1543 
 detection:
     selection_image:
         ImageLoaded|contains: '\DBUtil_2_3.Sys'
@@ -27,7 +28,3 @@ detection:
 falsepositives:
     - legitimate BIOS driver updates (should be rare)
 level: high
-tags:
-    - attack.persistence
-    - attack.defense_evasion
-    - attack.t1542.001

--- a/rules/windows/file_event/file_event_susp_task_write.yml
+++ b/rules/windows/file_event/file_event_susp_task_write.yml
@@ -8,6 +8,8 @@ author: Florian Roth
 date: 2021/11/16
 tags:
     - attack.persistence
+    - attack.execution
+    - attack.t1053 
 logsource:
     product: windows
     category: file_event
@@ -22,6 +24,3 @@ detection:
 falsepositives:
     - Unknown
 level: high
-tags:
-    - attack.execution
-    - attack.t1053 

--- a/rules/windows/file_event/file_event_susp_task_write.yml
+++ b/rules/windows/file_event/file_event_susp_task_write.yml
@@ -22,3 +22,6 @@ detection:
 falsepositives:
     - Unknown
 level: high
+tags:
+    - attack.execution
+    - attack.t1053 

--- a/rules/windows/file_event/win_cve_2021_1675_printspooler.yml
+++ b/rules/windows/file_event/win_cve_2021_1675_printspooler.yml
@@ -28,3 +28,6 @@ fields:
     - TargetFilename
 falsepositives:
     - Unknown
+tags:
+    - attack.resource_development
+    - attack.t1587

--- a/rules/windows/file_event/win_cve_2021_1675_printspooler.yml
+++ b/rules/windows/file_event/win_cve_2021_1675_printspooler.yml
@@ -13,6 +13,8 @@ modified: 2021/07/01
 tags:
     - attack.execution
     - attack.privilege_escalation
+    - attack.resource_development
+    - attack.t1587
     - cve.2021.1675
 logsource:
     category: file_event
@@ -28,6 +30,3 @@ fields:
     - TargetFilename
 falsepositives:
     - Unknown
-tags:
-    - attack.resource_development
-    - attack.t1587

--- a/rules/windows/file_event/win_file_winword_cve_2021_40444.yml
+++ b/rules/windows/file_event/win_file_winword_cve_2021_40444.yml
@@ -27,3 +27,6 @@ fields:
 falsepositives:
     - unknown
 level: critical
+tags:
+    - attack.resource_development
+    - attack.t1587

--- a/rules/windows/image_load/image_load_silenttrinity_stage_use.yml
+++ b/rules/windows/image_load/image_load_silenttrinity_stage_use.yml
@@ -12,6 +12,7 @@ date: 2019/10/22
 modified: 2021/10/04
 tags:
     - attack.command_and_control
+    - attack.t1071
 logsource:
     category: image_load
     product: windows

--- a/rules/windows/image_load/sysmon_foggyweb_nobelium.yml
+++ b/rules/windows/image_load/sysmon_foggyweb_nobelium.yml
@@ -16,3 +16,6 @@ detection:
 falsepositives:
     - Unlikely
 level: critical
+tags:
+    - attack.resource_development
+    - attack.t1587

--- a/rules/windows/image_load/win_susp_svchost_clfsw32.yml
+++ b/rules/windows/image_load/win_susp_svchost_clfsw32.yml
@@ -17,3 +17,7 @@ detection:
 falsepositives:
     - Rarely observed
 level: high
+tags:
+    - attack.defense_evasion
+    - attack.privilege_escalation
+    - attack.t1055

--- a/rules/windows/malware/av_hacktool.yml
+++ b/rules/windows/malware/av_hacktool.yml
@@ -26,3 +26,4 @@ falsepositives:
 level: high
 tags:
     - attack.execution
+    - attack.t1204

--- a/rules/windows/network_connection/win_net_crypto_mining.yml
+++ b/rules/windows/network_connection/win_net_crypto_mining.yml
@@ -38,3 +38,6 @@ detection:
 falsepositives:
     - Legitimate use of crypto miners
 level: high
+tags:
+    - attack.impact
+    - attack.t1496

--- a/rules/windows/other/win_exchange_cve_2021_42321.yml
+++ b/rules/windows/other/win_exchange_cve_2021_42321.yml
@@ -17,3 +17,6 @@ detection:
 falsepositives:
     - Unknown, please report false positives via https://github.com/SigmaHQ/sigma/issues
 level: critical
+tags:
+    - attack.lateral_movement
+    - attack.t1210

--- a/rules/windows/pipe_created/sysmon_apt_turla_namedpipes.yml
+++ b/rules/windows/pipe_created/sysmon_apt_turla_namedpipes.yml
@@ -4,9 +4,12 @@ status: experimental
 description: Detects a named pipe used by Turla group samples
 references:
     - Internal Research
+    - https://attack.mitre.org/groups/G0010/
 date: 2017/11/06
 tags:
     - attack.g0010
+    - attack.execution
+    - attack.t1106 
 author: Markus Neis
 logsource:
     product: windows

--- a/rules/windows/pipe_created/sysmon_susp_wmi_consumer_namedpipe.yml
+++ b/rules/windows/pipe_created/sysmon_susp_wmi_consumer_namedpipe.yml
@@ -7,13 +7,16 @@ references:
 date: 2021/09/01
 author: Florian Roth
 logsource:
-   product: windows
-   category: pipe_created
-   definition: 'Note that you have to configure logging for Named Pipe Events in Sysmon config (Event ID 17 and Event ID 18). The basic configuration is in popular sysmon configuration (https://github.com/SwiftOnSecurity/sysmon-config), but it is worth verifying. You can also use other repo, e.g. https://github.com/Neo23x0/sysmon-config, https://github.com/olafhartong/sysmon-modular. How to test detection? You can check powershell script from this site https://svch0st.medium.com/guide-to-named-pipes-and-hunting-for-cobalt-strike-pipes-dc46b2c5f575'
+    product: windows
+    category: pipe_created
+    definition: 'Note that you have to configure logging for Named Pipe Events in Sysmon config (Event ID 17 and Event ID 18). The basic configuration is in popular sysmon configuration (https://github.com/SwiftOnSecurity/sysmon-config), but it is worth verifying. You can also use other repo, e.g. https://github.com/Neo23x0/sysmon-config, https://github.com/olafhartong/sysmon-modular. How to test detection? You can check powershell script from this site https://svch0st.medium.com/guide-to-named-pipes-and-hunting-for-cobalt-strike-pipes-dc46b2c5f575'
 detection:
-   selection:
-      Image|endswith: '\scrcons.exe'
-   condition: selection
+    selection:
+        Image|endswith: '\scrcons.exe'
+    condition: selection
 falsepositives:
-   - Unknown
+    - Unknown
 level: high
+tags:
+    - attack.t1047 
+    - attack.execution

--- a/rules/windows/powershell/powershell_script/powershell_invoke_nightmare.yml
+++ b/rules/windows/powershell/powershell_script/powershell_invoke_nightmare.yml
@@ -20,3 +20,4 @@ falsepositives:
 level: high
 tags:
     - attack.privilege_escalation
+    - attack.t1548

--- a/rules/windows/powershell/powershell_script/powershell_windows_firewall_profile_disabled.yml
+++ b/rules/windows/powershell/powershell_script/powershell_windows_firewall_profile_disabled.yml
@@ -6,23 +6,24 @@ author: Austin Songer @austinsonger
 date: 2021/10/12
 modified: 2021/10/16
 references:
-- https://docs.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2019-ps
-- https://www.tutorialspoint.com/how-to-get-windows-firewall-profile-settings-using-powershell
-- http://powershellhelp.space/commands/set-netfirewallrule-psv5.php
-- http://woshub.com/manage-windows-firewall-powershell/
+    - https://docs.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2019-ps
+    - https://www.tutorialspoint.com/how-to-get-windows-firewall-profile-settings-using-powershell
+    - http://powershellhelp.space/commands/set-netfirewallrule-psv5.php
+    - http://woshub.com/manage-windows-firewall-powershell/
 logsource:
-  product: windows
-  category: ps_script
+      product: windows
+      category: ps_script
 detection: 
-  selection:
-    ScriptBlockText|contains|all:
-      - Set-NetFirewallProfile
-      - -Profile
-      - -Enabled
-      - 'False'
-  condition: selection
+    selection:
+        ScriptBlockText|contains|all:
+            - Set-NetFirewallProfile
+            - -Profile
+            - -Enabled
+            - 'False'
+    condition: selection
 tags:
-- attack.defense_evasion
+    - attack.defense_evasion
+    - attack.t1562.004
 level: high
 falsepositives:
-- Unknown
+    - Unknown

--- a/rules/windows/process_creation/process_creation_apt_gallium.yml
+++ b/rules/windows/process_creation/process_creation_apt_gallium.yml
@@ -13,7 +13,9 @@ references:
     - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn800669(v=ws.11)
 tags:
     - attack.credential_access
+    - attack.t1212 
     - attack.command_and_control
+    - attack.t1071
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/process_creation_apt_gallium_sha1.yml
+++ b/rules/windows/process_creation/process_creation_apt_gallium_sha1.yml
@@ -10,7 +10,9 @@ references:
     - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-R2-and-2012/dn800669(v=ws.11)
 tags:
     - attack.credential_access
+    - attack.t1212 
     - attack.command_and_control
+    - attack.t1071
 logsource:
     product: windows
     category: process_creation

--- a/rules/windows/process_creation/process_creation_apt_slingshot.yml
+++ b/rules/windows/process_creation/process_creation_apt_slingshot.yml
@@ -9,6 +9,7 @@ references:
     - https://securelist.com/apt-slingshot/84312/
 tags:
     - attack.persistence
+    - attack.t1053.005
     - attack.s0111
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/process_creation_coti_sqlcmd.yml
+++ b/rules/windows/process_creation/process_creation_coti_sqlcmd.yml
@@ -10,6 +10,7 @@ references:
     - https://docs.microsoft.com/en-us/sql/tools/sqlcmd-utility?view=sql-server-ver15
 tags:
     - attack.collection
+    - attack.t1005
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_apt_dragonfly.yml
+++ b/rules/windows/process_creation/win_apt_dragonfly.yml
@@ -4,8 +4,13 @@ description: Detects CrackMapExecWin Activity as Described by NCSC
 status: experimental
 references:
     - https://www.ncsc.gov.uk/alerts/hostile-state-actors-compromising-uk-organisations-focus-engineering-and-industrial-control
+    - https://attack.mitre.org/software/S0488/
 tags:
     - attack.g0035
+    - attack.credential_access
+    - attack.discovery
+    - attack.t1110
+    - attack.t1087
 author: Markus Neis
 date: 2018/04/08
 logsource:

--- a/rules/windows/process_creation/win_apt_lazarus_activity_apr21.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_activity_apr21.yml
@@ -6,6 +6,8 @@ references:
     - https://blog.malwarebytes.com/malwarebytes-news/2021/04/lazarus-apt-conceals-malicious-code-within-bmp-file-to-drop-its-rat/
 tags:
     - attack.g0032
+    - attack.execution
+    - attack.t1106 
 author: Bhabesh Raj
 date: 2021/04/20
 modified: 2021/06/27

--- a/rules/windows/process_creation/win_apt_lazarus_activity_dec20.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_activity_dec20.yml
@@ -7,6 +7,8 @@ references:
     - https://www.hvs-consulting.de/lazarus-report/
 tags:
     - attack.g0032
+    - attack.execution
+    - attack.t1059 
 author: Florian Roth
 date: 2020/12/23
 modified: 2021/06/27

--- a/rules/windows/process_creation/win_apt_lazarus_loader.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_loader.yml
@@ -7,6 +7,8 @@ references:
     - https://securelist.com/lazarus-covets-covid-19-related-intelligence/99906/
 tags:
     - attack.g0032
+    - attack.execution
+    - attack.t1059 
 author: Florian Roth, wagga
 date: 2020/12/23
 modified: 2021/06/27

--- a/rules/windows/process_creation/win_apt_revil_kaseya.yml
+++ b/rules/windows/process_creation/win_apt_revil_kaseya.yml
@@ -13,6 +13,7 @@ date: 2021/07/03
 modified: 2021/07/05
 tags:
     - attack.execution
+    - attack.t1059 
     - attack.g0115
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_apt_ta505_dropper.yml
+++ b/rules/windows/process_creation/win_apt_ta505_dropper.yml
@@ -7,6 +7,7 @@ references:
 tags:
     - attack.execution
     - attack.g0092
+    - attack.t1106 
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_cobaltstrike_process_patterns.yml
+++ b/rules/windows/process_creation/win_cobaltstrike_process_patterns.yml
@@ -10,6 +10,7 @@ date: 2021/07/27
 modified: 2021/08/30
 tags:
     - attack.execution
+    - attack.t1059 
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_crypto_mining_monero.yml
+++ b/rules/windows/process_creation/win_crypto_mining_monero.yml
@@ -10,27 +10,30 @@ logsource:
     category: process_creation
     product: windows
 detection:
-   selection:
-      CommandLine|contains:
-        - ' --cpu-priority='
-        - '--donate-level=0'
-        - ' -o pool.'
-        - ' --nicehash'
-        - ' --algo=rx/0 '
-        - 'stratum+tcp://'
-        - 'stratum+udp://'
-        # base64 encoded: --donate-level=
-        - 'LS1kb25hdGUtbGV2ZWw9'
-        - '0tZG9uYXRlLWxldmVsP'
-        - 'tLWRvbmF0ZS1sZXZlbD'
-        # base64 encoded: stratum+tcp:// and stratum+udp:// 
-        - 'c3RyYXR1bSt0Y3A6Ly'
-        - 'N0cmF0dW0rdGNwOi8v'
-        - 'zdHJhdHVtK3RjcDovL'
-        - 'c3RyYXR1bSt1ZHA6Ly'
-        - 'N0cmF0dW0rdWRwOi8v'
-        - 'zdHJhdHVtK3VkcDovL'
-   condition: selection
+    selection:
+         CommandLine|contains:
+            - ' --cpu-priority='
+            - '--donate-level=0'
+            - ' -o pool.'
+            - ' --nicehash'
+            - ' --algo=rx/0 '
+            - 'stratum+tcp://'
+            - 'stratum+udp://'
+            # base64 encoded: --donate-level=
+            - 'LS1kb25hdGUtbGV2ZWw9'
+            - '0tZG9uYXRlLWxldmVsP'
+            - 'tLWRvbmF0ZS1sZXZlbD'
+            # base64 encoded: stratum+tcp:// and stratum+udp:// 
+            - 'c3RyYXR1bSt0Y3A6Ly'
+            - 'N0cmF0dW0rdGNwOi8v'
+            - 'zdHJhdHVtK3RjcDovL'
+            - 'c3RyYXR1bSt1ZHA6Ly'
+            - 'N0cmF0dW0rdWRwOi8v'
+            - 'zdHJhdHVtK3VkcDovL'
+    condition: selection
 falsepositives:
-   - Legitimate use of crypto miners
+    - Legitimate use of crypto miners
 level: high
+tags:
+    - attack.impact
+    - attack.t1496

--- a/rules/windows/process_creation/win_malware_trickbot_wermgr.yml
+++ b/rules/windows/process_creation/win_malware_trickbot_wermgr.yml
@@ -9,6 +9,7 @@ author: Florian Roth
 date: 2020/11/26
 tags:
     - attack.execution
+    - attack.t1559 
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_monitoring_for_persistence_via_bits.yml
+++ b/rules/windows/process_creation/win_monitoring_for_persistence_via_bits.yml
@@ -7,6 +7,7 @@ date: 2020/10/29
 modified: 2021/07/15
 tags:
     - attack.defense_evasion
+    - attack.t1197
 references:
     - https://www.fireeye.com/blog/threat-research/2020/10/kegtap-and-singlemalt-with-a-ransomware-chaser.html
     - http://0xthem.blogspot.com/2014/03/t-emporal-persistence-with-and-schtasks.html

--- a/rules/windows/process_creation/win_multiple_suspicious_cli.yml
+++ b/rules/windows/process_creation/win_multiple_suspicious_cli.yml
@@ -9,6 +9,8 @@ date: 2019/01/16
 modified: 2021/06/13
 tags:
     - car.2013-04-002
+    - attack.execution
+    - attack.t1059 
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_silenttrinity_stage_use.yml
+++ b/rules/windows/process_creation/win_silenttrinity_stage_use.yml
@@ -9,6 +9,7 @@ date: 2019/10/22
 modified: 2021/09/19
 tags:
     - attack.command_and_control
+    - attack.t1071
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_mshta_pattern.yml
+++ b/rules/windows/process_creation/win_susp_mshta_pattern.yml
@@ -8,6 +8,7 @@ references:
     - https://app.any.run/tasks/34221348-072d-4b70-93f3-aa71f6ebecad/
 tags:
     - attack.execution
+    - attack.t1106 
 author: Florian Roth
 date: 2021/07/17
 logsource:

--- a/rules/windows/process_creation/win_susp_razorinstaller_explorer.yml
+++ b/rules/windows/process_creation/win_susp_razorinstaller_explorer.yml
@@ -10,6 +10,7 @@ date: 2021/08/23
 modified: 2021/08/24
 tags:
     - attack.privilege_escalation
+    - attack.t1553
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_regsvr32_no_dll.yml
+++ b/rules/windows/process_creation/win_susp_regsvr32_no_dll.yml
@@ -9,6 +9,7 @@ references:
     - https://app.any.run/tasks/34221348-072d-4b70-93f3-aa71f6ebecad/
 tags:
     - attack.defense_evasion
+    - attack.t1574
     - attack.execution
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/win_susp_renamed_debugview.yml
+++ b/rules/windows/process_creation/win_susp_renamed_debugview.yml
@@ -22,5 +22,5 @@ falsepositives:
     - Unknown
 level: high
 tags:
-    - attack.lateral_movement
-    - attack.discovery
+    - attack.resource_development 
+    - attack.t1588.002

--- a/rules/windows/process_creation/win_susp_script_exec_from_temp.yml
+++ b/rules/windows/process_creation/win_susp_script_exec_from_temp.yml
@@ -9,6 +9,7 @@ date: 2021/07/14
 modified: 2021/11/11
 tags:
     - attack.execution
+    - attack.t1059
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/win_susp_servu_process_pattern.yml
+++ b/rules/windows/process_creation/win_susp_servu_process_pattern.yml
@@ -11,6 +11,7 @@ logsource:
     product: windows
 tags:
     - attack.credential_access
+    - attack.t1555 
     - cve.2021.35211
 detection:
     selection:

--- a/rules/windows/process_creation/win_susp_sysprep_appdata.yml
+++ b/rules/windows/process_creation/win_susp_sysprep_appdata.yml
@@ -7,6 +7,7 @@ references:
     - https://app.any.run/tasks/61a296bb-81ad-4fee-955f-3b399f4aaf4b
 tags:
     - attack.execution
+    - attack.t1059
 author: Florian Roth
 date: 2018/06/22
 modified: 2018/12/11

--- a/rules/windows/registry_event/sysmon_hybridconnectionmgr_svc_installation.yml
+++ b/rules/windows/registry_event/sysmon_hybridconnectionmgr_svc_installation.yml
@@ -5,7 +5,8 @@ status: experimental
 date: 2021/04/12
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 tags:
-    - attack.persistence
+    - attack.resource_development
+    - attack.t1608
 references:
     - https://twitter.com/Cyb3rWard0g/status/1381642789369286662
 logsource:

--- a/rules/windows/registry_event/sysmon_registry_susp_printer_driver.yml
+++ b/rules/windows/registry_event/sysmon_registry_susp_printer_driver.yml
@@ -8,6 +8,7 @@ author: Florian Roth
 date: 2020/07/01
 tags:
     - attack.privilege_escalation
+    - attack.t1574
     - cve.2021.1675
 logsource:
     category: registry_event

--- a/rules/windows/registry_event/win_registry_mimikatz_printernightmare.yml
+++ b/rules/windows/registry_event/win_registry_mimikatz_printernightmare.yml
@@ -9,6 +9,7 @@ references:
 author: Markus Neis, @markus_neis, Florian Roth
 tags:
   - attack.execution
+  - attack.t1204
   - cve.2021.1675
   - cve.2021.34527
 date: 2021/07/04


### PR DESCRIPTION
Hello,
I have do my best to add correct missing [Techniques](https://attack.mitre.org/techniques/enterprise/) in windows rules.
