### PR TITLE
refactor: change all " of them" expressions

### DIFF
--- a/rules/linux/auditd/lnx_auditd_coinminer.yml
+++ b/rules/linux/auditd/lnx_auditd_coinminer.yml
@@ -27,7 +27,7 @@ detection:
         a6|startswith: '--cpu-priority'
     cmd7:
         a7|startswith: '--cpu-priority'
-    condition: 1 of them
+    condition: 1 of cmd*
 falsepositives:
     - Other tools that use a --cpu-priority flag
 level: critical

--- a/rules/linux/auditd/lnx_auditd_susp_cmds.yml
+++ b/rules/linux/auditd/lnx_auditd_susp_cmds.yml
@@ -27,7 +27,7 @@ detection:
     type: 'EXECVE'
     a0: 'cp'
     a1: '/bin/sh'
-  condition: 1 of them
+  condition: 1 of cmd*
 falsepositives:
   - Admin activity
 level: medium

--- a/rules/linux/auditd/lnx_data_compressed.yml
+++ b/rules/linux/auditd/lnx_data_compressed.yml
@@ -22,7 +22,7 @@ detection:
     type: 'execve'
     a0: 'tar'
     a1|contains: '-c'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate use of archiving tools by legitimate user.
 level: low

--- a/rules/linux/macos/process_creation/macos_creds_from_keychain.yml
+++ b/rules/linux/macos/process_creation/macos_creds_from_keychain.yml
@@ -21,7 +21,7 @@ detection:
     CommandLine|contains:
       - ' dump-keychain '
       - ' login-keychain '
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate administration activities
 level: medium

--- a/rules/linux/macos/process_creation/macos_file_and_directory_discovery.yml
+++ b/rules/linux/macos/process_creation/macos_file_and_directory_discovery.yml
@@ -11,19 +11,19 @@ logsource:
   category: process_creation
   product: macos
 detection:
-  file_with_asterisk:
+  select_file_with_asterisk:
     Image: '/usr/bin/file'
     CommandLine|re: '(.){200,}' # execution of the 'file */* *>> /tmp/output.txt' will produce huge commandline
-  recursive_ls:
+  select_recursive_ls:
     Image: '/bin/ls'
     CommandLine|contains: '-R'
-  find_execution:
+  select_find_execution:
     Image: '/usr/bin/find'
-  mdfind_execution:
+  select_mdfind_execution:
     Image: '/usr/bin/mdfind'
-  tree_execution|endswith:
+  select_tree_execution|endswith:
     Image: '/tree'
-  condition: 1 of them
+  condition: 1 of select*
 falsepositives:
   - Legitimate activities
 level: informational

--- a/rules/linux/macos/process_creation/macos_local_account.yml
+++ b/rules/linux/macos/process_creation/macos_local_account.yml
@@ -40,7 +40,7 @@ detection:
       - '/lsof'
     CommandLine|contains:
       - '-u'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate administration activities
 level: low

--- a/rules/linux/macos/process_creation/macos_local_groups.yml
+++ b/rules/linux/macos/process_creation/macos_local_groups.yml
@@ -28,7 +28,7 @@ detection:
     CommandLine|contains|all:
       - '-list'
       - '/groups'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate administration activities
 level: informational

--- a/rules/linux/macos/process_creation/macos_remote_system_discovery.yml
+++ b/rules/linux/macos/process_creation/macos_remote_system_discovery.yml
@@ -40,7 +40,7 @@ detection:
       - ' 172.31.'
       - ' 127.' #127.0.0.0/8
       - ' 169.254.' #169.254.0.0/16
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate administration activities
 level: informational

--- a/rules/linux/process_creation/lnx_file_and_directory_discovery.yml
+++ b/rules/linux/process_creation/lnx_file_and_directory_discovery.yml
@@ -11,17 +11,17 @@ logsource:
   category: process_creation
   product: linux
 detection:
-  file_with_asterisk:
+  select_file_with_asterisk:
     Image|endswith: '/file'
     CommandLine|re: '(.){200,}' # execution of the 'file */* *>> /tmp/output.txt' will produce huge commandline
