### PR TITLE
Log4j OR each section vs implicit AND

### DIFF
--- a/rules/web/web_cve_2021_44228_log4j_fields.yml
+++ b/rules/web/web_cve_2021_44228_log4j_fields.yml
@@ -114,7 +114,7 @@ detection:
          - '${${lower:j}ndi:${lower:l}${lower:d}a${lower:p}://'
          - '${${upper:j}ndi:${upper:l}${upper:d}a${lower:p}://'
          - '${${::-j}${::-n}${::-d}${::-i}:'
-   condition: selection1 OR selection2 OR selection3 OR selection4
+   condition: condition: 1 of selection*
 falsepositives:
     - Vulnerability scanning
 level: high

--- a/rules/web/web_cve_2021_44228_log4j_fields.yml
+++ b/rules/web/web_cve_2021_44228_log4j_fields.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects exploitation attempt against log4j RCE vulnerability reported as CVE-2021-44228 in different header fields found in web server logs (Log4Shell)
 author: Florian Roth
 date: 2021/12/10
-modified: 2021/12/12
+modified: 2021/12/16
 references:
    - https://www.lunasec.io/docs/blog/log4j-zero-day/
    - https://news.ycombinator.com/item?id=29504755
@@ -18,7 +18,7 @@ tags:
 logsource:
    category: webserver
 detection:
-   selection:
+   selection1:
       cs-User-Agent|contains:
          - '${jndi:ldap:/'
          - '${jndi:rmi:/'
@@ -42,6 +42,7 @@ detection:
          - '${${lower:j}ndi:${lower:l}${lower:d}a${lower:p}://'
          - '${${upper:j}ndi:${upper:l}${upper:d}a${lower:p}://'
          - '${${::-j}${::-n}${::-d}${::-i}:'
+   selection2:         
       user-agent|contains:
          - '${jndi:ldap:/'
          - '${jndi:rmi:/'
@@ -65,6 +66,7 @@ detection:
          - '${${lower:j}ndi:${lower:l}${lower:d}a${lower:p}://'
          - '${${upper:j}ndi:${upper:l}${upper:d}a${lower:p}://'
          - '${${::-j}${::-n}${::-d}${::-i}:'
+   selection3:
       cs-uri|contains:
          - '${jndi:ldap:/'
          - '${jndi:rmi:/'
@@ -88,6 +90,7 @@ detection:
          - '${${lower:j}ndi:${lower:l}${lower:d}a${lower:p}://'
          - '${${upper:j}ndi:${upper:l}${upper:d}a${lower:p}://'
          - '${${::-j}${::-n}${::-d}${::-i}:'
+   selection4:
       cs-referer|contains:
          - '${jndi:ldap:/'
          - '${jndi:rmi:/'
@@ -111,7 +114,7 @@ detection:
          - '${${lower:j}ndi:${lower:l}${lower:d}a${lower:p}://'
          - '${${upper:j}ndi:${upper:l}${upper:d}a${lower:p}://'
          - '${${::-j}${::-n}${::-d}${::-i}:'
-   condition: selection
+   condition: selection1 OR selection2 OR selection3 OR selection4
 falsepositives:
     - Vulnerability scanning
 level: high

--- a/rules/web/web_cve_2021_44228_log4j_fields.yml
+++ b/rules/web/web_cve_2021_44228_log4j_fields.yml
@@ -114,7 +114,7 @@ detection:
          - '${${lower:j}ndi:${lower:l}${lower:d}a${lower:p}://'
          - '${${upper:j}ndi:${upper:l}${upper:d}a${lower:p}://'
          - '${${::-j}${::-n}${::-d}${::-i}:'
-   condition: condition: 1 of selection*
+   condition: 1 of selection*
 falsepositives:
     - Vulnerability scanning
 level: high


### PR DESCRIPTION
When the original is compiled it requires one TRUE from each Field (implicit AND) ... believe the intent is to search all fields of any trace which hence explicit OR in "condition"