### PR TITLE
adding allow for wsmprovhost.exe to call powershell pipes

### DIFF
--- a/rules/windows/pipe_created/sysmon_alternate_powershell_hosts_pipe.yml
+++ b/rules/windows/pipe_created/sysmon_alternate_powershell_hosts_pipe.yml
@@ -6,7 +6,7 @@ author: Roberto Rodriguez @Cyb3rWard0g
 references:
   - https://threathunterplaybook.com/notebooks/windows/02_execution/WIN-190815181010.html
 date: 2019/09/12
-modified: 2021/12/03
+modified: 2021/12/09
 logsource:
   product: windows
   category: pipe_created
@@ -18,9 +18,8 @@ detection:
       - '\powershell.exe'
       - '\powershell_ise.exe'
       - '\WINDOWS\System32\sdiagnhost.exe'
-  filter2:
-    Image:
-  condition: selection and not filter1 and not filter2
+      - '\WINDOWS\System32\wsmprovhost.exe'
+  condition: selection and not filter1
 fields:
   - ComputerName
   - User


### PR DESCRIPTION
```
2021-12-09 19:10:19 device-01.company.pvt Sysmon: 17: Pipe Created | RuleName=- | EventType=CreatePipe | UtcTime=2021-12-09 19:10:19.609 | ProcessGuid={8eb39540-5499-61b2-aca2-000000004000} | ProcessId=10216 | PipeName=\PSHost.132835506178328728.10216.DefaultAppDomain.wsmprovhost | Image=C:\Windows\system32\wsmprovhost.exe | pid=10272 | level=0 | sys_version=1 | category=Pipe Created (rule: PipeEvent) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=8630 | app="C:\Windows\sysmon64.exe" | tid=11388 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) | [E] | Archived=true | Company=Microsoft Corporation | CreationUtcTime=2021-12-09 19:10:19.453 | Description=OLE32 Extensions for Win32 | FileVersion=11.00.17763.2183 (WinBuild.160101.0800) | Hashes=SHA1=89B7DBD69347F950A7308B6063A2EE876129B9D7,MD5=FF4732D59DED5613E42F42A77F6BB359,SHA256=2A5317F2E0CE3F54466FF447842EB53A9367A98A2CA348BE6A13506177DCB052,IMPHASH=00000000000000000000000000000000 | ImageLoaded=C:\Windows\System32\urlmon.dll | IsExecutable=false | OriginalFileName=UrlMon.dll | Product=Internet Explorer | Signature=Microsoft Windows | SignatureStatus=Valid | Signed=true | TargetFilename=C:\Users\USERNAME\AppData\Local\Temp\__PSScriptPolicyTest_xvjqv3iv.td2.ps1 | User=DOMAIN\USERNAME | [ES] |
```