### PR TITLE
Split sysmon_asep_reg_keys_modification

### DIFF
--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification.yml
@@ -1,7 +1,7 @@
 title: Autorun Keys Modification
 id: 17f878b8-9968-4578-b814-c4217fc5768c
 description: Detects modification of autostart extensibility point (ASEP) in registry.
-status: experimental
+status: deprecated
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
     - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_classes.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_classes.yml
@@ -37,8 +37,7 @@ detection:
             - '\ShellEx\PropertySheetHandlers'
             - '\ShellEx\ContextMenuHandlers'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: classes_base and classes and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_classes.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_classes.yml
@@ -1,0 +1,54 @@
+title: Classes Autorun Keys Modification
+id: 9df5f547-c86a-433e-b533-f2794357e242
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    classes_base:
+        TargetObject|contains: '\Software\Classes'
+    classes:
+        TargetObject|contains:
+            - '\Folder\ShellEx\ExtShellFolderViews'
+            - '\Folder\ShellEx\DragDropHandlers'
+            - '\Folder\Shellex\ColumnHandlers'
+            - '\Filter'
+            - '\Exefile\Shell\Open\Command\(Default)'
+            - '\Directory\Shellex\DragDropHandlers'
+            - '\Directory\Shellex\CopyHookHandlers'
+            - '\CLSID\{AC757296-3522-4E11-9862-C17BE5A1767E}\Instance'
+            - '\CLSID\{ABE3B9A4-257D-4B97-BD1A-294AF496222E}\Instance'
+            - '\CLSID\{7ED96837-96F0-4812-B211-F13C24117ED3}\Instance'
+            - '\CLSID\{083863F1-70DE-11d0-BD40-00A0C911CE86}\Instance'
+            - '\Classes\AllFileSystemObjects\ShellEx\DragDropHandlers'
+            - '\.exe'
+            - '\.cmd'
+            - '\ShellEx\PropertySheetHandlers'
+            - '\ShellEx\ContextMenuHandlers'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: classes_base and classes and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_commun.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_commun.yml
@@ -1,0 +1,54 @@
+title: Commun Autorun Keys Modification
+id: f59c3faf-50f3-464b-9f4c-1b67ab512d99
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    main_selection:
+        TargetObject|contains:
+            - '\SOFTWARE\Wow6432Node\Microsoft\Windows CE Services\AutoStart'
+            - '\Software\Wow6432Node\Microsoft\Command Processor\Autorun'
+            - '\SOFTWARE\Wow6432Node\Microsoft\Active Setup\Installed Components'
+            - '\SOFTWARE\Microsoft\Windows CE Services\AutoStartOnDisconnect'
+            - '\SOFTWARE\Microsoft\Windows CE Services\AutoStartOnConnect'
+            - '\SYSTEM\Setup\CmdLine'
+            - '\Software\Microsoft\Ctf\LangBarAddin'
+            - '\Software\Microsoft\Command Processor\Autorun'
+            - '\SOFTWARE\Microsoft\Active Setup\Installed Components'
+            - '\SOFTWARE\Classes\Protocols\Handler'
+            - '\SOFTWARE\Classes\Protocols\Filter'
+            - '\SOFTWARE\Classes\Htmlfile\Shell\Open\Command\(Default)'
+            - '\Environment\UserInitMprLogonScript'
+            - '\SOFTWARE\Policies\Microsoft\Windows\Control Panel\Desktop\Scrnsave.exe'
+            - '\Software\Microsoft\Internet Explorer\UrlSearchHooks'
+            - '\SOFTWARE\Microsoft\Internet Explorer\Desktop\Components'
+            - '\Software\Classes\Clsid\{AB8902B4-09CA-4bb6-B78D-A8F59079A8D5}\Inprocserver32'
+            - '\Control Panel\Desktop\Scrnsave.exe'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition:  main_selection and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_commun.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_commun.yml
@@ -39,7 +39,7 @@ detection:
     filter:
         - Details: '(Empty)'
         - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
