### PR TITLE
Hawk tags enrichment

### DIFF
--- a/tools/config/hawk.yml
+++ b/tools/config/hawk.yml
@@ -5,6 +5,8 @@ backends:
 logsources:
  antivirus:
    product: antivirus
+   conditions:
+     vendor_type: 'Antivirus'
  apache:
    product: apache
    conditions:

--- a/tools/sigma/backends/hawk.py
+++ b/tools/sigma/backends/hawk.py
@@ -638,13 +638,16 @@ class HAWKBackend(SingleTextQueryBackend):
             "public" : True,
             "references" : ref,
             "group_name" : ".",
+            "tags" : [ "sigma" ],
             "hawk_id" : sigmaparser.parsedyaml['id']
         }
         if 'tags' in sigmaparser.parsedyaml:
-            record["tags"] = [ item.replace("attack.", "") for item in sigmaparser.parsedyaml['tags']]
+            record["tags"] = record['tags'] + [ item.replace("attack.", "") for item in sigmaparser.parsedyaml['tags']]
 
         if not 'status' in self.sigmaparser.parsedyaml or 'status' in self.sigmaparser.parsedyaml and self.sigmaparser.parsedyaml['status'] != 'experimental':
             record['correlation_action'] += 10.0;
+        elif 'status' in self.sigmaparser.parsedyaml and self.sigmaparser.parsedyaml['status'] == 'experimental':
+            record["tags"].append("qa")
         if 'falsepositives' in self.sigmaparser.parsedyaml and len(self.sigmaparser.parsedyaml['falsepositives']) > 1:
             record['correlation_action'] -= (2.0 * len(self.sigmaparser.parsedyaml['falsepositives']) )
 


### PR DESCRIPTION
Small update to HAWK sigmac backend.  All rules receive a "sigma" tag, and additionally a "qa" tag if marked as experimental