-  recursive_ls:
+  select_recursive_ls:
     Image|endswith: '/ls'
     CommandLine|contains: '-R'
-  find_execution:
+  select_find_execution:
     Image|endswith: '/find'
-  tree_execution:
+  select_tree_execution:
     Image|endswith: '/tree'
-  condition: 1 of them
+  condition: 1 of select*
 falsepositives:
   - Legitimate activities
 level: informational

--- a/rules/linux/process_creation/lnx_local_account.yml
+++ b/rules/linux/process_creation/lnx_local_account.yml
@@ -31,7 +31,7 @@ detection:
       - '/lsof'
     CommandLine|contains:
       - '-u'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate administration activities
 level: low

--- a/rules/linux/process_creation/lnx_local_groups.yml
+++ b/rules/linux/process_creation/lnx_local_groups.yml
@@ -19,7 +19,7 @@ detection:
       - '/cat'
     CommandLine|contains:
       - '/etc/group'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate administration activities
 level: low

--- a/rules/linux/process_creation/lnx_remote_system_discovery.yml
+++ b/rules/linux/process_creation/lnx_remote_system_discovery.yml
@@ -37,7 +37,7 @@ detection:
       - ' 172.31.'
       - ' 127.' #127.0.0.0/8
       - ' 169.254.' #169.254.0.0/16
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate administration activities
 level: low

--- a/rules/linux/process_creation/lnx_security_tools_disabling.yml
+++ b/rules/linux/process_creation/lnx_security_tools_disabling.yml
@@ -15,70 +15,70 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    iptables_1:
+    selection_iptables_1:
         Image|endswith: '/service'
         CommandLine|contains|all:
           - 'iptables'
           - 'stop'
-    iptables_2:
+    selection_iptables_2:
         Image|endswith: '/service'
         CommandLine|contains|all:
           - 'ip6tables'
           - 'stop'
-    iptables_3:
+    selection_iptables_3:
         Image|endswith: '/chkconfig'
         CommandLine|contains|all:
           - 'iptables'
           - 'stop'
-    iptables_4:
+    selection_iptables_4:
         Image|endswith: '/chkconfig'
         CommandLine|contains|all:
           - 'ip6tables'
           - 'stop'
-    firewall_1:
+    selection_firewall_1:
         Image|endswith: '/systemctl'
         CommandLine|contains|all:
           - 'firewalld'
           - 'stop'
-    firewall_2:
+    selection_firewall_2:
         Image|endswith: '/systemctl'
         CommandLine|contains|all:
           - 'firewalld'
           - 'disable'
-    carbonblack_1:
+    selection_carbonblack_1:
         Image|endswith: '/service'
         CommandLine|contains|all:
           - 'cbdaemon'
           - 'stop'
-    carbonblack_2:
+    selection_carbonblack_2:
         Image|endswith: '/chkconfig'
         CommandLine|contains|all:
           - 'cbdaemon'
           - 'off'
-    carbonblack_3:
+    selection_carbonblack_3:
         Image|endswith: '/systemctl'
         CommandLine|contains|all:
           - 'cbdaemon'
           - 'stop'
-    carbonblack_4:
+    selection_carbonblack_4:
         Image|endswith: '/systemctl'
         CommandLine|contains|all:
           - 'cbdaemon'
           - 'disable'
-    selinux:
+    selection_selinux:
         Image|endswith: '/setenforce'
         CommandLine|contains: '0'
-    crowdstrike_1:
+    selection_crowdstrike_1:
         Image|endswith: '/systemctl'
         CommandLine|contains|all:
           - 'stop'
           - 'falcon-sensor'
-    crowdstrike_2:
+    selection_crowdstrike_2:
         Image|endswith: '/systemctl'
         CommandLine|contains|all:
           - 'disable'
           - 'falcon-sensor'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Legitimate administration activities
 level: medium

--- a/rules/network/net_apt_equationgroup_c2.yml
+++ b/rules/network/net_apt_equationgroup_c2.yml
@@ -11,15 +11,15 @@ modified: 2021/11/27
 logsource:
   category: firewall
 detection:
