### PR TITLE
Add rules for uncommon process creation events

### DIFF
--- a/rules/windows/process_creation/process_creation_susp_image_missing.yml
+++ b/rules/windows/process_creation/process_creation_susp_image_missing.yml
@@ -19,4 +19,4 @@ detection:
     condition: not image_absolute_path and not filter
 falsepositives:
     - unknown
-level: medium
+level: high

--- a/rules/windows/process_creation/process_creation_susp_image_missing.yml
+++ b/rules/windows/process_creation/process_creation_susp_image_missing.yml
@@ -1,0 +1,22 @@
+title: Execution Of Not Existing File
+id: 71158e3f-df67-472b-930e-7d287acaa3e1
+status: experimental
+description: Checks whether the image specified in a process creation event is not a full, absolute path (caused by process ghosting or other unorthodox methods to start a process)
+author: Max Altgelt
+date: 2021/12/09
+references:
+    - https://pentestlaboratories.com/2021/12/08/process-ghosting/
+tags:
+    - attack.defense_evasion
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    image_absolute_path:
+        Image|contains: '\'
+    filter:
+        Image: null
+    condition: not image_absolute_path and not filter
+falsepositives:
+    - unknown
+level: medium

--- a/rules/windows/process_creation/process_creation_susp_non_exe_image.yml
+++ b/rules/windows/process_creation/process_creation_susp_non_exe_image.yml
@@ -1,0 +1,22 @@
+title: Execution Of Other File Type Than .exe
+id: c09dad97-1c78-4f71-b127-7edb2b8e491a
+status: experimental
+description: Checks whether the image specified in a process creation event doesn't refer to an .exe file (caused by process ghosting or other unorthodox methods to start a process)
+author: Max Altgelt
+date: 2021/12/09
+references:
+    - https://pentestlaboratories.com/2021/12/08/process-ghosting/
+tags:
+    - attack.defense_evasion
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    image_exe:
+        Image|endswith: '.exe'
+    filter:
+        Image: null
+    condition: not image_exe and not filter
+falsepositives:
+    - unknown
+level: medium

--- a/rules/windows/process_creation/process_creation_susp_non_exe_image.yml
+++ b/rules/windows/process_creation/process_creation_susp_non_exe_image.yml
@@ -19,4 +19,4 @@ detection:
     condition: not image_exe and not filter
 falsepositives:
     - unknown
-level: medium
+level: high

--- a/rules/windows/process_creation/win_lolbin_execution_via_winget.yml
+++ b/rules/windows/process_creation/win_lolbin_execution_via_winget.yml
@@ -16,8 +16,7 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|re:
-            - '.*(?i)winget install (--m|-m).*'
+        CommandLine|re: '.*(?i)winget install (--m|-m).*'
     condition: selection
 falsepositives:
     - Admin activity installing packages not in the official Microsoft repo. Winget probably won't be used by most users.

--- a/rules/windows/process_creation/win_lolbin_execution_via_winget.yml
+++ b/rules/windows/process_creation/win_lolbin_execution_via_winget.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/windows/package-manager/winget/install#local-install
 author: Sreeman
 date: 2020/21/04
-modified: 2021/06/11
+modified: 2021/09/12
 tags:
     - attack.defense_evasion
     - attack.execution
@@ -16,7 +16,7 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains:
+        CommandLine|re:
             - '.*(?i)winget install (--m|-m).*'
     condition: selection
 falsepositives:


### PR DESCRIPTION
Add two new rules that detect uncommon process creation events (executable deleted, executable is no .exe file).

Also fixes a bug in an unrelated rule.