### PR TITLE
feat: discourage the usage of 'all of them'

### DIFF
--- a/rules-unsupported/sysmon_process_reimaging.yml
+++ b/rules-unsupported/sysmon_process_reimaging.yml
@@ -18,8 +18,9 @@ references:
 tags:
     - attack.defense_evasion
 date: 2019/10/25
+modified: 2021/12/02
 detection:
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - unknown
 level: high

--- a/rules/cloud/gworkspace/gworkspace_mfa_disabled.yml
+++ b/rules/cloud/gworkspace/gworkspace_mfa_disabled.yml
@@ -4,7 +4,7 @@ description: Detects when multi-factor authentication (MFA) is disabled.
 author: Austin Songer
 status: experimental
 date: 2021/08/26
-modified: 2021/08/29
+modified: 2021/12/02
 references:
     - https://cloud.google.com/logging/docs/audit/gsuite-audit-logging#3
     - https://developers.google.com/admin-sdk/reports/v1/appendix/activity/admin-security-settings#ENFORCE_STRONG_AUTHENTICATION
@@ -13,14 +13,14 @@ logsource:
   product: google_workspace
   service: google_workspace.admin
 detection:
-    selection:
+    selection_base:
         eventService: admin.googleapis.com
         eventName: 
             - ENFORCE_STRONG_AUTHENTICATION
             - ALLOW_STRONG_AUTHENTICATION
-    eventValue:
+    selection_eventValue:
         new_value: 'false'
-    condition: all of them
+    condition: all of selection*
 level: medium
 tags:
     - attack.impact

--- a/rules/linux/macos/process_creation/macos_gui_input_capture.yml
+++ b/rules/linux/macos/process_creation/macos_gui_input_capture.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects attempts to use system dialog prompts to capture user credentials
 author: remotephone, oscd.community
 date: 2020/10/13
-modified: 2021/11/11
+modified: 2021/12/02
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1056.002/T1056.002.md
     - https://scriptingosx.com/2018/08/user-interaction-from-bash-scripts/
@@ -31,7 +31,7 @@ detection:
             - 'pass'
             - 'password'
             - 'unlock'
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Legitimate administration tools and activities
 level: low

--- a/rules/windows/builtin/win_alert_active_directory_user_control.yml
+++ b/rules/windows/builtin/win_alert_active_directory_user_control.yml
@@ -6,18 +6,18 @@ author: '@neu5ron'
 references:
   - https://www.harmj0y.net/blog/activedirectory/the-most-dangerous-user-right-you-probably-have-never-heard-of/
 date: 2017/07/30
-modified: 2021/11/27
+modified: 2021/12/02
 logsource:
   product: windows
   service: security
   definition: 'Requirements: Audit Policy : Policy Change > Audit Authorization Policy Change, Group Policy : Computer Configuration\Windows Settings\Security Settings\Advanced Audit Policy Configuration\Audit Policies\Policy Change\Audit Authorization Policy Change'
 detection:
-  selection:
+  selection_base:
     EventID: 4704
-  keywords:
+  selection_keywords:
     PrivilegeList|contains:
       - 'SeEnableDelegationPrivilege'
-  condition: all of them
+  condition: all of selection*
 falsepositives:
   - Unknown
 level: high

--- a/rules/windows/builtin/win_invoke_obfuscation_var_services_security.yml
+++ b/rules/windows/builtin/win_invoke_obfuscation_var_services_security.yml
@@ -7,7 +7,7 @@ description: Detects Obfuscated use of Environment Variables to execute PowerShe
 status: experimental
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2021/09/17
+modified: 2021/12/02
 references:
      - https://github.com/Neo23x0/sigma/issues/1009 #(Task 24)
 tags:
@@ -21,9 +21,9 @@ logsource:
 detection:
     selection_eventid:
         EventID: 4697
-    selection:
+    selection_value:
         ServiceFileName|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/deprecated/powershell_suspicious_invocation_generic.yml
+++ b/rules/windows/deprecated/powershell_suspicious_invocation_generic.yml
@@ -8,21 +8,22 @@ tags:
     - attack.t1086  #an old one
 author: Florian Roth (rule)
 date: 2017/03/12
+modified: 2021/12/02
 logsource:
     product: windows
     service: powershell
 detection:
