### PR TITLE
Fix FP sysmon_wdigest_enable_uselogoncredential

### DIFF
--- a/rules/windows/registry_event/sysmon_wdigest_enable_uselogoncredential.yml
+++ b/rules/windows/registry_event/sysmon_wdigest_enable_uselogoncredential.yml
@@ -3,7 +3,7 @@ id: d6a9b252-c666-4de6-8806-5561bbbd3bdc
 description: Detects potential malicious modification of the property value of UseLogonCredential from HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\WDigest to enable clear-text credentials
 status: experimental
 date: 2019/09/12
-modified: 2021/05/27
+modified: 2022/02/01
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 tags:
     - attack.defense_evasion

--- a/rules/windows/registry_event/sysmon_wdigest_enable_uselogoncredential.yml
+++ b/rules/windows/registry_event/sysmon_wdigest_enable_uselogoncredential.yml
@@ -10,12 +10,15 @@ tags:
     - attack.t1112
 references:
     - https://threathunterplaybook.com/notebooks/windows/02_execution/WIN-190511223310.html
+    - https://support.microsoft.com/en-us/topic/microsoft-security-advisory-update-to-improve-credentials-protection-and-management-may-13-2014-93434251-04ac-b7f3-52aa-9f951c14b649
 logsource:
     category: registry_event
     product: windows
 detection:
     selection:
+        EventType: SetValue
         TargetObject|endswith: 'WDigest\UseLogonCredential'
+        Details: DWORD (0x00000001) 
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
Get mamy FP when a GPO is use to secure 😃 
The bad behavior is to set to `1` the key cf ref
