### PR TITLE
FP on valid remote call of Powershell Archive.psm1, maybe beneficial …

### DIFF
--- a/rules/windows/powershell/powershell_module/posh_pm_remote_powershell_session.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_remote_powershell_session.yml
@@ -3,8 +3,8 @@ id: 96b9f619-aa91-478f-bacb-c3e50f8df575
 description: Detects remote PowerShell sessions
 status: test
 date: 2019/08/10
-modified: 2021/10/16
-author: Roberto Rodriguez @Cyb3rWard0g
+modified: 2022/03/14
+author: Roberto Rodriguez @Cyb3rWard0g, Tim Shelton
 references:
     - https://threathunterplaybook.com/notebooks/windows/02_execution/WIN-190511223310.html
 tags:
@@ -21,7 +21,11 @@ detection:
         ContextInfo|contains|all:
             - ' = ServerRemoteHost ' #  HostName: 'ServerRemoteHost'  french : Nom d’hôte = 
             - 'wsmprovhost.exe'      #  HostApplication|contains: 'wsmprovhost.exe' french  Application hôte = 
-    condition: selection
+    false_positive_1:
+        ContextInfo|contains:
+            - '\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Archive\Microsoft.PowerShell.Archive.psm1'
+    condition: selection and not 1 of false_positive*
+
 falsepositives:
     - Legitimate use remote PowerShell sessions
 level: high


### PR DESCRIPTION
…to filter all powershell modules in future


FP Example:
```
022-02-17 22:38:08 redacted.host.name PowerShell: 4103: CommandInvocation(Add-Type): "Add-Type" | ContextInfo= Severity = Informational Host Name = ServerRemoteHost Host Version = 1.0.0.0 Host ID = 82d3b15f-4d72-493a-a6ad-2b83d1bfc6c9 Host Application = C:\Windows\system32\wsmprovhost.exe -Embedding Engine Version = 5.1.14393.4583 Runspace ID = d70e7598-5018-4460-af82-fcf2963d741f Pipeline ID = 25 Command Name = Add-Type Command Type = Cmdlet Script Name = C:\Windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Archive\Microsoft.PowerShell.Archive.psm1 Command Path = Sequence Number = 18 User = REDACTED\Username Connected User = REDACTED\Username  Shell ID = Microsoft.PowerShell | UserData= | Payload=CommandInvocation(Add-Type): "Add-Type" ParameterBinding(Add-Type): name="AssemblyName"; value="System.IO.Compression.FileSystem" | pid=10316 | level=0 | sys_version=1 | category=Executing Pipeline | op=To be used when operation is just executing a method | key=0x0 | id=113571 | app="C:\Windows\System32\wsmprovhost.exe" | tid=9316 | channel="Microsoft-Windows-PowerShell/Operational" | pid_user="REDACTED\Username " | sid=S-1-5-21-2133283647-2127258011-326569147-65789 | account type=User | type=notice(4)
```