### PR TITLE
Update nircmd rules

### DIFF
--- a/rules/windows/process_creation/process_creation_tool_nircmd.yml
+++ b/rules/windows/process_creation/process_creation_tool_nircmd.yml
@@ -2,11 +2,12 @@ title: NirCmd Tool Execution
 id: 4e2ed651-1906-4a59-a78a-18220fca1b22
 status: experimental
 description: Detects the use of NirCmd tool for command execution, which could be the result of legitimate administrative activity
-author: Florian Roth
+author: 'Florian Roth, Nasreddine Bencherchali @nas_bench'
 date: 2022/01/24
 references:
     - https://www.nirsoft.net/utils/nircmd.html
     - https://www.winhelponline.com/blog/run-program-as-system-localsystem-account-windows/
+    - https://www.nirsoft.net/utils/nircmd2.html#using
 tags:
     - attack.execution
     - attack.t1569.002
@@ -16,20 +17,16 @@ logsource:
     product: windows
 detection:
     selection:
-        Image|endswith: '\nircmd.exe'
-    selection_params1:
-        CommandLine|contains|all:
-            - ' execmd '
-            - ' attrib ' 
-    selection_params2:
-        CommandLine|contains|all:
-            - ' execmd '
-            - ' copy ' 
-    selection_params3:
-        CommandLine|contains|all:
-            - ' execmd '
-            - ' del '
-            - ' /Q '
+        Image|endswith:
+            - '\nircmd.exe'
+            - '\nircmdc.exe'
+    selection_params:
+        CommandLine|contains:
+            - 'execmd'
+            - 'exec'
+            - 'exec2'
+            - 'elevate'
+            - 'runinteractive'
     condition: 1 of selection*
 fields:
     - CommandLine

--- a/rules/windows/process_creation/process_creation_tool_nircmd.yml
+++ b/rules/windows/process_creation/process_creation_tool_nircmd.yml
@@ -22,12 +22,13 @@ detection:
             - '\nircmdc.exe'
     selection_params:
         CommandLine|contains:
-            - 'execmd'
-            - 'exec'
-            - 'exec2'
-            - 'elevate'
-            - 'runinteractive'
-    condition: 1 of selection*
+            - ' execmd '
+            - ' exec2 '
+    selection_commands:
+        CommandLine|contains:
+            - ' copy '
+            - ' del '
+    condition: selection or ( selection_params and selection_commands )
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/process_creation/process_creation_tool_nircmd_as_system.yml
+++ b/rules/windows/process_creation/process_creation_tool_nircmd_as_system.yml
@@ -2,11 +2,12 @@ title: NirCmd Tool Execution As LOCAL SYSTEM
 id: d9047477-0359-48c9-b8c7-792cedcdc9c4
 status: experimental
 description: Detects the use of NirCmd tool for command execution as SYSTEM user
-author: Florian Roth
+author: 'Florian Roth, Nasreddine Bencherchali @nas_bench'
 date: 2022/01/24
 references:
     - https://www.nirsoft.net/utils/nircmd.html
     - https://www.winhelponline.com/blog/run-program-as-system-localsystem-account-windows/
+    - https://www.nirsoft.net/utils/nircmd2.html#using
 tags:
     - attack.execution
     - attack.t1569.002

--- a/rules/windows/process_creation/process_creation_tool_nircmd_as_system.yml
+++ b/rules/windows/process_creation/process_creation_tool_nircmd_as_system.yml
@@ -17,8 +17,7 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains|all:
-            - 'runassystem'
+        CommandLine|contains: ' runassystem '
     condition: selection
 fields:
     - CommandLine

--- a/rules/windows/process_creation/process_creation_tool_nircmd_as_system.yml
+++ b/rules/windows/process_creation/process_creation_tool_nircmd_as_system.yml
@@ -17,7 +17,6 @@ logsource:
 detection:
     selection:
         CommandLine|contains|all:
-            - 'elevatecmd'
             - 'runassystem'
     condition: selection
 fields:


### PR DESCRIPTION
- I've modified the "process_creation_tool_nircmd_as_system.yml" rule and removed the "elevatecmd" as it's not really necessary. When the tool is run with the following commandline: "elevatecmd runassystem" it will actually spawn another "nircmd" process with just the "runassystem" commandline

- I've also modified the "process_creation_tool_nircmd.yml" and removed edge cases with a more generic form (that is maybe more prone to FP tbh). I've added other ways to execute commands from the docs.