### PR TITLE
Fp attempting to detect suspicious xor encoded powershell

### DIFF
--- a/rules/windows/process_creation/win_powershell_xor_commandline.yml
+++ b/rules/windows/process_creation/win_powershell_xor_commandline.yml
@@ -2,9 +2,9 @@ title: Suspicious XOR Encoded PowerShell Command Line
 id: bb780e0c-16cf-4383-8383-1e5471db6cf9
 status: test
 description: Detects suspicious powershell process which includes bxor command, alternative obfuscation method to b64 encoded commands.
-author: Sami Ruohonen, Harish Segar (improvement)
+author: Sami Ruohonen, Harish Segar (improvement), Tim Shelton
 date: 2018/09/05
-modified: 2021/11/27
+modified: 2022/01/10
 logsource:
   category: process_creation
   product: windows
@@ -15,7 +15,8 @@ detection:
   filter:
     CommandLine|contains:
       - 'bxor'
-      - 'join'
+      - '-join '
+      - '-join\''
       - 'char'
   false_positives:
     ParentImage: 

--- a/rules/windows/process_creation/win_powershell_xor_commandline.yml
+++ b/rules/windows/process_creation/win_powershell_xor_commandline.yml
@@ -18,6 +18,7 @@ detection:
       - '-join '
       - "-join'"
       - '-join"'
+      - '-join`'
       - 'char'
   false_positives:
     ParentImage: 

--- a/rules/windows/process_creation/win_powershell_xor_commandline.yml
+++ b/rules/windows/process_creation/win_powershell_xor_commandline.yml
@@ -16,7 +16,7 @@ detection:
     CommandLine|contains:
       - 'bxor'
       - '-join '
-      - '-join\''
+      - "-join'"
       - '-join"'
       - 'char'
   false_positives:

--- a/rules/windows/process_creation/win_powershell_xor_commandline.yml
+++ b/rules/windows/process_creation/win_powershell_xor_commandline.yml
@@ -17,6 +17,7 @@ detection:
       - 'bxor'
       - '-join '
       - '-join\''
+      - '-join"'
       - 'char'
   false_positives:
     ParentImage: 


### PR DESCRIPTION
Fixes a false positive when joinppath is used, along with other items... example of fp:

```
 Export-DhcpServer -Leases -File (Join-Path $env:TEMP dhcp_output.txt) 
```

This attempts to narrow down the use of join with a -, and either a space, single quote or double quote.  Other string markers can also be added, not sure of ` works