### PR TITLE
Update win_susp_proc_access_lsass.yml

### DIFF
--- a/rules/windows/process_access/win_susp_proc_access_lsass.yml
+++ b/rules/windows/process_access/win_susp_proc_access_lsass.yml
@@ -99,6 +99,9 @@ detection:
         GrantedAccess: 
             - '0x1410'
             - '0x410'
+    filter8:
+        SourceImage: 'C:\Windows\sysWOW64\wbem\wmiprvse.exe'
+        GrantedAccess: '0x1010'
     # Generic Filter for 0x1410 filter (caused by so many programs like DropBox updates etc.)
     filter_generic:
         SourceImage|startswith: 


### PR DESCRIPTION
Added a filter for when "C:\Windows\sysWOW64\wbem\wmiprvse.exe" the 32bit version request lsass access 0x1010

This event is being generated every 2 minutes as seen from my aurora instance. I don't know the source behind the access but I found the following KB from carbon black that describes similar behavior.

https://community.carbonblack.com/t5/Knowledge-Base/CB-Defense-WmiPrvSE-exe-blocked-terminated-for-potentially/ta-p/72235