### PR TITLE
Added Defender to win_susp_lsass_dump_generic.yml

### DIFF
--- a/rules/windows/builtin/security/win_susp_lsass_dump_generic.yml
+++ b/rules/windows/builtin/security/win_susp_lsass_dump_generic.yml
@@ -56,12 +56,14 @@ detection:
             - '\MicrosoftEdgeUpdate.exe'
             - '\GamingServices.exe'
             - '\svchost.exe'
+            - '\MsMpEng.exe'     # Defender
         ProcessName|startswith:
             - C:\Windows\System32\
             - C:\Windows\SysWow64\
             - C:\Windows\SysNative\
             - C:\Program Files\
             - C:\Windows\Temp\asgard2-agent\
+            - C:\ProgramData\
     filter2:
         ProcessName|startswith:
             - 'C:\Program Files'  # too many false positives with legitimate AV and EDR solutions

--- a/rules/windows/builtin/security/win_susp_lsass_dump_generic.yml
+++ b/rules/windows/builtin/security/win_susp_lsass_dump_generic.yml
@@ -63,7 +63,7 @@ detection:
             - C:\Windows\SysNative\
             - C:\Program Files\
             - C:\Windows\Temp\asgard2-agent\
-            - C:\ProgramData\
+            - C:\ProgramData\Microsoft\Windows Defender\Platform\
     filter2:
         ProcessName|startswith:
             - 'C:\Program Files'  # too many false positives with legitimate AV and EDR solutions


### PR DESCRIPTION
G'day! I've found instances of Defender triggering the generic lsass dump rule.

This PR adds `MsMpEng.exe` to the filter list of known tools of that specific rule. It also adds `C:\ProgramData\` to the list, as the newer defender installations run the executable from `%ProgramData%\Microsoft\Windows Defender\Platform\<Version>\`.

See: https://support.microsoft.com/en-us/topic/update-for-microsoft-defender-antimalware-platform-92e21611-8cf1-8e0e-56d6-561a07d144cc (under "File location changes")