### PR TITLE
rule: add further reference in regsrv32 rule

### DIFF
--- a/rules/windows/process_creation/win_pc_susp_regsvr32_image.yml
+++ b/rules/windows/process_creation/win_pc_susp_regsvr32_image.yml
@@ -4,6 +4,7 @@ status: experimental
 description: utilizes REGSVR32.exe to execute this DLL masquerading as a Image file
 references:
     - https://thedfirreport.com/2021/11/29/continuing-the-bazar-ransomware-story/
+    - https://blog.talosintelligence.com/2021/10/threat-hunting-in-large-datasets-by.html
 tags:
     - attack.defense_evasion
     - attack.t1218.010 


### PR DESCRIPTION
would it be an option to use another logic: regsrv32 without .dll as a file extension? will check that, why limiting the rule to just jpg.