### PR TITLE
feat: check for the existence of a description field

### DIFF
--- a/rules/windows/file_event/file_event_susp_task_write.yml
+++ b/rules/windows/file_event/file_event_susp_task_write.yml
@@ -1,11 +1,12 @@
-title: Suspicious Scheduled Task Writ to System32 Tasks
+title: Suspicious Scheduled Task Write to System32 Tasks
 id: 80e1f67a-4596-4351-98f5-a9c3efabac95
 status: experimental
-description: 
+description: Detects the creation of tasks from processes executed from suspicious locations
 references:
-    - https://isc.sans.edu/forums/diary/Desktopini+as+a+postexploitation+tool/25912/
+    - Internal Research
 author: Florian Roth
 date: 2021/11/16
+modified: 2022/01/12
 tags:
     - attack.persistence
     - attack.execution

--- a/rules/windows/powershell/powershell_script/powershell_azurehound_commands.yml
+++ b/rules/windows/powershell/powershell_script/powershell_azurehound_commands.yml
@@ -1,16 +1,17 @@
 title: AzureHound PowerShell Commands
 id: 83083ac6-1816-4e76-97d7-59af9a9ae46e
 status: experimental
-description: 
+description: Detects the execution of AzureHound in PowerShell, a tool to gather data from Azure for BloodHound
 references:
     - https://github.com/BloodHoundAD/BloodHound/blob/master/Collectors/AzureHound.ps1
     - https://bloodhound.readthedocs.io/en/latest/data-collection/azurehound.html
 author: Austin Songer (@austinsonger)
 date: 2021/10/23
+modified: 2022/01/12
 logsource:
     product: windows
     category: ps_script
-    definition: Script Block Logging must be enable
+    definition: Script Block Logging must be enabled
 detection:
     selection:
         ScriptBlockText|contains: Invoke-AzureHound

--- a/rules/windows/process_creation/win_purplesharp_indicators.yml
+++ b/rules/windows/process_creation/win_purplesharp_indicators.yml
@@ -1,10 +1,10 @@
 title: PurpleSharp Indicator
 id: ff23ffbc-3378-435e-992f-0624dcf93ab4
 status: experimental
-description: Detect
+description: Detects the execution of the PurpleSharp adversary simulation tool
 author: Florian Roth
 date: 2021/06/18
-modified: 2021/07/06
+modified: 2022/01/12
 references:
     - https://github.com/mvelazc0/PurpleSharp
 logsource:
@@ -16,8 +16,7 @@ detection:
             - xyz123456.exe
             - PurpleSharp
     selection2:
-        OriginalFileName: 
-            - 'PurpleSharp.exe'
+        OriginalFileName: 'PurpleSharp.exe'
     condition: selection1 or selection2
 falsepositives:
     - Unlikely

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -375,6 +375,23 @@ class TestRules(unittest.TestCase):
         self.assertEqual(faulty_rules, [], Fore.RED +
                          "There are rules with missing or malformed 'date' fields. (create one, e.g. date: 2019/01/14)")
 
+    def test_missing_description(self):
+        faulty_rules = []
+        for file in self.yield_next_rule_file_path(self.path_to_rules):
+            descriptionfield = self.get_rule_part(file_path=file, part_name="description")
+            if not descriptionfield:
+                print(Fore.YELLOW + "Rule {} has no field 'description'.".format(file))
+                faulty_rules.append(file)
+            elif not isinstance(descriptionfield, str):
+                print(Fore.YELLOW + "Rule {} has a 'description' field that isn't a string.".format(file))
+                faulty_rules.append(file)
+            elif len(descriptionfield) < 16:
+                print(Fore.YELLOW + "Rule {} has a really short description. Please elaborate.".format(file))
+                faulty_rules.append(file)
+
+        self.assertEqual(faulty_rules, [], Fore.RED +
+                         "There are rules with missing or malformed 'description' field. (create one, e.g. description: Detects the suspicious behaviour of process XY doing YZ)")
+
     def test_optional_date_modified(self):
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):


### PR DESCRIPTION
It is not mandatory in the sigma standard but mandatory for this repository.
I added or changed descriptions for existing rules to not fail on the new constraint.

