### PR TITLE
Update lnx_shell_clear_cmd_history.yml

### DIFF
--- a/rules/linux/builtin/lnx_shell_clear_cmd_history.yml
+++ b/rules/linux/builtin/lnx_shell_clear_cmd_history.yml
@@ -23,7 +23,9 @@ detection:
         - 'rm *bash_history'
         - 'echo "" > *bash_history'
         - 'cat /dev/null > *bash_history'
+        - 'cat /dev/zero > *bash_history'
         - 'ln -sf /dev/null *bash_history'
+        - 'ln -sf /dev/zero *bash_history'
         - 'truncate -s0 *bash_history'
         # - 'unset HISTFILE'  # prone to false positives
         - 'export HISTFILESIZE=0'
@@ -31,6 +33,7 @@ detection:
         - 'history -w'
         - 'shred *bash_history'
         - 'empty_bash_history'
+        - 'chattr +i *bash_history'
     condition: keywords
 falsepositives:
     - Unknown


### PR DESCRIPTION
cat and ln can use zero or null
chattr does not clear but stops further logging