### PR TITLE
Rule to detect deceptive RTLO file extension social engineering

### DIFF
--- a/rules/windows/file_event/file_event_susp_rtlo.yml
+++ b/rules/windows/file_event/file_event_susp_rtlo.yml
@@ -14,9 +14,9 @@ logsource:
     category: file_event,process_creation
 detection:
     selection1:
-        TargetFilename|re: '.*‮[\w\d]{2,5}\.(exe|bat|js|vbs|hta)'
+        TargetFilename|re: '.*‮[\w\d]{2,5}\.(exe|bat|js|vbs|hta|vbe|jse|sct|wsf|xsl|cpl|xll)'
     selection2:
-        CommandLine|re: '.*‮[\w\d]{2,5}\.(exe|bat|js|vbs|hta)'
+        CommandLine|re: '.*‮[\w\d]{2,5}\.(exe|bat|js|vbs|hta|vbe|jse|sct|wsf|xsl|cpl|xll)'
     condition: selection1 or selection2
 falsepositives:
     - Unknown

--- a/rules/windows/file_event/file_event_susp_rtlo.yml
+++ b/rules/windows/file_event/file_event_susp_rtlo.yml
@@ -2,7 +2,7 @@ title: Suspicious RTLO executable
 id: FEEC2601-DE02-4E76-984A-EFF48A8A452F
 description: Detects an executable being written to disk or executed where a right-to-left-override character in the file name is written in a way that can mislead users to believe it has a different extension
 status: experimental
-author: @ag-michael
+author: ag-michael
 references:
     - https://attack.mitre.org/techniques/T1036/002/
 date: 2022/02/06

--- a/rules/windows/file_event/file_event_susp_rtlo.yml
+++ b/rules/windows/file_event/file_event_susp_rtlo.yml
@@ -1,0 +1,26 @@
+title: Suspicious RTLO executable
+id: FEEC2601-DE02-4E76-984A-EFF48A8A452F
+description: Detects an executable being written to disk or executed where a right-to-left-override character in the file name is written in a way that can mislead users to believe it has a different extension
+status: experimental
+author: @ag-michael
+references:
+    - https://attack.mitre.org/techniques/T1036/002/
+date: 2022/02/06
+tags:
+    - attack.defense_evasion
+    - attack.t1036.002
+logsource:
+    product: windows
+    category: file_event,process_creation
+detection:
+    selection1:
+        TargetFilename|re: '.*‮[\w\d]{2,5}\.(exe|bat|js|vbs|hta)'
+    selection2:
+        CommandLine|re: '.*‮[\w\d]{2,5}\.(exe|bat|js|vbs|hta)'
+    condition: selection1 or selection2
+falsepositives:
+    - Unknown
+level: low
+tags: 
+    - attack.t1036.002
+


### PR DESCRIPTION
Hi,

This rule detects when a file is written to disk or a commandline contains a right-to-left-override (U202E) character followed by an a string that would deceive users to believe the file has a different extension.  For example:  legitpic\u202Egpj.exe would appear in windows explorer as legitpicexe.jpg.  I have tested this scenario and validated the rule, but unfortunately I couldn't find a backend that supports regex and Sigma conversion to test the Sigma version of the rule.

P.S: Mind the "invisible" unicode character in the regex if you edit the rule.