### PR TITLE
feat: Add log sources for process listing within THOR

### DIFF
--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -370,3 +370,18 @@ logsources:
     category: logfile
     sources:
       - "File:*.log"
+  process-listing-windows:
+    category: process_creation
+    product: windows
+    sources:
+      - 'THOR:process-listing-windows'
+  process-listing-linux:
+    category: process_creation
+    product: linux
+    sources:
+      - 'THOR:process-listing-linux'
+  process-listing-macos:
+    category: process_creation
+    product: macos
+    sources:
+      - 'THOR:process-listing-darwin'


### PR DESCRIPTION
Add some log sources for events emitted by THOR itself. These events are used to check existing processes against sigma rules.