### PR TITLE
fix: referrer > referer adjustments

### DIFF
--- a/rules/web/web_cve_2021_44228_log4j_fields.yml
+++ b/rules/web/web_cve_2021_44228_log4j_fields.yml
@@ -76,7 +76,7 @@ detection:
          - '${${env:BARFOO:-j}'
          - '${::-l}${::-d}${::-a}${::-p}'
          - '${base64:JHtqbmRp'
-      cs-referrer|contains:
+      cs-referer|contains:
          - '${jndi:ldap:/'
          - '${jndi:rmi:/'
          - '${jndi:ldaps:/'

--- a/rules/web/web_fortinet_cve_2021_22123_exploit.yml
+++ b/rules/web/web_fortinet_cve_2021_22123_exploit.yml
@@ -17,9 +17,9 @@ detection:
         c-uri|contains: '/api/v2.0/user/remoteserver.saml'
         cs-method: POST
     filter1:
-        cs-referrer|contains: '/root/user/remote-user/saml-user/'
+        cs-referer|contains: '/root/user/remote-user/saml-user/'
     filter2:
-        cs-referrer: null
+        cs-referer: null
     condition: selection and not filter1 and not filter2
 fields:
     - c-ip

--- a/rules/web/win_webshell_regeorg.yml
+++ b/rules/web/win_webshell_regeorg.yml
@@ -19,13 +19,13 @@ detection:
             - 'cmd=disconnect'
             - 'cmd=forward'
     filter:
-        cs-referrer: null
+        cs-referer: null
         cs-User-Agent: null
         cs-method: POST
     condition: selection and filter
 fields:
     - cs-uri-query
-    - cs-referrer
+    - cs-referer
     - cs-method
     - cs-User-Agent
 falsepositives:

--- a/tools/config/arcsight-zeek.yml
+++ b/tools/config/arcsight-zeek.yml
@@ -380,7 +380,7 @@ fieldmappings:
     - destinationDnsDomain
     - destinationHost
   cs-method: requestMethod
-  cs-referrer:
+  cs-referer:
     - deviceCustomString4
     - requestContext
   cs-version: message
@@ -657,7 +657,7 @@ fieldmappings:
   #password: message
   post_body: message
   proxied: message
-  referrer:
+  referer:
     - deviceCustomString4
     - requestContext
   resp_filenames: fileName

--- a/tools/config/ecs-proxy.yml
+++ b/tools/config/ecs-proxy.yml
@@ -42,7 +42,7 @@ fieldmappings:
     - url.domain
     - destination.domain
   cs-method: http.request.method
-  cs-referrer: http.request.referrer
+  cs-referer: http.request.referrer
   cs-version: http.version
   r-dns:
     - destination.domain
@@ -208,7 +208,7 @@ fieldmappings:
   #password: source.user.password
   post_body: http.post_body
   proxied: http.proxied
-  referrer: http.request.referrer
+  referer: http.request.referrer
   request_body_len: http.request.body.bytes
   resp_filenames: http.resp_filenames
   resp_mime_types: http.resp_mime_types

--- a/tools/config/ecs-zeek-corelight.yml
+++ b/tools/config/ecs-zeek-corelight.yml
@@ -379,7 +379,7 @@ fieldmappings:
     - url.domain
     - destination.domain
   cs-method: http.request.method
-  cs-referrer: http.request.referrer
+  cs-referer: http.request.referrer
   cs-version: http.version
   # All log UIDs
   cert_chain_fuids: log.id.cert_chain_fuids

--- a/tools/config/ecs-zeek-elastic-beats-implementation.yml
+++ b/tools/config/ecs-zeek-elastic-beats-implementation.yml
@@ -455,7 +455,7 @@ fieldmappings:
     - url.domain
     - destination.domain
   cs-method: http.request.method
-  cs-referrer: http.request.referrer
+  cs-referer: http.request.referrer
   cs-version: http.version
   uid: zeek.session_id
   # Conn

--- a/tools/config/humio.yml
+++ b/tools/config/humio.yml
@@ -359,7 +359,7 @@ fieldmappings:
     product=zeek: host
   cs-method:
     product=zeek: method
-  cs-referrer:
+  cs-referer:
     product=zeek: referrer
   cs-version:
     product=zeek: version

--- a/tools/config/logstash-zeek-default-json.yml
+++ b/tools/config/logstash-zeek-default-json.yml
@@ -345,7 +345,7 @@ fieldmappings:
   c-useragent: user_agent
   cs-host: host
   cs-method: method
-  cs-referrer: referrer
+  cs-referer: referrer
   cs-version: version
   # Few other variations of names from zeek source itself
   id_orig_h: id.orig_h

--- a/tools/config/splunk-zeek.yml
+++ b/tools/config/splunk-zeek.yml
@@ -337,7 +337,7 @@ fieldmappings:
   c-useragent: user_agent
   cs-host: host
   cs-method: method
-  cs-referrer: referrer
+  cs-referer: referrer
   cs-version: version
   # Few other variations of names from zeek source itself
   id_orig_h: id.orig_h


### PR DESCRIPTION
The problem is that we use cs-referrer in our rules, which is the correct spelling of that word. But the field name in the header of requests is `referer`, which is a misspelled form, but used in HTTP requests. I would, for the sake of consistency, use that misspelled word in our rules, hoping that services also use that misspelled field name in their log data. 