### PR TITLE
Introducing Macros

### DIFF
--- a/macros/cmd.yml
+++ b/macros/cmd.yml
@@ -4,6 +4,16 @@ status: experimental
 description: Macro for detecting cmd.exe
 author: Tareq M. AlKhatib
 date: 2021/12/27
+# A definition that fits most log sources
+logsource:
+  category: generic
+  product: generic
+detection:
+  ImageName:
+    Image|endswith:
+      - '\cmd.exe'
+  condition: ImageName
+---
 logsource:
   category: process_creation
   product: windows

--- a/macros/cmd.yml
+++ b/macros/cmd.yml
@@ -1,0 +1,17 @@
+title: Powershell
+id: 960116ac-d502-47fd-a493-c21e49228d3e
+status: experimental
+description: Macro for detecting cmd.exe
+author: Tareq M. AlKhatib
+date: 2021/12/27
+logsource:
+  category: process_creation
+  product: windows
+detection:
+  OrgFileName:
+    OriginalFileName:
+      - "Cmd.exe"
+  ImageName:
+    Image|endswith:
+      - '\cmd.exe'
+  condition: OrgFileName or ImageName

--- a/macros/powershell.yml
+++ b/macros/powershell.yml
@@ -1,0 +1,17 @@
+title: Powershell
+id: adee5595-6839-4fb8-ae7a-2a0809383b99
+status: experimental
+description: Macro for detecting Powershell
+author: Tareq M. AlKhatib
+date: 2021/12/27
+logsource:
+  category: process_creation
+  product: windows
+detection:
+  OrgFileName:
+    OriginalFileName:
+      - "powershell.exe"
+  ImageName:
+    Image|endswith:
+      - '\powershell.exe'
+  condition: OrgFileName or ImageName

--- a/macros/powershell.yml
+++ b/macros/powershell.yml
@@ -4,6 +4,16 @@ status: experimental
 description: Macro for detecting Powershell
 author: Tareq M. AlKhatib
 date: 2021/12/27
+# A definition that fits most log sources
+logsource:
+  category: generic
+  product: generic
+detection:
+  ImageName:
+    Image|endswith:
+      - '\powershell.exe'
+  condition: ImageName
+---
 logsource:
   category: process_creation
   product: windows

--- a/rules/windows/process_creation/sysmon_always_install_elevated_msi_spawned_cmd_and_powershell.yml
+++ b/rules/windows/process_creation/sysmon_always_install_elevated_msi_spawned_cmd_and_powershell.yml
@@ -11,17 +11,15 @@ logsource:
   product: windows
   category: process_creation
 detection:
-  image:
-    Image|endswith:
-      - '\cmd.exe'
-      - '\powershell.exe'
+  cmd: macro
+  powershell: macro
   parent_image:
     ParentImage|contains|all:
       - '\Windows\Installer\'
       - 'msi'
     ParentImage|endswith:
       - 'tmp'
-  condition: image and parent_image
+  condition: (cmd or powershell) and parent_image
 fields:
   - Image
   - ParentImage


### PR DESCRIPTION
Hey team,

I got this idea a while ago. Sigma has a lot of detections that rely on the name of executables to trigger. For example, we might trigger a detection if someone uses Powershell to do a certain task. The thing is, there are different ways to detect if a process is Powershell, especially if the executable is renamed. One can rely on the image's version information, for example.

We can in theory edit rules to add version information checks but that would be quite cumbersome. More importantly, if someone decides to detect Powershell using a hash, we will need to redo the whole exercise.

Enter, Macros!

As with any programming language, Macros are reusable Sigma code blocks. So if you want to get creative with how you detect Powershell, you can do it in one place and it would carry across all rules that use the Macro. Of course, with a generic concept like this, there should be a lot of other uses beyond what I described.

Worth mentioning, I am aware that Sigma has rules to detect renamed Powershell executables. My thinking is that seeing a process doing something malicious carries more weight that seeing a renamed executable and then tracing whether or not it was used for malicious uses. I'm also aware that a majority of users don't use all Sigma rules so missing a renamed executable rule would be devastating. 

The code here is a proof of concept. I haven't spent a lot of time testing it yet and it is certainly not ready for production. That said, I wanted to see if you guys are interested in such a feature before I spend more time on it.

Thanks,

Tareq