-  outgoing:
+  select_outgoing:
     dst_ip:
       - '69.42.98.86'
       - '89.185.234.145'
-  incoming:
+  select_incoming:
     src_ip:
       - '69.42.98.86'
       - '89.185.234.145'
-  condition: 1 of them
+  condition: 1 of select*
 falsepositives:
   - Unknown
 level: high

--- a/rules/network/net_mal_dns_cobaltstrike.yml
+++ b/rules/network/net_mal_dns_cobaltstrike.yml
@@ -17,7 +17,7 @@ detection:
             - 'post.1'
     selection2:
         query|contains: '.stage.123456.'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Unknown
 level: critical

--- a/rules/network/zeek/zeek_dce_rpc_mitre_bzar_execution.yml
+++ b/rules/network/zeek/zeek_dce_rpc_mitre_bzar_execution.yml
@@ -41,7 +41,7 @@ detection:
   op10:
     endpoint: 'svcctl'
     operation: 'StartServiceW'
-  condition: 1 of them
+  condition: 1 of op*
 falsepositives:
   - 'Windows administrator tasks or troubleshooting'
   - 'Windows management scripts or software'

--- a/rules/network/zeek/zeek_dce_rpc_mitre_bzar_persistence.yml
+++ b/rules/network/zeek/zeek_dce_rpc_mitre_bzar_persistence.yml
@@ -29,7 +29,7 @@ detection:
   op6:
     endpoint: 'ISecLogon'
     operation: 'SeclCreateProcessWithLogonExW'
-  condition: 1 of them
+  condition: 1 of op*
 falsepositives:
   - 'Windows administrator tasks or troubleshooting'
   - 'Windows management scripts or software'

--- a/rules/proxy/proxy_cobalt_malformed_uas.yml
+++ b/rules/proxy/proxy_cobalt_malformed_uas.yml
@@ -17,7 +17,7 @@ detection:
       - "Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 5.2) Java/1.5.0_08"
   selection2:
     c-useragent|endswith: '; MANM; MANM)'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Unknown
 level: critical

--- a/rules/web/web_citrix_cve_2020_8193_8195_exploit.yml
+++ b/rules/web/web_citrix_cve_2020_8193_8195_exploit.yml
@@ -19,7 +19,7 @@ detection:
             - '/pcidss/report'
             - 'type=all_signatures'
             - 'sig_name=_default_signature_'
-    condition: 1 of them
+    condition: 1 of selection*
 fields:
     - client_ip
     - vhost

--- a/rules/web/web_exchange_exploitation_hafnium.yml
+++ b/rules/web/web_exchange_exploitation_hafnium.yml
@@ -56,7 +56,7 @@ detection:
     c-uri|contains|all:
       - '/ecp/'
       - '.js'   
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate access to other web applications that use the same folder names as Exchange (e.g. owa, ecp) but are not Microsoft Exchange related
 level: high

--- a/rules/web/web_unc2546_dewmode_php_webshell.yml
+++ b/rules/web/web_unc2546_dewmode_php_webshell.yml
@@ -22,7 +22,7 @@ detection:
             - '&dwn='
             - '?fn='
             - '.html?'
-    condition: 1 of them
+    condition: 1 of selection*
 fields:
     - client_ip
     - response

--- a/rules/windows/deprecated/sysmon_rclone_execution.yml
+++ b/rules/windows/deprecated/sysmon_rclone_execution.yml
@@ -43,4 +43,4 @@ detection:
             - '--auto-confirm'
             - '--transfers'
             - '--multi-thread-streams'
-    condition: 1 of them
+    condition: 1 of selection*

--- a/rules/windows/dns_query/dns_net_mal_cobaltstrike.yml
+++ b/rules/windows/dns_query/dns_net_mal_cobaltstrike.yml
@@ -21,7 +21,7 @@ detection:
             - 'post.1'
     selection2:
         QueryName|contains: '.stage.123456.'
-    condition: 1 of them
+    condition: 1 of selection*
 fields:
     - Image
     - CommandLine

