### PR TITLE
Add proc_creation_win_fsutil_symlinkevaluation

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_fsutil_symlinkevaluation.yml
+++ b/rules/windows/process_creation/proc_creation_win_fsutil_symlinkevaluation.yml
@@ -15,7 +15,7 @@ logsource:
 detection:
     selection:
         Image|endswith: fsutil.exe
-        CommandLine|contains:
+        CommandLine|contains|all:
             - 'behavior '
             - 'set '
             - 'SymlinkEvaluation'

--- a/rules/windows/process_creation/proc_creation_win_fsutil_symlinkevaluation.yml
+++ b/rules/windows/process_creation/proc_creation_win_fsutil_symlinkevaluation.yml
@@ -1,0 +1,28 @@
+title: Fsutil Behavior Set SymlinkEvaluation
+id: c0b2768a-dd06-4671-8339-b16ca8d1f27f
+status: experimental
+description: |
+  A symbolic link is a type of file that contains a reference to another file.
+  This is probably done to make sure that the ransomware is able to follow shortcuts on the machine in order to find the original file to encrypt
+references:
+    - https://www.cybereason.com/blog/cybereason-vs.-blackcat-ransomware
+    - https://docs.microsoft.com/fr-fr/windows-server/administration/windows-commands/fsutil-behavior
+author: frack113
+date: 2022/03/02
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: fsutil.exe
+        CommandLine|contains:
+            - 'behavior '
+            - 'set '
+            - 'SymlinkEvaluation'
+    condition: selection
+falsepositives:
+    - legitimate use
+level: medium
+tags:
+    - attack.execution
+    - attack.t1059 


### PR DESCRIPTION
From https://www.cybereason.com/blog/cybereason-vs.-blackcat-ransomware

```
BlackCat enables local and remote [symbolic links](https://en.wikipedia.org/wiki/Symbolic_link) on the infected machine. A symbolic link is a type of file that contains a reference to another file. This is probably done to make sure that the ransomware is able to follow shortcuts on the machine in order to find the original file to encrypt:

    fsutil behavior set SymlinkEvaluation R2L:1

    fsutil behavior set SymlinkEvaluation R2R:1

```