### PR TITLE
Added two filters in Credentials Dumping Tools Accessing LSASS Memory

### DIFF
--- a/rules/windows/process_access/sysmon_cred_dump_lsass_access.yml
+++ b/rules/windows/process_access/sysmon_cred_dump_lsass_access.yml
@@ -5,7 +5,7 @@ description: Detects process access LSASS memory which is typical for credential
 author: Florian Roth, Roberto Rodriguez, Dimitrios Slamaris, Mark Russinovich, Thomas Patzke, Teymur Kheirkhabarov, Sherif Eldeeb, James Dickenson, Aleksey Potapov,
     oscd.community (update)
 date: 2017/02/16
-modified: 2021/12/10
+modified: 2022/01/12
 references:
     - https://onedrive.live.com/view.aspx?resid=D026B4699190F1E6!2843&ithint=file%2cpptx&app=PowerPoint&authkey=!AMvCRTKB_V1J5ow
     - https://cyberwardog.blogspot.com/2017/03/chronicles-of-threat-hunter-hunting-for_22.html
@@ -82,6 +82,14 @@ detection:
     filter9:
         SourceImage|endswith: '\explorer.exe'
         GrantedAccess: '0x401'
+    filter10:
+        SourceImage: 'C:\Windows\system32\wininit.exe'
+        GrantedAccess: '0x1000000'
+    filter11:
+        SourceImage: 'C:\Windows\system32\MRT.exe' # Windows Malicious Software Removal Tool
+        GrantedAccess: 
+            - '0x1410'
+            - '0x1418'
     filter_generic:
         SourceImage|startswith: 
             - 'C:\Program Files\'


### PR DESCRIPTION
@Neo23x0, Directly not related to this PR but I have a query regarding a certain change done to this rule.

This rule will not detect _mimikatz_ accessing LSASS (sekurlsa::logonPasswords) since **0x1010** access was removed in _fix: FPs with Aurora_ commit a month ago.

So, this means we are intentionally removing coverage for _mimikatz_ and delegating it to _Suspicious GrantedAccess Flags on LSASS Access_ rule instead? Also, if Aurora generates **0x1010** then it defeats the purpose of the commit.