### PR TITLE
Fix detection criteria modifier to contains 'bckupkey'

### DIFF
--- a/rules/windows/builtin/security/win_dpapi_domain_backupkey_extraction.yml
+++ b/rules/windows/builtin/security/win_dpapi_domain_backupkey_extraction.yml
@@ -6,7 +6,7 @@ author: Roberto Rodriguez @Cyb3rWard0g
 references:
   - https://threathunterplaybook.com/notebooks/windows/06_credential_access/WIN-190620024610.html
 date: 2019/06/20
-modified: 2021/11/27
+modified: 2022/02/24
 logsource:
   product: windows
   service: security

--- a/rules/windows/builtin/security/win_dpapi_domain_backupkey_extraction.yml
+++ b/rules/windows/builtin/security/win_dpapi_domain_backupkey_extraction.yml
@@ -15,7 +15,7 @@ detection:
     EventID: 4662
     ObjectType: 'SecretObject'
     AccessMask: '0x2'
-    ObjectName: 'BCKUPKEY'
+    ObjectName|contains: 'BCKUPKEY'
   condition: selection
 falsepositives:
   - Unknown


### PR DESCRIPTION
For  4ac1f50b-3bd0-4968-902d-868b4647937e the resources denote that the objectName should be LIKE (contains) bckupkey
https://threathunterplaybook.com/notebooks/windows/06_credential_access/WIN-190620024610.html
`WHERE LOWER(Channel) = "security"
    AND o.EventID = 4662
    AND o.AccessMask = "0x2"
    AND lower(o.ObjectName) LIKE "%bckupkey%"`
    