### PR TITLE
rule: abuse of permissions to hide services

### DIFF
--- a/rules/windows/process_creation/win_using_sc_to_hide_sevices.yml
+++ b/rules/windows/process_creation/win_using_sc_to_hide_sevices.yml
@@ -1,0 +1,28 @@
+title: Abuse of Service Permissions to Hide Services in Tools
+id: a537cfc3-4297-4789-92b5-345bfd845ad0
+status: experimental
+description: Detection of sc.exe utility adding a new service with special permission which hides that service.
+author: Andreas Hunkeler (@Karneades)
+references:
+  - https://blog.talosintelligence.com/2021/10/threat-hunting-in-large-datasets-by.html
+  - https://www.sans.org/blog/red-team-tactics-hiding-windows-services/
+date: 2021/12/20
+logsource:
+  category: process_creation
+  product: windows
+detection:
+  sc:
+    Image|endswith: '\sc.exe'
+  cli:
+    CommandLine|contains|all:
+      - 'sdset'
+      - 'DCLCWPDTSD'
+  condition: sc and cli
+falsepositives:
+  - Intended use of hidden services
+level: high
+tags:
+  - attack.persistence
+  - attack.defense_evasion
+  - attack.privilege_escalation
+  - attack.t1574.011


### PR DESCRIPTION
This rule detects a cool trick to hide services from UI tools, seen in current Talos blog post which referred to a SANS blog post. Technique was used in an exchange compromise to hide the service.

Hide services when special permissions were set at service creation. Seen in section _Installation stealth and persistence_ in Talos' blog post [Threat hunting in large datasets by clustering security events](https://blog.talosintelligence.com/2021/10/threat-hunting-in-large-datasets-by.html). This blog post references another one from SANS, [Red Team Tactics: Hiding Windows Services](https://www.sans.org/blog/red-team-tactics-hiding-windows-services/).
   * _In the following steps, the script deletes PowerShell logs and registers the final payload as a Windows service using a long command line with some strange permission settings. A quick Google search reveals that these are used to make the service hidden and unremovable using the regular Windows administration tools, without some additional actions. [Talos]_
   * _A little known feature of Windows allows the red team or an attacker to hide services from view, creating an opportunity to evade detection from common host-based threat hunting techniques. [SANS]_