### PR TITLE
fix capitalization of user directory

### DIFF
--- a/rules/windows/process_creation/win_office_spawn_exe_from_users_directory.yml
+++ b/rules/windows/process_creation/win_office_spawn_exe_from_users_directory.yml
@@ -26,7 +26,7 @@ detection:
             - '\MSPUB.exe'
             - '\VISIO.exe'
             # - '\OUTLOOK.EXE' too many FPs
-        Image|startswith: 'C:\users\'
+        Image|startswith: 'C:\Users\'
         Image|endswith: '.exe'
     filter:
         Image|endswith: '\Teams.exe'


### PR DESCRIPTION
Tested this rule with Win10 logs and only worked with capital users directory