### PR TITLE
False positives on sysmon_volume_shadow_copy_service_keys.yml

### DIFF
--- a/rules/windows/registry_event/sysmon_esentutl_volume_shadow_copy_service_keys.yml
+++ b/rules/windows/registry_event/sysmon_esentutl_volume_shadow_copy_service_keys.yml
@@ -1,9 +1,9 @@
-title: Volume Shadow Copy Service Keys
+title: Esentutl Volume Shadow Copy Service Keys 
 id: 5aad0995-46ab-41bd-a9ff-724f41114971
-description: Detects the volume shadow copy service initialization and processing. Registry keys such as HKLM\\System\\CurrentControlSet\\Services\\VSS\\Diag\\VolSnap\\Volume are captured.
+description: Detects the volume shadow copy service initialization and processing via esentutl. Registry keys such as HKLM\\System\\CurrentControlSet\\Services\\VSS\\Diag\\VolSnap\\Volume are captured.
 status: experimental
 date: 2020/10/20
-modified: 2021/06/02
+modified: 2021/12/08
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 tags:
     - attack.credential_access
@@ -16,9 +16,10 @@ logsource:
 detection:
     selection:
         TargetObject|contains: 'System\CurrentControlSet\Services\VSS'
+        Image|endswith: 'esentutl.exe'
     filter:
-        TargetObject|contains: 'System\CurrentControlSet\Services\VSS\Start'
+        TargetObject|contains: 'System\CurrentControlSet\Services\VSS\Start'        
     condition: selection and not filter
 falsepositives:
-    - Other services accessing that key or sub keys
+    - Unknown
 level: high

--- a/rules/windows/registry_event/sysmon_esentutl_volume_shadow_copy_service_keys.yml
+++ b/rules/windows/registry_event/sysmon_esentutl_volume_shadow_copy_service_keys.yml
@@ -16,7 +16,7 @@ logsource:
 detection:
     selection:
         TargetObject|contains: 'System\CurrentControlSet\Services\VSS'
-        Image|endswith: 'esentutl.exe'
+        Image|endswith: 'esentutl.exe' # limit esentutl as in references, too many FP to filter
     filter:
         TargetObject|contains: 'System\CurrentControlSet\Services\VSS\Start'        
     condition: selection and not filter


### PR DESCRIPTION
Replace sysmon_volume_shadow_copy_service_keys.yml rule by sysmon_esentutl_volume_shadow_copy_service_keys.yml because of too many false positives