--- a/rules/windows/file_event/file_event_win_shell_write_susp_directory.yml
+++ b/rules/windows/file_event/file_event_win_shell_write_susp_directory.yml
@@ -38,7 +38,7 @@ detection:
             - 'C:\PerfLogs'
             - '\AppData\'
             - 'C:\Windows\Temp'
-    condition: 1 of them
+    condition: 1 of selection*
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/malware/process_creation_mal_darkside_ransomware.yml
+++ b/rules/windows/malware/process_creation_mal_darkside_ransomware.yml
@@ -21,7 +21,7 @@ detection:
             - 'DllHost.exe /Processid:{3E5FC7F9-9A51-4367-9063-A120244FBEC7}'
         Image|contains:
             - '\AppData\Local\Temp\'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Unknown
     - UAC bypass method used by other malware

--- a/rules/windows/pipe_created/sysmon_mal_cobaltstrike.yml
+++ b/rules/windows/pipe_created/sysmon_mal_cobaltstrike.yml
@@ -30,7 +30,7 @@ detection:
       PipeName|startswith: '\status_'
    selection_msagent:
       PipeName|startswith: '\msagent_'
-   condition: 1 of them
+   condition: 1 of selection*
 falsepositives:
    - Unknown
 level: critical

--- a/rules/windows/powershell/powershell_module/powershell_suspicious_invocation_specific_in_contextinfo.yml
+++ b/rules/windows/powershell/powershell_module/powershell_suspicious_invocation_specific_in_contextinfo.yml
@@ -61,7 +61,7 @@ detection:
             - 'New-Object'
             - 'Net.WebClient'
             - '.Download'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Penetration tests
 level: high

--- a/rules/windows/powershell/powershell_script/powershell_suspicious_invocation_specific_in_scripblocktext.yml
+++ b/rules/windows/powershell/powershell_script/powershell_suspicious_invocation_specific_in_scripblocktext.yml
@@ -17,14 +17,14 @@ logsource:
     category: ps_script
     definition: Script block logging must be enabled
 detection:
-    convert_b64:
+    select_convert_b64:
         ScriptBlockText|contains|all:
             - '-nop'
             - ' -w '
             - 'hidden'
             - ' -c '
             - '[Convert]::FromBase64String'
-    iex_selection:
+    select_iex_selection:
         ScriptBlockText|contains|all:
             - ' -w '
             - 'hidden'
@@ -33,20 +33,20 @@ detection:
             - ' -c '
             - 'iex'
             - 'New-Object'
-    enc_selection:
+    select_enc_selection:
         ScriptBlockText|contains|all:
             - ' -w '
             - 'hidden'
             - '-ep'
             - 'bypass'
             - '-Enc'
-    reg_selection:
+    select_reg_selection:
         ScriptBlockText|contains|all:
             - 'powershell'
             - 'reg'
             - 'add'
             - 'HKCU\software\microsoft\windows\currentversion\run'
-    webclient_selection:
+    select_webclient_selection:
         ScriptBlockText|contains|all:
             - 'bypass'
             - '-noprofile'
@@ -55,13 +55,13 @@ detection:
             - 'new-object'
             - 'system.net.webclient'
             - '.download'
-    iex_webclient:
+    select_iex_webclient:
         ScriptBlockText|contains|all:
             - 'iex'
             - 'New-Object'
             - 'Net.WebClient'
             - '.Download'
-    condition: 1 of them
+    condition: 1 of select*
 falsepositives:
     - Penetration tests
 level: high

--- a/rules/windows/process_creation/wim_pc_apt_chafer_mar18.yml
+++ b/rules/windows/process_creation/wim_pc_apt_chafer_mar18.yml
@@ -43,7 +43,7 @@ detection:
             - '\nslookup.exe'
             - '-q=TXT'
         ParentImage|contains: '\Autoit'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Unknown
 level: critical

--- a/rules/windows/process_creation/win_apt_elise.yml
+++ b/rules/windows/process_creation/win_apt_elise.yml
@@ -16,7 +16,7 @@ detection:
     CommandLine|contains: '\Windows\Caches\NavShExt.dll '
   selection2:
     CommandLine|endswith: '\AppData\Roaming\MICROS~1\Windows\Caches\NavShExt.dll,Setting'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Unknown
 level: critical

