### PR TITLE
 fixing false positive due to direct calls to xcopy and cmd.exe

### DIFF
--- a/rules/windows/process_creation/win_susp_copy_system32.yml
+++ b/rules/windows/process_creation/win_susp_copy_system32.yml
@@ -2,21 +2,19 @@ title: Suspicious Copy From or To System32
 id: fff9d2b7-e11c-4a69-93d3-40ef66189767
 status: test
 description: Detects a suspicious copy command that copies a system program from System32 to another directory on disk - sometimes used to use LOLBINs like certutil or desktopimgdownldr to a different location with a different name
-author: Florian Roth, Markus Neis
+author: Florian Roth, Markus Neis, Tim Shelton (HAWK.IO)
 references:
   - https://www.hybrid-analysis.com/sample/8da5b75b6380a41eee3a399c43dfe0d99eeefaa1fd21027a07b1ecaa4cd96fdd?environmentId=120
 date: 2020/07/03
-modified: 2021/11/27
+modified: 2021/12/30
 logsource:
   category: process_creation
   product: windows
 detection:
   selection:
     CommandLine|contains:
-      - ' /c copy'
-      - 'xcopy'
-    CommandLine|contains|all:
-      - '\System32\'
+      - 'xcopy*\System32\'
+      - 'cmd.exe*/c*copy*\System32\'
   condition: selection
 fields:
   - CommandLine
@@ -24,6 +22,7 @@ fields:
 falsepositives:
   - False positives depend on scripts and administrative tools used in the monitored environment
   - Admin scripts like https://www.itexperience.net/sccm-batch-files-and-32-bits-processes-on-64-bits-os/
+  - False positive when c:\windows\SYSTEM32\cmd.exe is called directly : C:\Windows\System32\cmd.exe /c copy file1 file2
 level: medium
 tags:
   - attack.defense_evasion

--- a/rules/windows/process_creation/win_susp_copy_system32.yml
+++ b/rules/windows/process_creation/win_susp_copy_system32.yml
@@ -22,7 +22,7 @@ fields:
 falsepositives:
   - False positives depend on scripts and administrative tools used in the monitored environment
   - Admin scripts like https://www.itexperience.net/sccm-batch-files-and-32-bits-processes-on-64-bits-os/
-  - False positive when c:\windows\SYSTEM32\cmd.exe is called directly : C:\Windows\System32\cmd.exe /c copy file1 file2
+  - False positive when cmd.exe and xcopy.exe are called directly #  C:\Windows\System32\cmd.exe /c copy file1 file2
 level: medium
 tags:
   - attack.defense_evasion


### PR DESCRIPTION
example:

Command=C:\Windows\System32\cmd.exe /c copy "C:\Program Files (x86)\BigFix Enterprise\BES Client\LMT\CIT\tmpDir\tmpArchiveWithTagFiles.zip" "C:\Program Files (x86)\BigFix Enterprise\BES Client\LMT\CIT\13126042_iso.zip