### PR TITLE
Update win_dcsync.yml

### DIFF
--- a/rules/windows/builtin/security/win_dcsync.yml
+++ b/rules/windows/builtin/security/win_dcsync.yml
@@ -3,11 +3,13 @@ id: 611eab06-a145-4dfa-a295-3ccc5c20f59a
 description: Detects Mimikatz DC sync security events
 status: experimental
 date: 2018/06/03
-modified: 2021/08/09
-author: Benjamin Delpy, Florian Roth, Scott Dermott
+modified: 2022/03/15
+author: Benjamin Delpy, Florian Roth, Scott Dermott, Sorina Ionescu
 references:
     - https://twitter.com/gentilkiwi/status/1003236624925413376
     - https://gist.github.com/gentilkiwi/dcc132457408cf11ad2061340dcb53c2
+    - https://blog.blacklanternsecurity.com/p/detecting-dcsync?s=r
+    - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4662
 tags:
     - attack.credential_access
     - attack.s0002
@@ -21,6 +23,10 @@ detection:
         Properties|contains:
             - 'Replicating Directory Changes All'
             - '1131f6ad-9c07-11d1-f79f-00c04fc2dcd2'
+            - '1131f6aa-9c07-11d1-f79f-00c04fc2dcd2'
+            - '9923a32a-3607-11d2-b9be-0000f87a36b2'
+            - '89e95b76-444d-4c62-991a-0facbeda640c'
+        AccessMask: '0x100'
     filter1:
         SubjectDomainName: 'Window Manager'
     filter2:


### PR DESCRIPTION
Added a more detailed source on this detection.
Also included the AccessMask corresponding to “control access” that is specifically registered when access is allowed following extended rights verification (typically associated with the use of high level and explicit permissions that are required to initiate the DCSync attack) as is described in the Black Landern Security blog post.
Added 3 other GUIDs that corresponds to:
1131f6aa-9c07-11d1-f79f-00c04fc2dcd2 - DS-Replication-Get-Changes
9923a32a-3607-11d2-b9be-0000f87a36b2 - DS-Install-Replica
89e95b76-444d-4c62-991a-0facbeda640c - DS-Replication-Get-Changes-In-Filtered-Set