### PR TITLE
Add not_bound_keyword option for elastic backend

### DIFF
--- a/tools/sigma/backends/elasticsearch.py
+++ b/tools/sigma/backends/elasticsearch.py
@@ -69,6 +69,7 @@ class ElasticsearchWildcardHandlingMixin(object):
             ("case_insensitive_blacklist", None, "Fields to exclude from being made into case insensitive regex. Valid options are: list of fields, single field. Also, wildcards * and ? allowed.", None),
             ("wildcard_use_keyword", "true", "Use analyzed field or wildcard field if the query uses a wildcard value (ie: '*mall_wear.exe'). Set this to 'False' to use analyzed field or wildcard field. Valid options are: true/false", None),
             ("hash_normalize", None, "Normalize hash fields to lowercase, uppercase or both. If this option is not used the field value stays untouched. Valid options are: lower/upper/both (default: both)", None),
+            ("not_bound_keyword", "\\*.keyword", "field name to use for keyword list search (default is: '\\*.keyword')", None),
             )
     reContainsWildcard = re.compile("(?:(?<!\\\\)|\\\\\\\\)[*?]").search
     uuid_regex = re.compile( "[0-9a-fA-F]{8}(\\\)?-[0-9a-fA-F]{4}(\\\)?-[0-9a-fA-F]{4}(\\\)?-[0-9a-fA-F]{4}(\\\)?-[0-9a-fA-F]{12}", re.IGNORECASE )
