### PR TITLE
Filters false positive from msiexec.exe

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
@@ -23,7 +23,7 @@ detection:
         CommandLine|contains: '.cpl'
     filter_msiexec:
         ParentImage|endswith: ':\Windows\SysWOW64\msiexec.exe'
-        CommandLine|beginswith: 'C:\Windows\syswow64\MsiExec.exe -Embedding'
+        CommandLine|beginwith: 'C:\Windows\syswow64\MsiExec.exe -Embedding'
     condition: selection and not 1 of filter*
 fields:
     - Image

--- a/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/mrd0x/status/1481630810495139841?s=12
 author: Tim Shelton, Florian Roth
 date: 2022/01/13
-modified: 2022/01/27
+modified: 2022/02/25
 logsource:
     category: process_creation
     product: windows
@@ -21,6 +21,9 @@ detection:
     filter_iexplorer:
         ParentImage|endswith: ':\Program Files\Internet Explorer\iexplore.exe'
         CommandLine|contains: '.cpl'
+    filter_msiexec:
+        ParentImage|endswith: ':\Windows\SysWOW64\msiexec.exe'
+        CommandLine|beginswith: 'C:\Windows\syswow64\MsiExec.exe -Embedding'
     condition: selection and not 1 of filter*
 fields:
     - Image

--- a/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
@@ -23,7 +23,7 @@ detection:
         CommandLine|contains: '.cpl'
     filter_msiexec:
         ParentImage|endswith: ':\Windows\SysWOW64\msiexec.exe'
-        CommandLine|beginwith: 'C:\Windows\syswow64\MsiExec.exe -Embedding'
+        CommandLine|startswith: 'C:\Windows\syswow64\MsiExec.exe -Embedding'
     condition: selection and not 1 of filter*
 fields:
     - Image


### PR DESCRIPTION


example fp:

```
2022-02-23 18:39:35 redacted.host.name Sysmon: 1: Process Create | RuleName=technique_id=T1218.002,technique_name=rundll32.exe | UtcTime=2022-02-23 18:39:35.534 | ProcessGuid={f4b6f253-7f67-6216-6b09-000000006e01} | ProcessId=8036 | Image=C:\Windows\SysWOW64\rundll32.exe | FileVersion=10.0.17763.1697 (WinBuild.160101.0800) | Description=Windows host process (Rundll32) | Company=Microsoft Corporation | OriginalFileName=RUNDLL32.EXE | OriginalCommandLine=rundll32.exe "C:\Windows\Installer\MSIEF64.tmp",zzzzInvokeManagedCustomActionOutOfProc SfxCA_89714750 3 CustomAction1!DeleteRegistry.CustomActions.RemoveEmptyRegistry | CommandLine=rundll32.exe C:\Windows\Installer\MSIEF64.tmp,zzzzInvokeManagedCustomActionOutOfProc SfxCA_89714750 3 CustomAction1!DeleteRegistry.CustomActions.RemoveEmptyRegistry | CurrentDirectory=C:\Windows\SysWOW64\ | User=NT AUTHORITY\SYSTEM | LogonGuid={f4b6f253-20f9-6215-e703-000000000000} | LogonId=0x3e7 | TerminalSessionId=0 | IntegrityLevel=System | Hashes=SHA1=55AC33D1EBFA28296C5128617D29CCBFED11157E,MD5=8459D693C951248A5E8E128F299E9618,SHA256=82611E60A2C5DE23A1B976BB3B9A32C4427CB60A002E4C27CADFA84031D87999,IMPHASH=BB17B2FBBFF4BBF5EBDCA7D0BB9E4A5B | ParentProcessGuid={f4b6f253-7f67-6216-6a09-000000006e01} | ParentProcessId=8804 | ParentImage=C:\Windows\SysWOW64\msiexec.exe | OriginalParentCommandLine=C:\Windows\syswow64\MsiExec.exe -Embedding B532973236866496313AB93205E0EF00 E Global\MSI0000 | ParentCommandLine=C:\Windows\syswow64\MsiExec.exe -Embedding B532973236866496313AB93205E0EF00 E Global\MSI0000 | ParentCommandLineObfuscated=false | pid=3148 | level=0 | sys_version=5 | category=Process Create (rule: ProcessCreate) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=2932235 | app="C:\Windows\sysmon64.exe" | tid=4800 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) 
```