### PR TITLE
rule: add new rule to detect shell spawn by Java keytool

### DIFF
--- a/rules/windows/process_creation/process_creation_susp_shell_spawn_by_java_keytool.yml
+++ b/rules/windows/process_creation/process_creation_susp_shell_spawn_by_java_keytool.yml
@@ -1,0 +1,44 @@
+title: Suspicious Shells Spawn by Java Utility Keytool
+id: 90fb5e62-ca1f-4e22-b42e-cc521874c938
+description: Detects suspicious shell spawn from Java utility keytool process (e.g. adselfservice plus exploitation)
+status: experimental
+author: Andreas Hunkeler (@Karneades)
+date: 2021/12/22
+references:
+    - https://redcanary.com/blog/intelligence-insights-december-2021
+    - https://www.synacktiv.com/en/publications/how-to-exploit-cve-2021-40539-on-manageengine-adselfservice-plus.html
+tags:
+    - attack.initial_access
+    - attack.persistence
+    - attack.privilege_escalation
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        ParentImage|endswith: '\keytool.exe'
+        Image|endswith:
+            - '\cmd.exe'
+            - '\sh.exe'
+            - '\bash.exe'
+            - '\powershell.exe'
+            - '\schtasks.exe'
+            - '\certutil.exe'
+            - '\whoami.exe'
+            - '\bitsadmin.exe'
+            - '\wscript.exe'
+            - '\cscript.exe'
+            - '\scrcons.exe'
+            - '\regsvr32.exe'
+            - '\hh.exe'
+            - '\wmic.exe'
+            - '\mshta.exe'
+            - '\rundll32.exe'
+            - '\forfiles.exe'
+            - '\scriptrunner.exe'
+            - '\mftrace.exe'
+            - '\AppVLP.exe'
+    condition: selection
+falsepositives:
+    - unknown
+level: high


### PR DESCRIPTION
Rule (around ADSelfService Plus RCE) described in https://redcanary.com/blog/intelligence-insights-december-2021 and references to https://www.synacktiv.com/en/publications/how-to-exploit-cve-2021-40539-on-manageengine-adselfservice-plus.html are found in RedCanary's article.