--- a/rules/windows/process_creation/win_apt_empiremonkey.yml
+++ b/rules/windows/process_creation/win_apt_empiremonkey.yml
@@ -17,7 +17,7 @@ detection:
   selection_regsvr32:
     CommandLine|endswith: '/i:%APPDATA%\logs.txt scrobj.dll'
     Description: 'Microsoft(C) Registerserver'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Very Unlikely
 level: critical

--- a/rules/windows/process_creation/win_apt_equationgroup_dll_u_load.yml
+++ b/rules/windows/process_creation/win_apt_equationgroup_dll_u_load.yml
@@ -18,7 +18,7 @@ detection:
     CommandLine|endswith: ',dll_u'
   selection2:
     CommandLine|contains: ' -export dll_u '
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Unknown
 level: critical

--- a/rules/windows/process_creation/win_apt_greenbug_may20.yml
+++ b/rules/windows/process_creation/win_apt_greenbug_may20.yml
@@ -50,7 +50,7 @@ detection:
             - '\programdata\oracle\java.exe'
             - 'CSIDL_COMMON_APPDATA\comms\comms.exe'
             - '\Programdata\VMware\Vmware.exe'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Unknown
 level: critical

--- a/rules/windows/process_creation/win_apt_hafnium.yml
+++ b/rules/windows/process_creation/win_apt_hafnium.yml
@@ -66,7 +66,7 @@ detection:
             - 'dsquery'
             - ' -uco '
             - '\inetpub\wwwroot'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/win_apt_lazarus_activity_apr21.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_activity_apr21.yml
@@ -29,7 +29,7 @@ detection:
             - ':\Users\Public\'
         Image:
             - 'C:\Windows\System32\rundll32.exe'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Should not be any false positives
 level: critical

--- a/rules/windows/process_creation/win_apt_lazarus_activity_dec20.yml
+++ b/rules/windows/process_creation/win_apt_lazarus_activity_dec20.yml
@@ -34,7 +34,7 @@ detection:
     selection4:
         CommandLine|contains:
             - '.255 10 C:\ProgramData\'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Overlap with legitimate process activity in some cases (especially selection 3 and 4)
 level: critical

--- a/rules/windows/process_creation/win_apt_mustangpanda.yml
+++ b/rules/windows/process_creation/win_apt_mustangpanda.yml
@@ -26,7 +26,7 @@ detection:
       - '/F'
   selection2:
     Image|endswith: 'Temp\winwsh.exe'
-  condition: 1 of them
+  condition: 1 of selection*
 fields:
   - CommandLine
   - ParentCommandLine

--- a/rules/windows/process_creation/win_apt_turla_comrat_may20.yml
+++ b/rules/windows/process_creation/win_apt_turla_comrat_may20.yml
@@ -20,7 +20,7 @@ detection:
     CommandLine|contains|all:
       - 'net use https://docs.live.net'
       - '@aol.co.uk'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Unknown
 level: critical

--- a/rules/windows/process_creation/win_apt_winnti_mal_hk_jan20.yml
+++ b/rules/windows/process_creation/win_apt_winnti_mal_hk_jan20.yml
@@ -27,7 +27,7 @@ detection:
   selection5:
     ParentImage|startswith: 'C:\ProgramData\DRM\Windows'
     Image|endswith: '\SearchFilterHost.exe'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Unlikely
 level: critical

--- a/rules/windows/process_creation/win_apt_winnti_pipemon.yml
+++ b/rules/windows/process_creation/win_apt_winnti_pipemon.yml
@@ -21,7 +21,7 @@ detection:
       - '-x:0'
       - '-x:1'
       - '-x:2'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate setups that use similar flags
 level: critical

--- a/rules/windows/process_creation/win_bypass_squiblytwo.yml
+++ b/rules/windows/process_creation/win_bypass_squiblytwo.yml
@@ -27,7 +27,7 @@ detection:
     CommandLine|contains|all:
       - 'format:'
       - 'http'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Unknown
 level: medium

