### PR TITLE
Add Datadog Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ tools/sigmac -t splunk -c ~/my-splunk-mapping.yml -c tools/config/generic/window
 * [uberAgent ESA](https://uberagent.com/)
 * [Devo](https://devo.com)
 * [LogRhythm](https://logrhythm.com/)
+* [Datadog Logs](https://docs.datadoghq.com/logs/explorer/search_syntax/)
 
 Current work-in-progress
 * [Splunk Data Models](https://docs.splunk.com/Documentation/Splunk/7.1.0/Knowledge/Aboutdatamodels)

--- a/tools/README.md
+++ b/tools/README.md
@@ -363,3 +363,20 @@ For example, in order to translate a windows-related Sigma rule, one would use:
 ```bash
 tools/sigmac -t devo -c tools/config/devo-windows.yml rules/windows/sysmon/sysmon_wmi_susp_scripting.yml
 ```
+
+### Datadog
+The Datadog backend currently supports converting Sigma files to the [Log Search Syntax](https://docs.datadoghq.com/logs/explorer/search_syntax/) 
+with the identifier `datadog-logs`.
+
+#### Config file
+This backend does not require a config file though it is possible to add a config file for fieldmapping and defining facets as a list. 
+While attributes will be queried with `@my-attribute:my-attribute` facets will be queried with `my-facet:my-facet`.
+For an example, see `tools/config/datadog.yml`.
+
+#### Backend options
+The backend options support `index` and `service` fields, as they are built-in facets and widely used.
+
+Example
+```
+tools/sigmac -t datadog-logs /rules/cloud/aws/aws_attached_malicious_lambda_layer.yml --backend-option index=my_index
+```

--- a/tools/README.md
+++ b/tools/README.md
@@ -365,8 +365,8 @@ tools/sigmac -t devo -c tools/config/devo-windows.yml rules/windows/sysmon/sysmo
 ```
 
 ### Datadog
-The Datadog backend currently supports converting Sigma files to the [Log Search Syntax](https://docs.datadoghq.com/logs/explorer/search_syntax/) 
-with the identifier `datadog-logs`.
+The Datadog backend currently supports converting Sigma files to the [Log Search Syntax](https://docs.datadoghq.com/logs/explorer/search_syntax/)
+with the identifier `datadog-logs`. This query can be used in the Security Monitoring product. 
 
 #### Config file
 This backend does not require a config file though it is possible to add a config file for fieldmapping and defining facets as a list. 
@@ -374,9 +374,9 @@ While attributes will be queried with `@my-attribute:my-attribute` facets will b
 For an example, see `tools/config/datadog.yml`.
 
 #### Backend options
-The backend options support `index` and `service` fields, as they are built-in facets and widely used.
+The backend options support `index` and `service` facets.
 
 Example
 ```
-tools/sigmac -t datadog-logs /rules/cloud/aws/aws_attached_malicious_lambda_layer.yml --backend-option index=my_index
+tools/sigmac -t datadog-logs /rules/cloud/aws/aws_attached_malicious_lambda_layer.yml --backend-option index=my_index --backend-option service=my_service
 ```

--- a/tools/README.md
+++ b/tools/README.md
@@ -173,7 +173,7 @@ Sample usages:
 
 ```yaml
 # Backend configuration file (here for Elastalert)
-$ cat backend_config.yml 
+$ cat backend_config.yml
 alert_methods: email
 emails: alerts@mydomain.tld
 smtp_host: smtp.google.com
@@ -366,15 +366,15 @@ tools/sigmac -t devo -c tools/config/devo-windows.yml rules/windows/sysmon/sysmo
 
 ### Datadog
 The Datadog backend currently supports converting Sigma files to the [Log Search Syntax](https://docs.datadoghq.com/logs/explorer/search_syntax/)
-with the identifier `datadog-logs`. This query can be used in the Security Monitoring product. 
+with the identifier `datadog-logs`. This query can be used in the Security Monitoring product.
 
 #### Config file
-This backend does not require a config file though it is possible to add a config file for fieldmapping and defining facets as a list. 
+This backend does not require a config file though it is possible to add a config file for fieldmapping and defining facets as a list.
 While attributes will be queried with `@my-attribute:my-attribute` facets will be queried with `my-facet:my-facet`.
 For an example, see `tools/config/datadog.yml`.
 
 #### Backend options
-The backend options support `index` and `service` facets.
+The backend options support `index`, `service` and `source` facets.
 
 Example
 ```

--- a/tools/config/datadog.yml
+++ b/tools/config/datadog.yml
@@ -2,3 +2,4 @@ title: Datadog
 order: 20
 backends:
   - datadog
+facets: []

--- a/tools/config/datadog.yml
+++ b/tools/config/datadog.yml
@@ -1,0 +1,4 @@
+title: Datadog
+order: 20
+backends:
+  - datadog

--- a/tools/config/datadog.yml
+++ b/tools/config/datadog.yml
@@ -1,5 +1,5 @@
-title: Datadog
+title: Datadog Example Config
 order: 20
 backends:
-  - datadog
+  - datadog-logs
 facets: []

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -30,11 +30,12 @@ class DatadogBackend(SingleTextQueryBackend):
 
     facets = ["index", "service"]
 
-    def __init__(self, sigmaconfig, backend_options):
+    def __init__(self, sigmaconfig, backend_options=dict()):
         if "index" in backend_options:
             self.dd_index = backend_options["index"]
 
-        self.facets += sigmaconfig.config.get("facets", [])
+        if sigmaconfig.config:
+            self.facets += sigmaconfig.config.get("facets", [])
 
         super().__init__(sigmaconfig)
 

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -2,6 +2,7 @@ from sigma.backends.base import SingleTextQueryBackend
 
 
 class DatadogBackend(SingleTextQueryBackend):
+    """Converts Sigma rule into Datadog log search queries."""
     identifier = "datadog"  # TODO: more specific?
     active = True
     config_required = False
@@ -10,4 +11,20 @@ class DatadogBackend(SingleTextQueryBackend):
     orToken = " OR "
     notToken = "-"
     subExpression = "(%s)"
+    listExpression = "(%s)"
+    listSeparator = " OR "
+    valueExpression = "%s"
     mapExpression = "%s:%s"
+    nullExpression = ""
+
+    service = None
+
+    def generate(self, sigmaparser):
+        self.service = sigmaparser.parsedyaml['logsource'].get('service', "")
+        return super().generate(sigmaparser)
+
+    def generateQuery(self, parsed):
+        return self.generateANDNode([
+            self.generateMapItemNode(["service", self.service]),
+            self.generateNode(parsed.parsedSearch),
+        ])

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -1,0 +1,13 @@
+from sigma.backends.base import SingleTextQueryBackend
+
+
+class DatadogBackend(SingleTextQueryBackend):
+    identifier = "datadog"  # TODO: more specific?
+    active = True
+    config_required = False
+
+    andToken = " AND "
+    orToken = " OR "
+    notToken = "-"
+    subExpression = "(%s)"
+    mapExpression = "%s:%s"

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -22,9 +22,9 @@ class DatadogBackend(SingleTextQueryBackend):
 
     # The escaped characters list comes from https://docs.datadoghq.com/logs/explorer/search_syntax/#escaping-of-special-characters.
     specialCharactersRegexp = re.compile(
-        '([\+\-\=\&\|\>\<\!\(\)\{\}\[\]\^"\~\?\:\\\/]+)'
+        r'([\+\-\=\&\|\>\<\!\(\)\{\}\[\]\^"\~\?\:\\\/]+)'
     )
-    whitespacesRegexp = re.compile(r"(\s+)")
+    whitespacesRegexp = re.compile(r"\s+")
 
     def __init__(self, sigmaconfig, backend_options):
         if "index" in backend_options:

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -1,6 +1,7 @@
 import re
 
 from sigma.backends.base import SingleTextQueryBackend
+from sigma.parser.condition import NodeSubexpression
 
 
 class DatadogBackend(SingleTextQueryBackend):
@@ -18,7 +19,8 @@ class DatadogBackend(SingleTextQueryBackend):
     listSeparator = " OR "
     valueExpression = "%s"
     mapExpression = "%s:%s"
-    nullExpression = ""
+    nullExpression = "-%s:*"
+    notNullExpression = "%s:*"
 
     # The escaped characters list comes from https://docs.datadoghq.com/logs/explorer/search_syntax/#escaping-of-special-characters.
     specialCharactersRegexp = re.compile(
@@ -47,7 +49,10 @@ class DatadogBackend(SingleTextQueryBackend):
         if hasattr(self, "dd_service"):
             nodes.append(("service", self.dd_service))
 
-        nodes.append(parsed.parsedSearch)
+        if type(parsed.parsedSearch) == NodeSubexpression:
+            nodes.append(parsed.parsedSearch.items)
+        else:
+            nodes.append(parsed.parsedSearch)
 
         return self.generateANDNode(nodes)
 

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -35,7 +35,7 @@ class DatadogBackend(SingleTextQueryBackend):
             self.generateNode(parsed.parsedSearch),
         ]
 
-        if self.dd_index:
+        if hasattr(self, "dd_index"):
             nodes = [self.generateMapItemNode(["index", self.dd_index])] + nodes
 
         return self.generateANDNode(nodes)

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -1,3 +1,5 @@
+import re
+
 from sigma.backends.base import SingleTextQueryBackend
 
 
@@ -14,9 +16,15 @@ class DatadogBackend(SingleTextQueryBackend):
     subExpression = "(%s)"
     listExpression = "(%s)"
     listSeparator = " OR "
-    valueExpression = "%s"  # TODO: escape string containing special chars
+    valueExpression = "%s"
     mapExpression = "%s:%s"
     nullExpression = ""
+
+    # The escaped characters list comes from https://docs.datadoghq.com/logs/explorer/search_syntax/#escaping-of-special-characters.
+    specialCharactersRegexp = re.compile(
+        '([\+\-\=\&\|\>\<\!\(\)\{\}\[\]\^"\~\?\:\\\/]+)'
+    )
+    whitespacesRegexp = re.compile(r"(\s+)")
 
     def __init__(self, sigmaconfig, backend_options):
         if "index" in backend_options:
@@ -34,11 +42,19 @@ class DatadogBackend(SingleTextQueryBackend):
         nodes = []
 
         if hasattr(self, "dd_index"):
-            nodes.append(self.generateMapItemNode(["index", self.dd_index]))
+            nodes.append(("index", self.dd_index))
 
         if hasattr(self, "dd_service"):
-            nodes.append(self.generateMapItemNode(["service", self.dd_service]))
+            nodes.append(("service", self.dd_service))
 
-        nodes.append(self.generateNode(parsed.parsedSearch))
+        nodes.append(parsed.parsedSearch)
 
         return self.generateANDNode(nodes)
+
+    def cleanValue(self, val):
+        if type(val) == int:
+            return val
+        else:
+            return self.whitespacesRegexp.sub(
+                "?", self.specialCharactersRegexp.sub("\\\\\g<1>", val)
+            )

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -24,7 +24,7 @@ class DatadogLogsBackend(SingleTextQueryBackend):
 
     # The escaped characters list comes from https://docs.datadoghq.com/logs/explorer/search_syntax/#escaping-of-special-characters.
     specialCharactersRegexp = re.compile(
-        r'([\+\-\=\&\|\>\<\!\(\)\{\}\[\]\^"\~\?\:\\\/]+)'
+        r'([+\-=&|><!(){}\[\]^"~?:\\/]+)'
     )
     whitespacesRegexp = re.compile(r"\s+")
 

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -5,9 +5,12 @@ from sigma.parser.condition import NodeSubexpression
 
 
 class DatadogBackend(SingleTextQueryBackend):
-    """Converts Sigma rule into Datadog log search queries."""
+    """
+    Converts Sigma rule into Datadog log search queries.
+    Syntax Reference: https://docs.datadoghq.com/logs/explorer/search_syntax/
+    """
 
-    identifier = "datadog"  # TODO: more specific?
+    identifier = "datadog-logs"
     active = True
     config_required = False
 

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -1,3 +1,19 @@
+# Output backends for sigmac
+# Copyright 2021 Datadog, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import re
 
 from sigma.backends.base import SingleTextQueryBackend

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -39,12 +39,10 @@ class DatadogLogsBackend(SingleTextQueryBackend):
     notNullExpression = "%s:*"
 
     # The escaped characters list comes from https://docs.datadoghq.com/logs/explorer/search_syntax/#escaping-of-special-characters.
-    specialCharactersRegexp = re.compile(
-        r'([+\-=&|><!(){}\[\]^"~?:\\/]+)'
-    )
+    specialCharactersRegexp = re.compile(r'([+\-=&|><!(){}\[\]^"~?:\\/]+)')
     whitespacesRegexp = re.compile(r"\s+")
 
-    facets = ["index", "service"]
+    facets = ["index", "service", "source"]
 
     def __init__(self, sigmaconfig, backend_options=dict()):
         if "index" in backend_options:
@@ -52,6 +50,9 @@ class DatadogLogsBackend(SingleTextQueryBackend):
 
         if "service" in backend_options:
             self.dd_service = backend_options["service"]
+
+        if "source" in backend_options:
+            self.dd_source = backend_options["source"]
 
         if sigmaconfig.config:
             self.facets += sigmaconfig.config.get("facets", [])
@@ -66,6 +67,9 @@ class DatadogLogsBackend(SingleTextQueryBackend):
 
         if hasattr(self, "dd_service"):
             nodes.append(("service", self.dd_service))
+
+        if hasattr(self, "dd_source"):
+            nodes.append(("source", self.dd_source))
 
         if type(parsed.parsedSearch) == NodeSubexpression:
             nodes.append(parsed.parsedSearch.items)

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -34,16 +34,13 @@ class DatadogLogsBackend(SingleTextQueryBackend):
         if "index" in backend_options:
             self.dd_index = backend_options["index"]
 
+        if "service" in backend_options:
+            self.dd_service = backend_options["service"]
+
         if sigmaconfig.config:
             self.facets += sigmaconfig.config.get("facets", [])
 
         super().__init__(sigmaconfig)
-
-    def generate(self, sigmaparser):
-        if "service" in sigmaparser.parsedyaml.get("logsource", {}):
-            self.dd_service = sigmaparser.parsedyaml["logsource"]["service"]
-
-        return super().generate(sigmaparser)
 
     def generateQuery(self, parsed):
         nodes = []

--- a/tools/sigma/backends/datadog.py
+++ b/tools/sigma/backends/datadog.py
@@ -4,11 +4,8 @@ from sigma.backends.base import SingleTextQueryBackend
 from sigma.parser.condition import NodeSubexpression
 
 
-class DatadogBackend(SingleTextQueryBackend):
-    """
-    Converts Sigma rule into Datadog log search queries.
-    Syntax Reference: https://docs.datadoghq.com/logs/explorer/search_syntax/
-    """
+class DatadogLogsBackend(SingleTextQueryBackend):
+    """Converts Sigma rule into Datadog log search queries."""
 
     identifier = "datadog-logs"
     active = True

--- a/tools/tests/test_backend_datadog.py
+++ b/tools/tests/test_backend_datadog.py
@@ -80,7 +80,7 @@ class TestDatadogBackend(unittest.TestCase):
         expected_query = "@attribute:test AND test-facet:myfacet"
         self.assertEqual(query, expected_query)
 
-    def test_regex_escape(self):
+    def test_special_characters_escape(self):
         self.basic_rule["detection"]["selection"][
             "regex-attribute"
         ] = "anything?inbetween"
@@ -89,7 +89,7 @@ class TestDatadogBackend(unittest.TestCase):
         expected_query = "@attribute:test AND @regex-attribute:anything\\?inbetween"
         self.assertEqual(query, expected_query)
 
-    def test_space(self):
+    def test_space_escape(self):
         self.basic_rule["detection"]["selection"]["space-attribute"] = "with space"
         self.parser = SigmaParser(self.basic_rule, self.config)
         query = self.backend.generate(self.parser)

--- a/tools/tests/test_backend_datadog.py
+++ b/tools/tests/test_backend_datadog.py
@@ -5,7 +5,7 @@ import unittest
 
 from sigma.configuration import SigmaConfiguration
 from sigma.parser.rule import SigmaParser
-from sigma.backends.datadog import DatadogBackend
+from sigma.backends.datadog import DatadogLogsBackend
 
 
 class TestDatadogBackend(unittest.TestCase):
@@ -19,7 +19,7 @@ class TestDatadogBackend(unittest.TestCase):
     def generate_query(self, rule, backend_options=dict(), config=dict()):
         cfg = SigmaConfiguration()
         cfg.config = config
-        backend = DatadogBackend(cfg, backend_options)
+        backend = DatadogLogsBackend(cfg, backend_options)
         parser = SigmaParser(rule, cfg)
 
         return backend.generate(parser)
@@ -33,7 +33,7 @@ class TestDatadogBackend(unittest.TestCase):
         total = 0
 
         config = SigmaConfiguration()
-        backend = DatadogBackend(config)
+        backend = DatadogLogsBackend(config)
 
         for (dirpath, _, filenames) in os.walk("../rules"):
             for filename in filenames:

--- a/tools/tests/test_backend_datadog.py
+++ b/tools/tests/test_backend_datadog.py
@@ -1,0 +1,57 @@
+import os
+import yaml
+
+import unittest
+
+from sigma.configuration import SigmaConfiguration
+from sigma.parser.rule import SigmaParser
+from sigma.backends.datadog import DatadogBackend
+
+
+class TestDatadogBackend(unittest.TestCase):
+    """Test cases for the Datadog backend."""
+
+    def setUp(self):
+        self.config = SigmaConfiguration()
+        self.backend = DatadogBackend(self.config)
+
+    def test_all_sigma_rules(self):
+        """Test the Datadog backend over all the Sigma rules in the repository."""
+
+        skipped = 0
+        errors = 0
+        successes = 0
+        total = 0
+
+        for (dirpath, _, filenames) in os.walk("../rules"):
+            for filename in filenames:
+                if filename.endswith(".yaml") or filename.endswith(".yml"):
+                    with self.subTest(filename):
+                        rule_path = os.path.join(dirpath, filename)
+
+                        with open(rule_path, "r") as rule_file:
+                            total += 1
+
+                            try:
+                                query = self.backend.generate(
+                                    SigmaParser(yaml.safe_load(rule_file), self.config)
+                                )
+                            except NotImplementedError as err:
+                                print("[SKIPPED] {}: {}".format(rule_path, err))
+                                skipped += 1
+                            except BaseException as err:
+                                print("[FAILED] {}: {}".format(rule_path, err))
+                                errors += 1
+                            else:
+                                print("[OK] {}".format(rule_path))
+                                successes += 1
+
+        print("\n==========Statistics==========\n")
+        print(
+            "SUCCESSES: {}/{} ({:.2f}%)".format(
+                successes, total, successes / total * 100
+            )
+        )
+        print("SKIPPED: {}/{} ({:.2f}%)".format(skipped, total, skipped / total * 100))
+        print("ERRORS: {}/{} ({:.2f}%)".format(errors, total, errors / total * 100))
+        print("\n==============================\n")

--- a/tools/tests/test_backend_datadog.py
+++ b/tools/tests/test_backend_datadog.py
@@ -14,7 +14,9 @@ class TestDatadogBackend(unittest.TestCase):
     def setUp(self):
         self.config = SigmaConfiguration()
         self.backend = DatadogBackend(self.config)
-        self.basic_rule = {"detection": {"selection": {"attribute": "test"}, "condition": "selection"}}
+        self.basic_rule = {
+            "detection": {"selection": {"attribute": "test"}, "condition": "selection"}
+        }
         self.parser = SigmaParser(self.basic_rule, self.config)
 
     def test_all_sigma_rules(self):
@@ -61,13 +63,13 @@ class TestDatadogBackend(unittest.TestCase):
     def test_attribute(self):
         query = self.backend.generate(self.parser)
         expected_query = "@attribute:test"
-        assert query == expected_query
+        self.assertEqual(query, expected_query)
 
     def test_facets_backend_option(self):
         test_backend = DatadogBackend(self.config, {"index": "test_index"})
         query = test_backend.generate(self.parser)
         expected_query = "index:test_index AND @attribute:test"
-        assert query == expected_query
+        self.assertEqual(query, expected_query)
 
     def test_facets_config(self):
         # TODO: currently failing because it adds an @ to the facet
@@ -76,18 +78,20 @@ class TestDatadogBackend(unittest.TestCase):
         parser = SigmaParser(self.basic_rule, self.config)
         query = self.backend.generate(parser)
         expected_query = "test-facet:myfacet AND @attribute:test"
-        assert expected_query == query
+        self.assertEqual(query, expected_query)
 
     def test_regex_escape(self):
-        self.basic_rule["detection"]["selection"]["regex-attribute"] = "anything?inbetween"
+        self.basic_rule["detection"]["selection"][
+            "regex-attribute"
+        ] = "anything?inbetween"
         self.parser = SigmaParser(self.basic_rule, self.config)
         query = self.backend.generate(self.parser)
         expected_query = "@attribute:test AND @regex-attribute:anything\\?inbetween"
-        assert expected_query == query
+        self.assertEqual(query, expected_query)
 
     def test_space(self):
         self.basic_rule["detection"]["selection"]["space-attribute"] = "with space"
         self.parser = SigmaParser(self.basic_rule, self.config)
         query = self.backend.generate(self.parser)
         expected_query = "@attribute:test AND @space-attribute:with?space"
-        assert expected_query == query
+        self.assertEqual(query, expected_query)

--- a/tools/tests/test_backend_datadog.py
+++ b/tools/tests/test_backend_datadog.py
@@ -1,3 +1,19 @@
+# Output backends for sigmac
+# Copyright 2021 Datadog, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import yaml
 
@@ -16,60 +32,6 @@ class TestDatadogBackend(unittest.TestCase):
         self.basic_rule = {
             "detection": {"selection": {"attribute": "test"}, "condition": "selection"}
         }
-
-    def generate_query(
-        self, rule, backend_options=dict(), config=dict(), fieldmappings=dict()
-    ):
-        cfg = SigmaConfiguration()
-        cfg.config = config
-        cfg.fieldmappings = fieldmappings
-        backend = DatadogLogsBackend(cfg, backend_options)
-        parser = SigmaParser(rule, cfg)
-
-        return backend.generate(parser)
-
-    def test_all_sigma_rules(self):
-        """Test the Datadog backend over all the Sigma rules in the repository."""
-
-        skipped = 0
-        errors = 0
-        successes = 0
-        total = 0
-
-        config = SigmaConfiguration()
-        backend = DatadogLogsBackend(config)
-
-        for (dirpath, _, filenames) in os.walk("../rules"):
-            for filename in filenames:
-                if filename.endswith(".yaml") or filename.endswith(".yml"):
-                    with self.subTest(filename):
-                        rule_path = os.path.join(dirpath, filename)
-
-                        with open(rule_path, "r") as rule_file:
-                            total += 1
-                            parser = SigmaParser(yaml.safe_load(rule_file), config)
-
-                            try:
-                                query = backend.generate(parser)
-                            except NotImplementedError as err:
-                                print("[SKIPPED] {}: {}".format(rule_path, err))
-                                skipped += 1
-                            except BaseException as err:
-                                print("[FAILED] {}: {}".format(rule_path, err))
-                                errors += 1
-                            else:
-                                print("[OK] {}".format(rule_path))
-                                successes += 1
-
-        print("\n==========Statistics==========\n")
-        print(
-            "SUCCESSES: {}/{} ({:.2f}%)".format(
-                successes, total, successes / total * 100
-            )
-        )
-        print("SKIPPED: {}/{} ({:.2f}%)".format(skipped, total, skipped / total * 100))
-        print("ERRORS: {}/{} ({:.2f}%)".format(errors, total, errors / total * 100))
-        print("\n==============================\n")
 
     def test_attribute(self):
         query = self.generate_query(self.basic_rule)
@@ -110,3 +72,61 @@ class TestDatadogBackend(unittest.TestCase):
         )
         expected_query = "@another_attribute:test"
         self.assertEqual(query, expected_query)
+
+    def generate_query(
+        self, rule, backend_options=dict(), config=dict(), fieldmappings=dict()
+    ):
+        cfg = SigmaConfiguration()
+        cfg.config = config
+        cfg.fieldmappings = fieldmappings
+        backend = DatadogLogsBackend(cfg, backend_options)
+        parser = SigmaParser(rule, cfg)
+
+        return backend.generate(parser)
+
+    def test_all_sigma_rules(self):
+        """Test the Datadog backend over all the Sigma rules in the repository."""
+        verbose_report = False
+
+        skipped = 0
+        errors = 0
+        successes = 0
+        total = 0
+
+        config = SigmaConfiguration()
+        backend = DatadogLogsBackend(config)
+
+        for (dirpath, _, filenames) in os.walk("../rules"):
+            for filename in filenames:
+                if filename.endswith(".yaml") or filename.endswith(".yml"):
+                    with self.subTest(filename):
+                        rule_path = os.path.join(dirpath, filename)
+
+                        with open(rule_path, "r") as rule_file:
+                            total += 1
+                            parser = SigmaParser(yaml.safe_load(rule_file), config)
+
+                            try:
+                                query = backend.generate(parser)
+                            except NotImplementedError as err:
+                                if verbose_report:
+                                    print("[SKIPPED] {}: {}".format(rule_path, err))
+                                skipped += 1
+                            except BaseException as err:
+                                if verbose_report:
+                                    print("[FAILED] {}: {}".format(rule_path, err))
+                                errors += 1
+                            else:
+                                if verbose_report:
+                                    print("[OK] {}".format(rule_path))
+                                successes += 1
+
+        print("\n==========Statistics==========\n")
+        print(
+            "SUCCESSES: {}/{} ({:.2f}%)".format(
+                successes, total, successes / total * 100
+            )
+        )
+        print("SKIPPED: {}/{} ({:.2f}%)".format(skipped, total, skipped / total * 100))
+        print("ERRORS: {}/{} ({:.2f}%)".format(errors, total, errors / total * 100))
+        print("\n==============================\n")

--- a/tools/tests/test_backend_datadog.py
+++ b/tools/tests/test_backend_datadog.py
@@ -72,12 +72,12 @@ class TestDatadogBackend(unittest.TestCase):
         self.assertEqual(query, expected_query)
 
     def test_facets_config(self):
-        # TODO: currently failing because it adds an @ to the facet
         self.config.config = {"facets": ["test-facet"]}
         self.basic_rule["detection"]["selection"]["test-facet"] = "myfacet"
+        test_backend = DatadogBackend(self.config)
         parser = SigmaParser(self.basic_rule, self.config)
-        query = self.backend.generate(parser)
-        expected_query = "test-facet:myfacet AND @attribute:test"
+        query = test_backend.generate(parser)
+        expected_query = "@attribute:test AND test-facet:myfacet"
         self.assertEqual(query, expected_query)
 
     def test_regex_escape(self):


### PR DESCRIPTION
This PR adds the Datadog backend to be used as a Sigma target. The output query will follow the [Log Search Syntax](https://docs.datadoghq.com/logs/explorer/search_syntax/).