### PR TITLE
Fix incorrectly formatted Winget LOLbin creation date

### DIFF
--- a/rules/windows/process_creation/win_lolbin_execution_via_winget.yml
+++ b/rules/windows/process_creation/win_lolbin_execution_via_winget.yml
@@ -5,7 +5,7 @@ status: experimental
 references: 
     - https://docs.microsoft.com/en-us/windows/package-manager/winget/install#local-install
 author: Sreeman, Florian Roth, Frack113
-date: 2020/21/04
+date: 2020/04/21
 modified: 2022/01/11
 tags:
     - attack.defense_evasion


### PR DESCRIPTION
Hello, 

A sanity check of our rule deployment pipeline noticed that the creation date of this rule is formatted incorrectly.
![image](https://user-images.githubusercontent.com/81748765/149152775-590673a5-44de-4482-aae6-b6146a5c8686.png)

I think the date should be as proposed in this PR. (Of course we can manually overwrite this internally, but it's better to have this changed in the Sigma master.)