### PR TITLE
adding filter for benign error from sysmon configuration

### DIFF
--- a/rules/windows/sysmon/sysmon_config_modification_error.yml
+++ b/rules/windows/sysmon/sysmon_config_modification_error.yml
@@ -4,7 +4,7 @@ description: Someone try to hide from Sysmon
 status: experimental
 author: frack113
 date: 2021/06/04
-modified: 2021/11/12
+modified: 2021/12/02
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1562.001/T1562.001.md
     - https://talesfrominfosec.blogspot.com/2017/12/killing-sysmon-silently.html
@@ -20,8 +20,8 @@ detection:
             - 'Failed to open service configuration with error'
             - 'Failed to connect to the driver to update configuration'
     selection_filter:
-        Description: 'Failed to open service configuration with error 19'
-    condition: selection_error
+        Description: 'Failed to open service configuration with error 19 - Last error: The media is write protected.'
+    condition: selection_error and not selection_filter
 falsepositives:
     - legitimate administrative action
 level: high 


### PR DESCRIPTION
Benign error:

```
2021-12-02 06:00:52 device01.company.pvt Sysmon: 255: Error report | UtcTime=2021-12-02 06:00:52.306 | ID=GetConfigurationOptions | Description=Failed to open service configuration with error 19 - Last error: The media is write protected. | pid=2100 | level=0 | sys_version=3 | category=255 | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=27633868 | app="?" | tid=9868 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=error(2) 
```