### PR TITLE
Multiple adjustments in different rules

### DIFF
--- a/rules/windows/powershell/powershell_classic/posh_pc_delete_volume_shadow_copies.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_delete_volume_shadow_copies.yml
@@ -8,7 +8,7 @@ references:
 tags:
     - attack.impact
     - attack.t1490
-status: experimental
+status: stable
 author: frack113
 date: 2021/06/03
 modified: 2021/10/16

--- a/rules/windows/powershell/powershell_script/posh_ps_susp_win32_shadowcopy.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_susp_win32_shadowcopy.yml
@@ -1,6 +1,6 @@
 title: Delete Volume Shadow Copies via WMI with PowerShell
 id: e17121b4-ef2a-4418-8a59-12fb1631fa9e
-status: experimental
+status: test
 author: frack113
 date: 2021/12/26
 description: Deletes Windows Volume Shadow Copies with PowerShell code and Get-WMIObject. This technique is used by numerous ransomware families such as Sodinokibi/REvil

--- a/rules/windows/process_creation/proc_creation_win_bypass_squiblytwo.yml
+++ b/rules/windows/process_creation/proc_creation_win_bypass_squiblytwo.yml
@@ -7,27 +7,32 @@ references:
   - https://subt0x11.blogspot.ch/2018/04/wmicexe-whitelisting-bypass-hacking.html
   - https://twitter.com/mattifestation/status/986280382042595328
 date: 2019/01/16
-modified: 2021/11/27
+modified: 2022/03/04
 logsource:
   category: process_creation
   product: windows
 detection:
-  selection1:
+  selection_one:
     Image|endswith:
       - '\wmic.exe'
     CommandLine|contains|all:
       - wmic
       - format
       - http
-  selection2:
-    Imphash:
+  selection_wmic_imphash:
+    - Imphash:
       - 1B1A3F43BF37B5BFE60751F2EE2F326E
       - 37777A96245A3C74EB217308F3546F4C
       - 9D87C9D67CE724033C0B40CC4CA1B206
+    - Hashes|contains:  # Sysmon field hashes contains all types
+      - 1B1A3F43BF37B5BFE60751F2EE2F326E
+      - 37777A96245A3C74EB217308F3546F4C
+      - 9D87C9D67CE724033C0B40CC4CA1B206
+  selection_flags:
     CommandLine|contains|all:
       - 'format:'
       - 'http'
-  condition: 1 of selection*
+  condition: selection_one or (selection_wmic_imphash and selection_flags)
 falsepositives:
   - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_cobaltstrike_load_by_rundll32.yml
+++ b/rules/windows/process_creation/proc_creation_win_cobaltstrike_load_by_rundll32.yml
@@ -3,6 +3,7 @@ status: experimental
 id: ae9c6a7c-9521-42a6-915e-5aaa8689d529
 author: Wojciech Lesicki
 date: 2021/06/01
+modified: 2022/03/04
 description: Rundll32 can be use by Cobalt Strike with StartW function to load DLLs from the command line.
 references:
     - https://www.cobaltstrike.com/help-windows-executable
@@ -19,7 +20,9 @@ detection:
         CommandLine|contains|all:
             - 'rundll32.exe'
             - '.dll'
-            - 'StartW'
+        CommandLine|endswith: 
+            - ' StartW'
+            - ',StartW'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_hack_wce.yml
+++ b/rules/windows/process_creation/proc_creation_win_hack_wce.yml
@@ -6,7 +6,7 @@ author: Florian Roth
 references:
     - https://www.ampliasecurity.com/research/windows-credentials-editor/
 date: 2019/12/31
-modified: 2021/07/15
+modified: 2022/03/04
 tags:
     - attack.credential_access
     - attack.t1003.001
@@ -16,9 +16,12 @@ logsource:
     product: windows
 detection:
     selection1:
-        Imphash: 
-          - a53a02b997935fd8eedcb5f7abab9b9f
-          - e96a73c7bf33a464c510ede582318bf2
+        - Imphash: 
+            - a53a02b997935fd8eedcb5f7abab9b9f
+            - e96a73c7bf33a464c510ede582318bf2
+        - Hashes|contains:  # Sysmon field hashes contains all types
+            - a53a02b997935fd8eedcb5f7abab9b9f
+            - e96a73c7bf33a464c510ede582318bf2
     selection2:
         CommandLine|endswith: '.exe -S'
         ParentImage|endswith: '\services.exe'

