### PR TITLE
Update sysmon_lsass_memdump.yml

### DIFF
--- a/rules/windows/process_access/sysmon_lsass_memdump.yml
+++ b/rules/windows/process_access/sysmon_lsass_memdump.yml
@@ -1,12 +1,15 @@
 title: LSASS Memory Dump
 id: 5ef9853e-4d0e-4a70-846f-a9ca37d876da
 status: experimental
-description: Detects process LSASS memory dump using procdump or taskmgr based on the CallTrace pointing to dbghelp.dll or dbgcore.dll for win10
-author: Samir Bousseaden
+description: Detects process LSASS memory dump using Mimikatz, NanoDump, Invoke-Mimikatz, Procdump or Taskmgr based on the CallTrace pointing to ntdll.dll, dbghelp.dll or dbgcore.dll for win10, server2016 and up.
+author: Samir Bousseaden, Michael Haag
 date: 2019/04/03
-modified: 2021/06/21
+modified: 2022/01/25
 references:
     - https://blog.menasec.net/2019/02/threat-hunting-21-procdump-or-taskmgr.html
+    - https://cyberwardog.blogspot.com/2017/03/chronicles-of-threat-hunter-hunting-for_22.html
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1003.001/T1003.001.md
+    - https://research.splunk.com/endpoint/windows_possible_credential_dumping/
 tags:
     - attack.credential_access
     - attack.t1003.001
@@ -17,11 +20,22 @@ logsource:
 detection:
     selection:
         TargetImage|endswith: '\lsass.exe'
-        GrantedAccess: '0x1fffff'
+        GrantedAccess|contains: 
+         - '0x1fffff'
+         - '0x01000'
+         - '0x1010'
+         - '0x1038'
+         - '0x40'
+         - '0x1400'
+         - '0x1410'
+         - '0x1438'
+         - '0x143a'
+         - '0x1000'
         CallTrace|contains:
          - 'dbghelp.dll'
          - 'dbgcore.dll'
+         - 'ntdll.dll'
     condition: selection
 falsepositives:
-    - unknown
+    - False positives are present when looking for 0x1410. Exclusions may be required.
 level: high


### PR DESCRIPTION
Updated Sysmon Lsass Memdump to detect memory dumping from mimikatz, nanodump, invoke-mimikatz, and so forth. This adds additional GrantedAccess permissions and adds ntdll.dll to CallTrace. Tested with Atomic Red Team T1003.001, MimiKatz, Invoke-Mimikatz and Cobalt Strike. 