### PR TITLE
Adding filter for ipv6 local for rundll32 net connections

### DIFF
--- a/rules/windows/network_connection/sysmon_dllhost_net_connections.yml
+++ b/rules/windows/network_connection/sysmon_dllhost_net_connections.yml
@@ -34,7 +34,7 @@ detection:
       - '172.29.'
       - '172.30.'
       - '172.31.'
-   filter2:
+  filter2:
     DestinationIp:
       - '0:0:0:0:0:0:0:1'
   condition: selection and not filter and not filter2

--- a/rules/windows/network_connection/sysmon_dllhost_net_connections.yml
+++ b/rules/windows/network_connection/sysmon_dllhost_net_connections.yml
@@ -37,7 +37,7 @@ detection:
   filter2:
     DestinationIp:
       - '0:0:0:0:0:0:0:1'
-  condition: selection and not filter and not filter2
+  condition: selection and not 1 of filter*
 falsepositives:
   - Communication to other corporate systems that use IP addresses from public address spaces
 level: medium

--- a/rules/windows/network_connection/sysmon_dllhost_net_connections.yml
+++ b/rules/windows/network_connection/sysmon_dllhost_net_connections.yml
@@ -6,7 +6,7 @@ author: bartblaze
 references:
   - https://github.com/Neo23x0/sigma/blob/master/rules/windows/network_connection/sysmon_rundll32_net_connections.yml
 date: 2020/07/13
-modified: 2021/11/27
+modified: 2021/12/07
 logsource:
   category: network_connection
   product: windows
@@ -34,8 +34,10 @@ detection:
       - '172.29.'
       - '172.30.'
       - '172.31.'
-      - '127.'
-  condition: selection and not filter
+   filter2:
+    DestinationIp:
+      - '0:0:0:0:0:0:0:1'
+  condition: selection and not filter and not filter2
 falsepositives:
   - Communication to other corporate systems that use IP addresses from public address spaces
 level: medium


### PR DESCRIPTION
Ex:

```
2021-12-07 19:39:05 devie-01.company.pvt Sysmon: 3: Network connection detected | RuleName=- | UtcTime=2021-12-07 19:38:22.376 | ProcessGuid={B7C4C965-9752-61A7-1443-000003006800} | ProcessId=14332 | Image=C:\Windows\System32\dllhost.exe | User=DOMAIN\Username | Protocol=tcp | Initiated=true | SourceIsIpv6=true | SourceIp=0:0:0:0:0:0:0:1 | SourceHostname=- | SourcePort=65521 | SourcePortName=- | DestinationIsIpv6=true | DestinationIp=0:0:0:0:0:0:0:1 | DestinationHostname=- | DestinationPort=50985 | DestinationPortName=- | pid=2664 | level=0 | sys_version=5 | category=Network connection detected (rule: NetworkConnect) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=337207190 | app="C:\Windows\sysmon64.exe" | tid=12228 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) | [E] | [ES] |
```
