### PR TITLE
FP filter was lost during commit over weekend

### DIFF
--- a/rules/windows/file_event/sysmon_susp_desktop_ini.yml
+++ b/rules/windows/file_event/sysmon_susp_desktop_ini.yml
@@ -13,6 +13,12 @@ logsource:
 detection:
   selection:
     TargetFilename|endswith: '\desktop.ini'
+    AccessList|contains:
+      - 'WriteData'
+      - 'DELETE'
+      - 'WriteDAC'
+      - 'AppendData'
+      - 'AddSubdirectory'
   filter:
     Image|startswith:
       - 'C:\Windows\'


### PR DESCRIPTION
FP fix from last week was overwritten.  

Without it, it triggers on read access only, which is a false positive.