### PR TITLE
Update sysmon_raw_disk_access_using_illegitimate_tools.yml

### DIFF
--- a/rules/windows/raw_access_thread/sysmon_raw_disk_access_using_illegitimate_tools.yml
+++ b/rules/windows/raw_access_thread/sysmon_raw_disk_access_using_illegitimate_tools.yml
@@ -40,6 +40,7 @@ detection:
             - '\SearchApp.exe'
             - '\powershell.exe'
             - '\GamingServices.exe'
+            - '\SearchUI.exe'
     filter_3:
         ProcessId: 4
     filter_specific:


### PR DESCRIPTION
Add exclusion for the "SearchUI.exe" process (Related to Cortana). 
According to the tests I did, the event is generated when Cortana is enabled and you make a search using the search button.

```
CommandLine: "C:\Windows\SystemApps\Microsoft.Windows.Cortana_cw5n1h2txyewy\SearchUI.exe" -ServerName:CortanaUI.AppXa50dqqa5gqv4a428c9y1jjw7m3btvepj.mca 
Image: C:\Windows\SystemApps\Microsoft.Windows.Cortana_cw5n1h2txyewy\SearchUI.exe
ParentImage: C:\Windows\System32\svchost.exe
DeviceAccessed: \Device\HarddiskVolume1
```




