### PR TITLE
Detects executable running with non executable extension

### DIFF
--- a/rules/windows/process_creation/win_run_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/win_run_executable_invalid_extension.yml
@@ -1,27 +1,23 @@
 title: Application Executed Non-Executable Extension
 id: c3a99af4-35a9-4668-879e-c09aeb4f2bdf
 status: experimental
-description: Detects execution of files using an invalid file extension
-author: Tim Shelton
-date: 2022/01/12
+description: Detects the execution of rundll32 with a command line that doesn't contain a .dll file
+references:
+    - https://twitter.com/mrd0x/status/1481630810495139841?s=12
+author: Tim Shelton, Florian Roth
+date: 2022/01/13
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection1:
-        Image|endswith:
-        - '.exe'
-        - '.ex_'
-        - '.com'
-        - '.cmd'
-        - '.bat'
-        - '.bin'
-        - '.pif'
-    selection2:
-        Image|endswith: 'rundll32.exe'
-    selection2b:
-        CommandLine|contains: ".dll"
-    condition: not selection1 or (selection2 and not selection2b)
+    selection:
+        Image|endswith: '\rundll32.exe'
+    filter_empty:
+        CommandLine: null
+    filter:
+        - CommandLine|contains: '.dll'
+        - CommandLine: ''
+    condition: selection and not 1 of filter*
 fields:
     - Image
     - CommandLine

--- a/rules/windows/process_creation/win_run_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/win_run_executable_invalid_extension.yml
@@ -1,0 +1,30 @@
+title: Application Executed Non-Executable Extension
+id: c3a99af4-35a9-4668-879e-c09aeb4f2bdf
+status: experimental
+description: Detects execution of files using an invalid file extension
+author: Tim Shelton
+date: 2022/01/12
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection1:
+        Image|endswith:
+        - '.exe'
+        - '.ex_'
+        - '.com'
+        - '.cmd'
+        - '.bat'
+        - '.bin'
+        - '.pif'
+    selection2:
+        Image|endswith: 'rundll32.exe'
+    selection2b:
+        CommandLine|contains: ".dll"
+    condition: not selection1 or (selection2 and not selection2b)
+fields:
+    - Image
+    - CommandLine
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
If extension does not match known extensions for executables, can be used for av bypass. dumb trick but works against defender