-    encoded:
+    selection_encoded:
         - ' -enc '
         - ' -EncodedCommand '
-    hidden:
+    selection_hidden:
         - ' -w hidden '
         - ' -window hidden '
         - ' -windowstyle hidden '
-    noninteractive:
+    selection_noninteractive:
         - ' -noni '
         - ' -noninteractive '
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Penetration tests
     - Very special / sneaky PowerShell scripts

--- a/rules/windows/powershell/powershell_module/powershell_suspicious_invocation_generic_in_contextinfo.yml
+++ b/rules/windows/powershell/powershell_module/powershell_suspicious_invocation_generic_in_contextinfo.yml
@@ -11,25 +11,25 @@ tags:
     - attack.t1086  #an old one
 author: Florian Roth (rule)
 date: 2017/03/12
-modified: 2021/10/18
+modified: 2021/12/02
 logsource:
     product: windows
     category: ps_module
 detection:
-    encoded:
+    selection_encoded:
         ContextInfo|contains:
             - ' -enc '
             - ' -EncodedCommand '
-    hidden:
+    selection_hidden:
         ContextInfo|contains:
             - ' -w hidden '
             - ' -window hidden '
             - ' -windowstyle hidden '
-    noninteractive:
+    selection_noninteractive:
         ContextInfo|contains:
             - ' -noni '
             - ' -noninteractive '
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Penetration tests
     - Very special / sneaky PowerShell scripts

--- a/rules/windows/powershell/powershell_script/powershell_automated_collection.yml
+++ b/rules/windows/powershell/powershell_script/powershell_automated_collection.yml
@@ -3,7 +3,7 @@ id: c1dda054-d638-4c16-afc8-53e007f3fbc5
 status: experimental
 author: frack113
 date: 2021/07/28
-modified: 2021/10/16
+modified: 2021/12/02
 description: Once established within a system or network, an adversary may use automated techniques for collecting internal data.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1119/T1119.md
@@ -31,7 +31,7 @@ detection:
             - 'Get-ChildItem'
             - ' -Recurse '
             - ' -Include '
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_script/powershell_detect_vm_env.yml
+++ b/rules/windows/powershell/powershell_script/powershell_detect_vm_env.yml
@@ -3,7 +3,7 @@ id: d93129cd-1ee0-479f-bc03-ca6f129882e3
 status: experimental
 author: frack113
 date: 2021/08/03
-modified: 2021/10/16
+modified: 2021/12/02
 description: Adversaries may employ various system checks to detect and avoid virtualization and analysis environments. This may include changing behaviors based on the results of checks for the presence of artifacts indicative of a virtual machine environment (VME) or sandbox
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1497.001/T1497.001.md
@@ -22,7 +22,7 @@ detection:
         ScriptBlockText|contains: 
             - MSAcpi_ThermalZoneTemperature
             - Win32_ComputerSystem
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_script/powershell_ntfs_ads_access.yml
+++ b/rules/windows/powershell/powershell_script/powershell_ntfs_ads_access.yml
@@ -14,20 +14,20 @@ tags:
     - attack.t1086  # an old one
 author: Sami Ruohonen
 date: 2018/07/24
-modified: 2021/10/16
+modified: 2021/12/02
 logsource:
     product: windows
     category: ps_script
     definition: Script block logging must be enabled
 detection:
-    content:
+    selection_content:
         ScriptBlockText|contains:
             - "set-content"
             - "add-content"
-    stream:
+    selection_stream:
         ScriptBlockText|contains:
             - "-stream"
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - unknown
 level: high

--- a/rules/windows/powershell/powershell_script/powershell_suspicious_invocation_generic_in_scriptblocktext.yml
+++ b/rules/windows/powershell/powershell_script/powershell_suspicious_invocation_generic_in_scriptblocktext.yml
@@ -11,25 +11,25 @@ tags:
     - attack.t1086  #an old one
 author: Florian Roth (rule)
 date: 2017/03/12
-modified: 2021/10/18
+modified: 2021/12/02
 logsource:
     product: windows
     category: ps_script
 detection:
-    encoded:
+    selection_encoded:
         ScriptBlockText|contains:
             - ' -enc '
             - ' -EncodedCommand '
-    hidden:
+    selection_hidden:
         ScriptBlockText|contains:
             - ' -w hidden '
             - ' -window hidden '
             - ' -windowstyle hidden '
