### PR TITLE
fix: False Positives

### DIFF
--- a/rules/windows/process_access/sysmon_mimikatz_trough_winrm.yml
+++ b/rules/windows/process_access/sysmon_mimikatz_trough_winrm.yml
@@ -14,7 +14,9 @@ detection:
     selection:
         TargetImage|endswith: '\lsass.exe'
         SourceImage: 'C:\Windows\system32\wsmprovhost.exe'
-    condition: selection
+    filter:
+      - GrantedAccess: '0x80000000'
+    condition: selection and not 1 of filter
 tags:
     - attack.credential_access
     - attack.execution


### PR DESCRIPTION
Rule Matched this event on my Testsystem:
```
MESSAGE: Sigma match found
RULE_TITLE: Mimikatz through Windows Remote Management
RULE_AUTHOR: Patryk Prauze - ING Tech
RULE_DESCRIPTION: Detects usage of mimikatz through WinRM protocol by monitoring access to lsass process by wsmprovhost.exe.
RULE_FALSEPOSITIVES: low
RULE_ID: aa35a627-33fb-4d04-a165-d33b4afca3e8
RULE_LEVEL: high
RULE_LINK: https://github.com/SigmaHQ/sigma/blob/0.20-3022-gbebfe4bf/rules/windows/process_access/sysmon_mimikatz_trough_winrm.yml
RULE_MODIFIED: 2021/06/21
RULE_PATH: public\windows\process_access\sysmon_mimikatz_trough_winrm.yms
RULE_REFERENCES: https://pentestlab.blog/2018/05/15/lateral-movement-winrm/
RULE_SIGTYPE: public
COMPANYNAME:
COMPUTER: DESKTOP-F9B4H68
CORRELATION_ACTIVITYID: {00000000-0000-0000-0000-000000000000}
DESIREDACCESS: 2147483648
EVENTID: 5
EXECUTION_PROCESSID: 7340
EXECUTION_THREADID: 4548
FILEAGE: 1258d01h19m43s
FILECREATIONDATE: 2018-09-15T09:28:26
FILEDESCRIPTION:
FILEVERSION: 10.0.17763.1 (WinBuild.160101.0800)
GRANTEDACCESS: 0x80000000
HASHES: MD5=AB4AB98654635CABADB5F1A60BDA1C05,SHA1=147FCAC6D6C4E2C397BAC2F1173F0183E05F6636,SHA256=5FCCFF57D379CDC4CF6196FEF554CEF753B4C76DC315F371F90AEBF07B6A18C3,IMPHASH=07398D92FA392D4B7A06CC612E10EABE
KEYWORDS: 0x0
LEVEL: 4
MATCH_STRINGS: C:\Windows\System32\wsmprovhost.exe in SourceImage, \lsass.exe in TargetImage
OPCODE: 0
ORIGINALFILENAME:
PRODUCTNAME:
PROVIDER_GUID: {E02A841C-75A3-4FA7-AFC8-AE09CF9B7F23}
PROVIDER_NAME: Microsoft-Windows-Kernel-Audit-API-Calls
RETURNCODE: 0
SECURITY_USERID: S-1-5-21-1402956857-3965826527-2327998311-1001
SOURCECOMMANDLINE: C:\Windows\system32\wsmprovhost.exe -Embedding
SOURCEIMAGE: C:\Windows\System32\wsmprovhost.exe
SOURCEUSER: DESKTOP-F9B4H68\testuser
TARGETIMAGE: C:\Windows\System32\lsass.exe
TARGETPROCESSID: 688
TARGETUSER: NT AUTHORITY\SYSTEM
TASK: 0
TIMECREATED_SYSTEMTIME: 2022-02-24T09:52:10.0409093+01:00
TIMESTAMP: 2026-12-13T04:40:32
VERSION: 0
```