### PR TITLE
(win_susp_rundll32_activity.yml) Rule syntax error

### DIFF
--- a/rules/windows/process_creation/win_susp_rundll32_activity.yml
+++ b/rules/windows/process_creation/win_susp_rundll32_activity.yml
@@ -58,7 +58,7 @@ detection:
       - 'OpenURL'
     - CommandLine|contains|all:
       - 'syssetup.dll'
-      - SetupInfObjectInstallAction'
+      - 'SetupInfObjectInstallAction'
     - CommandLine|contains|all:
       - 'setupapi.dll'
       - 'InstallHinfSection'


### PR DESCRIPTION
es-dsl does not work properly because the rule syntax is not valid

https://github.com/SigmaHQ/sigma/blob/master/rules/windows/process_creation/win_susp_rundll32_activity.yml

59 to 61 lines
     - CommandLine|contains|all:
       - 'syssetup.dll'
       - SetupInfObjectInstallAction'

should be like below
     - CommandLine|contains|all:
       - 'syssetup.dll'
       - 'SetupInfObjectInstallAction'