### PR TITLE
Adjust case sensitivity of Provider_Name field

### DIFF
--- a/rules/windows/builtin/security/win_user_added_to_local_administrators.yml
+++ b/rules/windows/builtin/security/win_user_added_to_local_administrators.yml
@@ -16,7 +16,7 @@ logsource:
     service: security
 detection:
     selection:
-        provider_Name: Microsoft-Windows-Security-Auditing
+        Provider_Name: Microsoft-Windows-Security-Auditing
         EventID: 4732
     selection_group1:
         TargetUserName|startswith: 'Administr'

--- a/rules/windows/builtin/security/win_user_added_to_local_administrators.yml
+++ b/rules/windows/builtin/security/win_user_added_to_local_administrators.yml
@@ -5,7 +5,7 @@ description: This rule triggers on user accounts that are added to the local Adm
 status: stable
 author: Florian Roth
 date: 2017/03/14
-modified: 2021/11/30
+modified: 2021/01/17
 tags:
     - attack.privilege_escalation
     - attack.t1078

--- a/rules/windows/builtin/security/win_user_creation.yml
+++ b/rules/windows/builtin/security/win_user_creation.yml
@@ -6,7 +6,7 @@ author: Patrick Bareiss
 references:
   - https://patrick-bareiss.com/detecting-local-user-creation-in-ad-with-sigma/
 date: 2019/04/18
-modified: 2021/11/30
+modified: 2021/01/17
 logsource:
   product: windows
   service: security

--- a/rules/windows/builtin/security/win_user_creation.yml
+++ b/rules/windows/builtin/security/win_user_creation.yml
@@ -12,7 +12,7 @@ logsource:
   service: security
 detection:
   selection:
-    provider_Name: Microsoft-Windows-Security-Auditing
+    Provider_Name: Microsoft-Windows-Security-Auditing
     EventID: 4720
   condition: selection
 fields:


### PR DESCRIPTION
Just seems like a typo because all other found rules use `Provider_Name` instead of `provider_Name`.