-    condition:  main_selection and not filter
+    condition: main_selection and not filter
 fields:
     - SecurityID
     - ObjectName

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_commun.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_commun.yml
@@ -37,8 +37,7 @@ detection:
             - '\Software\Classes\Clsid\{AB8902B4-09CA-4bb6-B78D-A8F59079A8D5}\Inprocserver32'
             - '\Control Panel\Desktop\Scrnsave.exe'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: main_selection and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentcontrolset.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentcontrolset.yml
@@ -1,0 +1,48 @@
+title: CurrentControlSet Autorun Keys Modification
+id: f674e36a-4b91-431e-8aef-f8a96c2aca35
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    system_control_base:
+        TargetObject|contains: '\SYSTEM\CurrentControlSet\Control'
+    system_control:
+        TargetObject|contains:
+            - '\Terminal Server\WinStations\RDP-Tcp\InitialProgram'
+            - '\Terminal Server\Wds\rdpwd\StartupPrograms'
+            - '\SecurityProviders\SecurityProviders'
+            - '\SafeBoot\AlternateShell'
+            - '\Print\Providers'
+            - '\Print\Monitors'
+            - '\NetworkProvider\Order'
+            - '\Lsa\Notification Packages'
+            - '\Lsa\Authentication Packages'
+            - '\BootVerificationProgram\ImagePath'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: system_control_base and system_control and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentcontrolset.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentcontrolset.yml
@@ -31,8 +31,7 @@ detection:
             - '\Lsa\Authentication Packages'
             - '\BootVerificationProgram\ImagePath'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: system_control_base and system_control and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentversion.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentversion.yml
@@ -1,0 +1,54 @@
+title: CurrentVersion Autorun Keys Modification
+id: 20f0ee37-5942-4e45-b7d5-c5b5db9df5cd
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    current_version_base:
+        TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion'
+    current_version:
+        TargetObject|contains:
+            - '\ShellServiceObjectDelayLoad'
+            - '\Run'
+            - '\Policies\System\Shell'
+            - '\Policies\Explorer\Run'
+            - '\Group Policy\Scripts\Startup'
+            - '\Group Policy\Scripts\Shutdown'
+            - '\Group Policy\Scripts\Logon'
+            - '\Group Policy\Scripts\Logoff'
+            - '\Explorer\ShellServiceObjects'
+            - '\Explorer\ShellIconOverlayIdentifiers'
+            - '\Explorer\ShellExecuteHooks'
+            - '\Explorer\SharedTaskScheduler'
+            - '\Explorer\Browser Helper Objects'
+            - '\Authentication\PLAP Providers'
+            - '\Authentication\Credential Providers'
+            - '\Authentication\Credential Provider Filters'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: current_version_base and current_version and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentversion_nt.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentversion_nt.yml
@@ -35,8 +35,7 @@ detection:
             - '\Windows\Run'
             - '\Windows\Load'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: nt_current_version_base and nt_current_version and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentversion_nt.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_currentversion_nt.yml