-    noninteractive:
+    selection_noninteractive:
         ScriptBlockText|contains:
             - ' -noni '
             - ' -noninteractive '
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Penetration tests
     - Very special / sneaky PowerShell scripts

--- a/rules/windows/powershell/powershell_script/powershell_suspicious_recon.yml
+++ b/rules/windows/powershell/powershell_script/powershell_suspicious_recon.yml
@@ -3,7 +3,7 @@ id: a9723fcc-881c-424c-8709-fd61442ab3c3
 status: experimental
 author: frack113
 date: 2021/07/30
-modified: 2021/10/16
+modified: 2021/12/02
 description: Once established within a system or network, an adversary may use automated techniques for collecting internal data
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1119/T1119.md
@@ -22,7 +22,7 @@ detection:
             - 'Get-Process '
     selection_redirect:
         ScriptBlockText|contains: '> $env:TEMP\'
-    condition: all of them 
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/process_creation_coti_sqlcmd.yml
+++ b/rules/windows/process_creation/process_creation_coti_sqlcmd.yml
@@ -3,6 +3,7 @@ id: 2f47f1fd-0901-466e-a770-3b7092834a1b
 status: experimental
 author: frack113
 date: 2021/08/16
+modified: 2021/12/02
 description: Detects a command used by conti to dump database 
 references:
     - https://twitter.com/vxunderground/status/1423336151860002816?s=20 #the leak info not the files itself 
@@ -26,7 +27,7 @@ detection:
             - 'sys.sysprocesses'
             - 'master.dbo.sysdatabases'
             - 'BACKUP DATABASE'
-    condition: all of them 
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/process_creation_susp_7z.yml
+++ b/rules/windows/process_creation/process_creation_susp_7z.yml
@@ -3,6 +3,7 @@ id: 9fbf5927-5261-4284-a71d-f681029ea574
 status: experimental
 author: frack113
 date: 2021/07/27
+modified: 2021/12/02
 description: An adversary may compress or encrypt data that is collected prior to exfiltration using 3rd party utilities
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1560.001/T1560.001.md
@@ -23,7 +24,7 @@ detection:
         CommandLine|contains:
             - ' a '
             - ' u '
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Command line parameter combinations that contain all included strings
 level: medium

--- a/rules/windows/process_creation/process_creation_susp_winzip.yml
+++ b/rules/windows/process_creation/process_creation_susp_winzip.yml
@@ -3,6 +3,7 @@ id: e2e80da2-8c66-4e00-ae3c-2eebd29f6b6d
 status: experimental
 author: frack113
 date: 2021/07/27
+modified: 2021/12/02
 description: An adversary may compress or encrypt data that is collected prior to exfiltration using 3rd party utilities
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1560.001/T1560.001.md
@@ -24,7 +25,7 @@ detection:
         CommandLine|contains:
             - ' -min '
             - ' -a '
-    condition: all of them 
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
+++ b/rules/windows/process_creation/sysmon_long_powershell_commandline.yml
@@ -9,20 +9,20 @@ tags:
 status: experimental
 author: oscd.community, Natalia Shornikova
 date: 2020/10/06
-modified: 2021/05/21
+modified: 2021/12/02
 logsource:
     category: process_creation
     product: windows
 detection:
-    Powershell_selection:
+    selection_powershell:
       - CommandLine|contains:
         - 'powershell'
         - 'pwsh'
       - Description: 'Windows Powershell'
       - Product: 'PowerShell Core 6'
-    Length_selection:
+    selection_length:
       CommandLine|re: '.{1000,}'
-    condition: all of them
+    condition: all of selection*
 falsepositives:
  - Unknown
 level: medium

--- a/rules/windows/process_creation/sysmon_susp_service_modification.yml
+++ b/rules/windows/process_creation/sysmon_susp_service_modification.yml
@@ -3,6 +3,7 @@ id: 6783aa9e-0dc3-49d4-a94a-8b39c5fd700b
 status: experimental
 author: frack113
 date: 2021/07/07
+modified: 2021/12/02
 description: Adversaries may disable security tools to avoid possible detection of their tools and activities by stopping antivirus service
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1562.001/T1562.001.md
@@ -23,7 +24,7 @@ detection:
             - ' Trend Micro Deep Security Manager'
             - ' TMBMServer'
             # Feel free to add more service name         
