### PR TITLE
Added rule for shellcode injection by Metasploit and Empire

### DIFF
--- a/rules/windows/process_access/process_access_win_shellcode_inject_msf_empire.yml
+++ b/rules/windows/process_access/process_access_win_shellcode_inject_msf_empire.yml
@@ -1,0 +1,23 @@
+title: Shellcode Injection
+id: 250ae82f-736e-4844-a68b-0b5e8cc887da
+status: experimental
+description: Detects shellcode injection by Metasploit's migrate and Empire's psinject
+author: Bhabesh Raj
+date: 2022/03/11
+tags:
+    - attack.defense_evasion
+    - attack.privilege_escalation
+    - attack.t1055
+logsource:
+    category: process_access
+    product: windows
+detection:
+    selection:
+        GrantedAccess: 
+            - '0x147a'
+            - '0x1f3fff'
+        CallTrace|contains: 'UNKNOWN'
+    condition: selection
+falsepositives:
+    - Empire's csharp_exe payload uses 0x1f3fff for process enumeration as well
+level: high


### PR DESCRIPTION
@Neo23x0, I am not seeing any FPs from my side so far when using this sysmon & sigma rule combination. If you see some, let me know.

```xml
<ProcessAccess onmatch="include">
    <!-- Process access pattern of Metasploit's migrate (0x147a) and Empire's psinject (0x1f3fff) -->
    <Rule groupRelation="and">
        <CallTrace condition="contains">UNKNOWN</CallTrace>
        <GrantedAccess name="T1055" condition="contains any">0x147a;0x1f3fff</GrantedAccess>
    </Rule>
</ProcessAccess>
```