### PR TITLE
CobaltStrike typo

### DIFF
--- a/rules/application/antivirus/av_exploiting.yml
+++ b/rules/application/antivirus/av_exploiting.yml
@@ -17,7 +17,7 @@ detection:
       - 'Meterpreter'
       - 'Metasploit'
       - 'PowerSploit'
-      - 'CobaltSrike'
+      - 'CobaltStrike'
       - 'Swrort'
       - 'Rozena'
       - 'Backdoor.Cobalt'


### PR DESCRIPTION
This typo keeps sneaking back in - critical for detection. 
Spelling correct according to https://www.nextron-systems.com/wp-content/uploads/2018/09/Antivirus_Event_Analysis_CheatSheet_1.5-2.pdf

https://github.com/SigmaHQ/sigma/pull/1363