### PR TITLE
Logsource condition applied once in nested expression

### DIFF
--- a/tools/sigma/parser/condition.py
+++ b/tools/sigma/parser/condition.py
@@ -516,7 +516,7 @@ class SigmaConditionParser:
             self.parsedSearch = self.parseSearch(tokens)
             self.parsedAgg = None
 
-    def parseSearch(self, tokens):
+    def parseSearch(self, tokens, depth=0):
         """
         Iterative parsing of search expression.
         """
@@ -561,7 +561,7 @@ class SigmaConditionParser:
             if lPos > rPos:
                 raise SigmaParseError("Closing parentheses at position " + str(rTok.pos) + " precedes opening at position " + str(lTok.pos))
 
-            subparsed = self.parseSearch(tokens[lPos + 1:rPos])
+            subparsed = self.parseSearch(tokens[lPos + 1:rPos], depth=depth+1)
             tokens = tokens[:lPos] + NodeSubexpression(subparsed) + tokens[rPos + 1:]   # replace parentheses + expression with group node that contains parsed subexpression
 
         # 2. Iterate over all known operators in given precedence
@@ -590,13 +590,14 @@ class SigmaConditionParser:
             raise ValueError("Parse tree must have exactly one start node!")
         query_cond = tokens[0]
 
-        # 4. Integrate conditions from logsources in configurations
-        ls_cond = self.sigmaParser.get_logsource_condition()
-        if ls_cond is not None:
-            cond = ConditionAND()
-            cond.add(ls_cond)
-            cond.add(query_cond)
-            query_cond = cond
+        # 4. Integrate conditions from logsources in configurations to outermost expression
+        if depth == 0:
+            ls_cond = self.sigmaParser.get_logsource_condition()
+            if ls_cond is not None:
+                cond = ConditionAND()
+                cond.add(ls_cond)
+                cond.add(query_cond)
+                query_cond = cond
 
         return self._optimizer.optimizeTree(query_cond)
 


### PR DESCRIPTION
Good day! There might be a possible bug - or potential improvement in the way the parser creates the resulting expression. 

If a rule has a `detection.condition` with an expression that contains a sub-expression, the parser will insert the logsource condition that results from the configuration to each expression - possibly creating duplicate checks in the resulting query. 

A condition of `cond1 and (cond2 or cond3)` will generate a query that includes the logsource condition for both the `cond1` and the subexpression `(cond2 or cond3)`.

This PR mitigates this by introducing a `depth` parameter to `SigmaConditionParser.parseSearch` to track the depth of the nested expressions, adding the logsource condition only to the outermost expression (`depth==0`)