--- a/rules/windows/process_creation/proc_creation_win_hacktool_imphashes.yml
+++ b/rules/windows/process_creation/proc_creation_win_hacktool_imphashes.yml
@@ -1,0 +1,61 @@
+title: Windows Hacktool Imphash
+id: 24e3e58a-646b-4b50-adef-02ef935b9fc8
+description: Detects the use of Windows hacktools based on their import hash (imphash) even if the files have been renamed
+status: experimental
+author: Florian Roth
+references:
+    - Internal Research
+date: 2022/03/04
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        - Imphash: 
+            - bcca3c247b619dcd13c8cdff5f123932 # PetitPotam
+            - 3a19059bd7688cb88e70005f18efc439 # PetitPotam
+            - 9da6d5d77be11712527dcab86df449a3 # Mimikatz
+            - a6e01bc1ab89f8d91d9eab72032aae88 # Mimikatz
+            - d21bbc50dcc169d7b4d0f01962793154 # Mimikatz
+            - 9528a0e91e28fbb88ad433feabca2456 # Mimikatz
+            - 4c1b52a19748428e51b14c278d0f58e3 # Mimikatz
+            - 725bb81dc24214f6ecacc0cfb36ad30d # Mimikatz
+            - 672b13f4a0b6f27d29065123fe882dfc # Mimikatz
+            - 0c106686a31bfe2ba931ae1cf6e9dbc6 # Mimikatz
+            - 23867a89c2b8fc733be6cf5ef902f2d1 # JuicyPotato 
+            - 9fb060c2977a9d9b782440b98d410c3e # RoguePotato
+            - b18a1401ff8f444056d29450fbc0a6ce # Pwdump
+            - 13f08707f759af6003837a150a371ba1 # Pwdump
+            - 749a7bb1f0b4c4455949c0b2bf7f9e9f # Pwdump
+            - 94cb940a1a6b65bed4d5a8f849ce9793 # PwDumpX
+            - 1781f06048a7e58b323f0b9259be798b # Pwdump
+            - cb567f9498452721d77a451374955f5f # Pwdump
+            - 730073214094cd328547bf1f72289752 # Htran
+            - 6eefd92bffbfb27f378b81c09ca96786 # Ncat
+            - ac615fb1d93576fa3c26077a619c9144 # Ncat
+        - Hashes|contains:  # Sysmon field hashes contains all types
+            - bcca3c247b619dcd13c8cdff5f123932 # PetitPotam
+            - 3a19059bd7688cb88e70005f18efc439 # PetitPotam
+            - 9da6d5d77be11712527dcab86df449a3 # Mimikatz
+            - a6e01bc1ab89f8d91d9eab72032aae88 # Mimikatz
+            - d21bbc50dcc169d7b4d0f01962793154 # Mimikatz
+            - 9528a0e91e28fbb88ad433feabca2456 # Mimikatz
+            - 4c1b52a19748428e51b14c278d0f58e3 # Mimikatz
+            - 725bb81dc24214f6ecacc0cfb36ad30d # Mimikatz
+            - 672b13f4a0b6f27d29065123fe882dfc # Mimikatz
+            - 0c106686a31bfe2ba931ae1cf6e9dbc6 # Mimikatz
+            - 23867a89c2b8fc733be6cf5ef902f2d1 # JuicyPotato 
+            - 9fb060c2977a9d9b782440b98d410c3e # RoguePotato
+            - b18a1401ff8f444056d29450fbc0a6ce # Pwdump
+            - 13f08707f759af6003837a150a371ba1 # Pwdump
+            - 749a7bb1f0b4c4455949c0b2bf7f9e9f # Pwdump
+            - 94cb940a1a6b65bed4d5a8f849ce9793 # PwDumpX
+            - 1781f06048a7e58b323f0b9259be798b # Pwdump
+            - cb567f9498452721d77a451374955f5f # Pwdump
+            - 730073214094cd328547bf1f72289752 # Htran
+            - 6eefd92bffbfb27f378b81c09ca96786 # Ncat
+            - ac615fb1d93576fa3c26077a619c9144 # Ncat
+    condition: selection
+falsepositives:
+    - Legitimate use of one of these tools
+level: high

--- a/rules/windows/process_creation/proc_creation_win_hktl_createminidump.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_createminidump.yml
@@ -6,7 +6,7 @@ author: Florian Roth
 references:
     - https://ired.team/offensive-security/credential-access-and-credential-dumping/dumping-lsass-passwords-without-mimikatz-minidumpwritedump-av-signature-bypass
 date: 2019/12/22
-modified: 2021/09/19
+modified: 2022/03/04
 tags:
     - attack.credential_access
     - attack.t1003.001
@@ -17,7 +17,8 @@ detection:
     selection1:
         Image|contains: '\CreateMiniDump.exe'
     selection2:
-        Imphash: '4a07f944a83e8a7c2525efa35dd30e2f'
+        - Imphash: '4a07f944a83e8a7c2525efa35dd30e2f'
+        - Hashes|contains: '4a07f944a83e8a7c2525efa35dd30e2f'
     condition: 1 of selection*
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_powershell_defender_base64.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_defender_base64.yml
@@ -1,0 +1,33 @@
+title: Powershell Defender Base64 MpPreference
+id: 17769c90-230e-488b-a463-e05c08e9d48f
+status: experimental
+description: Detects base64 encoded PowerShell code that modifies Windows Defender
+references:
+    - https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/configure-process-opened-file-exclusions-microsoft-defender-antivirus
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1562.001/T1562.001.md
+    - https://twitter.com/AdamTheAnalyst/status/1483497517119590403
+tags:
+    - attack.defense_evasion
+    - attack.t1562.001
+author: Florian Roth
+date: 2022/03/04
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_encoded:
+        CommandLine|base64offset|contains:
+            - 'Add-MpPreference '
+            - 'Set-MpPreference '
+            - 'add-mppreference '
+            - 'set-mppreference '
+        #CommandLine|utf16le|base64offset|contains:
+        #    - 'Add-MpPreference '
+        #    - 'Set-MpPreference '
+        #    - 'add-mppreference '
+        #    - 'set-mppreference '
+    condition: selection_encoded
+falsepositives:
+    - Possible Admin Activity
+    - Other Cmdlets that may use the same parameters
+level: high