--- a/rules/windows/process_creation/win_cobaltstrike_process_patterns.yml
+++ b/rules/windows/process_creation/win_cobaltstrike_process_patterns.yml
@@ -34,7 +34,7 @@ detection:
         Image|endswith: '\cmd.exe'
         ParentImage|endswith: '\runonce.exe'
         ParentCommandLine|endswith: '\runonce.exe'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Other programs that cause these patterns (please report)
 level: high

--- a/rules/windows/process_creation/win_commandline_path_traversal_evasion.yml
+++ b/rules/windows/process_creation/win_commandline_path_traversal_evasion.yml
@@ -22,7 +22,7 @@ detection:
             - '\..\..\'
     selection2:
         CommandLine|contains: '.exe\..\'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/win_crime_maze_ransomware.yml
+++ b/rules/windows/process_creation/win_crime_maze_ransomware.yml
@@ -35,7 +35,7 @@ detection:
     selection3: 
         CommandLine|endswith: 'shadowcopy delete'
         CommandLine|contains: '\..\..\system32'
-    condition: 1 of them
+    condition: 1 of selection*
 fields:
     - ComputerName
     - User

--- a/rules/windows/process_creation/win_etw_trace_evasion.yml
+++ b/rules/windows/process_creation/win_etw_trace_evasion.yml
@@ -47,7 +47,7 @@ detection:
       - 'trace'
       - '--p'
       - '-ets'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Unknown
 level: high

--- a/rules/windows/process_creation/win_hack_bloodhound.yml
+++ b/rules/windows/process_creation/win_hack_bloodhound.yml
@@ -30,7 +30,7 @@ detection:
     CommandLine|contains|all:
       - ' DCOnly '
       - ' --NoSaveCache '
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Other programs that use these command line option and accepts an 'All' parameter
 level: high

--- a/rules/windows/process_creation/win_hack_secutyxploded.yml
+++ b/rules/windows/process_creation/win_hack_secutyxploded.yml
@@ -23,7 +23,7 @@ detection:
         Image|endswith: 'PasswordDump.exe'
     selection3:
         OriginalFileName|endswith: 'PasswordDump.exe'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - unlikely
 level: critical

--- a/rules/windows/process_creation/win_hktl_createminidump.yml
+++ b/rules/windows/process_creation/win_hktl_createminidump.yml
@@ -19,7 +19,7 @@ detection:
         Image|contains: '\CreateMiniDump.exe'
     selection2:
         Imphash: '4a07f944a83e8a7c2525efa35dd30e2f'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/win_malware_notpetya.yml
+++ b/rules/windows/process_creation/win_malware_notpetya.yml
@@ -12,18 +12,18 @@ logsource:
   category: process_creation
   product: windows
 detection:
-  pipe_com:
+  select_pipe_com:
     CommandLine|contains|all:
       - '\AppData\Local\Temp\'
       - '\\.\pipe\\'
-  rundll32_dash1:
+  select_rundll32_dash1:
     Image|endswith: '\rundll32.exe'
     CommandLine|endswith: 
       - '.dat,#1'
       - '.dat #1' # Sysmon removes comma
-  perfc_keyword:
+  select_perfc_keyword:
     - '\perfc.dat'
-  condition: 1 of them
+  condition: 1 of select*
 fields:
   - CommandLine
   - ParentCommandLine

--- a/rules/windows/process_creation/win_malware_wannacry.yml
+++ b/rules/windows/process_creation/win_malware_wannacry.yml
@@ -44,7 +44,7 @@ detection:
       - 'catalog'
       - '-quiet'
     - CommandLine|contains: '@Please_Read_Me@.txt'
-  condition: 1 of them
+  condition: 1 of selection*
 fields:
   - CommandLine
   - ParentCommandLine

--- a/rules/windows/process_creation/win_netsh_allow_port_rdp.yml
+++ b/rules/windows/process_creation/win_netsh_allow_port_rdp.yml
@@ -23,7 +23,7 @@ detection:
       - action=allow
       - protocol=TCP
       - localport=3389
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Legitimate administration
 level: high