@@ -1,0 +1,52 @@
+title: CurrentVersion NT Autorun Keys Modification
+id: cbf93e5d-ca6c-4722-8bea-e9119007c248
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    nt_current_version_base:
+        TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
+    nt_current_version:
+        TargetObject|contains:
+            - '\Winlogon\VmApplet'
+            - '\Winlogon\Userinit'
+            - '\Winlogon\Taskman'
+            - '\Winlogon\Shell'
+            - '\Winlogon\GpExtensions'
+            - '\Winlogon\AppSetup'
+            - '\Winlogon\AlternateShells\AvailableShells'
+            - '\Windows\IconServiceLib'
+            - '\Windows\Appinit_Dlls'
+            - '\Image File Execution Options'
+            - '\Font Drivers'
+            - '\Drivers32'
+            - '\Windows\Run'
+            - '\Windows\Load'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: nt_current_version_base and nt_current_version and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_internet_explorer.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_internet_explorer.yml
@@ -1,0 +1,44 @@
+title: Internet Explorer Autorun Keys Modification
+id: a80f662f-022f-4429-9b8c-b1a41aaa6688
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    ie:
+        TargetObject|contains:
+            - '\Software\Wow6432Node\Microsoft\Internet Explorer'
+            - '\Software\Microsoft\Internet Explorer'
+    ie_details:
+        TargetObject|contains:
+            - '\Toolbar'
+            - '\Extensions'
+            - '\Explorer Bars'
+
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: ie and ie_details and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_internet_explorer.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_internet_explorer.yml
@@ -27,8 +27,7 @@ detection:
             - '\Explorer Bars'
 
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: ie and ie_details and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_office.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_office.yml
@@ -1,0 +1,47 @@
+title: Office Autorun Keys Modification
+id: baecf8fb-edbf-429f-9ade-31fc3f22b970
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    office:
+        TargetObject|contains:
+            - '\Software\Wow6432Node\Microsoft\Office'
+            - '\Software\Microsoft\Office'
+    office_details:
+        TargetObject|contains:
+            - '\Word\Addins'
+            - '\PowerPoint\Addins'
+            - '\Outlook\Addins'
+            - '\Onenote\Addins'
+            - '\Excel\Addins'
+            - '\Access\Addins'
+            - 'test\Special\Perf'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: office and office_details and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_office.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_office.yml
@@ -30,8 +30,7 @@ detection:
             - '\Access\Addins'
             - 'test\Special\Perf'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: office and office_details and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_session_manager.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_session_manager.yml
@@ -1,0 +1,44 @@
+title: Session Manager Autorun Keys Modification
+id: 046218bd-e0d8-4113-a3c3-895a12b2b298
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    session_manager_base:
+        TargetObject|contains: '\System\CurrentControlSet\Control\Session Manager'
+    session_manager:
+        TargetObject|contains:
+            - '\SetupExecute'
+            - '\S0InitialCommand'
+            - '\KnownDlls'
+            - '\Execute'
+            - '\BootExecute'
+            - '\AppCertDlls'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: session_manager_base and session_manager and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_session_manager.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_session_manager.yml
@@ -27,8 +27,7 @@ detection:
             - '\BootExecute'
             - '\AppCertDlls'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: session_manager_base and session_manager and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_system_scripts.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_system_scripts.yml
@@ -26,8 +26,7 @@ detection:
             - '\Logoff'
 
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: scripts_base and scripts and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_system_scripts.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_system_scripts.yml
@@ -1,0 +1,43 @@
+title: System Scripts Autorun Keys Modification
+id: e7a2fd40-3ae1-4a85-bf80-15cf624fb1b1
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    scripts_base:
+        TargetObject|contains: '\Software\Policies\Microsoft\Windows\System\Scripts'
+    scripts:
+        TargetObject|contains:
+            - '\Startup'
+            - '\Shutdown'
+            - '\Logon'
+            - '\Logoff'
+
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: scripts_base and scripts and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_winsock2.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_winsock2.yml
@@ -23,8 +23,7 @@ detection:
             - '\Protocol_Catalog9\Catalog_Entries'
             - '\NameSpace_Catalog5\Catalog_Entries'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: winsock_parameters_base and winsock_parameters and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_winsock2.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_winsock2.yml
@@ -1,0 +1,40 @@
+title: WinSock2 Autorun Keys Modification
+id: d6c2ce7e-afb5-4337-9ca4-4b5254ed0565
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    winsock_parameters_base:
+        TargetObject|contains: '\System\CurrentControlSet\Services\WinSock2\Parameters'
+    winsock_parameters:
+        TargetObject|contains:
+            - '\Protocol_Catalog9\Catalog_Entries'
+            - '\NameSpace_Catalog5\Catalog_Entries'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: winsock_parameters_base and winsock_parameters and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node.yml
@@ -28,8 +28,7 @@ detection:
             - '\Explorer\SharedTaskScheduler'
             - '\Explorer\Browser Helper Objects'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: wow_current_version_base and wow_current_version and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node.yml
