### PR TITLE
adding amazon ec2 to list of false positives for powershell cmdlet detection

### DIFF
--- a/rules/windows/powershell/powershell_script/powershell_malicious_commandlets.yml
+++ b/rules/windows/powershell/powershell_script/powershell_malicious_commandlets.yml
@@ -10,7 +10,7 @@ tags:
     - attack.t1086  #an old one
 author: Sean Metcalf (source), Florian Roth (rule), Bartlomiej Czyz @bczyz1 (update), oscd.community (update)
 date: 2017/03/05
-modified: 2021/10/16
+modified: 2021/11/29
 logsource:
     product: windows
     category: ps_script
@@ -115,6 +115,7 @@ detection:
             - "Invoke-AllChecks"
     false_positives:
         ScriptBlockText|contains: Get-SystemDriveInfo  # http://bheltborg.dk/Windows/WinSxS/amd64_microsoft-windows-maintenancediagnostic_31bf3856ad364e35_10.0.10240.16384_none_91ef7543a4514b5e/CL_Utility.ps1
+        ScriptBlockText:contains: "C:\ProgramData\Amazon\EC2-Windows\Launch\Module\Scripts\Set-Wallpaper.ps1"  # false positive form Amazon EC2
     condition: select_Malicious and not false_positives
 falsepositives:
     - Penetration testing

--- a/rules/windows/powershell/powershell_script/powershell_malicious_commandlets.yml
+++ b/rules/windows/powershell/powershell_script/powershell_malicious_commandlets.yml
@@ -115,7 +115,7 @@ detection:
             - "Invoke-AllChecks"
     false_positives:
         ScriptBlockText|contains: Get-SystemDriveInfo  # http://bheltborg.dk/Windows/WinSxS/amd64_microsoft-windows-maintenancediagnostic_31bf3856ad364e35_10.0.10240.16384_none_91ef7543a4514b5e/CL_Utility.ps1
-        ScriptBlockText:contains: "C:\ProgramData\Amazon\EC2-Windows\Launch\Module\Scripts\Set-Wallpaper.ps1"  # false positive form Amazon EC2
+        ScriptBlockText:contains: C:\ProgramData\Amazon\EC2-Windows\Launch\Module\Scripts\Set-Wallpaper.ps1  # false positive form Amazon EC2
     condition: select_Malicious and not false_positives
 falsepositives:
     - Penetration testing


### PR DESCRIPTION

Added EC2 to list of fp's.

Per:

2021-11-29 17:48:45 device-01.company.pvt PowerShell: 4103: CommandInvocation(Add-Type): "Add-Type" | ContextInfo= Severity = Informational Host Name = ConsoleHost Host Version = 5.1.14393.4583 Host ID = f4c1be35-faa8-44de-8743-5d38546eb1c3 Host Application = C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -NonInteractive -NoLogo -WindowStyle hidden -ExecutionPolicy Unrestricted Import-Module C:\ProgramData\Amazon\EC2-Windows\Launch\Module\Ec2Launch.psd1; so Runspace ID = e4359a73-0de6-486f-ba02-3d52af58a9d0 Pipeline ID = 6 Command Name = Add-Type Command Type = Cmdlet Script Name = C:\ProgramData\Amazon\EC2-Windows\Launch\Module\Scripts\Set-Wallpaper.ps1 Command Path = Sequence Number = 70 User = DOMAIN\Username Connected User = Shell ID = Microsoft.PowerShell