@@ -326,7 +327,7 @@ class ElasticsearchQuerystringBackend(DeepFieldMappingMixin, ElasticsearchWildca
                     newitems.append(item)
             newnode = NodeSubexpression(nodetype(None, None, *newitems))
             self.matchKeyword = True
-            result = "\\*.keyword:" + super().generateSubexpressionNode(newnode)
+            result = self.not_bound_keyword + ":" + super().generateSubexpressionNode(newnode)
             self.matchKeyword = False       # one of the reasons why the converter needs some major overhaul
             return result
         else:


### PR DESCRIPTION
Get perf trouble with the `\*.keyword` query.
So add a backend-option `not_bound_keyword`

Without  the option get the current query
```bash
D:\FrackSigma\sigma\tools>python sigmac -t es-qs -c config\winlogbeat-modules-enabled.yml ..\rules\linux\builtin\lnx_apt_equationgroup_lnx.yml
\*.keyword:(*chown\ root*chmod\ 4777\ * OR *cp\ \/bin\/sh\ .;chown* OR *chmod\ 4777\ \/tmp\/.scsi\/dev\/bin\/gsh* OR *chown\ root\:root\ \/tmp\/.scsi\/dev\/bin\/* OR *chown\ root\:root\ x;* OR *\/bin\/telnet\ locip\ locport\ <\ \/dev\/console\ |\ \/bin\/sh* OR *\/tmp\/ratload* OR *ewok\ \-t\ * OR *xspy\ \-display\ * OR *cat\ >\ \/dev\/tcp\/127.0.0.1\/80\ <<END* OR *rm\ \-f\ \/current\/tmp\/ftshell.latest* OR *ghost_*\ \-v\ * OR *\ \-\-wipe\ >\ \/dev\/null* OR *ping\ \-c\ 2\ *;\ grep\ *\ \/proc\/net\/arp\ >\/tmp\/gx* OR *iptables\ *\ OUTPUT\ \-p\ tcp\ \-d\ 127.0.0.1\ \-\-tcp\-flags\ RST\ RST\ \-j\ DROP;* OR *>\ \/var\/log\/audit\/audit.log;\ rm\ \-f\ .* OR *cp\ \/var\/log\/audit\/audit.log\ .tmp* OR *sh\ >\/dev\/tcp\/*\ <&1\ 2>&1* OR *ncat\ \-vv\ \-l\ \-p\ *\ <* OR *nc\ \-vv\ \-l\ \-p\ *\ <* OR *<\ \/dev\/console\ |\ uudecode\ \&&\ uncompress* OR *sendmail\ \-osendmail;chmod\ \+x\ sendmail* OR *\/usr\/bin\/wget\ \-O\ \/tmp\/a\ http*\ \&&\ chmod\ 755\ \/tmp\/cron* OR *chmod\ 666\ \/var\/run\/utmp\~* OR *chmod\ 700\ nscd\ crond* OR *cp\ \/etc\/shadow\ \/tmp\/.* OR *<\/dev\/console\ |uudecode\ >\ \/dev\/null\ 2>&1\ \&&\ uncompress* OR *chmod\ 700\ jp\&&netstat\ \-an|grep* OR *uudecode\ >\ \/dev\/null\ 2>&1\ \&&\ uncompress\ \-f\ *\ \&&\ chmod\ 755* OR *chmod\ 700\ crond* OR *wget\ http*;\ chmod\ \+x\ \/tmp\/sendmail* OR *chmod\ 700\ fp\ sendmail\ pt* OR *chmod\ 755\ \/usr\/vmsys\/bin\/pipe* OR *chmod\ \-R\ 755\ \/usr\/vmsys* OR *chmod\ 755\ $opbin\/*tunnel* OR *chmod\ 700\ sendmail* OR *chmod\ 0700\ sendmail* OR *\/usr\/bin\/wget\ http*sendmail;chmod\ \+x\ sendmail;* OR *\&&\ telnet\ *\ 2>&1\ <\/dev\/console*)
```
With the option
```bash
D:\FrackSigma\sigma\tools>python sigmac -t es-qs -c config\winlogbeat-modules-enabled.yml --backend-option not_bound_keyword="message" ..\rules\linux\builtin\lnx_apt_equationgroup_lnx.yml
message:(*chown\ root*chmod\ 4777\ * OR *cp\ \/bin\/sh\ .;chown* OR *chmod\ 4777\ \/tmp\/.scsi\/dev\/bin\/gsh* OR *chown\ root\:root\ \/tmp\/.scsi\/dev\/bin\/* OR *chown\ root\:root\ x;* OR *\/bin\/telnet\ locip\ locport\ <\ \/dev\/console\ |\ \/bin\/sh* OR *\/tmp\/ratload* OR *ewok\ \-t\ * OR *xspy\ \-display\ * OR *cat\ >\ \/dev\/tcp\/127.0.0.1\/80\ <<END* OR *rm\ \-f\ \/current\/tmp\/ftshell.latest* OR *ghost_*\ \-v\ * OR *\ \-\-wipe\ >\ \/dev\/null* OR *ping\ \-c\ 2\ *;\ grep\ *\ \/proc\/net\/arp\ >\/tmp\/gx* OR *iptables\ *\ OUTPUT\ \-p\ tcp\ \-d\ 127.0.0.1\ \-\-tcp\-flags\ RST\ RST\ \-j\ DROP;* OR *>\ \/var\/log\/audit\/audit.log;\ rm\ \-f\ .* OR *cp\ \/var\/log\/audit\/audit.log\ .tmp* OR *sh\ >\/dev\/tcp\/*\ <&1\ 2>&1* OR *ncat\ \-vv\ \-l\ \-p\ *\ <* OR *nc\ \-vv\ \-l\ \-p\ *\ <* OR *<\ \/dev\/console\ |\ uudecode\ \&&\ uncompress* OR *sendmail\ \-osendmail;chmod\ \+x\ sendmail* OR *\/usr\/bin\/wget\ \-O\ \/tmp\/a\ http*\ \&&\ chmod\ 755\ \/tmp\/cron* OR *chmod\ 666\ \/var\/run\/utmp\~* OR *chmod\ 700\ nscd\ crond* OR *cp\ \/etc\/shadow\ \/tmp\/.* OR *<\/dev\/console\ |uudecode\ >\ \/dev\/null\ 2>&1\ \&&\ uncompress* OR *chmod\ 700\ jp\&&netstat\ \-an|grep* OR *uudecode\ >\ \/dev\/null\ 2>&1\ \&&\ uncompress\ \-f\ *\ \&&\ chmod\ 755* OR *chmod\ 700\ crond* OR *wget\ http*;\ chmod\ \+x\ \/tmp\/sendmail* OR *chmod\ 700\ fp\ sendmail\ pt* OR *chmod\ 755\ \/usr\/vmsys\/bin\/pipe* OR *chmod\ \-R\ 755\ \/usr\/vmsys* OR *chmod\ 755\ $opbin\/*tunnel* OR *chmod\ 700\ sendmail* OR *chmod\ 0700\ sendmail* OR *\/usr\/bin\/wget\ http*sendmail;chmod\ \+x\ sendmail;* OR *\&&\ telnet\ *\ 2>&1\ <\/dev\/console*) 
```