### PR TITLE
Adds root folder monitoring for bash configs

### DIFF
--- a/rules/linux/auditd/lnx_auditd_alter_bash_profile.yml
+++ b/rules/linux/auditd/lnx_auditd_alter_bash_profile.yml
@@ -14,6 +14,9 @@ detection:
   selection:
     type: 'PATH'
     name:
+      - '/root/.bashrc'
+      - '/root/.bash_profile'
+      - '/root/.profile'
       - '/home/*/.bashrc'
       - '/home/*/.bash_profile'
       - '/home/*/.profile'

--- a/rules/linux/auditd/lnx_auditd_alter_bash_profile.yml
+++ b/rules/linux/auditd/lnx_auditd_alter_bash_profile.yml
@@ -6,7 +6,7 @@ author: Peter Matkovski
 references:
   - 'MITRE Attack technique T1156; .bash_profile and .bashrc. '
 date: 2019/05/12
-modified: 2021/11/27
+modified: 2022/02/22
 logsource:
   product: linux
   service: auditd


### PR DESCRIPTION
By default, root user folders reside on `/root` instead of `/home`. This adds monitoring for that too.