### PR TITLE
Adding filter for calls using \WINDOWS\System32\sdiagnhost.exe

### DIFF
--- a/rules/windows/pipe_created/sysmon_alternate_powershell_hosts_pipe.yml
+++ b/rules/windows/pipe_created/sysmon_alternate_powershell_hosts_pipe.yml
@@ -6,7 +6,7 @@ author: Roberto Rodriguez @Cyb3rWard0g
 references:
   - https://threathunterplaybook.com/notebooks/windows/02_execution/WIN-190815181010.html
 date: 2019/09/12
-modified: 2021/11/27
+modified: 2021/12/03
 logsource:
   product: windows
   category: pipe_created
@@ -17,6 +17,7 @@ detection:
     Image|endswith:
       - '\powershell.exe'
       - '\powershell_ise.exe'
+      - '\WINDOWS\System32\sdiagnhost.exe'
   filter2:
     Image:
   condition: selection and not filter1 and not filter2


### PR DESCRIPTION
Used rule 867613fb-fa60-4497-a017-a82df74a172c as filter reference.  May be necessary to add more filters in the future.