@@ -1,0 +1,45 @@
+title: Wow6432Node CurrentVersion Autorun Keys Modification
+id: b29aed60-ebd1-442b-9cb5-16a1d0324adb
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    wow_current_version_base:
+        TargetObject|contains: '\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion'
+    wow_current_version:
+        TargetObject|contains:
+            - '\ShellServiceObjectDelayLoad'
+            - '\Run'
+            - '\Explorer\ShellServiceObjects'
+            - '\Explorer\ShellIconOverlayIdentifiers'
+            - '\Explorer\ShellExecuteHooks'
+            - '\Explorer\SharedTaskScheduler'
+            - '\Explorer\Browser Helper Objects'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: wow_current_version_base and wow_current_version and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node_classes.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node_classes.yml
@@ -33,8 +33,7 @@ detection:
             - '\ShellEx\PropertySheetHandlers'
             - '\ShellEx\ContextMenuHandlers'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: wow_classes_base and wow_classes and not filter
 fields:
     - SecurityID

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node_classes.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node_classes.yml
@@ -1,0 +1,50 @@
+title: Wow6432Node Classes Autorun Keys Modification
+id: 18f2065c-d36c-464a-a748-bcf909acb2e3
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    wow_classes_base:
+        TargetObject|contains: '\Software\Wow6432Node\Classes'
+    wow_classes:
+        TargetObject|contains:
+            - '\Folder\ShellEx\ExtShellFolderViews'
+            - '\Folder\ShellEx\DragDropHandlers'
+            - '\Folder\ShellEx\ColumnHandlers'
+            - '\Directory\Shellex\DragDropHandlers'
+            - '\Directory\Shellex\CopyHookHandlers'
+            - '\CLSID\{AC757296-3522-4E11-9862-C17BE5A1767E}\Instance'
+            - '\CLSID\{ABE3B9A4-257D-4B97-BD1A-294AF496222E}\Instance'
+            - '\CLSID\{7ED96837-96F0-4812-B211-F13C24117ED3}\Instance'
+            - '\CLSID\{083863F1-70DE-11d0-BD40-00A0C911CE86}\Instance'
+            - '\AllFileSystemObjects\ShellEx\DragDropHandlers'
+            - '\ShellEx\PropertySheetHandlers'
+            - '\ShellEx\ContextMenuHandlers'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: wow_classes_base and wow_classes and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node_currentversion.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node_currentversion.yml
@@ -1,0 +1,41 @@
+title: Wow6432Node CurrentVersion Autorun Keys Modification
+id: 480421f9-417f-4d3b-9552-fd2728443ec8
+related:
+    - id: 17f878b8-9968-4578-b814-c4217fc5768c
+      type: derived
+status: experimental
+description: Detects modification of autostart extensibility point (ASEP) in registry.
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1547.001/T1547.001.md
+    - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
+    - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
+date: 2019/10/25
+modified: 2021/12/05
+logsource:
+    category: registry_event
+    product: windows
+detection:
+    wow_nt_current_version_base:
+        TargetObject|contains: '\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion'
+    wow_nt_current_version:
+        TargetObject|contains:
+            - '\Windows\Appinit_Dlls'
+            - '\Image File Execution Options'
+            - '\Drivers32'
+    filter:
+        - Details: '(Empty)'
+        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+    condition: wow_nt_current_version_base and wow_nt_current_version and not filter
+fields:
+    - SecurityID
+    - ObjectName
+    - OldValueType
+    - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1547.001

--- a/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node_currentversion.yml
+++ b/rules/windows/registry_event/sysmon_asep_reg_keys_modification_wow6432node_currentversion.yml
@@ -24,8 +24,7 @@ detection:
             - '\Image File Execution Options'
             - '\Drivers32'
     filter:
-        - Details: '(Empty)'
-        - TargetObject|endswith: '\NgcFirst\ConsecutiveSwitchCount'
+        Details: '(Empty)'
     condition: wow_nt_current_version_base and wow_nt_current_version and not filter
 fields:
     - SecurityID


### PR DESCRIPTION
When alert trigger SOC operator cannot easily understand it.
So I have split it.
`condition` and `title` are more treatable by humans.

Filter part need to be optimize