### PR TITLE
Fixing false positive when cmd.exe is called with full path

### DIFF
--- a/rules/windows/process_creation/process_creation_susp_del.yml
+++ b/rules/windows/process_creation/process_creation_susp_del.yml
@@ -3,7 +3,7 @@ id: 204b17ae-4007-471b-917b-b917b315c5db
 status: experimental
 description: suspicious command line to remove exe or dll
 author: frack113
-date: 2021/10/26
+date: 2021/12/02
 references:
     - https://www.joesandbox.com/analysis/509330/0/html#1044F3BDBE3BB6F734E357235F4D5898582D
 tags:
@@ -15,15 +15,13 @@ logsource:
 detection:
     susp_del_exe:
         CommandLine|contains|all:
-            - 'del '
+            - 'del *.exe'
             - '/f '
             - '/q '
-            - '.exe'
     susp_del_dll:
         CommandLine|contains|all:
-            - 'del '
+            - 'del *.dll'
             - 'C:\ProgramData\'
-            - '.dll'
     condition: susp_del_exe or susp_del_dll
 #cmd.exe (PID: 1044 cmdline: 'C:\Windows\System32\cmd.exe' /c taskkill /im A8D4.exe /f & timeout /t 6 & del /f /q 'C:\Users\user~1\AppData\Local\Temp\A8D4.exe' & del C:\ProgramData\*.dll & exit 
 falsepositives:


### PR DESCRIPTION
When command begins with C:\Windows\System32\cmd.exe it will always match susp_del_exe # ex - C:\Windows\System32\cmd.exe" /c del /f /q "C:\Program Files (x86)\Software Package\Client\tmpDir\"

Update ensures that the matching of malicious behavior is on the right side of the del cmd