### PR TITLE
fix: FPs

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_accessing_win_api.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_accessing_win_api.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detecting use WinAPI Functions in PowerShell
 author: Nikita Nazarov, oscd.community
 date: 2020/10/06
-modified: 2022/02/11
+modified: 2022/02/23
 references:
     - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse
 tags:
@@ -63,7 +63,7 @@ detection:
             - 'Advapi32'
             - 'msvcrt'
             - 'ntdll'
-            - 'user32'
+            # - 'user32'  # FP with chocolatey
             - 'secur32'
     condition: selection
 falsepositives:

--- a/rules/windows/powershell/powershell_script/posh_ps_set_policies_to_unsecure_level.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_set_policies_to_unsecure_level.yml
@@ -1,4 +1,4 @@
-title: Change PowerShell Policies to a Unsecure Level
+title: Change PowerShell Policies to an Unsecure Level
 id: 61d0475c-173f-4844-86f7-f3eebae1c66b
 description: Detects use of Set-ExecutionPolicy to set a unsecure policies
 status: experimental
@@ -11,7 +11,7 @@ tags:
     - attack.t1059.001
 author: frack113
 date: 2021/10/20
-modified: 2022/02/11
+modified: 2022/02/23
 logsource:
     product: windows
     category: ps_script
@@ -26,8 +26,10 @@ detection:
     filter:
         - ParentImage:
             - 'C:\ProgramData\chocolatey\choco.exe'
-        - ScriptBlockText|contains: "(New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')"
+        - ScriptBlockText|contains:
+            - "(New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')"
+            - "(New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')"
     condition: cmdlet and option and not filter
 falsepositives:
     - Administrator script
-level: high
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_set_policies_to_unsecure_level.yml
+++ b/rules/windows/process_creation/proc_creation_win_set_policies_to_unsecure_level.yml
@@ -1,4 +1,4 @@
-title: Change PowerShell Policies to a Unsecure Level
+title: Change PowerShell Policies to an Unsecure Level
 id: 87e3c4e8-a6a8-4ad9-bb4f-46e7ff99a180
 description: Detects use of executionpolicy option to set a unsecure policies
 status: experimental
@@ -12,12 +12,16 @@ tags:
     - attack.t1059.001
 author: frack113
 date: 2021/11/01
+modified: 2022/02/23
 logsource:
     product: windows
     category: process_creation
 detection:
     option:
-        CommandLine|contains: '-executionpolicy '
+        CommandLine|contains:
+            - ' -executionpolicy '
+            - ' -ep '
+            - ' -exec '
     level:
         CommandLine|contains:
             - 'Unrestricted'
@@ -26,4 +30,4 @@ detection:
     condition: option and level
 falsepositives:
     - Administrator script
-level: high
+level: medium


### PR DESCRIPTION
reduce level of 2 rules and exclude user32 string because of legitimate usage example