### PR TITLE
Sysmon logon scripts userinitmprlogonscript proc

### DIFF
--- a/rules/windows/process_creation/sysmon_logon_scripts_userinitmprlogonscript_proc.yml
+++ b/rules/windows/process_creation/sysmon_logon_scripts_userinitmprlogonscript_proc.yml
@@ -6,7 +6,7 @@ author: Tom Ueltschi (@c_APT_ure)
 references:
   - https://attack.mitre.org/techniques/T1037/
 date: 2019/01/12
-modified: 2021/11/27
+modified: 2021/11/29
 logsource:
   category: process_creation
   product: windows
@@ -17,7 +17,7 @@ detection:
     Image|endswith: '\explorer.exe'
   exec_exclusion2:
     CommandLine|contains:
-      - 'netlogon.bat'
+      - 'netlogon*.bat'
       - 'UsrLogon.cmd'
   create_keywords_cli:
     CommandLine|contains: 'UserInitMprLogonScript'


### PR DESCRIPTION
Adding wildcard to netlogon to be a little more inclusive.


2021-11-29 19:45:32 device-01.company.pvt Sysmon: 1: Process Create | RuleName=technique_id=T1059.003,technique_name=Windows Command Shell | UtcTime=2021-11-29 19:45:32.212 | ProcessGuid={86DC4549-2DDC-61A5-15BE-030000003D00} | ProcessId=10540 | Image=C:\Windows\System32\cmd.exe | FileVersion=10.0.14393.0 (rs1_release.160715-1616) | Description=Windows Command Processor | Company=Microsoft Corporation | OriginalFileName=Cmd.Exe | OriginalCommandLine=C:\Windows\system32\cmd.exe /c ""\\remotehost\netlogon\cgllogin.bat" " | CommandLine=C:\Windows\system32\cmd.exe /c "\\remotehost\netlogon\cgllogin.bat " | CurrentDirectory=C:\Windows\system32\ | User=DOMAIN\Username | LogonGuid={86DC4549-2DC9-61A5-FF7B-B14A0A000000} | LogonId=0xa4ab17bff | TerminalSessionId=205 | IntegrityLevel=Medium | Hashes=SHA1=99AE9C73E9BEE6F9C76D6F4093A9882DF06832CF,MD5=F4F684066175B77E0C3A000549D2922C,SHA256=935C1861DF1F4018D698E8B65ABFA02D7E9037D8F68CA3C2065B6CA165D44AD2,IMPHASH=3062ED732D4B25D1C64F084DAC97D37A | ParentProcessGuid={86DC4549-2DD5-61A5-0BBE-030000003D00} | ParentProcessId=8520 | ParentImage=C:\Windows\System32\userinit.exe | OriginalParentCommandLine=C:\Windows\system32\userinit.exe | ParentCommandLine=C:\Windows\system32\userinit.exe | ParentCommandLineObfuscated=false | pid=232 | level=0 | sys_version=5 | category=Process Create (rule: ProcessCreate) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=3670820 | app="C:\Windows\sysmon64.exe" | tid=4248 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) |