--- a/rules/windows/process_creation/proc_creation_win_powershell_defender_base64.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_defender_base64.yml
@@ -1,5 +1,5 @@
 title: Powershell Defender Base64 MpPreference
-id: 17769c90-230e-488b-a463-e05c08e9d48f
+id: c6fb44c6-71f5-49e6-9462-1425d328aee3
 status: experimental
 description: Detects base64 encoded PowerShell code that modifies Windows Defender
 references:

--- a/rules/windows/process_creation/proc_creation_win_powershell_defender_disable_feature.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_defender_disable_feature.yml
@@ -11,6 +11,7 @@ tags:
     - attack.t1562.001
 author: Florian Roth
 date: 2022/03/03
+modified: 2022/03/04
 logsource:
     category: process_creation
     product: windows
@@ -39,6 +40,15 @@ detection:
             - 'disableioavprotection '
             - 'disablebehaviormonitoring '
             - 'disableblockatfirstseen '
+        #CommandLine|utf16le|base64offset|contains:
+        #    - 'DisableRealtimeMonitoring '
+        #    - 'DisableIOAVProtection '
+        #    - 'DisableBehaviorMonitoring '
+        #    - 'DisableBlockAtFirstSeen '
+        #    - 'disablerealtimemonitoring '
+        #    - 'disableioavprotection '
+        #    - 'disablebehaviormonitoring '
+        #    - 'disableblockatfirstseen '
     condition: all of selection* or encoded_command
 falsepositives:
     - Possible Admin Activity

--- a/rules/windows/process_creation/proc_creation_win_powershell_defender_exclusion.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_defender_exclusion.yml
@@ -11,7 +11,7 @@ tags:
     - attack.t1562.001
 author: Florian Roth
 date: 2021/04/29
-modified: 2022/03/03
+modified: 2022/03/04
 logsource:
     category: process_creation
     product: windows
@@ -25,14 +25,8 @@ detection:
             - ' -ExclusionPath '
             - ' -ExclusionExtension '
             - ' -ExclusionProcess '
-    selection_encoded:
-        CommandLine|base64offset|contains:
-            - 'Add-MpPreference '
-            - 'Set-MpPreference '
-            - 'add-mppreference '
-            - 'set-mppreference '
-    condition: ( selection1 and selection2 ) or selection_encoded
+    condition: all of selection*
 falsepositives:
     - Possible Admin Activity
     - Other Cmdlets that may use the same parameters
-level: high
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_renamed_paexec.yml
+++ b/rules/windows/process_creation/proc_creation_win_renamed_paexec.yml
@@ -7,7 +7,7 @@ references:
   - sha256=01a461ad68d11b5b5096f45eb54df9ba62c5af413fa9eb544eacb598373a26bc
   - https://summit.fireeye.com/content/dam/fireeye-www/summit/cds-2018/presentations/cds18-technical-s05-att&cking-fin7.pdf
 date: 2019/04/17
-modified: 2021/11/27
+modified: 2022/03/04
 logsource:
   category: process_creation
   product: windows
@@ -16,7 +16,12 @@ detection:
     Product|contains:
       - 'PAExec'
   selection2:
-    Imphash:
+    - Imphash:
+      - 11D40A7B7876288F919AB819CC2D9802
+      - 6444f8a34e99b8f7d9647de66aabe516
+      - dfd6aa3f7b2b1035b76b718f1ddc689f
+      - 1a6cca4d5460b1710a12dea39e4a592c
+    - Hashes|contains:
       - 11D40A7B7876288F919AB819CC2D9802
       - 6444f8a34e99b8f7d9647de66aabe516
       - dfd6aa3f7b2b1035b76b718f1ddc689f

--- a/rules/windows/process_creation/proc_creation_win_susp_mpiexec_lolbin.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_mpiexec_lolbin.yml
@@ -11,6 +11,7 @@ tags:
     - attack.t1218
 author: Florian Roth
 date: 2022/01/11
+modified: 2022/03/04
 logsource:
     category: process_creation
     product: windows
@@ -18,6 +19,7 @@ detection:
     selection_binary:
         - Image|endswith: '\mpiexec.exe'
         - Imphash: 'd8b52ef6aaa3a81501bdfff9dbb96217'
+        - Hashes|contains: 'd8b52ef6aaa3a81501bdfff9dbb96217'
     selection_flags:
         CommandLine|contains: 
             - ' /n 1 '


### PR DESCRIPTION
- Imphash fields adjusted to support fields that contain all hashes in a single value (like used in Sysmon events)
- disabled some strings that use "utf16le", which isn't supported by all backends yet
- tightened up CobaltStrike DLL loader rule
- some "status" values changed to reflect the level of stability of certain rules