### PR TITLE
The LimaCharlie "exists" operator has no case param.

### DIFF
--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -516,7 +516,7 @@ class LimaCharlieBackend(BaseBackend):
                 newOp["re"] = newVal
             elif op == "exists":
                 # Exists has no value.
-                pass
+                newOp.pop( "case sensitive", None )
             else:
                 newOp["value"] = newVal
             if self._postOpMapper is not None:
@@ -537,7 +537,7 @@ class LimaCharlieBackend(BaseBackend):
                     newOp["re"] = newVal
                 elif op == "exists":
                     # Exists has no value.
-                    pass
+                    newOp.pop( "case sensitive", None )
                 else:
                     newOp["value"] = newVal
                 if self._postOpMapper is not None:


### PR DESCRIPTION
Fixing an issue where the `exists` operators in LimaCharlie D&R rules do not support the `case sensitive` parameter. This fixes the validation of those rules by removing the parameter in that specific case.