### PR TITLE
adding false positive filter for amazon ssm-document-worker

### DIFF
--- a/rules/windows/process_creation/win_powershell_xor_commandline.yml
+++ b/rules/windows/process_creation/win_powershell_xor_commandline.yml
@@ -17,7 +17,10 @@ detection:
       - "bxor"
       - "join"
       - "char"
-  condition: selection and filter
+  false_positives:
+    ParentImage: 
+      - C:\Program Files\Amazon\SSM\ssm-document-worker.exe
+  condition: selection and filter and not false_positives
 falsepositives:
   - unknown
 level: medium


### PR DESCRIPTION

Adding filter for C:\Program Files\Amazon\SSM\ssm-document-worker.exe

per

2021-11-29 21:11:58 device-01.company.pvt Sysmon: 1: Process Create | RuleName=technique_id=T1059.001,technique_name=PowerShell | UtcTime=2021-11-29 21:11:58.966 | ProcessGuid={d7d4e535-421e-61a5-5417-01000000f500} | ProcessId=152 | Image=C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe | FileVersion=10.0.17763.1 (WinBuild.160101.0800) | Description=Windows PowerShell | Company=Microsoft Corporation | OriginalFileName=PowerShell.EXE | OriginalCommandLine=powershell " [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 $keyExists = Test-Path \"Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\OC Manager\Subcomponents\" $jsonObj = @() if ($keyExists) { $key = Get-Item \"Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\OC Manager\Subcomponents\" $valueNames = $key.GetValueNames(); foreach ($valueName in $valueNames) { $value = $key.GetValue($valueName); if ($value -gt 0) { $installed = \"True\" } else { $installed = \"False\" } $jsonObj += @\" {\"Name\": \"$valueName\", \"Installed\": \"$installed\"} \"@ } } $result = $jsonObj -join \",\" $result = \"[\" + $result + \"]\" [Console]::WriteLine($result) " | CommandLine=powershell " [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 $keyExists = Test-Path "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\OC Manager\Subcomponents" $jsonObj = @() if ($keyExists) { $key = Get-Item "Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\OC Manager\Subcomponents" $valueNames = $key.GetValueNames(); foreach ($valueName in $valueNames) { $value = $key.GetValue($valueName); if ($value -gt 0) { $installed = "True" } else { $installed = "False" } $jsonObj += @" {"Name": "$valueName", "Installed": "$installed"} "@ } } $result = $jsonObj -join "," $result = "[" + $result + "]" [Console]::WriteLine($result) " | CommandLineObfuscated=true | CommandLineObfuscatedReason=Obfuscation character '"' detected and data size deviated 12.00. | CurrentDirectory=C:\Windows\system32\ | User=NT AUTHORITY\SYSTEM | LogonGuid={d7d4e535-270c-618b-e703-000000000000} | LogonId=0x3e7 | TerminalSessionId=0 | IntegrityLevel=System | Hashes=SHA1=6CBCE4A295C163791B60FC23D285E6D84F28EE4C,MD5=7353F60B1739074EB17C5F4DDDEFE239,SHA256=DE96A6E69944335375DC1AC238336066889D9FFC7D73628EF4FE1B1B160AB32C,IMPHASH=741776AACCFC5B71FF59832DCDCACE0F | ParentProcessGuid={d7d4e535-420e-61a5-4917-01000000f500} | ParentProcessId=5672 | ParentImage=C:\Program Files\Amazon\SSM\ssm-document-worker.exe | OriginalParentCommandLine="C:\Program Files\Amazon\SSM\ssm-document-worker.exe" 6f554e28-55f5-410c-8e80-acfdf2cc4c9e.2021-11-29T21-11-42.402Z | ParentCommandLine="C:\Program Files\Amazon\SSM\ssm-document-worker.exe" 6f554e28-55f5-410c-8e80-acfdf2cc4c9e.2021-11-29T21-11-42.402Z | pid=2584 | level=0 | sys_version=5 | category=Process Create (rule: ProcessCreate) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=12906304 | app="C:\Windows\sysmon64.exe" | tid=3496 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) | 