-    condition: all of them 
+    condition: all of selection*
 fields:
     - ComputerName
     - User

--- a/rules/windows/process_creation/win_malware_conti_shadowcopy.yml
+++ b/rules/windows/process_creation/win_malware_conti_shadowcopy.yml
@@ -3,6 +3,7 @@ id: f57f8d16-1f39-4dcb-a604-6c73d9b54b3d
 description: Detects a command used by conti to access volume shadow backups
 author: Max Altgelt, Tobias Michalski
 date: 2021/08/09
+modified: 2021/12/02
 status: experimental
 references:
     - https://twitter.com/vxunderground/status/1423336151860002816?s=20
@@ -19,7 +20,7 @@ detection:
             - '\\SYSTEM'
             - '\\SECURITY'
             - 'C:\\tmp\\log'
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Some rare backup scenarios
 level: medium

--- a/rules/windows/process_creation/win_susp_disable_eventlog.yml
+++ b/rules/windows/process_creation/win_susp_disable_eventlog.yml
@@ -11,7 +11,7 @@ tags:
     - attack.t1070.001
 author: Florian Roth 
 date: 2021/02/11
-modified: 2021/06/21
+modified: 2021/12/02
 logsource:
     category: process_creation
     product: windows
@@ -26,7 +26,7 @@ detection:
     selection_service:
         CommandLine|contains: 
             - EventLog-System
-    condition: all of them
+    condition: all of selection*
 falsepositives:
     - Legitimate deactivation by administrative staff
     - Installer tools that disable services, e.g. before log collection agent installation

--- a/rules/windows/process_creation/win_susp_powershell_parent_process.yml
+++ b/rules/windows/process_creation/win_susp_powershell_parent_process.yml
@@ -6,7 +6,7 @@ author: Teymur Kheirkhabarov, Harish Segar (rule)
 references:
   - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse?slide=26
 date: 2020/03/20
-modified: 2021/11/27
+modified: 2021/12/02
 logsource:
   category: process_creation
   product: windows
@@ -50,7 +50,7 @@ detection:
       - "pwsh"
     - Description: "Windows PowerShell"
     - Product: "PowerShell Core 6"
-  condition: all of them
+  condition: all of selection*
 falsepositives:
   - Other scripts
 level: high

--- a/rules/windows/process_creation/win_susp_powershell_sam_access.yml
+++ b/rules/windows/process_creation/win_susp_powershell_sam_access.yml
@@ -6,6 +6,7 @@ references:
     - https://twitter.com/splinter_code/status/1420546784250769408
 author: Florian Roth
 date: 2021/07/29
+modified: 2021/12/02
 tags:
     - attack.credential_access
     - attack.t1003.002
@@ -24,7 +25,7 @@ detection:
             - 'cpi $_.'
             - 'copy $_.'
             - '.File]::Copy('
-    condition: all of them
+    condition: all of selection*
 falsepositives: 
     - Some rare backup scenarios
     - PowerShell scripts fixing HiveNightmare / SeriousSAM ACLs

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -184,6 +184,19 @@ class TestRules(unittest.TestCase):
         self.assertEqual(faulty_detections, [], Fore.RED +
                          "There are rules using '1/all of them' style conditions but only have one condition")
 
+    def test_all_of_them_condition(self):
+        faulty_detections = []
+
+        for file in self.yield_next_rule_file_path(self.path_to_rules):
+            yaml = self.get_rule_yaml(file_path = file)
+            detection = self.get_rule_part(file_path = file, part_name = "detection")
+
+            if "all of them" in detection["condition"]:
+                faulty_detections.append(file)
+
+        self.assertEqual(faulty_detections, [], Fore.RED +
+                         "There are rules using 'all of them'. Better use e.g. 'all of selection*' instead (and use the 'selection_' prefix as search-identifier).")
+
     def test_duplicate_detections(self):
         def compare_detections(detection1:dict, detection2:dict) -> bool:
 


### PR DESCRIPTION
... and migrate existing rules to use the preferred method 'all of selection*'
 
 I also updated the [specification](https://github.com/SigmaHQ/sigma/wiki/Specification#condition) (Ctrl+F `all of them`) with a hint that discourages the "all of them" usage and wrote a test in tests/test_rules.py that declines new rules using "all of them".