### PR TITLE
adding filter for fp of iexplorer calling cpl

### DIFF
--- a/rules/windows/process_creation/win_run_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/win_run_executable_invalid_extension.yml
@@ -6,6 +6,7 @@ references:
     - https://twitter.com/mrd0x/status/1481630810495139841?s=12
 author: Tim Shelton, Florian Roth
 date: 2022/01/13
+modified: 2022/01/27
 logsource:
     category: process_creation
     product: windows
@@ -17,6 +18,9 @@ detection:
     filter:
         - CommandLine|contains: '.dll'
         - CommandLine: ''
+    filter_iexplorer:
+        ParentImage|endswith: ':\Program Files\Internet Explorer\iexplore.exe'
+        CommandLine|contains: '.cpl'
     condition: selection and not 1 of filter*
 fields:
     - Image


### PR DESCRIPTION
```
2022-01-27 14:00:27 hostname.example.com Sysmon: 1: Process Create | RuleName=technique_id=T1218.002,technique_name=rundll32.exe | UtcTime=2022-01-27 14:00:27.882 | ProcessGuid={2CB38191-A57B-61F2-0977-000000005700} | ProcessId=9136 | Image=C:\Windows\System32\rundll32.exe | FileVersion=10.0.14393.4169 (rs1_release.210107-1130) | Description=Windows host process (Rundll32) | Company=Microsoft Corporation | OriginalFileName=RUNDLL32.EXE | OriginalCommandLine=C:\Windows\system32\rundll32.exe C:\Windows\system32\inetcpl.cpl,ClearMyTracksByProcess Flags:276824072 WinX:0 WinY:0 IEFrame:0000000000000000 | CommandLine=C:\Windows\system32\rundll32.exe C:\Windows\system32\inetcpl.cpl,ClearMyTracksByProcess Flags:276824072 WinX:0 WinY:0 IEFrame:0000000000000000 | CurrentDirectory=C:\Windows\system32\ | User=NT AUTHORITY\SYSTEM | LogonGuid={2CB38191-4C8C-61ED-E703-000000000000} | LogonId=0x3e7 | TerminalSessionId=0 | IntegrityLevel=Medium | Hashes=SHA1=5ECBE863F4BE35DE1C3DEFF2C24045AA7769EBA7,MD5=23DB802097F7B7E520E40068A7E68B14,SHA256=28DE7D3E8BF4B19E44063A4BFC2E7C30AE488CD9A1F63320ED374E14AAECA667,IMPHASH=7D1CE1BAFE48B63D9D19E8E0E5DF3E6C | ParentProcessGuid={2CB38191-A562-61F2-0377-000000005700} | ParentProcessId=7852 | ParentImage=C:\Program Files\Internet Explorer\iexplore.exe | OriginalParentCommandLine="C:\Program Files\Internet Explorer\iexplore.exe" -Embedding | ParentCommandLine="C:\Program Files\Internet Explorer\iexplore.exe" -Embedding | pid=2168 | level=0 | sys_version=5 | category=Process Create (rule: ProcessCreate) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=25885097 | app="C:\Windows\sysmon64.exe" | tid=4104 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4)
```