### PR TITLE
FP from wbengine when writing a system filename 

### DIFF
--- a/rules/windows/file_event/sysmon_creation_system_file.yml
+++ b/rules/windows/file_event/sysmon_creation_system_file.yml
@@ -2,9 +2,9 @@ title: File Created with System Process Name
 id: d5866ddf-ce8f-4aea-b28e-d96485a20d3d
 status: test
 description: Detects the creation of an executable with a system process name in a suspicious folder
-author: Sander Wiebing
+author: Sander Wiebing, Tim Shelton
 date: 2020/05/26
-modified: 2021/10/28
+modified: 2022/02/07
 tags:
     - attack.defense_evasion
     - attack.t1036.005
@@ -51,7 +51,10 @@ detection:
     filter2:
         TargetFilename|startswith: 'C:\$WINDOWS.~BT\'
         Image: 'C:\$WINDOWS.~BT\Sources\SetupHost.exe'
-    condition: selection and not filter1 and not filter2
+    filter3:
+        TargetFilename|endswith: '\RuntimeBroker.exe'
+        Image: 'C:\Windows\system32\wbengine.exe'
+    condition: selection and not 1 of filter*
 fields:
     - Image
 falsepositives:


### PR DESCRIPTION
Example fp:

```
2022-02-06 06:23:37 internal.host.entry Sysmon: 11: File created | RuleName=- | UtcTime=2022-02-06 06:23:37.208 | ProcessGuid={852e9484-55d1-61ff-a723-000000003600} | ProcessId=8664 | Image=C:\Windows\system32\wbengine.exe | TargetFilename=\\?\Volume{2cf5436b-adba-4d10-adf5-9bd82a8e1468}\Windows\WinSxS\amd64_microsoft-windows-com-runtimebroker_31bf3856ad364e35_10.0.17763.1697_none_e3c85f9d79f5ccf7\RuntimeBroker.exe | CreationUtcTime=2022-02-06 06:23:37.208 | pid=3136 | level=0 | sys_version=2 | category=File created (rule: FileCreate) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=31885047 | app="C:\Windows\sysmon64.exe" | tid=4100 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) 
```