--- a/rules/windows/process_creation/win_powershell_disable_windef_av.yml
+++ b/rules/windows/process_creation/win_powershell_disable_windef_av.yml
@@ -22,18 +22,18 @@ detection:
         CommandLine|contains:
             - '-DisableBehaviorMonitoring $true'
             - '-DisableRuntimeMonitoring $true'
-    tamper_cmd_stop:
+    selection_tamper_cmd_stop:
         CommandLine|contains|all:
             - sc
             - stop
             - WinDefend
-    tamper_cmd_disabled:
+    selection_tamper_cmd_disabled:
         CommandLine|contains|all:
             - sc
             - config
             - WinDefend
             - 'start=disabled'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - 'Minimal, for some older versions of dev tools, such as pycharm, developers were known to sometimes disable Windows Defender to improve performance, but this generally is not considered a good security practice.'
 level: high

--- a/rules/windows/process_creation/win_susp_disable_ie_features.yml
+++ b/rules/windows/process_creation/win_susp_disable_ie_features.yml
@@ -23,7 +23,7 @@ detection:
     CommandLine|contains|all:
       - ' -name DisableFirstRunCustomize '
       - ' -value 2 '
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - Unknown, maybe some security software installer disables these features temporarily
 level: high

--- a/rules/windows/process_creation/win_susp_disable_raccine.yml
+++ b/rules/windows/process_creation/win_susp_disable_raccine.yml
@@ -28,7 +28,7 @@ detection:
             - 'schtasks'
             - '/DELETE'
             - 'Raccine Rules Updater'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Legitimate deinstallation by administrative staff
 level: high

--- a/rules/windows/process_creation/win_susp_ngrok_pua.yml
+++ b/rules/windows/process_creation/win_susp_ngrok_pua.yml
@@ -38,7 +38,7 @@ detection:
             - ' tcp '
             - ' http '
             - ' authtoken '
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Another tool that uses the command line switches of Ngrok
     - ngrok http 3978 (https://docs.microsoft.com/en-us/azure/bot-service/bot-service-debug-channel-ngrok?view=azure-bot-service-4.0)

--- a/rules/windows/process_creation/win_susp_regsvr32_anomalies.yml
+++ b/rules/windows/process_creation/win_susp_regsvr32_anomalies.yml
@@ -50,7 +50,7 @@ detection:
         CommandLine|contains: 
             - '\AppData\Local'
             - 'C:\Users\Public'
-    condition: 1 of them
+    condition: 1 of selection*
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/process_creation/win_trust_discovery.yml
+++ b/rules/windows/process_creation/win_trust_discovery.yml
@@ -36,7 +36,7 @@ detection:
         CommandLine|contains|all:
             - '-filter'
             - 'trustedDomain'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - Legitimate use of the utilities by legitimate user for legitimate reason
 level: medium

--- a/rules/windows/registry_event/registry_event_mstsc_history_cleared.yml
+++ b/rules/windows/registry_event/registry_event_mstsc_history_cleared.yml
@@ -21,7 +21,7 @@ detection:
     selection2:
         EventType: DeleteKey
         TargetObject|contains: '\Microsoft\Terminal Server Client\Servers\'
-    condition: 1 of them
+    condition: 1 of selection*
 falsepositives:
     - unknown
 level: high

--- a/rules/windows/registry_event/sysmon_narrator_feedback_persistance.yml
+++ b/rules/windows/registry_event/sysmon_narrator_feedback_persistance.yml
@@ -16,7 +16,7 @@ detection:
     TargetObject|endswith: '\AppXypsaf9f1qserqevf0sws76dx4k9a5206\Shell\open\command\DelegateExecute'
   selection2:
     TargetObject|endswith: '\AppXypsaf9f1qserqevf0sws76dx4k9a5206\Shell\open\command\(Default)'
-  condition: 1 of them
+  condition: 1 of selection*
 falsepositives:
   - unknown
 level: high


### PR DESCRIPTION
In order to make it easier to automatically add false positive filters, the selections should address a pattern and don't use "of them"

This way, you can programatically add 
```
fp_filter_1: 'XXX'
...
condition:
... and not 1 of fp*
```