### PR TITLE
FP  perfmon.exe to sysmon_cred_dump_lsass_access.yml

### DIFF
--- a/rules/windows/process_access/sysmon_cred_dump_lsass_access.yml
+++ b/rules/windows/process_access/sysmon_cred_dump_lsass_access.yml
@@ -5,7 +5,7 @@ description: Detects process access LSASS memory which is typical for credential
 author: Florian Roth, Roberto Rodriguez, Dimitrios Slamaris, Mark Russinovich, Thomas Patzke, Teymur Kheirkhabarov, Sherif Eldeeb, James Dickenson, Aleksey Potapov,
     oscd.community (update)
 date: 2017/02/16
-modified: 2021/12/04
+modified: 2021/12/10
 references:
     - https://onedrive.live.com/view.aspx?resid=D026B4699190F1E6!2843&ithint=file%2cpptx&app=PowerPoint&authkey=!AMvCRTKB_V1J5ow
     - https://cyberwardog.blogspot.com/2017/03/chronicles-of-threat-hunter-hunting-for_22.html
@@ -40,6 +40,7 @@ detection:
     filter1:
         SourceImage:
             - 'C:\WINDOWS\system32\taskmgr.exe'
+            - 'C:\Windows\System32\perfmon.exe'
     filter2:
         SourceImage|startswith: 'C:\ProgramData\Microsoft\Windows Defender\'
         SourceImage|endswith: '\MsMpEng.exe'


### PR DESCRIPTION
Get a FP with perfmon.exe on windows 20H2
```
Process accessed:
RuleName: -
UtcTime: 2021-12-10 18:43:29.865
SourceProcessGUID: {d4b94734-9fd0-61b3-3704-000000000d00}
SourceProcessId: 6220
SourceThreadId: 7120
SourceImage: C:\Windows\System32\perfmon.exe
TargetProcessGUID: {d4b94734-92f0-61b3-0c00-000000000d00}
TargetProcessId: 760
TargetImage: C:\Windows\system32\lsass.exe
GrantedAccess: 0x1410
CallTrace: C:\Windows\SYSTEM32\ntdll.dll+9d234|C:\Windows\System32\KERNELBASE.dll+2c0ce|C:\Windows\System32\wdc.dll+7e50|C:\Windows\System32\wdc.dll+aa0d|C:\Windows\System32\wdc.dll+c910|C:\Windows\System32\wdc.dll+15280|C:\Windows\System32\KERNEL32.DLL+17034|C:\Windows\SYSTEM32\ntdll.dll+52651
SourceUser: DESKTOP-TR9HG5K\frack113
TargetUser: AUTORITE NT\Système
```