### PR TITLE
fp where symantec apparently performs this behavior with .scr files

### DIFF
--- a/rules/windows/file_event/win_fe_creation_scr_binary_file.yml
+++ b/rules/windows/file_event/win_fe_creation_scr_binary_file.yml
@@ -8,7 +8,7 @@ author: frack113
 references:
   - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1546.002/T1546.002.md
 date: 2021/12/29
-modified: 2022/01/08
+modified: 2022/01/10
 logsource:
   product: windows
   category: file_event
@@ -17,6 +17,7 @@ detection:
     TargetFilename|endswith: '.scr'
   filter:
     Image|endswith: '\Kindle.exe'
+    Image|endswith: '\Bin\ccSvcHst.exe' # Symantec Endpoint Protection
   condition: selection and not 1 of filter*
 falsepositives:
   - Unkown

--- a/rules/windows/file_event/win_fe_creation_scr_binary_file.yml
+++ b/rules/windows/file_event/win_fe_creation_scr_binary_file.yml
@@ -16,8 +16,9 @@ detection:
   selection:
     TargetFilename|endswith: '.scr'
   filter:
-    Image|endswith: '\Kindle.exe'
-    Image|endswith: '\Bin\ccSvcHst.exe' # Symantec Endpoint Protection
+    Image|endswith:
+      - '\Kindle.exe'
+      - '\Bin\ccSvcHst.exe' # Symantec Endpoint Protection
   condition: selection and not 1 of filter*
 falsepositives:
   - Unkown


### PR DESCRIPTION
Example

```
2022-01-10 22:13:56 device-01.domain.pvt Sysmon: 11: File created | RuleName=technique_id=T1047,technique_name=File System Permissions Weakness | UtcTime=2022-01-10 02:13:56.122 | ProcessGuid={520D48D4-358B-61DC-1C00-000000006506} | ProcessId=1816 | Image=C:\Program Files (x86)\Symantec\Symantec Endpoint Protection\14.3.1169.0100.105\Bin\ccSvcHst.exe | TargetFilename=C:\Windows\Temp\SymDelta_1816\content.zip.tmp\cur.scr | CreationUtcTime=2022-01-10 22:13:56.122 | pid=372 | level=0 | sys_version=2 | category=File created (rule: FileCreate) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=6627251 | app="sysmon64.exe" | tid=2600 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) 
```