### PR TITLE
Update MITRE ATT&CK tools to v10.1 with Groups and Software

### DIFF
--- a/tools/config/mitre/groups.json
+++ b/tools/config/mitre/groups.json
@@ -1,0 +1,1061 @@
+[
+  {
+    "group_id": "G0001",
+    "group": "Axiom",
+    "url": "https://attack.mitre.org/groups/G0001",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0002",
+    "group": "Moafee",
+    "url": "https://attack.mitre.org/groups/G0002",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0003",
+    "group": "Cleaver",
+    "url": "https://attack.mitre.org/groups/G0003",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0004",
+    "group": "Ke3chang",
+    "url": "https://attack.mitre.org/groups/G0004",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0005",
+    "group": "APT12",
+    "url": "https://attack.mitre.org/groups/G0005",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0006",
+    "group": "APT1",
+    "url": "https://attack.mitre.org/groups/G0006",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0007",
+    "group": "APT28",
+    "url": "https://attack.mitre.org/groups/G0007",
+    "domain": [
+      "Enterprise",
+      "Mobile"
+    ]
+  },
+  {
+    "group_id": "G0008",
+    "group": "Carbanak",
+    "url": "https://attack.mitre.org/groups/G0008",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0009",
+    "group": "Deep Panda",
+    "url": "https://attack.mitre.org/groups/G0009",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0010",
+    "group": "Turla",
+    "url": "https://attack.mitre.org/groups/G0010",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0011",
+    "group": "PittyTiger",
+    "url": "https://attack.mitre.org/groups/G0011",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0012",
+    "group": "Darkhotel",
+    "url": "https://attack.mitre.org/groups/G0012",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0013",
+    "group": "APT30",
+    "url": "https://attack.mitre.org/groups/G0013",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0014",
+    "group": "Night Dragon",
+    "url": "https://attack.mitre.org/groups/G0014",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0016",
+    "group": "APT29",
+    "url": "https://attack.mitre.org/groups/G0016",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0017",
+    "group": "DragonOK",
+    "url": "https://attack.mitre.org/groups/G0017",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0018",
+    "group": "admin@338",
+    "url": "https://attack.mitre.org/groups/G0018",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0019",
+    "group": "Naikon",
+    "url": "https://attack.mitre.org/groups/G0019",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0020",
+    "group": "Equation",
+    "url": "https://attack.mitre.org/groups/G0020",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0021",
+    "group": "Molerats",
+    "url": "https://attack.mitre.org/groups/G0021",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0022",
+    "group": "APT3",
+    "url": "https://attack.mitre.org/groups/G0022",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0023",
+    "group": "APT16",
+    "url": "https://attack.mitre.org/groups/G0023",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0024",
+    "group": "Putter Panda",
+    "url": "https://attack.mitre.org/groups/G0024",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0025",
+    "group": "APT17",
+    "url": "https://attack.mitre.org/groups/G0025",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0026",
+    "group": "APT18",
+    "url": "https://attack.mitre.org/groups/G0026",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0027",
+    "group": "Threat Group-3390",
+    "url": "https://attack.mitre.org/groups/G0027",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0028",
+    "group": "Threat Group-1314",
+    "url": "https://attack.mitre.org/groups/G0028",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0029",
+    "group": "Scarlet Mimic",
+    "url": "https://attack.mitre.org/groups/G0029",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0030",
+    "group": "Lotus Blossom",
+    "url": "https://attack.mitre.org/groups/G0030",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0031",
+    "group": "Dust Storm",
+    "url": "https://attack.mitre.org/groups/G0031",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0032",
+    "group": "Lazarus Group",
+    "url": "https://attack.mitre.org/groups/G0032",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ]
+  },
+  {
+    "group_id": "G0033",
+    "group": "Poseidon Group",
+    "url": "https://attack.mitre.org/groups/G0033",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0034",
+    "group": "Sandworm Team",
+    "url": "https://attack.mitre.org/groups/G0034",
+    "domain": [
+      "Enterprise",
+      "ICS",
+      "Mobile"
+    ]
+  },
+  {
+    "group_id": "G0035",
+    "group": "Dragonfly",
+    "url": "https://attack.mitre.org/groups/G0035",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ]
+  },
+  {
+    "group_id": "G0036",
+    "group": "GCMAN",
+    "url": "https://attack.mitre.org/groups/G0036",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0037",
+    "group": "FIN6",
+    "url": "https://attack.mitre.org/groups/G0037",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0038",
+    "group": "Stealth Falcon",
+    "url": "https://attack.mitre.org/groups/G0038",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0039",
+    "group": "Suckfly",
+    "url": "https://attack.mitre.org/groups/G0039",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0040",
+    "group": "Patchwork",
+    "url": "https://attack.mitre.org/groups/G0040",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0041",
+    "group": "Strider",
+    "url": "https://attack.mitre.org/groups/G0041",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0043",
+    "group": "Group5",
+    "url": "https://attack.mitre.org/groups/G0043",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0044",
+    "group": "Winnti Group",
+    "url": "https://attack.mitre.org/groups/G0044",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0045",
+    "group": "menuPass",
+    "url": "https://attack.mitre.org/groups/G0045",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0046",
+    "group": "FIN7",
+    "url": "https://attack.mitre.org/groups/G0046",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0047",
+    "group": "Gamaredon Group",
+    "url": "https://attack.mitre.org/groups/G0047",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0048",
+    "group": "RTM",
+    "url": "https://attack.mitre.org/groups/G0048",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0049",
+    "group": "OilRig",
+    "url": "https://attack.mitre.org/groups/G0049",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ]
+  },
+  {
+    "group_id": "G0050",
+    "group": "APT32",
+    "url": "https://attack.mitre.org/groups/G0050",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0051",
+    "group": "FIN10",
+    "url": "https://attack.mitre.org/groups/G0051",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0052",
+    "group": "CopyKittens",
+    "url": "https://attack.mitre.org/groups/G0052",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0053",
+    "group": "FIN5",
+    "url": "https://attack.mitre.org/groups/G0053",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0054",
+    "group": "Sowbug",
+    "url": "https://attack.mitre.org/groups/G0054",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0055",
+    "group": "NEODYMIUM",
+    "url": "https://attack.mitre.org/groups/G0055",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0056",
+    "group": "PROMETHIUM",
+    "url": "https://attack.mitre.org/groups/G0056",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0059",
+    "group": "Magic Hound",
+    "url": "https://attack.mitre.org/groups/G0059",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0060",
+    "group": "BRONZE BUTLER",
+    "url": "https://attack.mitre.org/groups/G0060",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0061",
+    "group": "FIN8",
+    "url": "https://attack.mitre.org/groups/G0061",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0062",
+    "group": "TA459",
+    "url": "https://attack.mitre.org/groups/G0062",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0063",
+    "group": "BlackOasis",
+    "url": "https://attack.mitre.org/groups/G0063",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0064",
+    "group": "APT33",
+    "url": "https://attack.mitre.org/groups/G0064",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ]
+  },
+  {
+    "group_id": "G0065",
+    "group": "Leviathan",
+    "url": "https://attack.mitre.org/groups/G0065",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0066",
+    "group": "Elderwood",
+    "url": "https://attack.mitre.org/groups/G0066",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0067",
+    "group": "APT37",
+    "url": "https://attack.mitre.org/groups/G0067",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0068",
+    "group": "PLATINUM",
+    "url": "https://attack.mitre.org/groups/G0068",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0069",
+    "group": "MuddyWater",
+    "url": "https://attack.mitre.org/groups/G0069",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0070",
+    "group": "Dark Caracal",
+    "url": "https://attack.mitre.org/groups/G0070",
+    "domain": [
+      "Enterprise",
+      "Mobile"
+    ]
+  },
+  {
+    "group_id": "G0071",
+    "group": "Orangeworm",
+    "url": "https://attack.mitre.org/groups/G0071",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0072",
+    "group": "Honeybee",
+    "url": "https://attack.mitre.org/groups/G0072",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0073",
+    "group": "APT19",
+    "url": "https://attack.mitre.org/groups/G0073",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0074",
+    "group": "Dragonfly 2.0",
+    "url": "https://attack.mitre.org/groups/G0074",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ]
+  },
+  {
+    "group_id": "G0075",
+    "group": "Rancor",
+    "url": "https://attack.mitre.org/groups/G0075",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0076",
+    "group": "Thrip",
+    "url": "https://attack.mitre.org/groups/G0076",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0077",
+    "group": "Leafminer",
+    "url": "https://attack.mitre.org/groups/G0077",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0078",
+    "group": "Gorgon Group",
+    "url": "https://attack.mitre.org/groups/G0078",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0079",
+    "group": "DarkHydrus",
+    "url": "https://attack.mitre.org/groups/G0079",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0080",
+    "group": "Cobalt Group",
+    "url": "https://attack.mitre.org/groups/G0080",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0081",
+    "group": "Tropic Trooper",
+    "url": "https://attack.mitre.org/groups/G0081",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0082",
+    "group": "APT38",
+    "url": "https://attack.mitre.org/groups/G0082",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0083",
+    "group": "SilverTerrier",
+    "url": "https://attack.mitre.org/groups/G0083",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0084",
+    "group": "Gallmaker",
+    "url": "https://attack.mitre.org/groups/G0084",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0085",
+    "group": "FIN4",
+    "url": "https://attack.mitre.org/groups/G0085",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0087",
+    "group": "APT39",
+    "url": "https://attack.mitre.org/groups/G0087",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0088",
+    "group": "TEMP.Veles",
+    "url": "https://attack.mitre.org/groups/G0088",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ]
+  },
+  {
+    "group_id": "G0089",
+    "group": "The White Company",
+    "url": "https://attack.mitre.org/groups/G0089",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0090",
+    "group": "WIRTE",
+    "url": "https://attack.mitre.org/groups/G0090",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0091",
+    "group": "Silence",
+    "url": "https://attack.mitre.org/groups/G0091",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0092",
+    "group": "TA505",
+    "url": "https://attack.mitre.org/groups/G0092",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0093",
+    "group": "GALLIUM",
+    "url": "https://attack.mitre.org/groups/G0093",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0094",
+    "group": "Kimsuky",
+    "url": "https://attack.mitre.org/groups/G0094",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0095",
+    "group": "Machete",
+    "url": "https://attack.mitre.org/groups/G0095",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0096",
+    "group": "APT41",
+    "url": "https://attack.mitre.org/groups/G0096",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0097",
+    "group": "Bouncing Golf",
+    "url": "https://attack.mitre.org/groups/G0097",
+    "domain": [
+      "Mobile"
+    ]
+  },
+  {
+    "group_id": "G0098",
+    "group": "BlackTech",
+    "url": "https://attack.mitre.org/groups/G0098",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0099",
+    "group": "APT-C-36",
+    "url": "https://attack.mitre.org/groups/G0099",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0100",
+    "group": "Inception",
+    "url": "https://attack.mitre.org/groups/G0100",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0101",
+    "group": "Frankenstein",
+    "url": "https://attack.mitre.org/groups/G0101",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0102",
+    "group": "Wizard Spider",
+    "url": "https://attack.mitre.org/groups/G0102",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0103",
+    "group": "Mofang",
+    "url": "https://attack.mitre.org/groups/G0103",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0104",
+    "group": "Sharpshooter",
+    "url": "https://attack.mitre.org/groups/G0104",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0105",
+    "group": "DarkVishnya",
+    "url": "https://attack.mitre.org/groups/G0105",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0106",
+    "group": "Rocke",
+    "url": "https://attack.mitre.org/groups/G0106",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0107",
+    "group": "Whitefly",
+    "url": "https://attack.mitre.org/groups/G0107",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0108",
+    "group": "Blue Mockingbird",
+    "url": "https://attack.mitre.org/groups/G0108",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0112",
+    "group": "Windshift",
+    "url": "https://attack.mitre.org/groups/G0112",
+    "domain": [
+      "Enterprise",
+      "Mobile"
+    ]
+  },
+  {
+    "group_id": "G0114",
+    "group": "Chimera",
+    "url": "https://attack.mitre.org/groups/G0114",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0115",
+    "group": "GOLD SOUTHFIELD",
+    "url": "https://attack.mitre.org/groups/G0115",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0116",
+    "group": "Operation Wocao",
+    "url": "https://attack.mitre.org/groups/G0116",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0117",
+    "group": "Fox Kitten",
+    "url": "https://attack.mitre.org/groups/G0117",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0119",
+    "group": "Indrik Spider",
+    "url": "https://attack.mitre.org/groups/G0119",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0120",
+    "group": "Evilnum",
+    "url": "https://attack.mitre.org/groups/G0120",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0121",
+    "group": "Sidewinder",
+    "url": "https://attack.mitre.org/groups/G0121",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0122",
+    "group": "Silent Librarian",
+    "url": "https://attack.mitre.org/groups/G0122",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0123",
+    "group": "Volatile Cedar",
+    "url": "https://attack.mitre.org/groups/G0123",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0124",
+    "group": "Windigo",
+    "url": "https://attack.mitre.org/groups/G0124",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0125",
+    "group": "HAFNIUM",
+    "url": "https://attack.mitre.org/groups/G0125",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0126",
+    "group": "Higaisa",
+    "url": "https://attack.mitre.org/groups/G0126",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0127",
+    "group": "TA551",
+    "url": "https://attack.mitre.org/groups/G0127",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0128",
+    "group": "ZIRCONIUM",
+    "url": "https://attack.mitre.org/groups/G0128",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0129",
+    "group": "Mustang Panda",
+    "url": "https://attack.mitre.org/groups/G0129",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0130",
+    "group": "Ajax Security Team",
+    "url": "https://attack.mitre.org/groups/G0130",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0131",
+    "group": "Tonto Team",
+    "url": "https://attack.mitre.org/groups/G0131",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0132",
+    "group": "CostaRicto",
+    "url": "https://attack.mitre.org/groups/G0132",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0133",
+    "group": "Nomadic Octopus",
+    "url": "https://attack.mitre.org/groups/G0133",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0134",
+    "group": "Transparent Tribe",
+    "url": "https://attack.mitre.org/groups/G0134",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0135",
+    "group": "BackdoorDiplomacy",
+    "url": "https://attack.mitre.org/groups/G0135",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0136",
+    "group": "IndigoZebra",
+    "url": "https://attack.mitre.org/groups/G0136",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0137",
+    "group": "Ferocious Kitten",
+    "url": "https://attack.mitre.org/groups/G0137",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0138",
+    "group": "Andariel",
+    "url": "https://attack.mitre.org/groups/G0138",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G0139",
+    "group": "TeamTNT",
+    "url": "https://attack.mitre.org/groups/G0139",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "group_id": "G1000",
+    "group": "ALLANITE",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Group/G0009",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "group_id": "G1001",
+    "group": "HEXANE",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Group/G0005",
+    "domain": [
+      "ICS"
+    ]
+  }
+]

--- a/tools/config/mitre/software.json
+++ b/tools/config/mitre/software.json
@@ -1,0 +1,7771 @@
+[
+  {
+    "software_id": "S0001",
+    "software": "Trojan.Mebromi",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0001",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0002",
+    "software": "Mimikatz",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0002",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0003",
+    "software": "RIPTIDE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0003",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0004",
+    "software": "TinyZBot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0004",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0005",
+    "software": "Windows Credential Editor",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0005",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0006",
+    "software": "pwdump",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0006",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0007",
+    "software": "Skeleton Key",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0007",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0008",
+    "software": "gsecdump",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0008",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0009",
+    "software": "Hikit",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0009",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0010",
+    "software": "Lurid",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0010",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0011",
+    "software": "Taidoor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0011",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0012",
+    "software": "PoisonIvy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0012",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0013",
+    "software": "PlugX",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0013",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0014",
+    "software": "BS2005",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0014",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0015",
+    "software": "Ixeshe",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0015",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0016",
+    "software": "P2P ZeuS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0016",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0017",
+    "software": "BISCUIT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0017",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0018",
+    "software": "Sykipot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0018",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0019",
+    "software": "Regin",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0019",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0020",
+    "software": "China Chopper",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0020",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0021",
+    "software": "Derusbi",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0021",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0022",
+    "software": "Uroburos",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0022",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0023",
+    "software": "CHOPSTICK",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0023",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0024",
+    "software": "Dyre",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0024",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0025",
+    "software": "CALENDAR",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0025",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0026",
+    "software": "GLOOXMAIL",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0026",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0027",
+    "software": "Zeroaccess",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0027",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0028",
+    "software": "SHIPSHAPE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0028",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0029",
+    "software": "PsExec",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0029",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0030",
+    "software": "Carbanak",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0030",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0031",
+    "software": "BACKSPACE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0031",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0032",
+    "software": "gh0st RAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0032",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0033",
+    "software": "NetTraveler",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0033",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0034",
+    "software": "NETEAGLE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0034",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0035",
+    "software": "SPACESHIP",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0035",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0036",
+    "software": "FLASHFLOOD",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0036",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0037",
+    "software": "HAMMERTOSS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0037",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0038",
+    "software": "Duqu",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0038",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0039",
+    "software": "Net",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0039",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0040",
+    "software": "HTRAN",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0040",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0041",
+    "software": "Wiper",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0041",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0042",
+    "software": "LOWBALL",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0042",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0043",
+    "software": "BUBBLEWRAP",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0043",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0044",
+    "software": "JHUHUGIT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0044",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0045",
+    "software": "ADVSTORESHELL",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0045",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0046",
+    "software": "CozyCar",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0046",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0047",
+    "software": "Hacking Team UEFI Rootkit",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0047",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": []
+  },
+  {
+    "software_id": "S0048",
+    "software": "PinchDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0048",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0049",
+    "software": "GeminiDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0049",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0050",
+    "software": "CosmicDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0050",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0051",
+    "software": "MiniDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0051",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0052",
+    "software": "OnionDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0052",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0053",
+    "software": "SeaDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0053",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0054",
+    "software": "CloudDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0054",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0055",
+    "software": "RARSTONE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0055",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0056",
+    "software": "Net Crawler",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0056",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0057",
+    "software": "Tasklist",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0057",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0058",
+    "software": "SslMM",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0058",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0059",
+    "software": "WinMM",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0059",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0060",
+    "software": "Sys10",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0060",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0061",
+    "software": "HDoor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0061",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0062",
+    "software": "DustySky",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0062",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0063",
+    "software": "SHOTPUT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0063",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0064",
+    "software": "ELMER",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0064",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0065",
+    "software": "4H RAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0065",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0066",
+    "software": "3PARA RAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0066",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0067",
+    "software": "pngdowner",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0067",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0068",
+    "software": "httpclient",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0068",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0069",
+    "software": "BLACKCOFFEE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0069",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0070",
+    "software": "HTTPBrowser",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0070",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0071",
+    "software": "hcdLoader",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0071",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0072",
+    "software": "OwaAuth",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0072",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0073",
+    "software": "ASPXSpy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0073",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0074",
+    "software": "Sakula",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0074",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0075",
+    "software": "Reg",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0075",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0076",
+    "software": "FakeM",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0076",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0077",
+    "software": "CallMe",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0077",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0078",
+    "software": "Psylo",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0078",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0079",
+    "software": "MobileOrder",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0079",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": []
+  },
+  {
+    "software_id": "S0080",
+    "software": "Mivast",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0080",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0081",
+    "software": "Elise",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0081",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0082",
+    "software": "Emissary",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0082",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0083",
+    "software": "Misdat",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0083",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0084",
+    "software": "Mis-Type",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0084",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0085",
+    "software": "S-Type",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0085",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0086",
+    "software": "ZLib",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0086",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0087",
+    "software": "Hi-Zor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0087",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0088",
+    "software": "Kasidet",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0088",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0089",
+    "software": "BlackEnergy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0089",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0090",
+    "software": "Rover",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0090",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0091",
+    "software": "Epic",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0091",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0092",
+    "software": "Agent.btz",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0092",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0093",
+    "software": "Backdoor.Oldrea",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0093",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0094",
+    "software": "Trojan.Karagany",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0094",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0095",
+    "software": "FTP",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0095",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0096",
+    "software": "Systeminfo",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0096",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0097",
+    "software": "Ping",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0097",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0098",
+    "software": "T9000",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0098",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0099",
+    "software": "Arp",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0099",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0100",
+    "software": "ipconfig",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0100",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0101",
+    "software": "ifconfig",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0101",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0102",
+    "software": "nbtstat",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0102",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0103",
+    "software": "route",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0103",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0104",
+    "software": "netstat",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0104",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0105",
+    "software": "dsquery",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0105",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0106",
+    "software": "cmd",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0106",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0107",
+    "software": "Cherry Picker",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0107",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0108",
+    "software": "netsh",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0108",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0109",
+    "software": "WEBC2",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0109",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0110",
+    "software": "at",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0110",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0111",
+    "software": "schtasks",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0111",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0112",
+    "software": "ROCKBOOT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0112",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0113",
+    "software": "Prikormka",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0113",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0114",
+    "software": "BOOTRASH",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0114",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0115",
+    "software": "Crimson",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0115",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0116",
+    "software": "UACMe",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0116",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0117",
+    "software": "XTunnel",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0117",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0118",
+    "software": "Nidiran",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0118",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0119",
+    "software": "Cachedump",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0119",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0120",
+    "software": "Fgdump",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0120",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0121",
+    "software": "Lslsass",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0121",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0122",
+    "software": "Pass-The-Hash Toolkit",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0122",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0123",
+    "software": "xCmd",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0123",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0124",
+    "software": "Pisloader",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0124",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0125",
+    "software": "Remsec",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0125",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0126",
+    "software": "ComRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0126",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0127",
+    "software": "BBSRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0127",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0128",
+    "software": "BADNEWS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0128",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0129",
+    "software": "AutoIt backdoor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0129",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0130",
+    "software": "Unknown Logger",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0130",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0131",
+    "software": "TINYTYPHON",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0131",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0132",
+    "software": "H1N1",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0132",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0133",
+    "software": "Miner-C",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0133",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0134",
+    "software": "Downdelph",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0134",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0135",
+    "software": "HIDEDRV",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0135",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0136",
+    "software": "USBStealer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0136",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0137",
+    "software": "CORESHELL",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0137",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0138",
+    "software": "OLDBAIT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0138",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0139",
+    "software": "PowerDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0139",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0140",
+    "software": "Shamoon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0140",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0141",
+    "software": "Winnti for Windows",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0141",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0142",
+    "software": "StreamEx",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0142",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0143",
+    "software": "Flame",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0143",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0144",
+    "software": "ChChes",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0144",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0145",
+    "software": "POWERSOURCE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0145",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0146",
+    "software": "TEXTMATE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0146",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0147",
+    "software": "Pteranodon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0147",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0148",
+    "software": "RTM",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0148",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0149",
+    "software": "MoonWind",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0149",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0150",
+    "software": "POSHSPY",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0150",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0151",
+    "software": "HALFBAKED",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0151",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0152",
+    "software": "EvilGrab",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0152",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0153",
+    "software": "RedLeaves",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0153",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0154",
+    "software": "Cobalt Strike",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0154",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0155",
+    "software": "WINDSHIELD",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0155",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0156",
+    "software": "KOMPROGO",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0156",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0157",
+    "software": "SOUNDBITE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0157",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0158",
+    "software": "PHOREAL",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0158",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0159",
+    "software": "SNUGRIDE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0159",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0160",
+    "software": "certutil",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0160",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0161",
+    "software": "XAgentOSX",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0161",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0162",
+    "software": "Komplex",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0162",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0163",
+    "software": "Janicab",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0163",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0164",
+    "software": "TDTESS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0164",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0165",
+    "software": "OSInfo",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0165",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0166",
+    "software": "RemoteCMD",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0166",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0167",
+    "software": "Matryoshka",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0167",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0168",
+    "software": "Gazer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0168",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0169",
+    "software": "RawPOS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0169",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0170",
+    "software": "Helminth",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0170",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0171",
+    "software": "Felismus",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0171",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0172",
+    "software": "Reaver",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0172",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0173",
+    "software": "FLIPSIDE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0173",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0174",
+    "software": "Responder",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0174",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0175",
+    "software": "meek",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0175",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0176",
+    "software": "Wingbird",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0176",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0177",
+    "software": "Power Loader",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0177",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0178",
+    "software": "Truvasys",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0178",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0179",
+    "software": "MimiPenguin",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0179",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0180",
+    "software": "Volgmer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0180",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0181",
+    "software": "FALLCHILL",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0181",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0182",
+    "software": "FinFisher",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0182",
+    "domain": [
+      "Enterprise",
+      "Mobile"
+    ],
+    "platform": [
+      "Windows",
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0183",
+    "software": "Tor",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0183",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0184",
+    "software": "POWRUNER",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0184",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0185",
+    "software": "SEASHARPEE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0185",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0186",
+    "software": "DownPaper",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0186",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0187",
+    "software": "Daserf",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0187",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0188",
+    "software": "Starloader",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0188",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0189",
+    "software": "ISMInjector",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0189",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0190",
+    "software": "BITSAdmin",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0190",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0191",
+    "software": "Winexe",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0191",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0192",
+    "software": "Pupy",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0192",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS",
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0193",
+    "software": "Forfiles",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0193",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0194",
+    "software": "PowerSploit",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0194",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0195",
+    "software": "SDelete",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0195",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0196",
+    "software": "PUNCHBUGGY",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0196",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0197",
+    "software": "PUNCHTRACK",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0197",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0198",
+    "software": "NETWIRE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0198",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0199",
+    "software": "TURNEDUP",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0199",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0200",
+    "software": "Dipsind",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0200",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0201",
+    "software": "JPIN",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0201",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0202",
+    "software": "adbupd",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0202",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0203",
+    "software": "Hydraq",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0203",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0204",
+    "software": "Briba",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0204",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0205",
+    "software": "Naid",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0205",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0206",
+    "software": "Wiarp",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0206",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0207",
+    "software": "Vasport",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0207",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0208",
+    "software": "Pasam",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0208",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0210",
+    "software": "Nerex",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0210",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0211",
+    "software": "Linfo",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0211",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0212",
+    "software": "CORALDECK",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0212",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0213",
+    "software": "DOGCALL",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0213",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0214",
+    "software": "HAPPYWORK",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0214",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0215",
+    "software": "KARAE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0215",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0216",
+    "software": "POORAIM",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0216",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0217",
+    "software": "SHUTTERSPEED",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0217",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0218",
+    "software": "SLOWDRIFT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0218",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0219",
+    "software": "WINERACK",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0219",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0220",
+    "software": "Chaos",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0220",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0221",
+    "software": "Umbreon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0221",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0222",
+    "software": "CCBkdr",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0222",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0223",
+    "software": "POWERSTATS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0223",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0224",
+    "software": "Havij",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0224",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0225",
+    "software": "sqlmap",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0225",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0226",
+    "software": "Smoke Loader",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0226",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0227",
+    "software": "spwebmember",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0227",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0228",
+    "software": "NanHaiShu",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0228",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0229",
+    "software": "Orz",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0229",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0230",
+    "software": "ZeroT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0230",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0231",
+    "software": "Invoke-PSImage",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0231",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0232",
+    "software": "HOMEFRY",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0232",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0233",
+    "software": "MURKYTOP",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0233",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0234",
+    "software": "Bandook",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0234",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0235",
+    "software": "CrossRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0235",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0236",
+    "software": "Kwampirs",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0236",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0237",
+    "software": "GravityRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0237",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0238",
+    "software": "Proxysvc",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0238",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0239",
+    "software": "Bankshot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0239",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0240",
+    "software": "ROKRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0240",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0241",
+    "software": "RATANKBA",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0241",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0242",
+    "software": "SynAck",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0242",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0243",
+    "software": "DealersChoice",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0243",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0244",
+    "software": "Comnie",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0244",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0245",
+    "software": "BADCALL",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0245",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0246",
+    "software": "HARDRAIN",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0246",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0247",
+    "software": "NavRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0247",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0248",
+    "software": "yty",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0248",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0249",
+    "software": "Gold Dragon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0249",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0250",
+    "software": "Koadic",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0250",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0251",
+    "software": "Zebrocy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0251",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0252",
+    "software": "Brave Prince",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0252",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0253",
+    "software": "RunningRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0253",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0254",
+    "software": "PLAINTEE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0254",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0255",
+    "software": "DDKONG",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0255",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0256",
+    "software": "Mosquito",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0256",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0257",
+    "software": "VERMIN",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0257",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0258",
+    "software": "RGDoor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0258",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0259",
+    "software": "InnaputRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0259",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0260",
+    "software": "InvisiMole",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0260",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0261",
+    "software": "Catchamas",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0261",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0262",
+    "software": "QuasarRAT",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0262",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0263",
+    "software": "TYPEFRAME",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0263",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0264",
+    "software": "OopsIE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0264",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0265",
+    "software": "Kazuar",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0265",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0266",
+    "software": "TrickBot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0266",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0267",
+    "software": "FELIXROOT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0267",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0268",
+    "software": "Bisonal",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0268",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0269",
+    "software": "QUADAGENT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0269",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0270",
+    "software": "RogueRobin",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0270",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0271",
+    "software": "KEYMARBLE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0271",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0272",
+    "software": "NDiskMonitor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0272",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0273",
+    "software": "Socksbot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0273",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0274",
+    "software": "Calisto",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0274",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0275",
+    "software": "UPPERCUT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0275",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0276",
+    "software": "Keydnap",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0276",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0277",
+    "software": "FruitFly",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0277",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0278",
+    "software": "iKitten",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0278",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0279",
+    "software": "Proton",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0279",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0280",
+    "software": "MirageFox",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0280",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0281",
+    "software": "Dok",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0281",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0282",
+    "software": "MacSpy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0282",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0283",
+    "software": "jRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0283",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS",
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0284",
+    "software": "More_eggs",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0284",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0285",
+    "software": "OldBoot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0285",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0286",
+    "software": "OBAD",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0286",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0287",
+    "software": "ZergHelper",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0287",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0288",
+    "software": "KeyRaider",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0288",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0289",
+    "software": "Pegasus for iOS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0289",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0290",
+    "software": "Gooligan",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0290",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0291",
+    "software": "PJApps",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0291",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0292",
+    "software": "AndroRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0292",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0293",
+    "software": "BrainTest",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0293",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0294",
+    "software": "ShiftyBug",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0294",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0295",
+    "software": "RCSAndroid",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0295",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0297",
+    "software": "XcodeGhost",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0297",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0298",
+    "software": "Xbot",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0298",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0299",
+    "software": "NotCompatible",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0299",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0300",
+    "software": "DressCode",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0300",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0301",
+    "software": "Dendroid",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0301",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0302",
+    "software": "Twitoor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0302",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0303",
+    "software": "MazarBOT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0303",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0304",
+    "software": "Android/Chuli.A",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0304",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0305",
+    "software": "SpyNote RAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0305",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0306",
+    "software": "Trojan-SMS.AndroidOS.FakeInst.a",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0306",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0307",
+    "software": "Trojan-SMS.AndroidOS.Agent.ao",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0307",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0308",
+    "software": "Trojan-SMS.AndroidOS.OpFake.a",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0308",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0309",
+    "software": "Adups",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0309",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0310",
+    "software": "ANDROIDOS_ANSERVER.A",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0310",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0311",
+    "software": "YiSpecter",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0311",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0312",
+    "software": "WireLurker",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0312",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0313",
+    "software": "RuMMS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0313",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0314",
+    "software": "X-Agent for Android",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0314",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0315",
+    "software": "DualToy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0315",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0316",
+    "software": "Pegasus for Android",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0316",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0317",
+    "software": "Marcher",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0317",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0318",
+    "software": "XLoader for Android",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0318",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0319",
+    "software": "Allwinner",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0319",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0320",
+    "software": "DroidJack",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0320",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0321",
+    "software": "HummingWhale",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0321",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0322",
+    "software": "HummingBad",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0322",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0323",
+    "software": "Charger",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0323",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0324",
+    "software": "SpyDealer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0324",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0325",
+    "software": "Judy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0325",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0326",
+    "software": "RedDrop",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0326",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0327",
+    "software": "Skygofree",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0327",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0328",
+    "software": "Stealth Mango",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0328",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0329",
+    "software": "Tangelo",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0329",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0330",
+    "software": "Zeus Panda",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0330",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0331",
+    "software": "Agent Tesla",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0331",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0332",
+    "software": "Remcos",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0332",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0333",
+    "software": "UBoatRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0333",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0334",
+    "software": "DarkComet",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0334",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0335",
+    "software": "Carbon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0335",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0336",
+    "software": "NanoCore",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0336",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0337",
+    "software": "BadPatch",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0337",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0338",
+    "software": "Cobian RAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0338",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0339",
+    "software": "Micropsia",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0339",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0340",
+    "software": "Octopus",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0340",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0341",
+    "software": "Xbash",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0341",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0342",
+    "software": "GreyEnergy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0342",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0343",
+    "software": "Exaramel for Windows",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0343",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0344",
+    "software": "Azorult",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0344",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0345",
+    "software": "Seasalt",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0345",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0346",
+    "software": "OceanSalt",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0346",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0347",
+    "software": "AuditCred",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0347",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0348",
+    "software": "Cardinal RAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0348",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0349",
+    "software": "LaZagne",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0349",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0350",
+    "software": "zwShell",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0350",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0351",
+    "software": "Cannon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0351",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0352",
+    "software": "OSX_OCEANLOTUS.D",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0352",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0353",
+    "software": "NOKKI",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0353",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0354",
+    "software": "Denis",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0354",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0355",
+    "software": "Final1stspy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0355",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0356",
+    "software": "KONNI",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0356",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0357",
+    "software": "Impacket",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0357",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0358",
+    "software": "Ruler",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0358",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
+    ]
+  },
+  {
+    "software_id": "S0359",
+    "software": "Nltest",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0359",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0360",
+    "software": "BONDUPDATER",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0360",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0361",
+    "software": "Expand",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0361",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0362",
+    "software": "Linux Rabbit",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0362",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0363",
+    "software": "Empire",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0363",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0364",
+    "software": "RawDisk",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0364",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0365",
+    "software": "Olympic Destroyer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0365",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0366",
+    "software": "WannaCry",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0366",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0367",
+    "software": "Emotet",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0367",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0368",
+    "software": "NotPetya",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0368",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0369",
+    "software": "CoinTicker",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0369",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0370",
+    "software": "SamSam",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0370",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0371",
+    "software": "POWERTON",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0371",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0372",
+    "software": "LockerGoga",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0372",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0373",
+    "software": "Astaroth",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0373",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0374",
+    "software": "SpeakUp",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0374",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0375",
+    "software": "Remexi",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0375",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0376",
+    "software": "HOPLIGHT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0376",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0377",
+    "software": "Ebury",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0377",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0378",
+    "software": "PoshC2",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0378",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0379",
+    "software": "Revenge RAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0379",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0380",
+    "software": "StoneDrill",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0380",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0381",
+    "software": "FlawedAmmyy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0381",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0382",
+    "software": "ServHelper",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0382",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0383",
+    "software": "FlawedGrace",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0383",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0384",
+    "software": "Dridex",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0384",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0385",
+    "software": "njRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0385",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0386",
+    "software": "Ursnif",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0386",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0387",
+    "software": "KeyBoy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0387",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0388",
+    "software": "YAHOYAH",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0388",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0389",
+    "software": "JCry",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0389",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": []
+  },
+  {
+    "software_id": "S0390",
+    "software": "SQLRat",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0390",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": []
+  },
+  {
+    "software_id": "S0391",
+    "software": "HAWKBALL",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0391",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0393",
+    "software": "PowerStallion",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0393",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0394",
+    "software": "HiddenWasp",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0394",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0395",
+    "software": "LightNeuron",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0395",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0396",
+    "software": "EvilBunny",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0396",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0397",
+    "software": "LoJax",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0397",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0398",
+    "software": "HyperBro",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0398",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0399",
+    "software": "Pallas",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0399",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0400",
+    "software": "RobbinHood",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0400",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0401",
+    "software": "Exaramel for Linux",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0401",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0402",
+    "software": "OSX/Shlayer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0402",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0403",
+    "software": "Riltok",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0403",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0404",
+    "software": "esentutl",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0404",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0405",
+    "software": "Exodus",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0405",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0406",
+    "software": "Gustuff",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0406",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0407",
+    "software": "Monokle",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0407",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0408",
+    "software": "FlexiSpy",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0408",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0409",
+    "software": "Machete",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0409",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0410",
+    "software": "Fysbis",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0410",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0411",
+    "software": "Rotexy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0411",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0412",
+    "software": "ZxShell",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0412",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0413",
+    "software": "MailSniper",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0413",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Office 365",
+      "Windows",
+      "Azure AD"
+    ]
+  },
+  {
+    "software_id": "S0414",
+    "software": "BabyShark",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0414",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0415",
+    "software": "BOOSTWRITE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0415",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0416",
+    "software": "RDFSNIFFER",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0416",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0417",
+    "software": "GRIFFON",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0417",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0418",
+    "software": "ViceLeaker",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0418",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0419",
+    "software": "SimBad",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0419",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0420",
+    "software": "Dvmap",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0420",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0421",
+    "software": "GolfSpy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0421",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0422",
+    "software": "Anubis",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0422",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0423",
+    "software": "Ginp",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0423",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0424",
+    "software": "Triada",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0424",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0425",
+    "software": "Corona Updates",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0425",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0426",
+    "software": "Concipit1248",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0426",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0427",
+    "software": "TrickMo",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0427",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0428",
+    "software": "PoetRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0428",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0430",
+    "software": "Winnti for Linux",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0430",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0431",
+    "software": "HotCroissant",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0431",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0432",
+    "software": "Bread",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0432",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0433",
+    "software": "Rifdoor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0433",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0434",
+    "software": "Imminent Monitor",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0434",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0435",
+    "software": "PLEAD",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0435",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0436",
+    "software": "TSCookie",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0436",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0437",
+    "software": "Kivars",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0437",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0438",
+    "software": "Attor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0438",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0439",
+    "software": "Okrum",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0439",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0440",
+    "software": "Agent Smith",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0440",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0441",
+    "software": "PowerShower",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0441",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0442",
+    "software": "VBShower",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0442",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0443",
+    "software": "MESSAGETAP",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0443",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0444",
+    "software": "ShimRat",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0444",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0445",
+    "software": "ShimRatReporter",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0445",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0446",
+    "software": "Ryuk",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0446",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0447",
+    "software": "Lokibot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0447",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0448",
+    "software": "Rising Sun",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0448",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0449",
+    "software": "Maze",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0449",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0450",
+    "software": "SHARPSTATS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0450",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0451",
+    "software": "LoudMiner",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0451",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0452",
+    "software": "USBferry",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0452",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0453",
+    "software": "Pony",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0453",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0454",
+    "software": "Cadelspy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0454",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0455",
+    "software": "Metamorfo",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0455",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0456",
+    "software": "Aria-body",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0456",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0457",
+    "software": "Netwalker",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0457",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0458",
+    "software": "Ramsay",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0458",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0459",
+    "software": "MechaFlounder",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0459",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0460",
+    "software": "Get2",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0460",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0461",
+    "software": "SDBbot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0461",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0462",
+    "software": "CARROTBAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0462",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0463",
+    "software": "INSOMNIA",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0463",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0464",
+    "software": "SYSCON",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0464",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0465",
+    "software": "CARROTBALL",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0465",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0466",
+    "software": "WindTail",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0466",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0467",
+    "software": "TajMahal",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0467",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0468",
+    "software": "Skidmap",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0468",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0469",
+    "software": "ABK",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0469",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0470",
+    "software": "BBK",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0470",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0471",
+    "software": "build_downer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0471",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0472",
+    "software": "down_new",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0472",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0473",
+    "software": "Avenger",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0473",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0475",
+    "software": "BackConfig",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0475",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0476",
+    "software": "Valak",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0476",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0477",
+    "software": "Goopy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0477",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0478",
+    "software": "EventBot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0478",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0479",
+    "software": "DEFENSOR ID",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0479",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0480",
+    "software": "Cerberus",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0480",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0481",
+    "software": "Ragnar Locker",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0481",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0482",
+    "software": "Bundlore",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0482",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0483",
+    "software": "IcedID",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0483",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0484",
+    "software": "Carberp",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0484",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0485",
+    "software": "Mandrake",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0485",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0486",
+    "software": "Bonadan",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0486",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0487",
+    "software": "Kessel",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0487",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0488",
+    "software": "CrackMapExec",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0488",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0489",
+    "software": "WolfRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0489",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0490",
+    "software": "XLoader for iOS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0490",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0491",
+    "software": "StrongPity",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0491",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0492",
+    "software": "CookieMiner",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0492",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0493",
+    "software": "GoldenSpy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0493",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0494",
+    "software": "Zen",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0494",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0495",
+    "software": "RDAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0495",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0496",
+    "software": "REvil",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0496",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0497",
+    "software": "Dacls",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0497",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Linux",
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0498",
+    "software": "Cryptoistic",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0498",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0499",
+    "software": "Hancitor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0499",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0500",
+    "software": "MCMD",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0500",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0501",
+    "software": "PipeMon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0501",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0502",
+    "software": "Drovorub",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0502",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0503",
+    "software": "FrameworkPOS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0503",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": []
+  },
+  {
+    "software_id": "S0504",
+    "software": "Anchor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0504",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0505",
+    "software": "Desert Scorpion",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0505",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0506",
+    "software": "ViperRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0506",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0507",
+    "software": "eSurv",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0507",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
+    ]
+  },
+  {
+    "software_id": "S0508",
+    "software": "Ngrok",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0508",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0509",
+    "software": "FakeSpy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0509",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0511",
+    "software": "RegDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0511",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0512",
+    "software": "FatDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0512",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0513",
+    "software": "LiteDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0513",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0514",
+    "software": "WellMess",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0514",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0515",
+    "software": "WellMail",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0515",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0516",
+    "software": "SoreFang",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0516",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0517",
+    "software": "Pillowmint",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0517",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0518",
+    "software": "PolyglotDuke",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0518",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0519",
+    "software": "SYNful Knock",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0519",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "software_id": "S0520",
+    "software": "BLINDINGCAN",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0520",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0521",
+    "software": "BloodHound",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0521",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0522",
+    "software": "Exobot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0522",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0524",
+    "software": "AndroidOS/MalLocker.B",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0524",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0525",
+    "software": "Android/AdDisplay.Ashas",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0525",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0526",
+    "software": "KGH_SPY",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0526",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0527",
+    "software": "CSPY Downloader",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0527",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0528",
+    "software": "Javali",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0528",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0529",
+    "software": "CarbonSteal",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0529",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0530",
+    "software": "Melcoz",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0530",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0531",
+    "software": "Grandoreiro",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0531",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0532",
+    "software": "Lucifer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0532",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0533",
+    "software": "SLOTHFULMEDIA",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0533",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0534",
+    "software": "Bazar",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0534",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0535",
+    "software": "Golden Cup",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0535",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0536",
+    "software": "GPlayed",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0536",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0537",
+    "software": "HyperStack",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0537",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0538",
+    "software": "Crutch",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0538",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0539",
+    "software": "Red Alert 2.0",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0539",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0540",
+    "software": "Asacub",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0540",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0543",
+    "software": "Spark",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0543",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0544",
+    "software": "HenBox",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0544",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0545",
+    "software": "TERRACOTTA",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0545",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0546",
+    "software": "SharpStage",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0546",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0547",
+    "software": "DropBook",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0547",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0549",
+    "software": "SilkBean",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0549",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0550",
+    "software": "DoubleAgent",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0550",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0551",
+    "software": "GoldenEagle",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0551",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": []
+  },
+  {
+    "software_id": "S0552",
+    "software": "AdFind",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0552",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0553",
+    "software": "MoleNet",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0553",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0554",
+    "software": "Egregor",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0554",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0555",
+    "software": "CHEMISTGAMES",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0555",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0556",
+    "software": "Pay2Key",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0556",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0558",
+    "software": "Tiktok Pro",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0558",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0559",
+    "software": "SUNBURST",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0559",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0560",
+    "software": "TEARDROP",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0560",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0561",
+    "software": "GuLoader",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0561",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0562",
+    "software": "SUNSPOT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0562",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0564",
+    "software": "BlackMould",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0564",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0565",
+    "software": "Raindrop",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0565",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0567",
+    "software": "Dtrack",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0567",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0568",
+    "software": "EVILNUM",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0568",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0569",
+    "software": "Explosive",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0569",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0570",
+    "software": "BitPaymer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0570",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0572",
+    "software": "Caterpillar WebShell",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0572",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0574",
+    "software": "BendyBear",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0574",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0575",
+    "software": "Conti",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0575",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0576",
+    "software": "MegaCortex",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0576",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0577",
+    "software": "FrozenCell",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0577",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0578",
+    "software": "SUPERNOVA",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0578",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0579",
+    "software": "Waterbear",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0579",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0581",
+    "software": "IronNetInjector",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0581",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0582",
+    "software": "LookBack",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0582",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0583",
+    "software": "Pysa",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0583",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0584",
+    "software": "AppleJeus",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0584",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0585",
+    "software": "Kerrdown",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0585",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0586",
+    "software": "TAINTEDSCRIBE",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0586",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0587",
+    "software": "Penquin",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0587",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0588",
+    "software": "GoldMax",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0588",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0589",
+    "software": "Sibot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0589",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0590",
+    "software": "NBTscan",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0590",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0591",
+    "software": "ConnectWise",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0591",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0592",
+    "software": "RemoteUtilities",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0592",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0593",
+    "software": "ECCENTRICBANDWAGON",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0593",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0594",
+    "software": "Out1",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0594",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0595",
+    "software": "ThiefQuest",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0595",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0596",
+    "software": "ShadowPad",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0596",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0597",
+    "software": "GoldFinder",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0597",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0598",
+    "software": "P.A.S. Webshell",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0598",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0599",
+    "software": "Kinsing",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0599",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Containers",
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0600",
+    "software": "Doki",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0600",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Containers"
+    ]
+  },
+  {
+    "software_id": "S0601",
+    "software": "Hildegard",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0601",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Containers",
+      "IaaS"
+    ]
+  },
+  {
+    "software_id": "S0602",
+    "software": "Circles",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0602",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": []
+  },
+  {
+    "software_id": "S0603",
+    "software": "Stuxnet",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0603",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0604",
+    "software": "Industroyer",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0604",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0605",
+    "software": "EKANS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0605",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0606",
+    "software": "Bad Rabbit",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0606",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0607",
+    "software": "KillDisk",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0607",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Linux",
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0608",
+    "software": "Conficker",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0608",
+    "domain": [
+      "Enterprise",
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0610",
+    "software": "SideTwist",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0610",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0611",
+    "software": "Clop",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0611",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0612",
+    "software": "WastedLocker",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0612",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0613",
+    "software": "PS1",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0613",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0614",
+    "software": "CostaBricks",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0614",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0615",
+    "software": "SombRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0615",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0616",
+    "software": "DEATHRANSOM",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0616",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0617",
+    "software": "HELLOKITTY",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0617",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0618",
+    "software": "FIVEHANDS",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0618",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0622",
+    "software": "AppleSeed",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0622",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0623",
+    "software": "Siloscape",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0623",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Containers"
+    ]
+  },
+  {
+    "software_id": "S0624",
+    "software": "Ecipekac",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0624",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0625",
+    "software": "Cuba",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0625",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0626",
+    "software": "P8RAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0626",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0627",
+    "software": "SodaMaster",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0627",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0628",
+    "software": "FYAnti",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0628",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0629",
+    "software": "RainyDay",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0629",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0630",
+    "software": "Nebulae",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0630",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0631",
+    "software": "Chaes",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0631",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0632",
+    "software": "GrimAgent",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0632",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0633",
+    "software": "Sliver",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0633",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S0634",
+    "software": "EnvyScout",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0634",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0635",
+    "software": "BoomBox",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0635",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0636",
+    "software": "VaporRage",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0636",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0637",
+    "software": "NativeZone",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0637",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0638",
+    "software": "Babuk",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0638",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0639",
+    "software": "Seth-Locker",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0639",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0640",
+    "software": "Avaddon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0640",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0641",
+    "software": "Kobalos",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0641",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0642",
+    "software": "BADFLICK",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0642",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0643",
+    "software": "Peppy",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0643",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0644",
+    "software": "ObliqueRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0644",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0645",
+    "software": "Wevtutil",
+    "type": "Tool",
+    "url": "https://attack.mitre.org/software/S0645",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0646",
+    "software": "SpicyOmelette",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0646",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0647",
+    "software": "Turian",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0647",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux"
+    ]
+  },
+  {
+    "software_id": "S0648",
+    "software": "JSS Loader",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0648",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0649",
+    "software": "SMOKEDHAM",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0649",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0650",
+    "software": "QakBot",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0650",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0651",
+    "software": "BoxCaon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0651",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0652",
+    "software": "MarkiRAT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0652",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0653",
+    "software": "xCaon",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0653",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0654",
+    "software": "ProLock",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0654",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0655",
+    "software": "BusyGasper",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0655",
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "software_id": "S0657",
+    "software": "BLUELIGHT",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0657",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S0658",
+    "software": "XCSSET",
+    "type": "Malware",
+    "url": "https://attack.mitre.org/software/S0658",
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "software_id": "S1000",
+    "software": "ACAD/Medre.A",
+    "type": "Malware",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Software/S0018",
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S1006",
+    "software": "PLC-Blaster",
+    "type": "Malware",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Software/S0009",
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S1009",
+    "software": "Triton",
+    "type": "Malware",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Software/S0013",
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "software_id": "S1010",
+    "software": "VPNFilter",
+    "type": "Malware",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Software/S0002",
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  }
+]

--- a/tools/config/mitre/tactics.json
+++ b/tools/config/mitre/tactics.json
@@ -1,207 +1,362 @@
 [
   {
     "external_id": "TA0001",
+    "tactic": "Initial Access",
+    "shortname": "initial-access",
     "url": "https://attack.mitre.org/tactics/TA0001",
-    "tactic": "Initial Access"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0002",
+    "tactic": "Execution",
+    "shortname": "execution",
     "url": "https://attack.mitre.org/tactics/TA0002",
-    "tactic": "Execution"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0003",
+    "tactic": "Persistence",
+    "shortname": "persistence",
     "url": "https://attack.mitre.org/tactics/TA0003",
-    "tactic": "Persistence"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0004",
+    "tactic": "Privilege Escalation",
+    "shortname": "privilege-escalation",
     "url": "https://attack.mitre.org/tactics/TA0004",
-    "tactic": "Privilege Escalation"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0005",
+    "tactic": "Defense Evasion",
+    "shortname": "defense-evasion",
     "url": "https://attack.mitre.org/tactics/TA0005",
-    "tactic": "Defense Evasion"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0006",
+    "tactic": "Credential Access",
+    "shortname": "credential-access",
     "url": "https://attack.mitre.org/tactics/TA0006",
-    "tactic": "Credential Access"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0007",
+    "tactic": "Discovery",
+    "shortname": "discovery",
     "url": "https://attack.mitre.org/tactics/TA0007",
-    "tactic": "Discovery"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0008",
+    "tactic": "Lateral Movement",
+    "shortname": "lateral-movement",
     "url": "https://attack.mitre.org/tactics/TA0008",
-    "tactic": "Lateral Movement"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0009",
+    "tactic": "Collection",
+    "shortname": "collection",
     "url": "https://attack.mitre.org/tactics/TA0009",
-    "tactic": "Collection"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0010",
+    "tactic": "Exfiltration",
+    "shortname": "exfiltration",
     "url": "https://attack.mitre.org/tactics/TA0010",
-    "tactic": "Exfiltration"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0011",
+    "tactic": "Command and Control",
+    "shortname": "command-and-control",
     "url": "https://attack.mitre.org/tactics/TA0011",
-    "tactic": "Command and Control"
-  },
-  {
-    "external_id": "TA0012",
-    "url": "https://attack.mitre.org/tactics/TA0012",
-    "tactic": "Priority Definition Planning"
-  },
-  {
-    "external_id": "TA0013",
-    "url": "https://attack.mitre.org/tactics/TA0013",
-    "tactic": "Priority Definition Direction"
-  },
-  {
-    "external_id": "TA0014",
-    "url": "https://attack.mitre.org/tactics/TA0014",
-    "tactic": "Target Selection"
-  },
-  {
-    "external_id": "TA0015",
-    "url": "https://attack.mitre.org/tactics/TA0015",
-    "tactic": "Technical Information Gathering"
-  },
-  {
-    "external_id": "TA0016",
-    "url": "https://attack.mitre.org/tactics/TA0016",
-    "tactic": "People Information Gathering"
-  },
-  {
-    "external_id": "TA0017",
-    "url": "https://attack.mitre.org/tactics/TA0017",
-    "tactic": "Organizational Information Gathering"
-  },
-  {
-    "external_id": "TA0018",
-    "url": "https://attack.mitre.org/tactics/TA0018",
-    "tactic": "Technical Weakness Identification"
-  },
-  {
-    "external_id": "TA0019",
-    "url": "https://attack.mitre.org/tactics/TA0019",
-    "tactic": "People Weakness Identification"
-  },
-  {
-    "external_id": "TA0020",
-    "url": "https://attack.mitre.org/tactics/TA0020",
-    "tactic": "Organizational Weakness Identification"
-  },
-  {
-    "external_id": "TA0021",
-    "url": "https://attack.mitre.org/tactics/TA0021",
-    "tactic": "Adversary OPSEC"
-  },
-  {
-    "external_id": "TA0022",
-    "url": "https://attack.mitre.org/tactics/TA0022",
-    "tactic": "Establish & Maintain Infrastructure"
-  },
-  {
-    "external_id": "TA0023",
-    "url": "https://attack.mitre.org/tactics/TA0023",
-    "tactic": "Persona Development"
-  },
-  {
-    "external_id": "TA0024",
-    "url": "https://attack.mitre.org/tactics/TA0024",
-    "tactic": "Build Capabilities"
-  },
-  {
-    "external_id": "TA0025",
-    "url": "https://attack.mitre.org/tactics/TA0025",
-    "tactic": "Test Capabilities"
-  },
-  {
-    "external_id": "TA0026",
-    "url": "https://attack.mitre.org/tactics/TA0026",
-    "tactic": "Stage Capabilities"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0027",
+    "tactic": "Initial Access",
+    "shortname": "initial-access",
     "url": "https://attack.mitre.org/tactics/TA0027",
-    "tactic": "Initial Access"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0028",
+    "tactic": "Persistence",
+    "shortname": "persistence",
     "url": "https://attack.mitre.org/tactics/TA0028",
-    "tactic": "Persistence"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0029",
+    "tactic": "Privilege Escalation",
+    "shortname": "privilege-escalation",
     "url": "https://attack.mitre.org/tactics/TA0029",
-    "tactic": "Privilege Escalation"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0030",
+    "tactic": "Defense Evasion",
+    "shortname": "defense-evasion",
     "url": "https://attack.mitre.org/tactics/TA0030",
-    "tactic": "Defense Evasion"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0031",
+    "tactic": "Credential Access",
+    "shortname": "credential-access",
     "url": "https://attack.mitre.org/tactics/TA0031",
-    "tactic": "Credential Access"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0032",
+    "tactic": "Discovery",
+    "shortname": "discovery",
     "url": "https://attack.mitre.org/tactics/TA0032",
-    "tactic": "Discovery"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0033",
+    "tactic": "Lateral Movement",
+    "shortname": "lateral-movement",
     "url": "https://attack.mitre.org/tactics/TA0033",
-    "tactic": "Lateral Movement"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0034",
+    "tactic": "Impact",
+    "shortname": "impact",
     "url": "https://attack.mitre.org/tactics/TA0034",
-    "tactic": "Impact"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0035",
+    "tactic": "Collection",
+    "shortname": "collection",
     "url": "https://attack.mitre.org/tactics/TA0035",
-    "tactic": "Collection"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0036",
+    "tactic": "Exfiltration",
+    "shortname": "exfiltration",
     "url": "https://attack.mitre.org/tactics/TA0036",
-    "tactic": "Exfiltration"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0037",
+    "tactic": "Command and Control",
+    "shortname": "command-and-control",
     "url": "https://attack.mitre.org/tactics/TA0037",
-    "tactic": "Command and Control"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0038",
+    "tactic": "Network Effects",
+    "shortname": "network-effects",
     "url": "https://attack.mitre.org/tactics/TA0038",
-    "tactic": "Network Effects"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0039",
+    "tactic": "Remote Service Effects",
+    "shortname": "remote-service-effects",
     "url": "https://attack.mitre.org/tactics/TA0039",
-    "tactic": "Remote Service Effects"
+    "domain": [
+      "Mobile"
+    ]
   },
   {
     "external_id": "TA0040",
+    "tactic": "Impact",
+    "shortname": "impact",
     "url": "https://attack.mitre.org/tactics/TA0040",
-    "tactic": "Impact"
+    "domain": [
+      "Enterprise"
+    ]
   },
   {
     "external_id": "TA0041",
+    "tactic": "Execution",
+    "shortname": "execution",
     "url": "https://attack.mitre.org/tactics/TA0041",
-    "tactic": "Execution"
+    "domain": [
+      "Mobile"
+    ]
+  },
+  {
+    "external_id": "TA0042",
+    "tactic": "Resource Development",
+    "shortname": "resource-development",
+    "url": "https://attack.mitre.org/tactics/TA0042",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "external_id": "TA0043",
+    "tactic": "Reconnaissance",
+    "shortname": "reconnaissance",
+    "url": "https://attack.mitre.org/tactics/TA0043",
+    "domain": [
+      "Enterprise"
+    ]
+  },
+  {
+    "external_id": "TA0100",
+    "tactic": "Collection",
+    "shortname": "collection-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Collection",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0101",
+    "tactic": "Command and Control",
+    "shortname": "command-and-control-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Command_and_Control",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0102",
+    "tactic": "Discovery",
+    "shortname": "discovery-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Discovery",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0103",
+    "tactic": "Evasion",
+    "shortname": "evasion-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Evasion",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0104",
+    "tactic": "Execution",
+    "shortname": "execution-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Execution",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0105",
+    "tactic": "Impact",
+    "shortname": "impact-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Impact",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0106",
+    "tactic": "Impair Process Control",
+    "shortname": "impair-process-control",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Impair_Process_Control",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0107",
+    "tactic": "Inhibit Response Function",
+    "shortname": "inhibit-response-function",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Inhibit_Response_Function",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0108",
+    "tactic": "Initial Access",
+    "shortname": "initial-access-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Initial_Access",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0109",
+    "tactic": "Lateral Movement",
+    "shortname": "lateral-movement-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Lateral_Movement",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0110",
+    "tactic": "Persistence",
+    "shortname": "persistence-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Persistence",
+    "domain": [
+      "ICS"
+    ]
+  },
+  {
+    "external_id": "TA0111",
+    "tactic": "Privilege Escalation",
+    "shortname": "privilege-escalation-ics",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Privilege_Escalation",
+    "domain": [
+      "ICS"
+    ]
   }
 ]

--- a/tools/config/mitre/techniques.json
+++ b/tools/config/mitre/techniques.json
@@ -1,26 +1,1276 @@
 [
   {
+    "technique_id": "T0800",
+    "technique": "Activate Firmware Update Mode",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0800",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0801",
+    "technique": "Monitor Process State",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0801",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Control Server",
+      "Data Historian",
+      "Field Controller/RTU/PLC/IED",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0802",
+    "technique": "Automated Collection",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0802",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED",
+      "Safety Instrumented System/Protection Relay",
+      "Control Server"
+    ]
+  },
+  {
+    "technique_id": "T0803",
+    "technique": "Block Command Message",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0803",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED",
+      "Device Configuration/Parameters"
+    ]
+  },
+  {
+    "technique_id": "T0804",
+    "technique": "Block Reporting Message",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0804",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED",
+      "Input/Output Server",
+      "Device Configuration/Parameters"
+    ]
+  },
+  {
+    "technique_id": "T0805",
+    "technique": "Block Serial COM",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0805",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED",
+      "Input/Output Server",
+      "Device Configuration/Parameters"
+    ]
+  },
+  {
+    "technique_id": "T0806",
+    "technique": "Brute Force I/O",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0806",
+    "tactic": [
+      "Impair Process Control"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0807",
+    "technique": "Command-Line Interface",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0807",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Data Historian",
+      "Field Controller/RTU/PLC/IED",
+      "Human-Machine Interface",
+      "Input/Output Server"
+    ]
+  },
+  {
+    "technique_id": "T0809",
+    "technique": "Data Destruction",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0809",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Human-Machine Interface",
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0811",
+    "technique": "Data from Information Repositories",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0811",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Data Historian",
+      "Engineering Workstation",
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0812",
+    "technique": "Default Credentials",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0812",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Field Controller/RTU/PLC/IED",
+      "Safety Instrumented System/Protection Relay",
+      "Control Server",
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0813",
+    "technique": "Denial of Control",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T813",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T0814",
+    "technique": "Denial of Service",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0814",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0815",
+    "technique": "Denial of View",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0815",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0816",
+    "technique": "Device Restart/Shutdown",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0816",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0817",
+    "technique": "Drive-by Compromise",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0817",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0819",
+    "technique": "Exploit Public-Facing Application",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0819",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0820",
+    "technique": "Exploitation for Evasion",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0820",
+    "tactic": [
+      "Evasion"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Safety Instrumented System/Protection Relay",
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0821",
+    "technique": "Modify Controller Tasking",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0821",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0822",
+    "technique": "External Remote Services",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0822",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Input/Output Server"
+    ]
+  },
+  {
+    "technique_id": "T0823",
+    "technique": "Graphical User Interface",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0823",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0826",
+    "technique": "Loss of Availability",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0826",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T0827",
+    "technique": "Loss of Control",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0827",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0828",
+    "technique": "Loss of Productivity and Revenue",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0828",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0829",
+    "technique": "Loss of View",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0829",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0830",
+    "technique": "Man in the Middle",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0830",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Field Controller/RTU/PLC/IED",
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0831",
+    "technique": "Manipulation of Control",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0831",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0832",
+    "technique": "Manipulation of View",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0832",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Engineering Workstation",
+      "Human-Machine Interface",
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0834",
+    "technique": "Native API",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0834",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Data Historian",
+      "Field Controller/RTU/PLC/IED",
+      "Human-Machine Interface",
+      "Input/Output Server",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0835",
+    "technique": "Manipulate I/O Image",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T835",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0836",
+    "technique": "Modify Parameter",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0836",
+    "tactic": [
+      "Impair Process Control"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Field Controller/RTU/PLC/IED",
+      "Safety Instrumented System/Protection Relay",
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0837",
+    "technique": "Loss of Protection",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0837",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0838",
+    "technique": "Modify Alarm Settings",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0838",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Control Server",
+      "Safety Instrumented System/Protection Relay",
+      "Field Controller/RTU/PLC/IED",
+      "Device Configuration/Parameters"
+    ]
+  },
+  {
+    "technique_id": "T0839",
+    "technique": "Module Firmware",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0839",
+    "tactic": [
+      "Persistence",
+      "Impair Process Control"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0840",
+    "technique": "Network Connection Enumeration",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0840",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0842",
+    "technique": "Network Sniffing",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0842",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0843",
+    "technique": "Program Download",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0843",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0845",
+    "technique": "Program Upload",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0845",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Safety Instrumented System/Protection Relay",
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0846",
+    "technique": "Remote System Discovery",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0846",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Data Historian",
+      "Safety Instrumented System/Protection Relay",
+      "Field Controller/RTU/PLC/IED",
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0847",
+    "technique": "Replication Through Removable Media",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0847",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Data Historian",
+      "Control Server"
+    ]
+  },
+  {
+    "technique_id": "T0848",
+    "technique": "Rogue Master",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0848",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Control Server",
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0849",
+    "technique": "Masquerading",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0849",
+    "tactic": [
+      "Evasion"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Control Server"
+    ]
+  },
+  {
+    "technique_id": "T0851",
+    "technique": "Rootkit",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0851",
+    "tactic": [
+      "Evasion",
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0852",
+    "technique": "Screen Capture",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0852",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0853",
+    "technique": "Scripting",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0853",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0855",
+    "technique": "Unauthorized Command Message",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0855",
+    "tactic": [
+      "Impair Process Control"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0856",
+    "technique": "Spoof Reporting Message",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0856",
+    "tactic": [
+      "Evasion",
+      "Impair Process Control"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server"
+    ]
+  },
+  {
+    "technique_id": "T0857",
+    "technique": "System Firmware",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0857",
+    "tactic": [
+      "Persistence",
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Safety Instrumented System/Protection Relay",
+      "Field Controller/RTU/PLC/IED",
+      "Input/Output Server"
+    ]
+  },
+  {
+    "technique_id": "T0858",
+    "technique": "Change Operating Mode",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0858",
+    "tactic": [
+      "Execution",
+      "Evasion"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Safety Instrumented System/Protection Relay",
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0859",
+    "technique": "Valid Accounts",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0859",
+    "tactic": [
+      "Persistence",
+      "Lateral Movement"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Data Historian",
+      "Engineering Workstation",
+      "Field Controller/RTU/PLC/IED",
+      "Human-Machine Interface",
+      "Input/Output Server",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0860",
+    "technique": "Wireless Compromise",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0860",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Field Controller/RTU/PLC/IED",
+      "Input/Output Server"
+    ]
+  },
+  {
+    "technique_id": "T0861",
+    "technique": "Point & Tag Identification",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0861",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Data Historian",
+      "Control Server",
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0862",
+    "technique": "Supply Chain Compromise",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0862",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Data Historian",
+      "Field Controller/RTU/PLC/IED",
+      "Human-Machine Interface",
+      "Input/Output Server",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0863",
+    "technique": "User Execution",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0863",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Engineering Workstation",
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0864",
+    "technique": "Transient Cyber Asset",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0864",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0865",
+    "technique": "Spearphishing Attachment",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0865",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Engineering Workstation",
+      "Human-Machine Interface",
+      "Control Server",
+      "Data Historian"
+    ]
+  },
+  {
+    "technique_id": "T0866",
+    "technique": "Exploitation of Remote Services",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0866",
+    "tactic": [
+      "Lateral Movement",
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Data Historian",
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0867",
+    "technique": "Lateral Tool Transfer",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0867",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Control Server",
+      "Data Historian"
+    ]
+  },
+  {
+    "technique_id": "T0868",
+    "technique": "Detect Operating Mode",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0868",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0869",
+    "technique": "Standard Application Layer Protocol",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0869",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Control Server",
+      "Data Historian",
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0871",
+    "technique": "Execution through API",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0871",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0872",
+    "technique": "Indicator Removal on Host",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0872",
+    "tactic": [
+      "Evasion"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0873",
+    "technique": "Project File Infection",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0873",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Engineering Workstation",
+      "Human-Machine Interface"
+    ]
+  },
+  {
+    "technique_id": "T0874",
+    "technique": "Hooking",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0874",
+    "tactic": [
+      "Execution",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0877",
+    "technique": "I/O Image",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0877",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0878",
+    "technique": "Alarm Suppression",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0878",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED",
+      "Safety Instrumented System/Protection Relay",
+      "Device Configuration/Parameters"
+    ]
+  },
+  {
+    "technique_id": "T0879",
+    "technique": "Damage to Property",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0879",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0880",
+    "technique": "Loss of Safety",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0880",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0881",
+    "technique": "Service Stop",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0881",
+    "tactic": [
+      "Inhibit Response Function"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Control Server",
+      "Data Historian",
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0882",
+    "technique": "Theft of Operational Information",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0882",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0883",
+    "technique": "Internet Accessible Device",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0883",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Control Server",
+      "Data Historian",
+      "Field Controller/RTU/PLC/IED",
+      "Human-Machine Interface",
+      "Input/Output Server",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
+    "technique_id": "T0884",
+    "technique": "Connection Proxy",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0884",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0885",
+    "technique": "Commonly Used Port",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0885",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Safety Instrumented System/Protection Relay",
+      "Field Controller/RTU/PLC/IED",
+      "Human-Machine Interface",
+      "Control Server",
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0886",
+    "technique": "Remote Services",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0886",
+    "tactic": [
+      "Initial Access",
+      "Lateral Movement"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Control Server",
+      "Engineering Workstation"
+    ]
+  },
+  {
+    "technique_id": "T0887",
+    "technique": "Wireless Sniffing",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0887",
+    "tactic": [
+      "Discovery",
+      "Collection"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "None"
+    ]
+  },
+  {
+    "technique_id": "T0888",
+    "technique": "Remote System Information Discovery",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0888",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Safety Instrumented System/Protection Relay",
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0889",
+    "technique": "Modify Program",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0889",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Field Controller/RTU/PLC/IED"
+    ]
+  },
+  {
+    "technique_id": "T0890",
+    "technique": "Exploitation for Privilege Escalation",
+    "url": "https://collaborate.mitre.org/attackics/index.php/Technique/T0890",
+    "tactic": [
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "ICS"
+    ],
+    "platform": [
+      "Human-Machine Interface",
+      "Safety Instrumented System/Protection Relay"
+    ]
+  },
+  {
     "technique_id": "T1001",
     "technique": "Data Obfuscation",
     "url": "https://attack.mitre.org/techniques/T1001",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1001.001",
-    "technique": "Data Obfuscation : Junk Data",
-    "url": "https://attack.mitre.org/techniques/T1001/001"
+    "technique": "Data Obfuscation: Junk Data",
+    "url": "https://attack.mitre.org/techniques/T1001/001",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1001.002",
-    "technique": "Data Obfuscation : Steganography",
-    "url": "https://attack.mitre.org/techniques/T1001/002"
+    "technique": "Data Obfuscation: Steganography",
+    "url": "https://attack.mitre.org/techniques/T1001/002",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1001.003",
-    "technique": "Data Obfuscation : Protocol Impersonation",
-    "url": "https://attack.mitre.org/techniques/T1001/003"
+    "technique": "Data Obfuscation: Protocol Impersonation",
+    "url": "https://attack.mitre.org/techniques/T1001/003",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1003",
@@ -28,47 +1278,127 @@
     "url": "https://attack.mitre.org/techniques/T1003",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
     ]
   },
   {
     "technique_id": "T1003.001",
-    "technique": "OS Credential Dumping : LSASS Memory",
-    "url": "https://attack.mitre.org/techniques/T1003/001"
+    "technique": "OS Credential Dumping: LSASS Memory",
+    "url": "https://attack.mitre.org/techniques/T1003/001",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1003.002",
-    "technique": "OS Credential Dumping : Security Account Manager",
-    "url": "https://attack.mitre.org/techniques/T1003/002"
+    "technique": "OS Credential Dumping: Security Account Manager",
+    "url": "https://attack.mitre.org/techniques/T1003/002",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1003.003",
-    "technique": "OS Credential Dumping : NTDS",
-    "url": "https://attack.mitre.org/techniques/T1003/003"
+    "technique": "OS Credential Dumping: NTDS",
+    "url": "https://attack.mitre.org/techniques/T1003/003",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1003.004",
-    "technique": "OS Credential Dumping : LSA Secrets",
-    "url": "https://attack.mitre.org/techniques/T1003/004"
+    "technique": "OS Credential Dumping: LSA Secrets",
+    "url": "https://attack.mitre.org/techniques/T1003/004",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1003.005",
-    "technique": "OS Credential Dumping : Cached Domain Credentials",
-    "url": "https://attack.mitre.org/techniques/T1003/005"
+    "technique": "OS Credential Dumping: Cached Domain Credentials",
+    "url": "https://attack.mitre.org/techniques/T1003/005",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1003.006",
-    "technique": "OS Credential Dumping : DCSync",
-    "url": "https://attack.mitre.org/techniques/T1003/006"
+    "technique": "OS Credential Dumping: DCSync",
+    "url": "https://attack.mitre.org/techniques/T1003/006",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1003.007",
-    "technique": "OS Credential Dumping : Proc Filesystem",
-    "url": "https://attack.mitre.org/techniques/T1003/007"
+    "technique": "OS Credential Dumping: Proc Filesystem",
+    "url": "https://attack.mitre.org/techniques/T1003/007",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1003.008",
-    "technique": "OS Credential Dumping : /etc/passwd and /etc/shadow",
-    "url": "https://attack.mitre.org/techniques/T1003/008"
+    "technique": "OS Credential Dumping: /etc/passwd and /etc/shadow",
+    "url": "https://attack.mitre.org/techniques/T1003/008",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1005",
@@ -76,6 +1406,14 @@
     "url": "https://attack.mitre.org/techniques/T1005",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -84,6 +1422,12 @@
     "url": "https://attack.mitre.org/techniques/T1006",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -92,6 +1436,13 @@
     "url": "https://attack.mitre.org/techniques/T1007",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -100,6 +1451,14 @@
     "url": "https://attack.mitre.org/techniques/T1008",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -108,6 +1467,13 @@
     "url": "https://attack.mitre.org/techniques/T1010",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -116,12 +1482,31 @@
     "url": "https://attack.mitre.org/techniques/T1011",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1011.001",
-    "technique": "Exfiltration Over Other Network Medium : Exfiltration Over Bluetooth",
-    "url": "https://attack.mitre.org/techniques/T1011/001"
+    "technique": "Exfiltration Over Other Network Medium: Exfiltration Over Bluetooth",
+    "url": "https://attack.mitre.org/techniques/T1011/001",
+    "tactic": [
+      "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1012",
@@ -129,6 +1514,12 @@
     "url": "https://attack.mitre.org/techniques/T1012",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -137,6 +1528,14 @@
     "url": "https://attack.mitre.org/techniques/T1014",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -145,6 +1544,30 @@
     "url": "https://attack.mitre.org/techniques/T1016",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1016.001",
+    "technique": "System Network Configuration Discovery: Internet Connection Discovery",
+    "url": "https://attack.mitre.org/techniques/T1016/001",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
     ]
   },
   {
@@ -153,6 +1576,14 @@
     "url": "https://attack.mitre.org/techniques/T1018",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -161,6 +1592,29 @@
     "url": "https://attack.mitre.org/techniques/T1020",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1020.001",
+    "technique": "Automated Exfiltration: Traffic Duplication",
+    "url": "https://attack.mitre.org/techniques/T1020/001",
+    "tactic": [
+      "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
     ]
   },
   {
@@ -169,37 +1623,102 @@
     "url": "https://attack.mitre.org/techniques/T1021",
     "tactic": [
       "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1021.001",
-    "technique": "Remote Services : Remote Desktop Protocol",
-    "url": "https://attack.mitre.org/techniques/T1021/001"
+    "technique": "Remote Services: Remote Desktop Protocol",
+    "url": "https://attack.mitre.org/techniques/T1021/001",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1021.002",
-    "technique": "Remote Services : SMB/Windows Admin Shares",
-    "url": "https://attack.mitre.org/techniques/T1021/002"
+    "technique": "Remote Services: SMB/Windows Admin Shares",
+    "url": "https://attack.mitre.org/techniques/T1021/002",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1021.003",
-    "technique": "Remote Services : Distributed Component Object Model",
-    "url": "https://attack.mitre.org/techniques/T1021/003"
+    "technique": "Remote Services: Distributed Component Object Model",
+    "url": "https://attack.mitre.org/techniques/T1021/003",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1021.004",
-    "technique": "Remote Services : SSH",
-    "url": "https://attack.mitre.org/techniques/T1021/004"
+    "technique": "Remote Services: SSH",
+    "url": "https://attack.mitre.org/techniques/T1021/004",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1021.005",
-    "technique": "Remote Services : VNC",
-    "url": "https://attack.mitre.org/techniques/T1021/005"
+    "technique": "Remote Services: VNC",
+    "url": "https://attack.mitre.org/techniques/T1021/005",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1021.006",
-    "technique": "Remote Services : Windows Remote Management",
-    "url": "https://attack.mitre.org/techniques/T1021/006"
+    "technique": "Remote Services: Windows Remote Management",
+    "url": "https://attack.mitre.org/techniques/T1021/006",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1025",
@@ -207,6 +1726,14 @@
     "url": "https://attack.mitre.org/techniques/T1025",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -215,32 +1742,110 @@
     "url": "https://attack.mitre.org/techniques/T1027",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1027.001",
-    "technique": "Obfuscated Files or Information : Binary Padding",
-    "url": "https://attack.mitre.org/techniques/T1027/001"
+    "technique": "Obfuscated Files or Information: Binary Padding",
+    "url": "https://attack.mitre.org/techniques/T1027/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1027.002",
-    "technique": "Obfuscated Files or Information : Software Packing",
-    "url": "https://attack.mitre.org/techniques/T1027/002"
+    "technique": "Obfuscated Files or Information: Software Packing",
+    "url": "https://attack.mitre.org/techniques/T1027/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1027.003",
-    "technique": "Obfuscated Files or Information : Steganography",
-    "url": "https://attack.mitre.org/techniques/T1027/003"
+    "technique": "Obfuscated Files or Information: Steganography",
+    "url": "https://attack.mitre.org/techniques/T1027/003",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1027.004",
-    "technique": "Obfuscated Files or Information : Compile After Delivery",
-    "url": "https://attack.mitre.org/techniques/T1027/004"
+    "technique": "Obfuscated Files or Information: Compile After Delivery",
+    "url": "https://attack.mitre.org/techniques/T1027/004",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1027.005",
-    "technique": "Obfuscated Files or Information : Indicator Removal from Tools",
-    "url": "https://attack.mitre.org/techniques/T1027/005"
+    "technique": "Obfuscated Files or Information: Indicator Removal from Tools",
+    "url": "https://attack.mitre.org/techniques/T1027/005",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1027.006",
+    "technique": "Obfuscated Files or Information: HTML Smuggling",
+    "url": "https://attack.mitre.org/techniques/T1027/006",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1029",
@@ -248,6 +1853,14 @@
     "url": "https://attack.mitre.org/techniques/T1029",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -256,6 +1869,14 @@
     "url": "https://attack.mitre.org/techniques/T1030",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -264,6 +1885,14 @@
     "url": "https://attack.mitre.org/techniques/T1033",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -272,37 +1901,125 @@
     "url": "https://attack.mitre.org/techniques/T1036",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1036.001",
-    "technique": "Masquerading : Invalid Code Signature",
-    "url": "https://attack.mitre.org/techniques/T1036/001"
+    "technique": "Masquerading: Invalid Code Signature",
+    "url": "https://attack.mitre.org/techniques/T1036/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1036.002",
-    "technique": "Masquerading : Right-to-Left Override",
-    "url": "https://attack.mitre.org/techniques/T1036/002"
+    "technique": "Masquerading: Right-to-Left Override",
+    "url": "https://attack.mitre.org/techniques/T1036/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1036.003",
-    "technique": "Masquerading : Rename System Utilities",
-    "url": "https://attack.mitre.org/techniques/T1036/003"
+    "technique": "Masquerading: Rename System Utilities",
+    "url": "https://attack.mitre.org/techniques/T1036/003",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1036.004",
-    "technique": "Masquerading : Masquerade Task or Service",
-    "url": "https://attack.mitre.org/techniques/T1036/004"
+    "technique": "Masquerading: Masquerade Task or Service",
+    "url": "https://attack.mitre.org/techniques/T1036/004",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1036.005",
-    "technique": "Masquerading : Match Legitimate Name or Location",
-    "url": "https://attack.mitre.org/techniques/T1036/005"
+    "technique": "Masquerading: Match Legitimate Name or Location",
+    "url": "https://attack.mitre.org/techniques/T1036/005",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1036.006",
-    "technique": "Masquerading : Space after Filename",
-    "url": "https://attack.mitre.org/techniques/T1036/006"
+    "technique": "Masquerading: Space after Filename",
+    "url": "https://attack.mitre.org/techniques/T1036/006",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "technique_id": "T1036.007",
+    "technique": "Masquerading: Double File Extension",
+    "url": "https://attack.mitre.org/techniques/T1036/007",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1037",
@@ -311,32 +2028,91 @@
     "tactic": [
       "Persistence",
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows",
+      "Linux"
     ]
   },
   {
     "technique_id": "T1037.001",
-    "technique": "Boot or Logon Initialization Scripts : Logon Script (Windows)",
-    "url": "https://attack.mitre.org/techniques/T1037/001"
+    "technique": "Boot or Logon Initialization Scripts: Logon Script (Windows)",
+    "url": "https://attack.mitre.org/techniques/T1037/001",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1037.002",
-    "technique": "Boot or Logon Initialization Scripts : Logon Script (Mac)",
-    "url": "https://attack.mitre.org/techniques/T1037/002"
+    "technique": "Boot or Logon Initialization Scripts: Logon Script (Mac)",
+    "url": "https://attack.mitre.org/techniques/T1037/002",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1037.003",
-    "technique": "Boot or Logon Initialization Scripts : Network Logon Script",
-    "url": "https://attack.mitre.org/techniques/T1037/003"
+    "technique": "Boot or Logon Initialization Scripts: Network Logon Script",
+    "url": "https://attack.mitre.org/techniques/T1037/003",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1037.004",
-    "technique": "Boot or Logon Initialization Scripts : Rc.common",
-    "url": "https://attack.mitre.org/techniques/T1037/004"
+    "technique": "Boot or Logon Initialization Scripts: RC Scripts",
+    "url": "https://attack.mitre.org/techniques/T1037/004",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1037.005",
-    "technique": "Boot or Logon Initialization Scripts : Startup Items",
-    "url": "https://attack.mitre.org/techniques/T1037/005"
+    "technique": "Boot or Logon Initialization Scripts: Startup Items",
+    "url": "https://attack.mitre.org/techniques/T1037/005",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1039",
@@ -344,6 +2120,14 @@
     "url": "https://attack.mitre.org/techniques/T1039",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -353,6 +2137,15 @@
     "tactic": [
       "Credential Access",
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Network"
     ]
   },
   {
@@ -361,6 +2154,14 @@
     "url": "https://attack.mitre.org/techniques/T1041",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -369,6 +2170,16 @@
     "url": "https://attack.mitre.org/techniques/T1046",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Containers"
     ]
   },
   {
@@ -377,6 +2188,12 @@
     "url": "https://attack.mitre.org/techniques/T1047",
     "tactic": [
       "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -385,22 +2202,63 @@
     "url": "https://attack.mitre.org/techniques/T1048",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1048.001",
-    "technique": "Exfiltration Over Alternative Protocol : Exfiltration Over Symmetric Encrypted Non-C2 Protocol",
-    "url": "https://attack.mitre.org/techniques/T1048/001"
+    "technique": "Exfiltration Over Alternative Protocol: Exfiltration Over Symmetric Encrypted Non-C2 Protocol",
+    "url": "https://attack.mitre.org/techniques/T1048/001",
+    "tactic": [
+      "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1048.002",
-    "technique": "Exfiltration Over Alternative Protocol : Exfiltration Over Asymmetric Encrypted Non-C2 Protocol",
-    "url": "https://attack.mitre.org/techniques/T1048/002"
+    "technique": "Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol",
+    "url": "https://attack.mitre.org/techniques/T1048/002",
+    "tactic": [
+      "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1048.003",
-    "technique": "Exfiltration Over Alternative Protocol : Exfiltration Over Unencrypted/Obfuscated Non-C2 Protocol",
-    "url": "https://attack.mitre.org/techniques/T1048/003"
+    "technique": "Exfiltration Over Alternative Protocol: Exfiltration Over Unencrypted/Obfuscated Non-C2 Protocol",
+    "url": "https://attack.mitre.org/techniques/T1048/003",
+    "tactic": [
+      "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1049",
@@ -408,6 +2266,15 @@
     "url": "https://attack.mitre.org/techniques/T1049",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS"
     ]
   },
   {
@@ -416,12 +2283,31 @@
     "url": "https://attack.mitre.org/techniques/T1052",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1052.001",
-    "technique": "Exfiltration Over Physical Medium : Exfiltration over USB",
-    "url": "https://attack.mitre.org/techniques/T1052/001"
+    "technique": "Exfiltration Over Physical Medium: Exfiltration over USB",
+    "url": "https://attack.mitre.org/techniques/T1052/001",
+    "tactic": [
+      "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1053",
@@ -431,32 +2317,113 @@
       "Execution",
       "Persistence",
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1053.001",
-    "technique": "Scheduled Task/Job : At (Linux)",
-    "url": "https://attack.mitre.org/techniques/T1053/001"
+    "technique": "Scheduled Task/Job: At (Linux)",
+    "url": "https://attack.mitre.org/techniques/T1053/001",
+    "tactic": [
+      "Execution",
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1053.002",
-    "technique": "Scheduled Task/Job : At (Windows)",
-    "url": "https://attack.mitre.org/techniques/T1053/002"
+    "technique": "Scheduled Task/Job: At (Windows)",
+    "url": "https://attack.mitre.org/techniques/T1053/002",
+    "tactic": [
+      "Execution",
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1053.003",
-    "technique": "Scheduled Task/Job : Cron",
-    "url": "https://attack.mitre.org/techniques/T1053/003"
-  },
-  {
-    "technique_id": "T1053.004",
-    "technique": "Scheduled Task/Job : Launchd",
-    "url": "https://attack.mitre.org/techniques/T1053/004"
+    "technique": "Scheduled Task/Job: Cron",
+    "url": "https://attack.mitre.org/techniques/T1053/003",
+    "tactic": [
+      "Execution",
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1053.005",
-    "technique": "Scheduled Task/Job : Scheduled Task",
-    "url": "https://attack.mitre.org/techniques/T1053/005"
+    "technique": "Scheduled Task/Job: Scheduled Task",
+    "url": "https://attack.mitre.org/techniques/T1053/005",
+    "tactic": [
+      "Execution",
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1053.006",
+    "technique": "Scheduled Task/Job: Systemd Timers",
+    "url": "https://attack.mitre.org/techniques/T1053/006",
+    "tactic": [
+      "Execution",
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "technique_id": "T1053.007",
+    "technique": "Scheduled Task/Job: Container Orchestration Job",
+    "url": "https://attack.mitre.org/techniques/T1053/007",
+    "tactic": [
+      "Execution",
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1055",
@@ -465,62 +2432,180 @@
     "tactic": [
       "Defense Evasion",
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1055.001",
-    "technique": "Process Injection : Dynamic-link Library Injection",
-    "url": "https://attack.mitre.org/techniques/T1055/001"
+    "technique": "Process Injection: Dynamic-link Library Injection",
+    "url": "https://attack.mitre.org/techniques/T1055/001",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1055.002",
-    "technique": "Process Injection : Portable Executable Injection",
-    "url": "https://attack.mitre.org/techniques/T1055/002"
+    "technique": "Process Injection: Portable Executable Injection",
+    "url": "https://attack.mitre.org/techniques/T1055/002",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1055.003",
-    "technique": "Process Injection : Thread Execution Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1055/003"
+    "technique": "Process Injection: Thread Execution Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1055/003",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1055.004",
-    "technique": "Process Injection : Asynchronous Procedure Call",
-    "url": "https://attack.mitre.org/techniques/T1055/004"
+    "technique": "Process Injection: Asynchronous Procedure Call",
+    "url": "https://attack.mitre.org/techniques/T1055/004",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1055.005",
-    "technique": "Process Injection : Thread Local Storage",
-    "url": "https://attack.mitre.org/techniques/T1055/005"
+    "technique": "Process Injection: Thread Local Storage",
+    "url": "https://attack.mitre.org/techniques/T1055/005",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1055.008",
-    "technique": "Process Injection : Ptrace System Calls",
-    "url": "https://attack.mitre.org/techniques/T1055/008"
+    "technique": "Process Injection: Ptrace System Calls",
+    "url": "https://attack.mitre.org/techniques/T1055/008",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1055.009",
-    "technique": "Process Injection : Proc Memory",
-    "url": "https://attack.mitre.org/techniques/T1055/009"
+    "technique": "Process Injection: Proc Memory",
+    "url": "https://attack.mitre.org/techniques/T1055/009",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1055.011",
-    "technique": "Process Injection : Extra Window Memory Injection",
-    "url": "https://attack.mitre.org/techniques/T1055/011"
+    "technique": "Process Injection: Extra Window Memory Injection",
+    "url": "https://attack.mitre.org/techniques/T1055/011",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1055.012",
-    "technique": "Process Injection : Process Hollowing",
-    "url": "https://attack.mitre.org/techniques/T1055/012"
+    "technique": "Process Injection: Process Hollowing",
+    "url": "https://attack.mitre.org/techniques/T1055/012",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1055.013",
-    "technique": "Process Injection : Process Doppelg\u00e4nging",
-    "url": "https://attack.mitre.org/techniques/T1055/013"
+    "technique": "Process Injection: Process Doppelg\u00e4nging",
+    "url": "https://attack.mitre.org/techniques/T1055/013",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1055.014",
-    "technique": "Process Injection : VDSO Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1055/014"
+    "technique": "Process Injection: VDSO Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1055/014",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1056",
@@ -529,27 +2614,83 @@
     "tactic": [
       "Collection",
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Network"
     ]
   },
   {
     "technique_id": "T1056.001",
-    "technique": "Input Capture : Keylogging",
-    "url": "https://attack.mitre.org/techniques/T1056/001"
+    "technique": "Input Capture: Keylogging",
+    "url": "https://attack.mitre.org/techniques/T1056/001",
+    "tactic": [
+      "Collection",
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux",
+      "Network"
+    ]
   },
   {
     "technique_id": "T1056.002",
-    "technique": "Input Capture : GUI Input Capture",
-    "url": "https://attack.mitre.org/techniques/T1056/002"
+    "technique": "Input Capture: GUI Input Capture",
+    "url": "https://attack.mitre.org/techniques/T1056/002",
+    "tactic": [
+      "Collection",
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1056.003",
-    "technique": "Input Capture : Web Portal Capture",
-    "url": "https://attack.mitre.org/techniques/T1056/003"
+    "technique": "Input Capture: Web Portal Capture",
+    "url": "https://attack.mitre.org/techniques/T1056/003",
+    "tactic": [
+      "Collection",
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1056.004",
-    "technique": "Input Capture : Credential API Hooking",
-    "url": "https://attack.mitre.org/techniques/T1056/004"
+    "technique": "Input Capture: Credential API Hooking",
+    "url": "https://attack.mitre.org/techniques/T1056/004",
+    "tactic": [
+      "Collection",
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1057",
@@ -557,6 +2698,14 @@
     "url": "https://attack.mitre.org/techniques/T1057",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -565,42 +2714,135 @@
     "url": "https://attack.mitre.org/techniques/T1059",
     "tactic": [
       "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Network"
     ]
   },
   {
     "technique_id": "T1059.001",
-    "technique": "Command and Scripting Interpreter : PowerShell",
-    "url": "https://attack.mitre.org/techniques/T1059/001"
+    "technique": "Command and Scripting Interpreter: PowerShell",
+    "url": "https://attack.mitre.org/techniques/T1059/001",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1059.002",
-    "technique": "Command and Scripting Interpreter : AppleScript",
-    "url": "https://attack.mitre.org/techniques/T1059/002"
+    "technique": "Command and Scripting Interpreter: AppleScript",
+    "url": "https://attack.mitre.org/techniques/T1059/002",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1059.003",
-    "technique": "Command and Scripting Interpreter : Windows Command Shell",
-    "url": "https://attack.mitre.org/techniques/T1059/003"
+    "technique": "Command and Scripting Interpreter: Windows Command Shell",
+    "url": "https://attack.mitre.org/techniques/T1059/003",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1059.004",
-    "technique": "Command and Scripting Interpreter : Unix Shell",
-    "url": "https://attack.mitre.org/techniques/T1059/004"
+    "technique": "Command and Scripting Interpreter: Unix Shell",
+    "url": "https://attack.mitre.org/techniques/T1059/004",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1059.005",
-    "technique": "Command and Scripting Interpreter : Visual Basic",
-    "url": "https://attack.mitre.org/techniques/T1059/005"
+    "technique": "Command and Scripting Interpreter: Visual Basic",
+    "url": "https://attack.mitre.org/techniques/T1059/005",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1059.006",
-    "technique": "Command and Scripting Interpreter : Python",
-    "url": "https://attack.mitre.org/techniques/T1059/006"
+    "technique": "Command and Scripting Interpreter: Python",
+    "url": "https://attack.mitre.org/techniques/T1059/006",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1059.007",
-    "technique": "Command and Scripting Interpreter : JavaScript/JScript",
-    "url": "https://attack.mitre.org/techniques/T1059/007"
+    "technique": "Command and Scripting Interpreter: JavaScript",
+    "url": "https://attack.mitre.org/techniques/T1059/007",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
+    ]
+  },
+  {
+    "technique_id": "T1059.008",
+    "technique": "Command and Scripting Interpreter: Network Device CLI",
+    "url": "https://attack.mitre.org/techniques/T1059/008",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
   },
   {
     "technique_id": "T1068",
@@ -608,6 +2850,15 @@
     "url": "https://attack.mitre.org/techniques/T1068",
     "tactic": [
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Containers"
     ]
   },
   {
@@ -616,22 +2867,71 @@
     "url": "https://attack.mitre.org/techniques/T1069",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1069.001",
-    "technique": "Permission Groups Discovery : Local Groups",
-    "url": "https://attack.mitre.org/techniques/T1069/001"
+    "technique": "Permission Groups Discovery: Local Groups",
+    "url": "https://attack.mitre.org/techniques/T1069/001",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1069.002",
-    "technique": "Permission Groups Discovery : Domain Groups",
-    "url": "https://attack.mitre.org/techniques/T1069/002"
+    "technique": "Permission Groups Discovery: Domain Groups",
+    "url": "https://attack.mitre.org/techniques/T1069/002",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1069.003",
-    "technique": "Permission Groups Discovery : Cloud Groups",
-    "url": "https://attack.mitre.org/techniques/T1069/003"
+    "technique": "Permission Groups Discovery: Cloud Groups",
+    "url": "https://attack.mitre.org/techniques/T1069/003",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1070",
@@ -639,37 +2939,107 @@
     "url": "https://attack.mitre.org/techniques/T1070",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1070.001",
-    "technique": "Indicator Removal on Host : Clear Windows Event Logs",
-    "url": "https://attack.mitre.org/techniques/T1070/001"
+    "technique": "Indicator Removal on Host: Clear Windows Event Logs",
+    "url": "https://attack.mitre.org/techniques/T1070/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1070.002",
-    "technique": "Indicator Removal on Host : Clear Linux or Mac System Logs",
-    "url": "https://attack.mitre.org/techniques/T1070/002"
+    "technique": "Indicator Removal on Host: Clear Linux or Mac System Logs",
+    "url": "https://attack.mitre.org/techniques/T1070/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1070.003",
-    "technique": "Indicator Removal on Host : Clear Command History",
-    "url": "https://attack.mitre.org/techniques/T1070/003"
+    "technique": "Indicator Removal on Host: Clear Command History",
+    "url": "https://attack.mitre.org/techniques/T1070/003",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1070.004",
-    "technique": "Indicator Removal on Host : File Deletion",
-    "url": "https://attack.mitre.org/techniques/T1070/004"
+    "technique": "Indicator Removal on Host: File Deletion",
+    "url": "https://attack.mitre.org/techniques/T1070/004",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1070.005",
-    "technique": "Indicator Removal on Host : Network Share Connection Removal",
-    "url": "https://attack.mitre.org/techniques/T1070/005"
+    "technique": "Indicator Removal on Host: Network Share Connection Removal",
+    "url": "https://attack.mitre.org/techniques/T1070/005",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1070.006",
-    "technique": "Indicator Removal on Host : Timestomp",
-    "url": "https://attack.mitre.org/techniques/T1070/006"
+    "technique": "Indicator Removal on Host: Timestomp",
+    "url": "https://attack.mitre.org/techniques/T1070/006",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1071",
@@ -677,27 +3047,79 @@
     "url": "https://attack.mitre.org/techniques/T1071",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1071.001",
-    "technique": "Application Layer Protocol : Web Protocols",
-    "url": "https://attack.mitre.org/techniques/T1071/001"
+    "technique": "Application Layer Protocol: Web Protocols",
+    "url": "https://attack.mitre.org/techniques/T1071/001",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1071.002",
-    "technique": "Application Layer Protocol : File Transfer Protocols",
-    "url": "https://attack.mitre.org/techniques/T1071/002"
+    "technique": "Application Layer Protocol: File Transfer Protocols",
+    "url": "https://attack.mitre.org/techniques/T1071/002",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1071.003",
-    "technique": "Application Layer Protocol : Mail Protocols",
-    "url": "https://attack.mitre.org/techniques/T1071/003"
+    "technique": "Application Layer Protocol: Mail Protocols",
+    "url": "https://attack.mitre.org/techniques/T1071/003",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1071.004",
-    "technique": "Application Layer Protocol : DNS",
-    "url": "https://attack.mitre.org/techniques/T1071/004"
+    "technique": "Application Layer Protocol: DNS",
+    "url": "https://attack.mitre.org/techniques/T1071/004",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1072",
@@ -706,6 +3128,14 @@
     "tactic": [
       "Execution",
       "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -714,17 +3144,49 @@
     "url": "https://attack.mitre.org/techniques/T1074",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS"
     ]
   },
   {
     "technique_id": "T1074.001",
-    "technique": "Data Staged : Local Data Staging",
-    "url": "https://attack.mitre.org/techniques/T1074/001"
+    "technique": "Data Staged: Local Data Staging",
+    "url": "https://attack.mitre.org/techniques/T1074/001",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1074.002",
-    "technique": "Data Staged : Remote Data Staging",
-    "url": "https://attack.mitre.org/techniques/T1074/002"
+    "technique": "Data Staged: Remote Data Staging",
+    "url": "https://attack.mitre.org/techniques/T1074/002",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1078",
@@ -735,27 +3197,106 @@
       "Persistence",
       "Privilege Escalation",
       "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1078.001",
-    "technique": "Valid Accounts : Default Accounts",
-    "url": "https://attack.mitre.org/techniques/T1078/001"
+    "technique": "Valid Accounts: Default Accounts",
+    "url": "https://attack.mitre.org/techniques/T1078/001",
+    "tactic": [
+      "Defense Evasion",
+      "Persistence",
+      "Privilege Escalation",
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1078.002",
-    "technique": "Valid Accounts : Domain Accounts",
-    "url": "https://attack.mitre.org/techniques/T1078/002"
+    "technique": "Valid Accounts: Domain Accounts",
+    "url": "https://attack.mitre.org/techniques/T1078/002",
+    "tactic": [
+      "Defense Evasion",
+      "Persistence",
+      "Privilege Escalation",
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1078.003",
-    "technique": "Valid Accounts : Local Accounts",
-    "url": "https://attack.mitre.org/techniques/T1078/003"
+    "technique": "Valid Accounts: Local Accounts",
+    "url": "https://attack.mitre.org/techniques/T1078/003",
+    "tactic": [
+      "Defense Evasion",
+      "Persistence",
+      "Privilege Escalation",
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1078.004",
-    "technique": "Valid Accounts : Cloud Accounts",
-    "url": "https://attack.mitre.org/techniques/T1078/004"
+    "technique": "Valid Accounts: Cloud Accounts",
+    "url": "https://attack.mitre.org/techniques/T1078/004",
+    "tactic": [
+      "Defense Evasion",
+      "Persistence",
+      "Privilege Escalation",
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1080",
@@ -763,6 +3304,16 @@
     "url": "https://attack.mitre.org/techniques/T1080",
     "tactic": [
       "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365",
+      "SaaS",
+      "Linux",
+      "macOS"
     ]
   },
   {
@@ -771,6 +3322,15 @@
     "url": "https://attack.mitre.org/techniques/T1082",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS"
     ]
   },
   {
@@ -779,6 +3339,14 @@
     "url": "https://attack.mitre.org/techniques/T1083",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -787,27 +3355,86 @@
     "url": "https://attack.mitre.org/techniques/T1087",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
     ]
   },
   {
     "technique_id": "T1087.001",
-    "technique": "Account Discovery : Local Account",
-    "url": "https://attack.mitre.org/techniques/T1087/001"
+    "technique": "Account Discovery: Local Account",
+    "url": "https://attack.mitre.org/techniques/T1087/001",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1087.002",
-    "technique": "Account Discovery : Domain Account",
-    "url": "https://attack.mitre.org/techniques/T1087/002"
+    "technique": "Account Discovery: Domain Account",
+    "url": "https://attack.mitre.org/techniques/T1087/002",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1087.003",
-    "technique": "Account Discovery : Email Account",
-    "url": "https://attack.mitre.org/techniques/T1087/003"
+    "technique": "Account Discovery: Email Account",
+    "url": "https://attack.mitre.org/techniques/T1087/003",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1087.004",
-    "technique": "Account Discovery : Cloud Account",
-    "url": "https://attack.mitre.org/techniques/T1087/004"
+    "technique": "Account Discovery: Cloud Account",
+    "url": "https://attack.mitre.org/techniques/T1087/004",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1090",
@@ -815,27 +3442,81 @@
     "url": "https://attack.mitre.org/techniques/T1090",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Network"
     ]
   },
   {
     "technique_id": "T1090.001",
-    "technique": "Proxy : Internal Proxy",
-    "url": "https://attack.mitre.org/techniques/T1090/001"
+    "technique": "Proxy: Internal Proxy",
+    "url": "https://attack.mitre.org/techniques/T1090/001",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1090.002",
-    "technique": "Proxy : External Proxy",
-    "url": "https://attack.mitre.org/techniques/T1090/002"
+    "technique": "Proxy: External Proxy",
+    "url": "https://attack.mitre.org/techniques/T1090/002",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1090.003",
-    "technique": "Proxy : Multi-hop Proxy",
-    "url": "https://attack.mitre.org/techniques/T1090/003"
+    "technique": "Proxy: Multi-hop Proxy",
+    "url": "https://attack.mitre.org/techniques/T1090/003",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Network"
+    ]
   },
   {
     "technique_id": "T1090.004",
-    "technique": "Proxy : Domain Fronting",
-    "url": "https://attack.mitre.org/techniques/T1090/004"
+    "technique": "Proxy: Domain Fronting",
+    "url": "https://attack.mitre.org/techniques/T1090/004",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1091",
@@ -844,6 +3525,12 @@
     "tactic": [
       "Lateral Movement",
       "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -852,6 +3539,14 @@
     "url": "https://attack.mitre.org/techniques/T1092",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -860,6 +3555,15 @@
     "url": "https://attack.mitre.org/techniques/T1095",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS",
+      "Network"
     ]
   },
   {
@@ -868,27 +3572,78 @@
     "url": "https://attack.mitre.org/techniques/T1098",
     "tactic": [
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
     ]
   },
   {
     "technique_id": "T1098.001",
-    "technique": "Account Manipulation : Additional Azure Service Principal Credentials",
-    "url": "https://attack.mitre.org/techniques/T1098/001"
+    "technique": "Account Manipulation: Additional Cloud Credentials",
+    "url": "https://attack.mitre.org/techniques/T1098/001",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS",
+      "Azure AD"
+    ]
   },
   {
     "technique_id": "T1098.002",
-    "technique": "Account Manipulation : Exchange Email Delegate Permissions",
-    "url": "https://attack.mitre.org/techniques/T1098/002"
+    "technique": "Account Manipulation: Exchange Email Delegate Permissions",
+    "url": "https://attack.mitre.org/techniques/T1098/002",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
+    ]
   },
   {
     "technique_id": "T1098.003",
-    "technique": "Account Manipulation : Add Office 365 Global Administrator Role",
-    "url": "https://attack.mitre.org/techniques/T1098/003"
+    "technique": "Account Manipulation: Add Office 365 Global Administrator Role",
+    "url": "https://attack.mitre.org/techniques/T1098/003",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Office 365"
+    ]
   },
   {
     "technique_id": "T1098.004",
-    "technique": "Account Manipulation : SSH Authorized Keys",
-    "url": "https://attack.mitre.org/techniques/T1098/004"
+    "technique": "Account Manipulation: SSH Authorized Keys",
+    "url": "https://attack.mitre.org/techniques/T1098/004",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1102",
@@ -896,22 +3651,63 @@
     "url": "https://attack.mitre.org/techniques/T1102",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1102.001",
-    "technique": "Web Service : Dead Drop Resolver",
-    "url": "https://attack.mitre.org/techniques/T1102/001"
+    "technique": "Web Service: Dead Drop Resolver",
+    "url": "https://attack.mitre.org/techniques/T1102/001",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1102.002",
-    "technique": "Web Service : Bidirectional Communication",
-    "url": "https://attack.mitre.org/techniques/T1102/002"
+    "technique": "Web Service: Bidirectional Communication",
+    "url": "https://attack.mitre.org/techniques/T1102/002",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1102.003",
-    "technique": "Web Service : One-Way Communication",
-    "url": "https://attack.mitre.org/techniques/T1102/003"
+    "technique": "Web Service: One-Way Communication",
+    "url": "https://attack.mitre.org/techniques/T1102/003",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1104",
@@ -919,6 +3715,14 @@
     "url": "https://attack.mitre.org/techniques/T1104",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -927,6 +3731,14 @@
     "url": "https://attack.mitre.org/techniques/T1105",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -935,6 +3747,14 @@
     "url": "https://attack.mitre.org/techniques/T1106",
     "tactic": [
       "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
     ]
   },
   {
@@ -943,27 +3763,105 @@
     "url": "https://attack.mitre.org/techniques/T1110",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1110.001",
-    "technique": "Brute Force : Password Guessing",
-    "url": "https://attack.mitre.org/techniques/T1110/001"
+    "technique": "Brute Force: Password Guessing",
+    "url": "https://attack.mitre.org/techniques/T1110/001",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1110.002",
-    "technique": "Brute Force : Password Cracking",
-    "url": "https://attack.mitre.org/techniques/T1110/002"
+    "technique": "Brute Force: Password Cracking",
+    "url": "https://attack.mitre.org/techniques/T1110/002",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Office 365",
+      "Azure AD"
+    ]
   },
   {
     "technique_id": "T1110.003",
-    "technique": "Brute Force : Password Spraying",
-    "url": "https://attack.mitre.org/techniques/T1110/003"
+    "technique": "Brute Force: Password Spraying",
+    "url": "https://attack.mitre.org/techniques/T1110/003",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1110.004",
-    "technique": "Brute Force : Credential Stuffing",
-    "url": "https://attack.mitre.org/techniques/T1110/004"
+    "technique": "Brute Force: Credential Stuffing",
+    "url": "https://attack.mitre.org/techniques/T1110/004",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1111",
@@ -971,6 +3869,14 @@
     "url": "https://attack.mitre.org/techniques/T1111",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -979,6 +3885,12 @@
     "url": "https://attack.mitre.org/techniques/T1112",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -987,6 +3899,14 @@
     "url": "https://attack.mitre.org/techniques/T1113",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -995,22 +3915,65 @@
     "url": "https://attack.mitre.org/techniques/T1114",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365",
+      "Google Workspace",
+      "macOS",
+      "Linux"
     ]
   },
   {
     "technique_id": "T1114.001",
-    "technique": "Email Collection : Local Email Collection",
-    "url": "https://attack.mitre.org/techniques/T1114/001"
+    "technique": "Email Collection: Local Email Collection",
+    "url": "https://attack.mitre.org/techniques/T1114/001",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1114.002",
-    "technique": "Email Collection : Remote Email Collection",
-    "url": "https://attack.mitre.org/techniques/T1114/002"
+    "technique": "Email Collection: Remote Email Collection",
+    "url": "https://attack.mitre.org/techniques/T1114/002",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Office 365",
+      "Windows",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1114.003",
-    "technique": "Email Collection : Email Forwarding Rule",
-    "url": "https://attack.mitre.org/techniques/T1114/003"
+    "technique": "Email Collection: Email Forwarding Rule",
+    "url": "https://attack.mitre.org/techniques/T1114/003",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Office 365",
+      "Windows",
+      "Google Workspace",
+      "macOS",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1115",
@@ -1018,6 +3981,14 @@
     "url": "https://attack.mitre.org/techniques/T1115",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -1026,6 +3997,14 @@
     "url": "https://attack.mitre.org/techniques/T1119",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -1034,6 +4013,13 @@
     "url": "https://attack.mitre.org/techniques/T1120",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -1042,6 +4028,14 @@
     "url": "https://attack.mitre.org/techniques/T1123",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -1050,6 +4044,12 @@
     "url": "https://attack.mitre.org/techniques/T1124",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -1058,6 +4058,13 @@
     "url": "https://attack.mitre.org/techniques/T1125",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -1066,12 +4073,27 @@
     "url": "https://attack.mitre.org/techniques/T1127",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
     "technique_id": "T1127.001",
-    "technique": "Trusted Developer Utilities Proxy Execution : MSBuild",
-    "url": "https://attack.mitre.org/techniques/T1127/001"
+    "technique": "Trusted Developer Utilities Proxy Execution: MSBuild",
+    "url": "https://attack.mitre.org/techniques/T1127/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1129",
@@ -1079,6 +4101,12 @@
     "url": "https://attack.mitre.org/techniques/T1129",
     "tactic": [
       "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -1087,17 +4115,47 @@
     "url": "https://attack.mitre.org/techniques/T1132",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1132.001",
-    "technique": "Data Encoding : Standard Encoding",
-    "url": "https://attack.mitre.org/techniques/T1132/001"
+    "technique": "Data Encoding: Standard Encoding",
+    "url": "https://attack.mitre.org/techniques/T1132/001",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1132.002",
-    "technique": "Data Encoding : Non-Standard Encoding",
-    "url": "https://attack.mitre.org/techniques/T1132/002"
+    "technique": "Data Encoding: Non-Standard Encoding",
+    "url": "https://attack.mitre.org/techniques/T1132/002",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1133",
@@ -1106,6 +4164,15 @@
     "tactic": [
       "Persistence",
       "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "Containers",
+      "macOS"
     ]
   },
   {
@@ -1115,32 +4182,88 @@
     "tactic": [
       "Defense Evasion",
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
     "technique_id": "T1134.001",
-    "technique": "Access Token Manipulation : Token Impersonation/Theft",
-    "url": "https://attack.mitre.org/techniques/T1134/001"
+    "technique": "Access Token Manipulation: Token Impersonation/Theft",
+    "url": "https://attack.mitre.org/techniques/T1134/001",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1134.002",
-    "technique": "Access Token Manipulation : Create Process with Token",
-    "url": "https://attack.mitre.org/techniques/T1134/002"
+    "technique": "Access Token Manipulation: Create Process with Token",
+    "url": "https://attack.mitre.org/techniques/T1134/002",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1134.003",
-    "technique": "Access Token Manipulation : Make and Impersonate Token",
-    "url": "https://attack.mitre.org/techniques/T1134/003"
+    "technique": "Access Token Manipulation: Make and Impersonate Token",
+    "url": "https://attack.mitre.org/techniques/T1134/003",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1134.004",
-    "technique": "Access Token Manipulation : Parent PID Spoofing",
-    "url": "https://attack.mitre.org/techniques/T1134/004"
+    "technique": "Access Token Manipulation: Parent PID Spoofing",
+    "url": "https://attack.mitre.org/techniques/T1134/004",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1134.005",
-    "technique": "Access Token Manipulation : SID-History Injection",
-    "url": "https://attack.mitre.org/techniques/T1134/005"
+    "technique": "Access Token Manipulation: SID-History Injection",
+    "url": "https://attack.mitre.org/techniques/T1134/005",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1135",
@@ -1148,6 +4271,14 @@
     "url": "https://attack.mitre.org/techniques/T1135",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows",
+      "Linux"
     ]
   },
   {
@@ -1156,22 +4287,68 @@
     "url": "https://attack.mitre.org/techniques/T1136",
     "tactic": [
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
     ]
   },
   {
     "technique_id": "T1136.001",
-    "technique": "Create Account : Local Account",
-    "url": "https://attack.mitre.org/techniques/T1136/001"
+    "technique": "Create Account: Local Account",
+    "url": "https://attack.mitre.org/techniques/T1136/001",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1136.002",
-    "technique": "Create Account : Domain Account",
-    "url": "https://attack.mitre.org/techniques/T1136/002"
+    "technique": "Create Account: Domain Account",
+    "url": "https://attack.mitre.org/techniques/T1136/002",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1136.003",
-    "technique": "Create Account : Cloud Account",
-    "url": "https://attack.mitre.org/techniques/T1136/003"
+    "technique": "Create Account: Cloud Account",
+    "url": "https://attack.mitre.org/techniques/T1136/003",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Azure AD",
+      "Office 365",
+      "IaaS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1137",
@@ -1179,37 +4356,104 @@
     "url": "https://attack.mitre.org/techniques/T1137",
     "tactic": [
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
     ]
   },
   {
     "technique_id": "T1137.001",
-    "technique": "Office Application Startup : Office Template Macros",
-    "url": "https://attack.mitre.org/techniques/T1137/001"
+    "technique": "Office Application Startup: Office Template Macros",
+    "url": "https://attack.mitre.org/techniques/T1137/001",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
+    ]
   },
   {
     "technique_id": "T1137.002",
-    "technique": "Office Application Startup : Office Test",
-    "url": "https://attack.mitre.org/techniques/T1137/002"
+    "technique": "Office Application Startup: Office Test",
+    "url": "https://attack.mitre.org/techniques/T1137/002",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
+    ]
   },
   {
     "technique_id": "T1137.003",
-    "technique": "Office Application Startup : Outlook Forms",
-    "url": "https://attack.mitre.org/techniques/T1137/003"
+    "technique": "Office Application Startup: Outlook Forms",
+    "url": "https://attack.mitre.org/techniques/T1137/003",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
+    ]
   },
   {
     "technique_id": "T1137.004",
-    "technique": "Office Application Startup : Outlook Home Page",
-    "url": "https://attack.mitre.org/techniques/T1137/004"
+    "technique": "Office Application Startup: Outlook Home Page",
+    "url": "https://attack.mitre.org/techniques/T1137/004",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
+    ]
   },
   {
     "technique_id": "T1137.005",
-    "technique": "Office Application Startup : Outlook Rules",
-    "url": "https://attack.mitre.org/techniques/T1137/005"
+    "technique": "Office Application Startup: Outlook Rules",
+    "url": "https://attack.mitre.org/techniques/T1137/005",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
+    ]
   },
   {
     "technique_id": "T1137.006",
-    "technique": "Office Application Startup : Add-ins",
-    "url": "https://attack.mitre.org/techniques/T1137/006"
+    "technique": "Office Application Startup: Add-ins",
+    "url": "https://attack.mitre.org/techniques/T1137/006",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
+    ]
   },
   {
     "technique_id": "T1140",
@@ -1217,6 +4461,14 @@
     "url": "https://attack.mitre.org/techniques/T1140",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
     ]
   },
   {
@@ -1225,14 +4477,28 @@
     "url": "https://attack.mitre.org/techniques/T1176",
     "tactic": [
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1185",
-    "technique": "Man in the Browser",
+    "technique": "Browser Session Hijacking",
     "url": "https://attack.mitre.org/techniques/T1185",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -1241,6 +4507,12 @@
     "url": "https://attack.mitre.org/techniques/T1187",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -1249,6 +4521,15 @@
     "url": "https://attack.mitre.org/techniques/T1189",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS",
+      "SaaS"
     ]
   },
   {
@@ -1257,6 +4538,17 @@
     "url": "https://attack.mitre.org/techniques/T1190",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Network",
+      "Linux",
+      "macOS",
+      "Containers"
     ]
   },
   {
@@ -1265,22 +4557,63 @@
     "url": "https://attack.mitre.org/techniques/T1195",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
     "technique_id": "T1195.001",
-    "technique": "Supply Chain Compromise : Compromise Software Dependencies and Development Tools",
-    "url": "https://attack.mitre.org/techniques/T1195/001"
+    "technique": "Supply Chain Compromise: Compromise Software Dependencies and Development Tools",
+    "url": "https://attack.mitre.org/techniques/T1195/001",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1195.002",
-    "technique": "Supply Chain Compromise : Compromise Software Supply Chain",
-    "url": "https://attack.mitre.org/techniques/T1195/002"
+    "technique": "Supply Chain Compromise: Compromise Software Supply Chain",
+    "url": "https://attack.mitre.org/techniques/T1195/002",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1195.003",
-    "technique": "Supply Chain Compromise : Compromise Hardware Supply Chain",
-    "url": "https://attack.mitre.org/techniques/T1195/003"
+    "technique": "Supply Chain Compromise: Compromise Hardware Supply Chain",
+    "url": "https://attack.mitre.org/techniques/T1195/003",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1197",
@@ -1289,6 +4622,12 @@
     "tactic": [
       "Defense Evasion",
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -1297,6 +4636,16 @@
     "url": "https://attack.mitre.org/techniques/T1199",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS"
     ]
   },
   {
@@ -1305,6 +4654,14 @@
     "url": "https://attack.mitre.org/techniques/T1200",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
     ]
   },
   {
@@ -1313,6 +4670,15 @@
     "url": "https://attack.mitre.org/techniques/T1201",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS",
+      "IaaS"
     ]
   },
   {
@@ -1321,6 +4687,12 @@
     "url": "https://attack.mitre.org/techniques/T1202",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -1329,6 +4701,14 @@
     "url": "https://attack.mitre.org/techniques/T1203",
     "tactic": [
       "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -1337,17 +4717,64 @@
     "url": "https://attack.mitre.org/techniques/T1204",
     "tactic": [
       "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS",
+      "IaaS",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1204.001",
-    "technique": "User Execution : Malicious Link",
-    "url": "https://attack.mitre.org/techniques/T1204/001"
+    "technique": "User Execution: Malicious Link",
+    "url": "https://attack.mitre.org/techniques/T1204/001",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1204.002",
-    "technique": "User Execution : Malicious File",
-    "url": "https://attack.mitre.org/techniques/T1204/002"
+    "technique": "User Execution: Malicious File",
+    "url": "https://attack.mitre.org/techniques/T1204/002",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1204.003",
+    "technique": "User Execution: Malicious Image",
+    "url": "https://attack.mitre.org/techniques/T1204/003",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS",
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1205",
@@ -1357,12 +4784,35 @@
       "Defense Evasion",
       "Persistence",
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Network"
     ]
   },
   {
     "technique_id": "T1205.001",
-    "technique": "Traffic Signaling : Port Knocking",
-    "url": "https://attack.mitre.org/techniques/T1205/001"
+    "technique": "Traffic Signaling: Port Knocking",
+    "url": "https://attack.mitre.org/techniques/T1205/001",
+    "tactic": [
+      "Defense Evasion",
+      "Persistence",
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Network"
+    ]
   },
   {
     "technique_id": "T1207",
@@ -1370,6 +4820,12 @@
     "url": "https://attack.mitre.org/techniques/T1207",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -1378,6 +4834,14 @@
     "url": "https://attack.mitre.org/techniques/T1210",
     "tactic": [
       "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -1386,6 +4850,14 @@
     "url": "https://attack.mitre.org/techniques/T1211",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -1394,6 +4866,14 @@
     "url": "https://attack.mitre.org/techniques/T1212",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -1402,17 +4882,62 @@
     "url": "https://attack.mitre.org/techniques/T1213",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS",
+      "SaaS",
+      "Office 365",
+      "Google Workspace",
+      "IaaS"
     ]
   },
   {
     "technique_id": "T1213.001",
-    "technique": "Data from Information Repositories : Confluence",
-    "url": "https://attack.mitre.org/techniques/T1213/001"
+    "technique": "Data from Information Repositories: Confluence",
+    "url": "https://attack.mitre.org/techniques/T1213/001",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "SaaS"
+    ]
   },
   {
     "technique_id": "T1213.002",
-    "technique": "Data from Information Repositories : Sharepoint",
-    "url": "https://attack.mitre.org/techniques/T1213/002"
+    "technique": "Data from Information Repositories: Sharepoint",
+    "url": "https://attack.mitre.org/techniques/T1213/002",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365"
+    ]
+  },
+  {
+    "technique_id": "T1213.003",
+    "technique": "Data from Information Repositories: Code Repositories",
+    "url": "https://attack.mitre.org/techniques/T1213/003",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "SaaS"
+    ]
   },
   {
     "technique_id": "T1216",
@@ -1420,12 +4945,27 @@
     "url": "https://attack.mitre.org/techniques/T1216",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
     "technique_id": "T1216.001",
-    "technique": "Signed Script Proxy Execution : PubPrn",
-    "url": "https://attack.mitre.org/techniques/T1216/001"
+    "technique": "Signed Script Proxy Execution: PubPrn",
+    "url": "https://attack.mitre.org/techniques/T1216/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1217",
@@ -1433,6 +4973,14 @@
     "url": "https://attack.mitre.org/techniques/T1217",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -1441,57 +4989,195 @@
     "url": "https://attack.mitre.org/techniques/T1218",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
     "technique_id": "T1218.001",
-    "technique": "Signed Binary Proxy Execution : Compiled HTML File",
-    "url": "https://attack.mitre.org/techniques/T1218/001"
+    "technique": "Signed Binary Proxy Execution: Compiled HTML File",
+    "url": "https://attack.mitre.org/techniques/T1218/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1218.002",
-    "technique": "Signed Binary Proxy Execution : Control Panel",
-    "url": "https://attack.mitre.org/techniques/T1218/002"
+    "technique": "Signed Binary Proxy Execution: Control Panel",
+    "url": "https://attack.mitre.org/techniques/T1218/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1218.003",
-    "technique": "Signed Binary Proxy Execution : CMSTP",
-    "url": "https://attack.mitre.org/techniques/T1218/003"
+    "technique": "Signed Binary Proxy Execution: CMSTP",
+    "url": "https://attack.mitre.org/techniques/T1218/003",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1218.004",
-    "technique": "Signed Binary Proxy Execution : InstallUtil",
-    "url": "https://attack.mitre.org/techniques/T1218/004"
+    "technique": "Signed Binary Proxy Execution: InstallUtil",
+    "url": "https://attack.mitre.org/techniques/T1218/004",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1218.005",
-    "technique": "Signed Binary Proxy Execution : Mshta",
-    "url": "https://attack.mitre.org/techniques/T1218/005"
+    "technique": "Signed Binary Proxy Execution: Mshta",
+    "url": "https://attack.mitre.org/techniques/T1218/005",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1218.007",
-    "technique": "Signed Binary Proxy Execution : Msiexec",
-    "url": "https://attack.mitre.org/techniques/T1218/007"
+    "technique": "Signed Binary Proxy Execution: Msiexec",
+    "url": "https://attack.mitre.org/techniques/T1218/007",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1218.008",
-    "technique": "Signed Binary Proxy Execution : Odbcconf",
-    "url": "https://attack.mitre.org/techniques/T1218/008"
+    "technique": "Signed Binary Proxy Execution: Odbcconf",
+    "url": "https://attack.mitre.org/techniques/T1218/008",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1218.009",
-    "technique": "Signed Binary Proxy Execution : Regsvcs/Regasm",
-    "url": "https://attack.mitre.org/techniques/T1218/009"
+    "technique": "Signed Binary Proxy Execution: Regsvcs/Regasm",
+    "url": "https://attack.mitre.org/techniques/T1218/009",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1218.010",
-    "technique": "Signed Binary Proxy Execution : Regsvr32",
-    "url": "https://attack.mitre.org/techniques/T1218/010"
+    "technique": "Signed Binary Proxy Execution: Regsvr32",
+    "url": "https://attack.mitre.org/techniques/T1218/010",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1218.011",
-    "technique": "Signed Binary Proxy Execution : Rundll32",
-    "url": "https://attack.mitre.org/techniques/T1218/011"
+    "technique": "Signed Binary Proxy Execution: Rundll32",
+    "url": "https://attack.mitre.org/techniques/T1218/011",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1218.012",
+    "technique": "Signed Binary Proxy Execution: Verclsid",
+    "url": "https://attack.mitre.org/techniques/T1218/012",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1218.013",
+    "technique": "Signed Binary Proxy Execution: Mavinject",
+    "url": "https://attack.mitre.org/techniques/T1218/013",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1218.014",
+    "technique": "Signed Binary Proxy Execution: MMC",
+    "url": "https://attack.mitre.org/techniques/T1218/014",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1219",
@@ -1499,6 +5185,14 @@
     "url": "https://attack.mitre.org/techniques/T1219",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
@@ -1507,6 +5201,12 @@
     "url": "https://attack.mitre.org/techniques/T1220",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -1515,6 +5215,12 @@
     "url": "https://attack.mitre.org/techniques/T1221",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
@@ -1523,1200 +5229,43 @@
     "url": "https://attack.mitre.org/techniques/T1222",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
     ]
   },
   {
     "technique_id": "T1222.001",
-    "technique": "File and Directory Permissions Modification : Windows File and Directory Permissions Modification",
-    "url": "https://attack.mitre.org/techniques/T1222/001"
+    "technique": "File and Directory Permissions Modification: Windows File and Directory Permissions Modification",
+    "url": "https://attack.mitre.org/techniques/T1222/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1222.002",
-    "technique": "File and Directory Permissions Modification : Linux and Mac File and Directory Permissions Modification",
-    "url": "https://attack.mitre.org/techniques/T1222/002"
-  },
-  {
-    "technique_id": "T1224",
-    "technique": "Assess leadership areas of interest",
-    "url": "https://attack.mitre.org/techniques/T1224",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1225",
-    "technique": "Identify gap areas",
-    "url": "https://attack.mitre.org/techniques/T1225",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1226",
-    "technique": "Conduct cost/benefit analysis",
-    "url": "https://attack.mitre.org/techniques/T1226",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1227",
-    "technique": "Develop KITs/KIQs",
-    "url": "https://attack.mitre.org/techniques/T1227",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1228",
-    "technique": "Assign KITs/KIQs into categories",
-    "url": "https://attack.mitre.org/techniques/T1228",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1229",
-    "technique": "Assess KITs/KIQs benefits",
-    "url": "https://attack.mitre.org/techniques/T1229",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1230",
-    "technique": "Derive intelligence requirements",
-    "url": "https://attack.mitre.org/techniques/T1230",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1231",
-    "technique": "Create strategic plan",
-    "url": "https://attack.mitre.org/techniques/T1231",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1232",
-    "technique": "Create implementation plan",
-    "url": "https://attack.mitre.org/techniques/T1232",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1233",
-    "technique": "Identify analyst level gaps",
-    "url": "https://attack.mitre.org/techniques/T1233",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1234",
-    "technique": "Generate analyst intelligence requirements",
-    "url": "https://attack.mitre.org/techniques/T1234",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1235",
-    "technique": "Receive operator KITs/KIQs tasking",
-    "url": "https://attack.mitre.org/techniques/T1235",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1236",
-    "technique": "Assess current holdings, needs, and wants",
-    "url": "https://attack.mitre.org/techniques/T1236",
-    "tactic": [
-      "Priority Definition Planning"
-    ]
-  },
-  {
-    "technique_id": "T1237",
-    "technique": "Submit KITs, KIQs, and intelligence requirements",
-    "url": "https://attack.mitre.org/techniques/T1237",
-    "tactic": [
-      "Priority Definition Direction"
-    ]
-  },
-  {
-    "technique_id": "T1238",
-    "technique": "Assign KITs, KIQs, and/or intelligence requirements",
-    "url": "https://attack.mitre.org/techniques/T1238",
-    "tactic": [
-      "Priority Definition Direction"
-    ]
-  },
-  {
-    "technique_id": "T1239",
-    "technique": "Receive KITs/KIQs and determine requirements",
-    "url": "https://attack.mitre.org/techniques/T1239",
-    "tactic": [
-      "Priority Definition Direction"
-    ]
-  },
-  {
-    "technique_id": "T1240",
-    "technique": "Task requirements",
-    "url": "https://attack.mitre.org/techniques/T1240",
-    "tactic": [
-      "Priority Definition Direction"
-    ]
-  },
-  {
-    "technique_id": "T1241",
-    "technique": "Determine strategic target",
-    "url": "https://attack.mitre.org/techniques/T1241",
-    "tactic": [
-      "Target Selection"
-    ]
-  },
-  {
-    "technique_id": "T1242",
-    "technique": "Determine operational element",
-    "url": "https://attack.mitre.org/techniques/T1242",
-    "tactic": [
-      "Target Selection"
-    ]
-  },
-  {
-    "technique_id": "T1243",
-    "technique": "Determine highest level tactical element",
-    "url": "https://attack.mitre.org/techniques/T1243",
-    "tactic": [
-      "Target Selection"
-    ]
-  },
-  {
-    "technique_id": "T1244",
-    "technique": "Determine secondary level tactical element",
-    "url": "https://attack.mitre.org/techniques/T1244",
-    "tactic": [
-      "Target Selection"
-    ]
-  },
-  {
-    "technique_id": "T1245",
-    "technique": "Determine approach/attack vector",
-    "url": "https://attack.mitre.org/techniques/T1245",
-    "tactic": [
-      "Target Selection"
-    ]
-  },
-  {
-    "technique_id": "T1246",
-    "technique": "Identify supply chains",
-    "url": "https://attack.mitre.org/techniques/T1246",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1247",
-    "technique": "Acquire OSINT data sets and information",
-    "url": "https://attack.mitre.org/techniques/T1247",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1248",
-    "technique": "Identify job postings and needs/gaps",
-    "url": "https://attack.mitre.org/techniques/T1248",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1249",
-    "technique": "Conduct social engineering",
-    "url": "https://attack.mitre.org/techniques/T1249",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1250",
-    "technique": "Determine domain and IP address space",
-    "url": "https://attack.mitre.org/techniques/T1250",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1251",
-    "technique": "Obtain domain/IP registration information",
-    "url": "https://attack.mitre.org/techniques/T1251",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1252",
-    "technique": "Map network topology",
-    "url": "https://attack.mitre.org/techniques/T1252",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1253",
-    "technique": "Conduct passive scanning",
-    "url": "https://attack.mitre.org/techniques/T1253",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1254",
-    "technique": "Conduct active scanning",
-    "url": "https://attack.mitre.org/techniques/T1254",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1255",
-    "technique": "Discover target logon/email address format",
-    "url": "https://attack.mitre.org/techniques/T1255",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1256",
-    "technique": "Identify web defensive services",
-    "url": "https://attack.mitre.org/techniques/T1256",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1257",
-    "technique": "Mine technical blogs/forums",
-    "url": "https://attack.mitre.org/techniques/T1257",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1258",
-    "technique": "Determine firmware version",
-    "url": "https://attack.mitre.org/techniques/T1258",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1259",
-    "technique": "Determine external network trust dependencies",
-    "url": "https://attack.mitre.org/techniques/T1259",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1260",
-    "technique": "Determine 3rd party infrastructure services",
-    "url": "https://attack.mitre.org/techniques/T1260",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1261",
-    "technique": "Enumerate externally facing software applications technologies, languages, and dependencies",
-    "url": "https://attack.mitre.org/techniques/T1261",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1262",
-    "technique": "Enumerate client configurations",
-    "url": "https://attack.mitre.org/techniques/T1262",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1263",
-    "technique": "Identify security defensive capabilities",
-    "url": "https://attack.mitre.org/techniques/T1263",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1264",
-    "technique": "Identify technology usage patterns",
-    "url": "https://attack.mitre.org/techniques/T1264",
-    "tactic": [
-      "Technical Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1265",
-    "technique": "Identify supply chains",
-    "url": "https://attack.mitre.org/techniques/T1265",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1266",
-    "technique": "Acquire OSINT data sets and information",
-    "url": "https://attack.mitre.org/techniques/T1266",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1267",
-    "technique": "Identify job postings and needs/gaps",
-    "url": "https://attack.mitre.org/techniques/T1267",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1268",
-    "technique": "Conduct social engineering",
-    "url": "https://attack.mitre.org/techniques/T1268",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1269",
-    "technique": "Identify people of interest",
-    "url": "https://attack.mitre.org/techniques/T1269",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1270",
-    "technique": "Identify groups/roles",
-    "url": "https://attack.mitre.org/techniques/T1270",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1271",
-    "technique": "Identify personnel with an authority/privilege",
-    "url": "https://attack.mitre.org/techniques/T1271",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1272",
-    "technique": "Identify business relationships",
-    "url": "https://attack.mitre.org/techniques/T1272",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1273",
-    "technique": "Mine social media",
-    "url": "https://attack.mitre.org/techniques/T1273",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1274",
-    "technique": "Identify sensitive personnel information",
-    "url": "https://attack.mitre.org/techniques/T1274",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1275",
-    "technique": "Aggregate individual's digital footprint",
-    "url": "https://attack.mitre.org/techniques/T1275",
-    "tactic": [
-      "People Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1276",
-    "technique": "Identify supply chains",
-    "url": "https://attack.mitre.org/techniques/T1276",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1277",
-    "technique": "Acquire OSINT data sets and information",
-    "url": "https://attack.mitre.org/techniques/T1277",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1278",
-    "technique": "Identify job postings and needs/gaps",
-    "url": "https://attack.mitre.org/techniques/T1278",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1279",
-    "technique": "Conduct social engineering",
-    "url": "https://attack.mitre.org/techniques/T1279",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1280",
-    "technique": "Identify business processes/tempo",
-    "url": "https://attack.mitre.org/techniques/T1280",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1281",
-    "technique": "Obtain templates/branding materials",
-    "url": "https://attack.mitre.org/techniques/T1281",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1282",
-    "technique": "Determine physical locations",
-    "url": "https://attack.mitre.org/techniques/T1282",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1283",
-    "technique": "Identify business relationships",
-    "url": "https://attack.mitre.org/techniques/T1283",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1284",
-    "technique": "Determine 3rd party infrastructure services",
-    "url": "https://attack.mitre.org/techniques/T1284",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1285",
-    "technique": "Determine centralization of IT management",
-    "url": "https://attack.mitre.org/techniques/T1285",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1286",
-    "technique": "Dumpster dive",
-    "url": "https://attack.mitre.org/techniques/T1286",
-    "tactic": [
-      "Organizational Information Gathering"
-    ]
-  },
-  {
-    "technique_id": "T1287",
-    "technique": "Analyze data collected",
-    "url": "https://attack.mitre.org/techniques/T1287",
-    "tactic": [
-      "Technical Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1288",
-    "technique": "Analyze architecture and configuration posture",
-    "url": "https://attack.mitre.org/techniques/T1288",
-    "tactic": [
-      "Technical Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1289",
-    "technique": "Analyze organizational skillsets and deficiencies",
-    "url": "https://attack.mitre.org/techniques/T1289",
-    "tactic": [
-      "Technical Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1290",
-    "technique": "Research visibility gap of security vendors",
-    "url": "https://attack.mitre.org/techniques/T1290",
-    "tactic": [
-      "Technical Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1291",
-    "technique": "Research relevant vulnerabilities/CVEs",
-    "url": "https://attack.mitre.org/techniques/T1291",
-    "tactic": [
-      "Technical Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1292",
-    "technique": "Test signature detection",
-    "url": "https://attack.mitre.org/techniques/T1292",
-    "tactic": [
-      "Technical Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1293",
-    "technique": "Analyze application security posture",
-    "url": "https://attack.mitre.org/techniques/T1293",
-    "tactic": [
-      "Technical Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1294",
-    "technique": "Analyze hardware/software security defensive capabilities",
-    "url": "https://attack.mitre.org/techniques/T1294",
-    "tactic": [
-      "Technical Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1295",
-    "technique": "Analyze social and business relationships, interests, and affiliations",
-    "url": "https://attack.mitre.org/techniques/T1295",
-    "tactic": [
-      "People Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1296",
-    "technique": "Assess targeting options",
-    "url": "https://attack.mitre.org/techniques/T1296",
-    "tactic": [
-      "People Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1297",
-    "technique": "Analyze organizational skillsets and deficiencies",
-    "url": "https://attack.mitre.org/techniques/T1297",
-    "tactic": [
-      "People Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1298",
-    "technique": "Assess vulnerability of 3rd party vendors",
-    "url": "https://attack.mitre.org/techniques/T1298",
-    "tactic": [
-      "Organizational Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1299",
-    "technique": "Assess opportunities created by business deals",
-    "url": "https://attack.mitre.org/techniques/T1299",
-    "tactic": [
-      "Organizational Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1300",
-    "technique": "Analyze organizational skillsets and deficiencies",
-    "url": "https://attack.mitre.org/techniques/T1300",
-    "tactic": [
-      "Organizational Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1301",
-    "technique": "Analyze business processes",
-    "url": "https://attack.mitre.org/techniques/T1301",
-    "tactic": [
-      "Organizational Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1302",
-    "technique": "Assess security posture of physical locations",
-    "url": "https://attack.mitre.org/techniques/T1302",
-    "tactic": [
-      "Organizational Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1303",
-    "technique": "Analyze presence of outsourced capabilities",
-    "url": "https://attack.mitre.org/techniques/T1303",
-    "tactic": [
-      "Organizational Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1304",
-    "technique": "Proxy/protocol relays",
-    "url": "https://attack.mitre.org/techniques/T1304",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1305",
-    "technique": "Private whois services",
-    "url": "https://attack.mitre.org/techniques/T1305",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1306",
-    "technique": "Anonymity services",
-    "url": "https://attack.mitre.org/techniques/T1306",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1307",
-    "technique": "Acquire and/or use 3rd party infrastructure services",
-    "url": "https://attack.mitre.org/techniques/T1307",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1308",
-    "technique": "Acquire and/or use 3rd party software services",
-    "url": "https://attack.mitre.org/techniques/T1308",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1309",
-    "technique": "Obfuscate infrastructure",
-    "url": "https://attack.mitre.org/techniques/T1309",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1310",
-    "technique": "Acquire or compromise 3rd party signing certificates",
-    "url": "https://attack.mitre.org/techniques/T1310",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1311",
-    "technique": "Dynamic DNS",
-    "url": "https://attack.mitre.org/techniques/T1311",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1312",
-    "technique": "Compromise 3rd party infrastructure to support delivery",
-    "url": "https://attack.mitre.org/techniques/T1312",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1313",
-    "technique": "Obfuscation or cryptography",
-    "url": "https://attack.mitre.org/techniques/T1313",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1314",
-    "technique": "Host-based hiding techniques",
-    "url": "https://attack.mitre.org/techniques/T1314",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1315",
-    "technique": "Network-based hiding techniques",
-    "url": "https://attack.mitre.org/techniques/T1315",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1316",
-    "technique": "Non-traditional or less attributable payment options",
-    "url": "https://attack.mitre.org/techniques/T1316",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1317",
-    "technique": "Secure and protect infrastructure",
-    "url": "https://attack.mitre.org/techniques/T1317",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1318",
-    "technique": "Obfuscate operational infrastructure",
-    "url": "https://attack.mitre.org/techniques/T1318",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1319",
-    "technique": "Obfuscate or encrypt code",
-    "url": "https://attack.mitre.org/techniques/T1319",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1320",
-    "technique": "Data Hiding",
-    "url": "https://attack.mitre.org/techniques/T1320",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1321",
-    "technique": "Common, high volume protocols and software",
-    "url": "https://attack.mitre.org/techniques/T1321",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1322",
-    "technique": "Misattributable credentials",
-    "url": "https://attack.mitre.org/techniques/T1322",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1326",
-    "technique": "Domain registration hijacking",
-    "url": "https://attack.mitre.org/techniques/T1326",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1327",
-    "technique": "Use multiple DNS infrastructures",
-    "url": "https://attack.mitre.org/techniques/T1327",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1328",
-    "technique": "Buy domain name",
-    "url": "https://attack.mitre.org/techniques/T1328",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1329",
-    "technique": "Acquire and/or use 3rd party infrastructure services",
-    "url": "https://attack.mitre.org/techniques/T1329",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1330",
-    "technique": "Acquire and/or use 3rd party software services",
-    "url": "https://attack.mitre.org/techniques/T1330",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1331",
-    "technique": "Obfuscate infrastructure",
-    "url": "https://attack.mitre.org/techniques/T1331",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1332",
-    "technique": "Acquire or compromise 3rd party signing certificates",
-    "url": "https://attack.mitre.org/techniques/T1332",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1333",
-    "technique": "Dynamic DNS",
-    "url": "https://attack.mitre.org/techniques/T1333",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1334",
-    "technique": "Compromise 3rd party infrastructure to support delivery",
-    "url": "https://attack.mitre.org/techniques/T1334",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1335",
-    "technique": "Procure required equipment and software",
-    "url": "https://attack.mitre.org/techniques/T1335",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1336",
-    "technique": "Install and configure hardware, network, and systems",
-    "url": "https://attack.mitre.org/techniques/T1336",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1337",
-    "technique": "SSL certificate acquisition for domain",
-    "url": "https://attack.mitre.org/techniques/T1337",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1338",
-    "technique": "SSL certificate acquisition for trust breaking",
-    "url": "https://attack.mitre.org/techniques/T1338",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1339",
-    "technique": "Create backup infrastructure",
-    "url": "https://attack.mitre.org/techniques/T1339",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1340",
-    "technique": "Shadow DNS",
-    "url": "https://attack.mitre.org/techniques/T1340",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1341",
-    "technique": "Build social network persona",
-    "url": "https://attack.mitre.org/techniques/T1341",
-    "tactic": [
-      "Persona Development"
-    ]
-  },
-  {
-    "technique_id": "T1342",
-    "technique": "Develop social network persona digital footprint",
-    "url": "https://attack.mitre.org/techniques/T1342",
-    "tactic": [
-      "Persona Development"
-    ]
-  },
-  {
-    "technique_id": "T1343",
-    "technique": "Choose pre-compromised persona and affiliated accounts",
-    "url": "https://attack.mitre.org/techniques/T1343",
-    "tactic": [
-      "Persona Development"
-    ]
-  },
-  {
-    "technique_id": "T1344",
-    "technique": "Friend/Follow/Connect to targets of interest",
-    "url": "https://attack.mitre.org/techniques/T1344",
-    "tactic": [
-      "Persona Development"
-    ]
-  },
-  {
-    "technique_id": "T1345",
-    "technique": "Create custom payloads",
-    "url": "https://attack.mitre.org/techniques/T1345",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1346",
-    "technique": "Obtain/re-use payloads",
-    "url": "https://attack.mitre.org/techniques/T1346",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1347",
-    "technique": "Build and configure delivery systems",
-    "url": "https://attack.mitre.org/techniques/T1347",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1348",
-    "technique": "Identify resources required to build capabilities",
-    "url": "https://attack.mitre.org/techniques/T1348",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1349",
-    "technique": "Build or acquire exploits",
-    "url": "https://attack.mitre.org/techniques/T1349",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1350",
-    "technique": "Discover new exploits and monitor exploit-provider forums",
-    "url": "https://attack.mitre.org/techniques/T1350",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1351",
-    "technique": "Remote access tool development",
-    "url": "https://attack.mitre.org/techniques/T1351",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1352",
-    "technique": "C2 protocol development",
-    "url": "https://attack.mitre.org/techniques/T1352",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1353",
-    "technique": "Post compromise tool development",
-    "url": "https://attack.mitre.org/techniques/T1353",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1354",
-    "technique": "Compromise 3rd party or closed-source vulnerability/exploit information",
-    "url": "https://attack.mitre.org/techniques/T1354",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1355",
-    "technique": "Create infected removable media",
-    "url": "https://attack.mitre.org/techniques/T1355",
-    "tactic": [
-      "Build Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1356",
-    "technique": "Test callback functionality",
-    "url": "https://attack.mitre.org/techniques/T1356",
-    "tactic": [
-      "Test Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1357",
-    "technique": "Test malware in various execution environments",
-    "url": "https://attack.mitre.org/techniques/T1357",
-    "tactic": [
-      "Test Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1358",
-    "technique": "Review logs and residual traces",
-    "url": "https://attack.mitre.org/techniques/T1358",
-    "tactic": [
-      "Test Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1359",
-    "technique": "Test malware to evade detection",
-    "url": "https://attack.mitre.org/techniques/T1359",
-    "tactic": [
-      "Test Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1360",
-    "technique": "Test physical access",
-    "url": "https://attack.mitre.org/techniques/T1360",
-    "tactic": [
-      "Test Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1361",
-    "technique": "Test signature detection for file upload/email filters",
-    "url": "https://attack.mitre.org/techniques/T1361",
-    "tactic": [
-      "Test Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1362",
-    "technique": "Upload, install, and configure software/tools",
-    "url": "https://attack.mitre.org/techniques/T1362",
-    "tactic": [
-      "Stage Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1363",
-    "technique": "Port redirector",
-    "url": "https://attack.mitre.org/techniques/T1363",
-    "tactic": [
-      "Stage Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1364",
-    "technique": "Friend/Follow/Connect to targets of interest",
-    "url": "https://attack.mitre.org/techniques/T1364",
-    "tactic": [
-      "Stage Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1365",
-    "technique": "Hardware or software supply chain implant",
-    "url": "https://attack.mitre.org/techniques/T1365",
-    "tactic": [
-      "Stage Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1379",
-    "technique": "Disseminate removable media",
-    "url": "https://attack.mitre.org/techniques/T1379",
-    "tactic": [
-      "Stage Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1389",
-    "technique": "Identify vulnerabilities in third-party software libraries",
-    "url": "https://attack.mitre.org/techniques/T1389",
-    "tactic": [
-      "Technical Weakness Identification"
-    ]
-  },
-  {
-    "technique_id": "T1390",
-    "technique": "OS-vendor provided communication channels",
-    "url": "https://attack.mitre.org/techniques/T1390",
-    "tactic": [
-      "Adversary OPSEC"
-    ]
-  },
-  {
-    "technique_id": "T1391",
-    "technique": "Choose pre-compromised mobile app developer account credentials or signing keys",
-    "url": "https://attack.mitre.org/techniques/T1391",
-    "tactic": [
-      "Persona Development"
-    ]
-  },
-  {
-    "technique_id": "T1392",
-    "technique": "Obtain Apple iOS enterprise distribution key pair and certificate",
-    "url": "https://attack.mitre.org/techniques/T1392",
-    "tactic": [
-      "Persona Development"
-    ]
-  },
-  {
-    "technique_id": "T1393",
-    "technique": "Test ability to evade automated mobile application security analysis performed by app stores",
-    "url": "https://attack.mitre.org/techniques/T1393",
-    "tactic": [
-      "Test Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1394",
-    "technique": "Distribute malicious software development tools",
-    "url": "https://attack.mitre.org/techniques/T1394",
-    "tactic": [
-      "Stage Capabilities"
-    ]
-  },
-  {
-    "technique_id": "T1396",
-    "technique": "Obtain booter/stressor subscription",
-    "url": "https://attack.mitre.org/techniques/T1396",
-    "tactic": [
-      "Establish & Maintain Infrastructure"
-    ]
-  },
-  {
-    "technique_id": "T1397",
-    "technique": "Spearphishing for Information",
-    "url": "https://attack.mitre.org/techniques/T1397",
-    "tactic": [
-      "Technical Information Gathering"
+    "technique": "File and Directory Permissions Modification: Linux and Mac File and Directory Permissions Modification",
+    "url": "https://attack.mitre.org/techniques/T1222/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Linux"
     ]
   },
   {
@@ -2726,6 +5275,13 @@
     "tactic": [
       "Defense Evasion",
       "Persistence"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2735,6 +5291,12 @@
     "tactic": [
       "Defense Evasion",
       "Persistence"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2745,14 +5307,27 @@
       "Defense Evasion",
       "Persistence",
       "Impact"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
     "technique_id": "T1401",
-    "technique": "Abuse Device Administrator Access to Prevent Removal",
+    "technique": "Device Administrator Permissions",
     "url": "https://attack.mitre.org/techniques/T1401",
     "tactic": [
-      "Persistence"
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2762,6 +5337,12 @@
     "tactic": [
       "Persistence",
       "Execution"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2770,6 +5351,12 @@
     "url": "https://attack.mitre.org/techniques/T1403",
     "tactic": [
       "Persistence"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2778,6 +5365,13 @@
     "url": "https://attack.mitre.org/techniques/T1404",
     "tactic": [
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2787,6 +5381,12 @@
     "tactic": [
       "Credential Access",
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2795,6 +5395,13 @@
     "url": "https://attack.mitre.org/techniques/T1406",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2803,6 +5410,13 @@
     "url": "https://attack.mitre.org/techniques/T1407",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2811,6 +5425,13 @@
     "url": "https://attack.mitre.org/techniques/T1408",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2820,6 +5441,13 @@
     "tactic": [
       "Collection",
       "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2829,6 +5457,13 @@
     "tactic": [
       "Collection",
       "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2837,6 +5472,13 @@
     "url": "https://attack.mitre.org/techniques/T1411",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2846,6 +5488,13 @@
     "tactic": [
       "Collection",
       "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2855,6 +5504,12 @@
     "tactic": [
       "Collection",
       "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2864,22 +5519,28 @@
     "tactic": [
       "Collection",
       "Credential Access"
-    ]
-  },
-  {
-    "technique_id": "T1415",
-    "technique": "URL Scheme Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1415",
-    "tactic": [
-      "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
     "technique_id": "T1416",
-    "technique": "Android Intent Hijacking",
+    "technique": "URI Hijacking",
     "url": "https://attack.mitre.org/techniques/T1416",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2889,6 +5550,13 @@
     "tactic": [
       "Collection",
       "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2898,6 +5566,13 @@
     "tactic": [
       "Defense Evasion",
       "Discovery"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2906,6 +5581,12 @@
     "url": "https://attack.mitre.org/techniques/T1420",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2914,6 +5595,12 @@
     "url": "https://attack.mitre.org/techniques/T1421",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2922,6 +5609,13 @@
     "url": "https://attack.mitre.org/techniques/T1422",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2930,6 +5624,13 @@
     "url": "https://attack.mitre.org/techniques/T1423",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2938,6 +5639,12 @@
     "url": "https://attack.mitre.org/techniques/T1424",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2946,6 +5653,13 @@
     "url": "https://attack.mitre.org/techniques/T1426",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2954,6 +5668,12 @@
     "url": "https://attack.mitre.org/techniques/T1427",
     "tactic": [
       "Lateral Movement"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -2962,6 +5682,13 @@
     "url": "https://attack.mitre.org/techniques/T1428",
     "tactic": [
       "Lateral Movement"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2970,6 +5697,13 @@
     "url": "https://attack.mitre.org/techniques/T1429",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2979,6 +5713,13 @@
     "tactic": [
       "Collection",
       "Discovery"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2987,6 +5728,13 @@
     "url": "https://attack.mitre.org/techniques/T1432",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -2995,6 +5743,13 @@
     "url": "https://attack.mitre.org/techniques/T1433",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3003,6 +5758,13 @@
     "url": "https://attack.mitre.org/techniques/T1435",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3012,6 +5774,13 @@
     "tactic": [
       "Command and Control",
       "Exfiltration"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3021,6 +5790,13 @@
     "tactic": [
       "Command and Control",
       "Exfiltration"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3030,6 +5806,13 @@
     "tactic": [
       "Command and Control",
       "Exfiltration"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3038,6 +5821,13 @@
     "url": "https://attack.mitre.org/techniques/T1439",
     "tactic": [
       "Network Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3047,6 +5837,13 @@
     "tactic": [
       "Initial Access",
       "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3056,6 +5853,13 @@
     "tactic": [
       "Impact",
       "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3063,7 +5867,14 @@
     "technique": "Delete Device Data",
     "url": "https://attack.mitre.org/techniques/T1447",
     "tactic": [
-      "Impact"
+      "Impact",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3072,6 +5883,12 @@
     "url": "https://attack.mitre.org/techniques/T1448",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3080,6 +5897,13 @@
     "url": "https://attack.mitre.org/techniques/T1449",
     "tactic": [
       "Network Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3088,6 +5912,13 @@
     "url": "https://attack.mitre.org/techniques/T1450",
     "tactic": [
       "Network Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3096,6 +5927,13 @@
     "url": "https://attack.mitre.org/techniques/T1451",
     "tactic": [
       "Network Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3104,6 +5942,13 @@
     "url": "https://attack.mitre.org/techniques/T1452",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3112,6 +5957,13 @@
     "url": "https://attack.mitre.org/techniques/T1456",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3120,6 +5972,13 @@
     "url": "https://attack.mitre.org/techniques/T1458",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3128,6 +5987,13 @@
     "url": "https://attack.mitre.org/techniques/T1461",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3136,6 +6002,13 @@
     "url": "https://attack.mitre.org/techniques/T1463",
     "tactic": [
       "Network Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3144,6 +6017,13 @@
     "url": "https://attack.mitre.org/techniques/T1464",
     "tactic": [
       "Network Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3152,6 +6032,13 @@
     "url": "https://attack.mitre.org/techniques/T1465",
     "tactic": [
       "Network Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3160,6 +6047,13 @@
     "url": "https://attack.mitre.org/techniques/T1466",
     "tactic": [
       "Network Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3168,6 +6062,13 @@
     "url": "https://attack.mitre.org/techniques/T1467",
     "tactic": [
       "Network Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3176,6 +6077,13 @@
     "url": "https://attack.mitre.org/techniques/T1468",
     "tactic": [
       "Remote Service Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3184,6 +6092,13 @@
     "url": "https://attack.mitre.org/techniques/T1469",
     "tactic": [
       "Remote Service Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3192,6 +6107,13 @@
     "url": "https://attack.mitre.org/techniques/T1470",
     "tactic": [
       "Remote Service Effects"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3200,6 +6122,12 @@
     "url": "https://attack.mitre.org/techniques/T1471",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3208,6 +6136,13 @@
     "url": "https://attack.mitre.org/techniques/T1472",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3216,6 +6151,13 @@
     "url": "https://attack.mitre.org/techniques/T1474",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3224,6 +6166,13 @@
     "url": "https://attack.mitre.org/techniques/T1475",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3232,6 +6181,13 @@
     "url": "https://attack.mitre.org/techniques/T1476",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3240,6 +6196,13 @@
     "url": "https://attack.mitre.org/techniques/T1477",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3249,6 +6212,13 @@
     "tactic": [
       "Defense Evasion",
       "Initial Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3257,12 +6227,31 @@
     "url": "https://attack.mitre.org/techniques/T1480",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1480.001",
-    "technique": "Execution Guardrails : Environmental Keying",
-    "url": "https://attack.mitre.org/techniques/T1480/001"
+    "technique": "Execution Guardrails: Environmental Keying",
+    "url": "https://attack.mitre.org/techniques/T1480/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1481",
@@ -3270,6 +6259,13 @@
     "url": "https://attack.mitre.org/techniques/T1481",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3278,15 +6274,59 @@
     "url": "https://attack.mitre.org/techniques/T1482",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
     ]
   },
   {
     "technique_id": "T1484",
-    "technique": "Group Policy Modification",
+    "technique": "Domain Policy Modification",
     "url": "https://attack.mitre.org/techniques/T1484",
     "tactic": [
       "Defense Evasion",
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD"
+    ]
+  },
+  {
+    "technique_id": "T1484.001",
+    "technique": "Domain Policy Modification: Group Policy Modification",
+    "url": "https://attack.mitre.org/techniques/T1484/001",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1484.002",
+    "technique": "Domain Policy Modification: Domain Trust Modification",
+    "url": "https://attack.mitre.org/techniques/T1484/002",
+    "tactic": [
+      "Defense Evasion",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD"
     ]
   },
   {
@@ -3295,6 +6335,15 @@
     "url": "https://attack.mitre.org/techniques/T1485",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS"
     ]
   },
   {
@@ -3303,6 +6352,15 @@
     "url": "https://attack.mitre.org/techniques/T1486",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "IaaS"
     ]
   },
   {
@@ -3311,6 +6369,14 @@
     "url": "https://attack.mitre.org/techniques/T1489",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
     ]
   },
   {
@@ -3319,6 +6385,14 @@
     "url": "https://attack.mitre.org/techniques/T1490",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
     ]
   },
   {
@@ -3327,17 +6401,49 @@
     "url": "https://attack.mitre.org/techniques/T1491",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS"
     ]
   },
   {
     "technique_id": "T1491.001",
-    "technique": "Defacement : Internal Defacement",
-    "url": "https://attack.mitre.org/techniques/T1491/001"
+    "technique": "Defacement: Internal Defacement",
+    "url": "https://attack.mitre.org/techniques/T1491/001",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1491.002",
-    "technique": "Defacement : External Defacement",
-    "url": "https://attack.mitre.org/techniques/T1491/002"
+    "technique": "Defacement: External Defacement",
+    "url": "https://attack.mitre.org/techniques/T1491/002",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1495",
@@ -3345,6 +6451,14 @@
     "url": "https://attack.mitre.org/techniques/T1495",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -3353,6 +6467,16 @@
     "url": "https://attack.mitre.org/techniques/T1496",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Containers"
     ]
   },
   {
@@ -3362,22 +6486,66 @@
     "tactic": [
       "Defense Evasion",
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
     ]
   },
   {
     "technique_id": "T1497.001",
-    "technique": "Virtualization/Sandbox Evasion : System Checks",
-    "url": "https://attack.mitre.org/techniques/T1497/001"
+    "technique": "Virtualization/Sandbox Evasion: System Checks",
+    "url": "https://attack.mitre.org/techniques/T1497/001",
+    "tactic": [
+      "Defense Evasion",
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1497.002",
-    "technique": "Virtualization/Sandbox Evasion : User Activity Based Checks",
-    "url": "https://attack.mitre.org/techniques/T1497/002"
+    "technique": "Virtualization/Sandbox Evasion: User Activity Based Checks",
+    "url": "https://attack.mitre.org/techniques/T1497/002",
+    "tactic": [
+      "Defense Evasion",
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1497.003",
-    "technique": "Virtualization/Sandbox Evasion : Time Based Evasion",
-    "url": "https://attack.mitre.org/techniques/T1497/003"
+    "technique": "Virtualization/Sandbox Evasion: Time Based Evasion",
+    "url": "https://attack.mitre.org/techniques/T1497/003",
+    "tactic": [
+      "Defense Evasion",
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1498",
@@ -3385,17 +6553,63 @@
     "url": "https://attack.mitre.org/techniques/T1498",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1498.001",
-    "technique": "Network Denial of Service : Direct Network Flood",
-    "url": "https://attack.mitre.org/techniques/T1498/001"
+    "technique": "Network Denial of Service: Direct Network Flood",
+    "url": "https://attack.mitre.org/techniques/T1498/001",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1498.002",
-    "technique": "Network Denial of Service : Reflection Amplification",
-    "url": "https://attack.mitre.org/techniques/T1498/002"
+    "technique": "Network Denial of Service: Reflection Amplification",
+    "url": "https://attack.mitre.org/techniques/T1498/002",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1499",
@@ -3403,27 +6617,100 @@
     "url": "https://attack.mitre.org/techniques/T1499",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1499.001",
-    "technique": "Endpoint Denial of Service : OS Exhaustion Flood",
-    "url": "https://attack.mitre.org/techniques/T1499/001"
+    "technique": "Endpoint Denial of Service: OS Exhaustion Flood",
+    "url": "https://attack.mitre.org/techniques/T1499/001",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1499.002",
-    "technique": "Endpoint Denial of Service : Service Exhaustion Flood",
-    "url": "https://attack.mitre.org/techniques/T1499/002"
+    "technique": "Endpoint Denial of Service: Service Exhaustion Flood",
+    "url": "https://attack.mitre.org/techniques/T1499/002",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1499.003",
-    "technique": "Endpoint Denial of Service : Application Exhaustion Flood",
-    "url": "https://attack.mitre.org/techniques/T1499/003"
+    "technique": "Endpoint Denial of Service: Application Exhaustion Flood",
+    "url": "https://attack.mitre.org/techniques/T1499/003",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1499.004",
-    "technique": "Endpoint Denial of Service : Application or System Exploitation",
-    "url": "https://attack.mitre.org/techniques/T1499/004"
+    "technique": "Endpoint Denial of Service: Application or System Exploitation",
+    "url": "https://attack.mitre.org/techniques/T1499/004",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1505",
@@ -3431,22 +6718,75 @@
     "url": "https://attack.mitre.org/techniques/T1505",
     "tactic": [
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
     ]
   },
   {
     "technique_id": "T1505.001",
-    "technique": "Server Software Component : SQL Stored Procedures",
-    "url": "https://attack.mitre.org/techniques/T1505/001"
+    "technique": "Server Software Component: SQL Stored Procedures",
+    "url": "https://attack.mitre.org/techniques/T1505/001",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1505.002",
-    "technique": "Server Software Component : Transport Agent",
-    "url": "https://attack.mitre.org/techniques/T1505/002"
+    "technique": "Server Software Component: Transport Agent",
+    "url": "https://attack.mitre.org/techniques/T1505/002",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1505.003",
-    "technique": "Server Software Component : Web Shell",
-    "url": "https://attack.mitre.org/techniques/T1505/003"
+    "technique": "Server Software Component: Web Shell",
+    "url": "https://attack.mitre.org/techniques/T1505/003",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "technique_id": "T1505.004",
+    "technique": "Server Software Component: IIS Components",
+    "url": "https://attack.mitre.org/techniques/T1505/004",
+    "tactic": [
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1507",
@@ -3454,6 +6794,12 @@
     "url": "https://attack.mitre.org/techniques/T1507",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3462,6 +6808,12 @@
     "url": "https://attack.mitre.org/techniques/T1508",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3470,6 +6822,13 @@
     "url": "https://attack.mitre.org/techniques/T1509",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3478,6 +6837,12 @@
     "url": "https://attack.mitre.org/techniques/T1510",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3486,6 +6851,13 @@
     "url": "https://attack.mitre.org/techniques/T1512",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3494,6 +6866,12 @@
     "url": "https://attack.mitre.org/techniques/T1513",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3503,6 +6881,12 @@
     "tactic": [
       "Defense Evasion",
       "Impact"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3512,6 +6896,12 @@
     "tactic": [
       "Collection",
       "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3520,12 +6910,41 @@
     "url": "https://attack.mitre.org/techniques/T1518",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
     ]
   },
   {
     "technique_id": "T1518.001",
-    "technique": "Software Discovery : Security Software Discovery",
-    "url": "https://attack.mitre.org/techniques/T1518/001"
+    "technique": "Software Discovery: Security Software Discovery",
+    "url": "https://attack.mitre.org/techniques/T1518/001",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1520",
@@ -3533,6 +6952,13 @@
     "url": "https://attack.mitre.org/techniques/T1520",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3541,6 +6967,13 @@
     "url": "https://attack.mitre.org/techniques/T1521",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3550,14 +6983,28 @@
     "tactic": [
       "Defense Evasion",
       "Discovery"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
     "technique_id": "T1525",
-    "technique": "Implant Container Image",
+    "technique": "Implant Internal Image",
     "url": "https://attack.mitre.org/techniques/T1525",
     "tactic": [
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS",
+      "Containers"
     ]
   },
   {
@@ -3566,6 +7013,16 @@
     "url": "https://attack.mitre.org/techniques/T1526",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Google Workspace"
     ]
   },
   {
@@ -3574,6 +7031,15 @@
     "url": "https://attack.mitre.org/techniques/T1528",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "SaaS",
+      "Office 365",
+      "Azure AD",
+      "Google Workspace"
     ]
   },
   {
@@ -3582,6 +7048,14 @@
     "url": "https://attack.mitre.org/techniques/T1529",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -3590,6 +7064,12 @@
     "url": "https://attack.mitre.org/techniques/T1530",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
     ]
   },
   {
@@ -3598,6 +7078,14 @@
     "url": "https://attack.mitre.org/techniques/T1531",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -3606,6 +7094,13 @@
     "url": "https://attack.mitre.org/techniques/T1532",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3614,6 +7109,13 @@
     "url": "https://attack.mitre.org/techniques/T1533",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3622,6 +7124,17 @@
     "url": "https://attack.mitre.org/techniques/T1534",
     "tactic": [
       "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux",
+      "Office 365",
+      "SaaS",
+      "Google Workspace"
     ]
   },
   {
@@ -3630,6 +7143,12 @@
     "url": "https://attack.mitre.org/techniques/T1535",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
     ]
   },
   {
@@ -3638,6 +7157,12 @@
     "url": "https://attack.mitre.org/techniques/T1537",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
     ]
   },
   {
@@ -3646,6 +7171,15 @@
     "url": "https://attack.mitre.org/techniques/T1538",
     "tactic": [
       "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Azure AD",
+      "Office 365",
+      "IaaS",
+      "Google Workspace"
     ]
   },
   {
@@ -3654,6 +7188,17 @@
     "url": "https://attack.mitre.org/techniques/T1539",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Office 365",
+      "SaaS",
+      "Google Workspace"
     ]
   },
   {
@@ -3664,6 +7209,13 @@
       "Persistence",
       "Privilege Escalation",
       "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3673,6 +7225,12 @@
     "tactic": [
       "Collection",
       "Persistence"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -3682,22 +7240,91 @@
     "tactic": [
       "Defense Evasion",
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "Network"
     ]
   },
   {
     "technique_id": "T1542.001",
-    "technique": "Pre-OS Boot : System Firmware",
-    "url": "https://attack.mitre.org/techniques/T1542/001"
+    "technique": "Pre-OS Boot: System Firmware",
+    "url": "https://attack.mitre.org/techniques/T1542/001",
+    "tactic": [
+      "Persistence",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1542.002",
-    "technique": "Pre-OS Boot : Component Firmware",
-    "url": "https://attack.mitre.org/techniques/T1542/002"
+    "technique": "Pre-OS Boot: Component Firmware",
+    "url": "https://attack.mitre.org/techniques/T1542/002",
+    "tactic": [
+      "Persistence",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1542.003",
-    "technique": "Pre-OS Boot : Bootkit",
-    "url": "https://attack.mitre.org/techniques/T1542/003"
+    "technique": "Pre-OS Boot: Bootkit",
+    "url": "https://attack.mitre.org/techniques/T1542/003",
+    "tactic": [
+      "Persistence",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1542.004",
+    "technique": "Pre-OS Boot: ROMMONkit",
+    "url": "https://attack.mitre.org/techniques/T1542/004",
+    "tactic": [
+      "Defense Evasion",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1542.005",
+    "technique": "Pre-OS Boot: TFTP Boot",
+    "url": "https://attack.mitre.org/techniques/T1542/005",
+    "tactic": [
+      "Defense Evasion",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
   },
   {
     "technique_id": "T1543",
@@ -3706,27 +7333,75 @@
     "tactic": [
       "Persistence",
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
     ]
   },
   {
     "technique_id": "T1543.001",
-    "technique": "Create or Modify System Process : Launch Agent",
-    "url": "https://attack.mitre.org/techniques/T1543/001"
+    "technique": "Create or Modify System Process: Launch Agent",
+    "url": "https://attack.mitre.org/techniques/T1543/001",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1543.002",
-    "technique": "Create or Modify System Process : Systemd Service",
-    "url": "https://attack.mitre.org/techniques/T1543/002"
+    "technique": "Create or Modify System Process: Systemd Service",
+    "url": "https://attack.mitre.org/techniques/T1543/002",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1543.003",
-    "technique": "Create or Modify System Process : Windows Service",
-    "url": "https://attack.mitre.org/techniques/T1543/003"
+    "technique": "Create or Modify System Process: Windows Service",
+    "url": "https://attack.mitre.org/techniques/T1543/003",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1543.004",
-    "technique": "Create or Modify System Process : Launch Daemon",
-    "url": "https://attack.mitre.org/techniques/T1543/004"
+    "technique": "Create or Modify System Process: Launch Daemon",
+    "url": "https://attack.mitre.org/techniques/T1543/004",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1544",
@@ -3734,6 +7409,13 @@
     "url": "https://attack.mitre.org/techniques/T1544",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
     ]
   },
   {
@@ -3743,82 +7425,242 @@
     "tactic": [
       "Privilege Escalation",
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1546.001",
-    "technique": "Event Triggered Execution : Change Default File Association",
-    "url": "https://attack.mitre.org/techniques/T1546/001"
+    "technique": "Event Triggered Execution: Change Default File Association",
+    "url": "https://attack.mitre.org/techniques/T1546/001",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.002",
-    "technique": "Event Triggered Execution : Screensaver",
-    "url": "https://attack.mitre.org/techniques/T1546/002"
+    "technique": "Event Triggered Execution: Screensaver",
+    "url": "https://attack.mitre.org/techniques/T1546/002",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.003",
-    "technique": "Event Triggered Execution : Windows Management Instrumentation Event Subscription",
-    "url": "https://attack.mitre.org/techniques/T1546/003"
+    "technique": "Event Triggered Execution: Windows Management Instrumentation Event Subscription",
+    "url": "https://attack.mitre.org/techniques/T1546/003",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.004",
-    "technique": "Event Triggered Execution : .bash_profile and .bashrc",
-    "url": "https://attack.mitre.org/techniques/T1546/004"
+    "technique": "Event Triggered Execution: Unix Shell Configuration Modification",
+    "url": "https://attack.mitre.org/techniques/T1546/004",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1546.005",
-    "technique": "Event Triggered Execution : Trap",
-    "url": "https://attack.mitre.org/techniques/T1546/005"
+    "technique": "Event Triggered Execution: Trap",
+    "url": "https://attack.mitre.org/techniques/T1546/005",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1546.006",
-    "technique": "Event Triggered Execution : LC_LOAD_DYLIB Addition",
-    "url": "https://attack.mitre.org/techniques/T1546/006"
+    "technique": "Event Triggered Execution: LC_LOAD_DYLIB Addition",
+    "url": "https://attack.mitre.org/techniques/T1546/006",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1546.007",
-    "technique": "Event Triggered Execution : Netsh Helper DLL",
-    "url": "https://attack.mitre.org/techniques/T1546/007"
+    "technique": "Event Triggered Execution: Netsh Helper DLL",
+    "url": "https://attack.mitre.org/techniques/T1546/007",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.008",
-    "technique": "Event Triggered Execution : Accessibility Features",
-    "url": "https://attack.mitre.org/techniques/T1546/008"
+    "technique": "Event Triggered Execution: Accessibility Features",
+    "url": "https://attack.mitre.org/techniques/T1546/008",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.009",
-    "technique": "Event Triggered Execution : AppCert DLLs",
-    "url": "https://attack.mitre.org/techniques/T1546/009"
+    "technique": "Event Triggered Execution: AppCert DLLs",
+    "url": "https://attack.mitre.org/techniques/T1546/009",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.010",
-    "technique": "Event Triggered Execution : AppInit DLLs",
-    "url": "https://attack.mitre.org/techniques/T1546/010"
+    "technique": "Event Triggered Execution: AppInit DLLs",
+    "url": "https://attack.mitre.org/techniques/T1546/010",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.011",
-    "technique": "Event Triggered Execution : Application Shimming",
-    "url": "https://attack.mitre.org/techniques/T1546/011"
+    "technique": "Event Triggered Execution: Application Shimming",
+    "url": "https://attack.mitre.org/techniques/T1546/011",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.012",
-    "technique": "Event Triggered Execution : Image File Execution Options Injection",
-    "url": "https://attack.mitre.org/techniques/T1546/012"
+    "technique": "Event Triggered Execution: Image File Execution Options Injection",
+    "url": "https://attack.mitre.org/techniques/T1546/012",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.013",
-    "technique": "Event Triggered Execution : PowerShell Profile",
-    "url": "https://attack.mitre.org/techniques/T1546/013"
+    "technique": "Event Triggered Execution: PowerShell Profile",
+    "url": "https://attack.mitre.org/techniques/T1546/013",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1546.014",
-    "technique": "Event Triggered Execution : Emond",
-    "url": "https://attack.mitre.org/techniques/T1546/014"
+    "technique": "Event Triggered Execution: Emond",
+    "url": "https://attack.mitre.org/techniques/T1546/014",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1546.015",
-    "technique": "Event Triggered Execution : Component Object Model Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1546/015"
+    "technique": "Event Triggered Execution: Component Object Model Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1546/015",
+    "tactic": [
+      "Privilege Escalation",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1547",
@@ -3827,62 +7669,241 @@
     "tactic": [
       "Persistence",
       "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1547.001",
-    "technique": "Boot or Logon Autostart Execution : Registry Run Keys / Startup Folder",
-    "url": "https://attack.mitre.org/techniques/T1547/001"
+    "technique": "Boot or Logon Autostart Execution: Registry Run Keys / Startup Folder",
+    "url": "https://attack.mitre.org/techniques/T1547/001",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1547.002",
-    "technique": "Boot or Logon Autostart Execution : Authentication Package",
-    "url": "https://attack.mitre.org/techniques/T1547/002"
+    "technique": "Boot or Logon Autostart Execution: Authentication Package",
+    "url": "https://attack.mitre.org/techniques/T1547/002",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1547.003",
-    "technique": "Boot or Logon Autostart Execution : Time Providers",
-    "url": "https://attack.mitre.org/techniques/T1547/003"
+    "technique": "Boot or Logon Autostart Execution: Time Providers",
+    "url": "https://attack.mitre.org/techniques/T1547/003",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1547.004",
-    "technique": "Boot or Logon Autostart Execution : Winlogon Helper DLL",
-    "url": "https://attack.mitre.org/techniques/T1547/004"
+    "technique": "Boot or Logon Autostart Execution: Winlogon Helper DLL",
+    "url": "https://attack.mitre.org/techniques/T1547/004",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1547.005",
-    "technique": "Boot or Logon Autostart Execution : Security Support Provider",
-    "url": "https://attack.mitre.org/techniques/T1547/005"
+    "technique": "Boot or Logon Autostart Execution: Security Support Provider",
+    "url": "https://attack.mitre.org/techniques/T1547/005",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1547.006",
-    "technique": "Boot or Logon Autostart Execution : Kernel Modules and Extensions",
-    "url": "https://attack.mitre.org/techniques/T1547/006"
+    "technique": "Boot or Logon Autostart Execution: Kernel Modules and Extensions",
+    "url": "https://attack.mitre.org/techniques/T1547/006",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1547.007",
-    "technique": "Boot or Logon Autostart Execution : Re-opened Applications",
-    "url": "https://attack.mitre.org/techniques/T1547/007"
+    "technique": "Boot or Logon Autostart Execution: Re-opened Applications",
+    "url": "https://attack.mitre.org/techniques/T1547/007",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1547.008",
-    "technique": "Boot or Logon Autostart Execution : LSASS Driver",
-    "url": "https://attack.mitre.org/techniques/T1547/008"
+    "technique": "Boot or Logon Autostart Execution: LSASS Driver",
+    "url": "https://attack.mitre.org/techniques/T1547/008",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1547.009",
-    "technique": "Boot or Logon Autostart Execution : Shortcut Modification",
-    "url": "https://attack.mitre.org/techniques/T1547/009"
+    "technique": "Boot or Logon Autostart Execution: Shortcut Modification",
+    "url": "https://attack.mitre.org/techniques/T1547/009",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1547.010",
-    "technique": "Boot or Logon Autostart Execution : Port Monitors",
-    "url": "https://attack.mitre.org/techniques/T1547/010"
+    "technique": "Boot or Logon Autostart Execution: Port Monitors",
+    "url": "https://attack.mitre.org/techniques/T1547/010",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1547.011",
-    "technique": "Boot or Logon Autostart Execution : Plist Modification",
-    "url": "https://attack.mitre.org/techniques/T1547/011"
+    "technique": "Boot or Logon Autostart Execution: Plist Modification",
+    "url": "https://attack.mitre.org/techniques/T1547/011",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
+  },
+  {
+    "technique_id": "T1547.012",
+    "technique": "Boot or Logon Autostart Execution: Print Processors",
+    "url": "https://attack.mitre.org/techniques/T1547/012",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1547.013",
+    "technique": "Boot or Logon Autostart Execution: XDG Autostart Entries",
+    "url": "https://attack.mitre.org/techniques/T1547/013",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux"
+    ]
+  },
+  {
+    "technique_id": "T1547.014",
+    "technique": "Boot or Logon Autostart Execution: Active Setup",
+    "url": "https://attack.mitre.org/techniques/T1547/014",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1547.015",
+    "technique": "Boot or Logon Autostart Execution: Login Items",
+    "url": "https://attack.mitre.org/techniques/T1547/015",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1548",
@@ -3891,27 +7912,77 @@
     "tactic": [
       "Privilege Escalation",
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1548.001",
-    "technique": "Abuse Elevation Control Mechanism : Setuid and Setgid",
-    "url": "https://attack.mitre.org/techniques/T1548/001"
+    "technique": "Abuse Elevation Control Mechanism: Setuid and Setgid",
+    "url": "https://attack.mitre.org/techniques/T1548/001",
+    "tactic": [
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1548.002",
-    "technique": "Abuse Elevation Control Mechanism : Bypass User Access Control",
-    "url": "https://attack.mitre.org/techniques/T1548/002"
+    "technique": "Abuse Elevation Control Mechanism: Bypass User Account Control",
+    "url": "https://attack.mitre.org/techniques/T1548/002",
+    "tactic": [
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1548.003",
-    "technique": "Abuse Elevation Control Mechanism : Sudo and Sudo Caching",
-    "url": "https://attack.mitre.org/techniques/T1548/003"
+    "technique": "Abuse Elevation Control Mechanism: Sudo and Sudo Caching",
+    "url": "https://attack.mitre.org/techniques/T1548/003",
+    "tactic": [
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1548.004",
-    "technique": "Abuse Elevation Control Mechanism : Elevated Execution with Prompt",
-    "url": "https://attack.mitre.org/techniques/T1548/004"
+    "technique": "Abuse Elevation Control Mechanism: Elevated Execution with Prompt",
+    "url": "https://attack.mitre.org/techniques/T1548/004",
+    "tactic": [
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1550",
@@ -3920,27 +7991,82 @@
     "tactic": [
       "Defense Evasion",
       "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365",
+      "SaaS",
+      "Google Workspace",
+      "IaaS"
     ]
   },
   {
     "technique_id": "T1550.001",
-    "technique": "Use Alternate Authentication Material : Application Access Token",
-    "url": "https://attack.mitre.org/techniques/T1550/001"
+    "technique": "Use Alternate Authentication Material: Application Access Token",
+    "url": "https://attack.mitre.org/techniques/T1550/001",
+    "tactic": [
+      "Defense Evasion",
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Office 365",
+      "SaaS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1550.002",
-    "technique": "Use Alternate Authentication Material : Pass the Hash",
-    "url": "https://attack.mitre.org/techniques/T1550/002"
+    "technique": "Use Alternate Authentication Material: Pass the Hash",
+    "url": "https://attack.mitre.org/techniques/T1550/002",
+    "tactic": [
+      "Defense Evasion",
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1550.003",
-    "technique": "Use Alternate Authentication Material : Pass the Ticket",
-    "url": "https://attack.mitre.org/techniques/T1550/003"
+    "technique": "Use Alternate Authentication Material: Pass the Ticket",
+    "url": "https://attack.mitre.org/techniques/T1550/003",
+    "tactic": [
+      "Defense Evasion",
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1550.004",
-    "technique": "Use Alternate Authentication Material : Web Session Cookie",
-    "url": "https://attack.mitre.org/techniques/T1550/004"
+    "technique": "Use Alternate Authentication Material: Web Session Cookie",
+    "url": "https://attack.mitre.org/techniques/T1550/004",
+    "tactic": [
+      "Defense Evasion",
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Office 365",
+      "SaaS",
+      "Google Workspace",
+      "IaaS"
+    ]
   },
   {
     "technique_id": "T1552",
@@ -3948,37 +8074,126 @@
     "url": "https://attack.mitre.org/techniques/T1552",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Azure AD",
+      "Office 365",
+      "SaaS",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Google Workspace",
+      "Containers"
     ]
   },
   {
     "technique_id": "T1552.001",
-    "technique": "Unsecured Credentials : Credentials In Files",
-    "url": "https://attack.mitre.org/techniques/T1552/001"
+    "technique": "Unsecured Credentials: Credentials In Files",
+    "url": "https://attack.mitre.org/techniques/T1552/001",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1552.002",
-    "technique": "Unsecured Credentials : Credentials in Registry",
-    "url": "https://attack.mitre.org/techniques/T1552/002"
+    "technique": "Unsecured Credentials: Credentials in Registry",
+    "url": "https://attack.mitre.org/techniques/T1552/002",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1552.003",
-    "technique": "Unsecured Credentials : Bash History",
-    "url": "https://attack.mitre.org/techniques/T1552/003"
+    "technique": "Unsecured Credentials: Bash History",
+    "url": "https://attack.mitre.org/techniques/T1552/003",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1552.004",
-    "technique": "Unsecured Credentials : Private Keys",
-    "url": "https://attack.mitre.org/techniques/T1552/004"
+    "technique": "Unsecured Credentials: Private Keys",
+    "url": "https://attack.mitre.org/techniques/T1552/004",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1552.005",
-    "technique": "Unsecured Credentials : Cloud Instance Metadata API",
-    "url": "https://attack.mitre.org/techniques/T1552/005"
+    "technique": "Unsecured Credentials: Cloud Instance Metadata API",
+    "url": "https://attack.mitre.org/techniques/T1552/005",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
+    ]
   },
   {
     "technique_id": "T1552.006",
-    "technique": "Unsecured Credentials : Group Policy Preferences",
-    "url": "https://attack.mitre.org/techniques/T1552/006"
+    "technique": "Unsecured Credentials: Group Policy Preferences",
+    "url": "https://attack.mitre.org/techniques/T1552/006",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1552.007",
+    "technique": "Unsecured Credentials: Container API",
+    "url": "https://attack.mitre.org/techniques/T1552/007",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Containers"
+    ]
   },
   {
     "technique_id": "T1553",
@@ -3986,27 +8201,103 @@
     "url": "https://attack.mitre.org/techniques/T1553",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
     ]
   },
   {
     "technique_id": "T1553.001",
-    "technique": "Subvert Trust Controls : Gatekeeper Bypass",
-    "url": "https://attack.mitre.org/techniques/T1553/001"
+    "technique": "Subvert Trust Controls: Gatekeeper Bypass",
+    "url": "https://attack.mitre.org/techniques/T1553/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1553.002",
-    "technique": "Subvert Trust Controls : Code Signing",
-    "url": "https://attack.mitre.org/techniques/T1553/002"
+    "technique": "Subvert Trust Controls: Code Signing",
+    "url": "https://attack.mitre.org/techniques/T1553/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1553.003",
-    "technique": "Subvert Trust Controls : SIP and Trust Provider Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1553/003"
+    "technique": "Subvert Trust Controls: SIP and Trust Provider Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1553/003",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1553.004",
-    "technique": "Subvert Trust Controls : Install Root Certificate",
-    "url": "https://attack.mitre.org/techniques/T1553/004"
+    "technique": "Subvert Trust Controls: Install Root Certificate",
+    "url": "https://attack.mitre.org/techniques/T1553/004",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1553.005",
+    "technique": "Subvert Trust Controls: Mark-of-the-Web Bypass",
+    "url": "https://attack.mitre.org/techniques/T1553/005",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1553.006",
+    "technique": "Subvert Trust Controls: Code Signing Policy Modification",
+    "url": "https://attack.mitre.org/techniques/T1553/006",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1554",
@@ -4014,6 +8305,14 @@
     "url": "https://attack.mitre.org/techniques/T1554",
     "tactic": [
       "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -4022,22 +8321,90 @@
     "url": "https://attack.mitre.org/techniques/T1555",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1555.001",
-    "technique": "Credentials from Password Stores : Keychain",
-    "url": "https://attack.mitre.org/techniques/T1555/001"
+    "technique": "Credentials from Password Stores: Keychain",
+    "url": "https://attack.mitre.org/techniques/T1555/001",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1555.002",
-    "technique": "Credentials from Password Stores : Securityd Memory",
-    "url": "https://attack.mitre.org/techniques/T1555/002"
+    "technique": "Credentials from Password Stores: Securityd Memory",
+    "url": "https://attack.mitre.org/techniques/T1555/002",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1555.003",
-    "technique": "Credentials from Password Stores : Credentials from Web Browsers",
-    "url": "https://attack.mitre.org/techniques/T1555/003"
+    "technique": "Credentials from Password Stores: Credentials from Web Browsers",
+    "url": "https://attack.mitre.org/techniques/T1555/003",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1555.004",
+    "technique": "Credentials from Password Stores: Windows Credential Manager",
+    "url": "https://attack.mitre.org/techniques/T1555/004",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1555.005",
+    "technique": "Credentials from Password Stores: Password Managers",
+    "url": "https://attack.mitre.org/techniques/T1555/005",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1556",
@@ -4045,37 +8412,132 @@
     "url": "https://attack.mitre.org/techniques/T1556",
     "tactic": [
       "Credential Access",
-      "Defense Evasion"
+      "Defense Evasion",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS",
+      "Network"
     ]
   },
   {
     "technique_id": "T1556.001",
-    "technique": "Modify Authentication Process : Domain Controller Authentication",
-    "url": "https://attack.mitre.org/techniques/T1556/001"
+    "technique": "Modify Authentication Process: Domain Controller Authentication",
+    "url": "https://attack.mitre.org/techniques/T1556/001",
+    "tactic": [
+      "Credential Access",
+      "Defense Evasion",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1556.002",
-    "technique": "Modify Authentication Process : Password Filter DLL",
-    "url": "https://attack.mitre.org/techniques/T1556/002"
+    "technique": "Modify Authentication Process: Password Filter DLL",
+    "url": "https://attack.mitre.org/techniques/T1556/002",
+    "tactic": [
+      "Credential Access",
+      "Defense Evasion",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1556.003",
-    "technique": "Modify Authentication Process : Pluggable Authentication Modules",
-    "url": "https://attack.mitre.org/techniques/T1556/003"
+    "technique": "Modify Authentication Process: Pluggable Authentication Modules",
+    "url": "https://attack.mitre.org/techniques/T1556/003",
+    "tactic": [
+      "Credential Access",
+      "Defense Evasion",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "technique_id": "T1556.004",
+    "technique": "Modify Authentication Process: Network Device Authentication",
+    "url": "https://attack.mitre.org/techniques/T1556/004",
+    "tactic": [
+      "Credential Access",
+      "Defense Evasion",
+      "Persistence"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
   },
   {
     "technique_id": "T1557",
-    "technique": "Man-in-the-Middle",
+    "technique": "Adversary-in-the-Middle",
     "url": "https://attack.mitre.org/techniques/T1557",
     "tactic": [
       "Credential Access",
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
     ]
   },
   {
     "technique_id": "T1557.001",
-    "technique": "Man-in-the-Middle : LLMNR/NBT-NS Poisoning and SMB Relay",
-    "url": "https://attack.mitre.org/techniques/T1557/001"
+    "technique": "Adversary-in-the-Middle: LLMNR/NBT-NS Poisoning and SMB Relay",
+    "url": "https://attack.mitre.org/techniques/T1557/001",
+    "tactic": [
+      "Credential Access",
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1557.002",
+    "technique": "Adversary-in-the-Middle: ARP Cache Poisoning",
+    "url": "https://attack.mitre.org/techniques/T1557/002",
+    "tactic": [
+      "Credential Access",
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1558",
@@ -4083,22 +8545,71 @@
     "url": "https://attack.mitre.org/techniques/T1558",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
     ]
   },
   {
     "technique_id": "T1558.001",
-    "technique": "Steal or Forge Kerberos Tickets : Golden Ticket",
-    "url": "https://attack.mitre.org/techniques/T1558/001"
+    "technique": "Steal or Forge Kerberos Tickets: Golden Ticket",
+    "url": "https://attack.mitre.org/techniques/T1558/001",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1558.002",
-    "technique": "Steal or Forge Kerberos Tickets : Silver Ticket",
-    "url": "https://attack.mitre.org/techniques/T1558/002"
+    "technique": "Steal or Forge Kerberos Tickets: Silver Ticket",
+    "url": "https://attack.mitre.org/techniques/T1558/002",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1558.003",
-    "technique": "Steal or Forge Kerberos Tickets : Kerberoasting",
-    "url": "https://attack.mitre.org/techniques/T1558/003"
+    "technique": "Steal or Forge Kerberos Tickets: Kerberoasting",
+    "url": "https://attack.mitre.org/techniques/T1558/003",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1558.004",
+    "technique": "Steal or Forge Kerberos Tickets: AS-REP Roasting",
+    "url": "https://attack.mitre.org/techniques/T1558/004",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1559",
@@ -4106,17 +8617,42 @@
     "url": "https://attack.mitre.org/techniques/T1559",
     "tactic": [
       "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS"
     ]
   },
   {
     "technique_id": "T1559.001",
-    "technique": "Inter-Process Communication : Component Object Model",
-    "url": "https://attack.mitre.org/techniques/T1559/001"
+    "technique": "Inter-Process Communication: Component Object Model",
+    "url": "https://attack.mitre.org/techniques/T1559/001",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1559.002",
-    "technique": "Inter-Process Communication : Dynamic Data Exchange",
-    "url": "https://attack.mitre.org/techniques/T1559/002"
+    "technique": "Inter-Process Communication: Dynamic Data Exchange",
+    "url": "https://attack.mitre.org/techniques/T1559/002",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1560",
@@ -4124,22 +8660,63 @@
     "url": "https://attack.mitre.org/techniques/T1560",
     "tactic": [
       "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1560.001",
-    "technique": "Archive Collected Data : Archive via Utility",
-    "url": "https://attack.mitre.org/techniques/T1560/001"
+    "technique": "Archive Collected Data: Archive via Utility",
+    "url": "https://attack.mitre.org/techniques/T1560/001",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1560.002",
-    "technique": "Archive Collected Data : Archive via Library",
-    "url": "https://attack.mitre.org/techniques/T1560/002"
+    "technique": "Archive Collected Data: Archive via Library",
+    "url": "https://attack.mitre.org/techniques/T1560/002",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1560.003",
-    "technique": "Archive Collected Data : Archive via Custom Method",
-    "url": "https://attack.mitre.org/techniques/T1560/003"
+    "technique": "Archive Collected Data: Archive via Custom Method",
+    "url": "https://attack.mitre.org/techniques/T1560/003",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1561",
@@ -4147,17 +8724,47 @@
     "url": "https://attack.mitre.org/techniques/T1561",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1561.001",
-    "technique": "Disk Wipe : Disk Content Wipe",
-    "url": "https://attack.mitre.org/techniques/T1561/001"
+    "technique": "Disk Wipe: Disk Content Wipe",
+    "url": "https://attack.mitre.org/techniques/T1561/001",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1561.002",
-    "technique": "Disk Wipe : Disk Structure Wipe",
-    "url": "https://attack.mitre.org/techniques/T1561/002"
+    "technique": "Disk Wipe: Disk Structure Wipe",
+    "url": "https://attack.mitre.org/techniques/T1561/002",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1562",
@@ -4165,37 +8772,157 @@
     "url": "https://attack.mitre.org/techniques/T1562",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365",
+      "IaaS",
+      "Linux",
+      "macOS",
+      "Containers",
+      "Network"
     ]
   },
   {
     "technique_id": "T1562.001",
-    "technique": "Impair Defenses : Disable or Modify Tools",
-    "url": "https://attack.mitre.org/techniques/T1562/001"
+    "technique": "Impair Defenses: Disable or Modify Tools",
+    "url": "https://attack.mitre.org/techniques/T1562/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux",
+      "Containers",
+      "IaaS"
+    ]
   },
   {
     "technique_id": "T1562.002",
-    "technique": "Impair Defenses : Disable Windows Event Logging",
-    "url": "https://attack.mitre.org/techniques/T1562/002"
+    "technique": "Impair Defenses: Disable Windows Event Logging",
+    "url": "https://attack.mitre.org/techniques/T1562/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1562.003",
-    "technique": "Impair Defenses : HISTCONTROL",
-    "url": "https://attack.mitre.org/techniques/T1562/003"
+    "technique": "Impair Defenses: Impair Command History Logging",
+    "url": "https://attack.mitre.org/techniques/T1562/003",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1562.004",
-    "technique": "Impair Defenses : Disable or Modify System Firewall",
-    "url": "https://attack.mitre.org/techniques/T1562/004"
+    "technique": "Impair Defenses: Disable or Modify System Firewall",
+    "url": "https://attack.mitre.org/techniques/T1562/004",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1562.006",
-    "technique": "Impair Defenses : Indicator Blocking",
-    "url": "https://attack.mitre.org/techniques/T1562/006"
+    "technique": "Impair Defenses: Indicator Blocking",
+    "url": "https://attack.mitre.org/techniques/T1562/006",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1562.007",
-    "technique": "Impair Defenses : Disable or Modify Cloud Firewall",
-    "url": "https://attack.mitre.org/techniques/T1562/007"
+    "technique": "Impair Defenses: Disable or Modify Cloud Firewall",
+    "url": "https://attack.mitre.org/techniques/T1562/007",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
+    ]
+  },
+  {
+    "technique_id": "T1562.008",
+    "technique": "Impair Defenses: Disable Cloud Logs",
+    "url": "https://attack.mitre.org/techniques/T1562/008",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
+    ]
+  },
+  {
+    "technique_id": "T1562.009",
+    "technique": "Impair Defenses: Safe Mode Boot",
+    "url": "https://attack.mitre.org/techniques/T1562/009",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1562.010",
+    "technique": "Impair Defenses: Downgrade Attack",
+    "url": "https://attack.mitre.org/techniques/T1562/010",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1563",
@@ -4203,17 +8930,44 @@
     "url": "https://attack.mitre.org/techniques/T1563",
     "tactic": [
       "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1563.001",
-    "technique": "Remote Service Session Hijacking : SSH Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1563/001"
+    "technique": "Remote Service Session Hijacking: SSH Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1563/001",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1563.002",
-    "technique": "Remote Service Session Hijacking : RDP Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1563/002"
+    "technique": "Remote Service Session Hijacking: RDP Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1563/002",
+    "tactic": [
+      "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1564",
@@ -4221,37 +8975,155 @@
     "url": "https://attack.mitre.org/techniques/T1564",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Office 365"
     ]
   },
   {
     "technique_id": "T1564.001",
-    "technique": "Hide Artifacts : Hidden Files and Directories",
-    "url": "https://attack.mitre.org/techniques/T1564/001"
+    "technique": "Hide Artifacts: Hidden Files and Directories",
+    "url": "https://attack.mitre.org/techniques/T1564/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1564.002",
-    "technique": "Hide Artifacts : Hidden Users",
-    "url": "https://attack.mitre.org/techniques/T1564/002"
+    "technique": "Hide Artifacts: Hidden Users",
+    "url": "https://attack.mitre.org/techniques/T1564/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1564.003",
-    "technique": "Hide Artifacts : Hidden Window",
-    "url": "https://attack.mitre.org/techniques/T1564/003"
+    "technique": "Hide Artifacts: Hidden Window",
+    "url": "https://attack.mitre.org/techniques/T1564/003",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1564.004",
-    "technique": "Hide Artifacts : NTFS File Attributes",
-    "url": "https://attack.mitre.org/techniques/T1564/004"
+    "technique": "Hide Artifacts: NTFS File Attributes",
+    "url": "https://attack.mitre.org/techniques/T1564/004",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1564.005",
-    "technique": "Hide Artifacts : Hidden File System",
-    "url": "https://attack.mitre.org/techniques/T1564/005"
+    "technique": "Hide Artifacts: Hidden File System",
+    "url": "https://attack.mitre.org/techniques/T1564/005",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1564.006",
-    "technique": "Hide Artifacts : Run Virtual Instance",
-    "url": "https://attack.mitre.org/techniques/T1564/006"
+    "technique": "Hide Artifacts: Run Virtual Instance",
+    "url": "https://attack.mitre.org/techniques/T1564/006",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1564.007",
+    "technique": "Hide Artifacts: VBA Stomping",
+    "url": "https://attack.mitre.org/techniques/T1564/007",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
+  },
+  {
+    "technique_id": "T1564.008",
+    "technique": "Hide Artifacts: Email Hiding Rules",
+    "url": "https://attack.mitre.org/techniques/T1564/008",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Office 365",
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "technique_id": "T1564.009",
+    "technique": "Hide Artifacts: Resource Forking",
+    "url": "https://attack.mitre.org/techniques/T1564/009",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1565",
@@ -4259,22 +9131,63 @@
     "url": "https://attack.mitre.org/techniques/T1565",
     "tactic": [
       "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1565.001",
-    "technique": "Data Manipulation : Stored Data Manipulation",
-    "url": "https://attack.mitre.org/techniques/T1565/001"
+    "technique": "Data Manipulation: Stored Data Manipulation",
+    "url": "https://attack.mitre.org/techniques/T1565/001",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1565.002",
-    "technique": "Data Manipulation : Transmitted Data Manipulation",
-    "url": "https://attack.mitre.org/techniques/T1565/002"
+    "technique": "Data Manipulation: Transmitted Data Manipulation",
+    "url": "https://attack.mitre.org/techniques/T1565/002",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1565.003",
-    "technique": "Data Manipulation : Runtime Data Manipulation",
-    "url": "https://attack.mitre.org/techniques/T1565/003"
+    "technique": "Data Manipulation: Runtime Data Manipulation",
+    "url": "https://attack.mitre.org/techniques/T1565/003",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1566",
@@ -4282,22 +9195,69 @@
     "url": "https://attack.mitre.org/techniques/T1566",
     "tactic": [
       "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "SaaS",
+      "Office 365",
+      "Google Workspace"
     ]
   },
   {
     "technique_id": "T1566.001",
-    "technique": "Phishing : Spearphishing Attachment",
-    "url": "https://attack.mitre.org/techniques/T1566/001"
+    "technique": "Phishing: Spearphishing Attachment",
+    "url": "https://attack.mitre.org/techniques/T1566/001",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Windows",
+      "Linux"
+    ]
   },
   {
     "technique_id": "T1566.002",
-    "technique": "Phishing : Spearphishing Link",
-    "url": "https://attack.mitre.org/techniques/T1566/002"
+    "technique": "Phishing: Spearphishing Link",
+    "url": "https://attack.mitre.org/techniques/T1566/002",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "Office 365",
+      "SaaS",
+      "Google Workspace"
+    ]
   },
   {
     "technique_id": "T1566.003",
-    "technique": "Phishing : Spearphishing via Service",
-    "url": "https://attack.mitre.org/techniques/T1566/003"
+    "technique": "Phishing: Spearphishing via Service",
+    "url": "https://attack.mitre.org/techniques/T1566/003",
+    "tactic": [
+      "Initial Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1567",
@@ -4305,17 +9265,47 @@
     "url": "https://attack.mitre.org/techniques/T1567",
     "tactic": [
       "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1567.001",
-    "technique": "Exfiltration Over Web Service : Exfiltration to Code Repository",
-    "url": "https://attack.mitre.org/techniques/T1567/001"
+    "technique": "Exfiltration Over Web Service: Exfiltration to Code Repository",
+    "url": "https://attack.mitre.org/techniques/T1567/001",
+    "tactic": [
+      "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1567.002",
-    "technique": "Exfiltration Over Web Service : Exfiltration to Cloud Storage",
-    "url": "https://attack.mitre.org/techniques/T1567/002"
+    "technique": "Exfiltration Over Web Service: Exfiltration to Cloud Storage",
+    "url": "https://attack.mitre.org/techniques/T1567/002",
+    "tactic": [
+      "Exfiltration"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1568",
@@ -4323,22 +9313,63 @@
     "url": "https://attack.mitre.org/techniques/T1568",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1568.001",
-    "technique": "Dynamic Resolution : Fast Flux DNS",
-    "url": "https://attack.mitre.org/techniques/T1568/001"
+    "technique": "Dynamic Resolution: Fast Flux DNS",
+    "url": "https://attack.mitre.org/techniques/T1568/001",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1568.002",
-    "technique": "Dynamic Resolution : Domain Generation Algorithms",
-    "url": "https://attack.mitre.org/techniques/T1568/002"
+    "technique": "Dynamic Resolution: Domain Generation Algorithms",
+    "url": "https://attack.mitre.org/techniques/T1568/002",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1568.003",
-    "technique": "Dynamic Resolution : DNS Calculation",
-    "url": "https://attack.mitre.org/techniques/T1568/003"
+    "technique": "Dynamic Resolution: DNS Calculation",
+    "url": "https://attack.mitre.org/techniques/T1568/003",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1569",
@@ -4346,17 +9377,42 @@
     "url": "https://attack.mitre.org/techniques/T1569",
     "tactic": [
       "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "macOS"
     ]
   },
   {
     "technique_id": "T1569.001",
-    "technique": "System Services : Launchctl",
-    "url": "https://attack.mitre.org/techniques/T1569/001"
+    "technique": "System Services: Launchctl",
+    "url": "https://attack.mitre.org/techniques/T1569/001",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1569.002",
-    "technique": "System Services : Service Execution",
-    "url": "https://attack.mitre.org/techniques/T1569/002"
+    "technique": "System Services: Service Execution",
+    "url": "https://attack.mitre.org/techniques/T1569/002",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1570",
@@ -4364,6 +9420,14 @@
     "url": "https://attack.mitre.org/techniques/T1570",
     "tactic": [
       "Lateral Movement"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -4372,6 +9436,14 @@
     "url": "https://attack.mitre.org/techniques/T1571",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -4380,6 +9452,14 @@
     "url": "https://attack.mitre.org/techniques/T1572",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
@@ -4388,17 +9468,47 @@
     "url": "https://attack.mitre.org/techniques/T1573",
     "tactic": [
       "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1573.001",
-    "technique": "Encrypted Channel : Symmetric Cryptography",
-    "url": "https://attack.mitre.org/techniques/T1573/001"
+    "technique": "Encrypted Channel: Symmetric Cryptography",
+    "url": "https://attack.mitre.org/techniques/T1573/001",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "Windows",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1573.002",
-    "technique": "Encrypted Channel : Asymmetric Cryptography",
-    "url": "https://attack.mitre.org/techniques/T1573/002"
+    "technique": "Encrypted Channel: Asymmetric Cryptography",
+    "url": "https://attack.mitre.org/techniques/T1573/002",
+    "tactic": [
+      "Command and Control"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1574",
@@ -4408,62 +9518,192 @@
       "Persistence",
       "Privilege Escalation",
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows"
     ]
   },
   {
     "technique_id": "T1574.001",
-    "technique": "Hijack Execution Flow : DLL Search Order Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1574/001"
+    "technique": "Hijack Execution Flow: DLL Search Order Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1574/001",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1574.002",
-    "technique": "Hijack Execution Flow : DLL Side-Loading",
-    "url": "https://attack.mitre.org/techniques/T1574/002"
+    "technique": "Hijack Execution Flow: DLL Side-Loading",
+    "url": "https://attack.mitre.org/techniques/T1574/002",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1574.004",
-    "technique": "Hijack Execution Flow : Dylib Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1574/004"
+    "technique": "Hijack Execution Flow: Dylib Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1574/004",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1574.005",
-    "technique": "Hijack Execution Flow : Executable Installer File Permissions Weakness",
-    "url": "https://attack.mitre.org/techniques/T1574/005"
+    "technique": "Hijack Execution Flow: Executable Installer File Permissions Weakness",
+    "url": "https://attack.mitre.org/techniques/T1574/005",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1574.006",
-    "technique": "Hijack Execution Flow : LD_PRELOAD",
-    "url": "https://attack.mitre.org/techniques/T1574/006"
+    "technique": "Hijack Execution Flow: Dynamic Linker Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1574/006",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS"
+    ]
   },
   {
     "technique_id": "T1574.007",
-    "technique": "Hijack Execution Flow : Path Interception by PATH Environment Variable",
-    "url": "https://attack.mitre.org/techniques/T1574/007"
+    "technique": "Hijack Execution Flow: Path Interception by PATH Environment Variable",
+    "url": "https://attack.mitre.org/techniques/T1574/007",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1574.008",
-    "technique": "Hijack Execution Flow : Path Interception by Search Order Hijacking",
-    "url": "https://attack.mitre.org/techniques/T1574/008"
+    "technique": "Hijack Execution Flow: Path Interception by Search Order Hijacking",
+    "url": "https://attack.mitre.org/techniques/T1574/008",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1574.009",
-    "technique": "Hijack Execution Flow : Path Interception by Unquoted Path",
-    "url": "https://attack.mitre.org/techniques/T1574/009"
+    "technique": "Hijack Execution Flow: Path Interception by Unquoted Path",
+    "url": "https://attack.mitre.org/techniques/T1574/009",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1574.010",
-    "technique": "Hijack Execution Flow : Services File Permissions Weakness",
-    "url": "https://attack.mitre.org/techniques/T1574/010"
+    "technique": "Hijack Execution Flow: Services File Permissions Weakness",
+    "url": "https://attack.mitre.org/techniques/T1574/010",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1574.011",
-    "technique": "Hijack Execution Flow : Services Registry Permissions Weakness",
-    "url": "https://attack.mitre.org/techniques/T1574/011"
+    "technique": "Hijack Execution Flow: Services Registry Permissions Weakness",
+    "url": "https://attack.mitre.org/techniques/T1574/011",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1574.012",
-    "technique": "Hijack Execution Flow : COR_PROFILER",
-    "url": "https://attack.mitre.org/techniques/T1574/012"
+    "technique": "Hijack Execution Flow: COR_PROFILER",
+    "url": "https://attack.mitre.org/techniques/T1574/012",
+    "tactic": [
+      "Persistence",
+      "Privilege Escalation",
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
   },
   {
     "technique_id": "T1575",
@@ -4472,6 +9712,12 @@
     "tactic": [
       "Defense Evasion",
       "Execution"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -4480,6 +9726,12 @@
     "url": "https://attack.mitre.org/techniques/T1576",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -4488,6 +9740,12 @@
     "url": "https://attack.mitre.org/techniques/T1577",
     "tactic": [
       "Persistence"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
     ]
   },
   {
@@ -4496,27 +9754,69 @@
     "url": "https://attack.mitre.org/techniques/T1578",
     "tactic": [
       "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
     ]
   },
   {
     "technique_id": "T1578.001",
-    "technique": "Modify Cloud Compute Infrastructure : Create Snapshot",
-    "url": "https://attack.mitre.org/techniques/T1578/001"
+    "technique": "Modify Cloud Compute Infrastructure: Create Snapshot",
+    "url": "https://attack.mitre.org/techniques/T1578/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
+    ]
   },
   {
     "technique_id": "T1578.002",
-    "technique": "Modify Cloud Compute Infrastructure : Create Cloud Instance",
-    "url": "https://attack.mitre.org/techniques/T1578/002"
+    "technique": "Modify Cloud Compute Infrastructure: Create Cloud Instance",
+    "url": "https://attack.mitre.org/techniques/T1578/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
+    ]
   },
   {
     "technique_id": "T1578.003",
-    "technique": "Modify Cloud Compute Infrastructure : Delete Cloud Instance",
-    "url": "https://attack.mitre.org/techniques/T1578/003"
+    "technique": "Modify Cloud Compute Infrastructure: Delete Cloud Instance",
+    "url": "https://attack.mitre.org/techniques/T1578/003",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
+    ]
   },
   {
     "technique_id": "T1578.004",
-    "technique": "Modify Cloud Compute Infrastructure : Revert Cloud Instance",
-    "url": "https://attack.mitre.org/techniques/T1578/004"
+    "technique": "Modify Cloud Compute Infrastructure: Revert Cloud Instance",
+    "url": "https://attack.mitre.org/techniques/T1578/004",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
+    ]
   },
   {
     "technique_id": "T1579",
@@ -4524,6 +9824,1612 @@
     "url": "https://attack.mitre.org/techniques/T1579",
     "tactic": [
       "Credential Access"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "iOS"
+    ]
+  },
+  {
+    "technique_id": "T1580",
+    "technique": "Cloud Infrastructure Discovery",
+    "url": "https://attack.mitre.org/techniques/T1580",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
+    ]
+  },
+  {
+    "technique_id": "T1581",
+    "technique": "Geofencing",
+    "url": "https://attack.mitre.org/techniques/T1581",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
+    ]
+  },
+  {
+    "technique_id": "T1582",
+    "technique": "SMS Control",
+    "url": "https://attack.mitre.org/techniques/T1582",
+    "tactic": [
+      "Impact"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "technique_id": "T1583",
+    "technique": "Acquire Infrastructure",
+    "url": "https://attack.mitre.org/techniques/T1583",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1583.001",
+    "technique": "Acquire Infrastructure: Domains",
+    "url": "https://attack.mitre.org/techniques/T1583/001",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1583.002",
+    "technique": "Acquire Infrastructure: DNS Server",
+    "url": "https://attack.mitre.org/techniques/T1583/002",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1583.003",
+    "technique": "Acquire Infrastructure: Virtual Private Server",
+    "url": "https://attack.mitre.org/techniques/T1583/003",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1583.004",
+    "technique": "Acquire Infrastructure: Server",
+    "url": "https://attack.mitre.org/techniques/T1583/004",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1583.005",
+    "technique": "Acquire Infrastructure: Botnet",
+    "url": "https://attack.mitre.org/techniques/T1583/005",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1583.006",
+    "technique": "Acquire Infrastructure: Web Services",
+    "url": "https://attack.mitre.org/techniques/T1583/006",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1584",
+    "technique": "Compromise Infrastructure",
+    "url": "https://attack.mitre.org/techniques/T1584",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1584.001",
+    "technique": "Compromise Infrastructure: Domains",
+    "url": "https://attack.mitre.org/techniques/T1584/001",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1584.002",
+    "technique": "Compromise Infrastructure: DNS Server",
+    "url": "https://attack.mitre.org/techniques/T1584/002",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1584.003",
+    "technique": "Compromise Infrastructure: Virtual Private Server",
+    "url": "https://attack.mitre.org/techniques/T1584/003",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1584.004",
+    "technique": "Compromise Infrastructure: Server",
+    "url": "https://attack.mitre.org/techniques/T1584/004",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1584.005",
+    "technique": "Compromise Infrastructure: Botnet",
+    "url": "https://attack.mitre.org/techniques/T1584/005",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1584.006",
+    "technique": "Compromise Infrastructure: Web Services",
+    "url": "https://attack.mitre.org/techniques/T1584/006",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1585",
+    "technique": "Establish Accounts",
+    "url": "https://attack.mitre.org/techniques/T1585",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1585.001",
+    "technique": "Establish Accounts: Social Media Accounts",
+    "url": "https://attack.mitre.org/techniques/T1585/001",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1585.002",
+    "technique": "Establish Accounts: Email Accounts",
+    "url": "https://attack.mitre.org/techniques/T1585/002",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1586",
+    "technique": "Compromise Accounts",
+    "url": "https://attack.mitre.org/techniques/T1586",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1586.001",
+    "technique": "Compromise Accounts: Social Media Accounts",
+    "url": "https://attack.mitre.org/techniques/T1586/001",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1586.002",
+    "technique": "Compromise Accounts: Email Accounts",
+    "url": "https://attack.mitre.org/techniques/T1586/002",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1587",
+    "technique": "Develop Capabilities",
+    "url": "https://attack.mitre.org/techniques/T1587",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1587.001",
+    "technique": "Develop Capabilities: Malware",
+    "url": "https://attack.mitre.org/techniques/T1587/001",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1587.002",
+    "technique": "Develop Capabilities: Code Signing Certificates",
+    "url": "https://attack.mitre.org/techniques/T1587/002",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1587.003",
+    "technique": "Develop Capabilities: Digital Certificates",
+    "url": "https://attack.mitre.org/techniques/T1587/003",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1587.004",
+    "technique": "Develop Capabilities: Exploits",
+    "url": "https://attack.mitre.org/techniques/T1587/004",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1588",
+    "technique": "Obtain Capabilities",
+    "url": "https://attack.mitre.org/techniques/T1588",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1588.001",
+    "technique": "Obtain Capabilities: Malware",
+    "url": "https://attack.mitre.org/techniques/T1588/001",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1588.002",
+    "technique": "Obtain Capabilities: Tool",
+    "url": "https://attack.mitre.org/techniques/T1588/002",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1588.003",
+    "technique": "Obtain Capabilities: Code Signing Certificates",
+    "url": "https://attack.mitre.org/techniques/T1588/003",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1588.004",
+    "technique": "Obtain Capabilities: Digital Certificates",
+    "url": "https://attack.mitre.org/techniques/T1588/004",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1588.005",
+    "technique": "Obtain Capabilities: Exploits",
+    "url": "https://attack.mitre.org/techniques/T1588/005",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1588.006",
+    "technique": "Obtain Capabilities: Vulnerabilities",
+    "url": "https://attack.mitre.org/techniques/T1588/006",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1589",
+    "technique": "Gather Victim Identity Information",
+    "url": "https://attack.mitre.org/techniques/T1589",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1589.001",
+    "technique": "Gather Victim Identity Information: Credentials",
+    "url": "https://attack.mitre.org/techniques/T1589/001",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1589.002",
+    "technique": "Gather Victim Identity Information: Email Addresses",
+    "url": "https://attack.mitre.org/techniques/T1589/002",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1589.003",
+    "technique": "Gather Victim Identity Information: Employee Names",
+    "url": "https://attack.mitre.org/techniques/T1589/003",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1590",
+    "technique": "Gather Victim Network Information",
+    "url": "https://attack.mitre.org/techniques/T1590",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1590.001",
+    "technique": "Gather Victim Network Information: Domain Properties",
+    "url": "https://attack.mitre.org/techniques/T1590/001",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1590.002",
+    "technique": "Gather Victim Network Information: DNS",
+    "url": "https://attack.mitre.org/techniques/T1590/002",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1590.003",
+    "technique": "Gather Victim Network Information: Network Trust Dependencies",
+    "url": "https://attack.mitre.org/techniques/T1590/003",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1590.004",
+    "technique": "Gather Victim Network Information: Network Topology",
+    "url": "https://attack.mitre.org/techniques/T1590/004",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1590.005",
+    "technique": "Gather Victim Network Information: IP Addresses",
+    "url": "https://attack.mitre.org/techniques/T1590/005",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1590.006",
+    "technique": "Gather Victim Network Information: Network Security Appliances",
+    "url": "https://attack.mitre.org/techniques/T1590/006",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1591",
+    "technique": "Gather Victim Org Information",
+    "url": "https://attack.mitre.org/techniques/T1591",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1591.001",
+    "technique": "Gather Victim Org Information: Determine Physical Locations",
+    "url": "https://attack.mitre.org/techniques/T1591/001",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1591.002",
+    "technique": "Gather Victim Org Information: Business Relationships",
+    "url": "https://attack.mitre.org/techniques/T1591/002",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1591.003",
+    "technique": "Gather Victim Org Information: Identify Business Tempo",
+    "url": "https://attack.mitre.org/techniques/T1591/003",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1591.004",
+    "technique": "Gather Victim Org Information: Identify Roles",
+    "url": "https://attack.mitre.org/techniques/T1591/004",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1592",
+    "technique": "Gather Victim Host Information",
+    "url": "https://attack.mitre.org/techniques/T1592",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1592.001",
+    "technique": "Gather Victim Host Information: Hardware",
+    "url": "https://attack.mitre.org/techniques/T1592/001",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1592.002",
+    "technique": "Gather Victim Host Information: Software",
+    "url": "https://attack.mitre.org/techniques/T1592/002",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1592.003",
+    "technique": "Gather Victim Host Information: Firmware",
+    "url": "https://attack.mitre.org/techniques/T1592/003",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1592.004",
+    "technique": "Gather Victim Host Information: Client Configurations",
+    "url": "https://attack.mitre.org/techniques/T1592/004",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1593",
+    "technique": "Search Open Websites/Domains",
+    "url": "https://attack.mitre.org/techniques/T1593",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1593.001",
+    "technique": "Search Open Websites/Domains: Social Media",
+    "url": "https://attack.mitre.org/techniques/T1593/001",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1593.002",
+    "technique": "Search Open Websites/Domains: Search Engines",
+    "url": "https://attack.mitre.org/techniques/T1593/002",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1594",
+    "technique": "Search Victim-Owned Websites",
+    "url": "https://attack.mitre.org/techniques/T1594",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1595",
+    "technique": "Active Scanning",
+    "url": "https://attack.mitre.org/techniques/T1595",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1595.001",
+    "technique": "Active Scanning: Scanning IP Blocks",
+    "url": "https://attack.mitre.org/techniques/T1595/001",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1595.002",
+    "technique": "Active Scanning: Vulnerability Scanning",
+    "url": "https://attack.mitre.org/techniques/T1595/002",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1596",
+    "technique": "Search Open Technical Databases",
+    "url": "https://attack.mitre.org/techniques/T1596",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1596.001",
+    "technique": "Search Open Technical Databases: DNS/Passive DNS",
+    "url": "https://attack.mitre.org/techniques/T1596/001",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1596.002",
+    "technique": "Search Open Technical Databases: WHOIS",
+    "url": "https://attack.mitre.org/techniques/T1596/002",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1596.003",
+    "technique": "Search Open Technical Databases: Digital Certificates",
+    "url": "https://attack.mitre.org/techniques/T1596/003",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1596.004",
+    "technique": "Search Open Technical Databases: CDNs",
+    "url": "https://attack.mitre.org/techniques/T1596/004",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1596.005",
+    "technique": "Search Open Technical Databases: Scan Databases",
+    "url": "https://attack.mitre.org/techniques/T1596/005",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1597",
+    "technique": "Search Closed Sources",
+    "url": "https://attack.mitre.org/techniques/T1597",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1597.001",
+    "technique": "Search Closed Sources: Threat Intel Vendors",
+    "url": "https://attack.mitre.org/techniques/T1597/001",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1597.002",
+    "technique": "Search Closed Sources: Purchase Technical Data",
+    "url": "https://attack.mitre.org/techniques/T1597/002",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1598",
+    "technique": "Phishing for Information",
+    "url": "https://attack.mitre.org/techniques/T1598",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1598.001",
+    "technique": "Phishing for Information: Spearphishing Service",
+    "url": "https://attack.mitre.org/techniques/T1598/001",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1598.002",
+    "technique": "Phishing for Information: Spearphishing Attachment",
+    "url": "https://attack.mitre.org/techniques/T1598/002",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1598.003",
+    "technique": "Phishing for Information: Spearphishing Link",
+    "url": "https://attack.mitre.org/techniques/T1598/003",
+    "tactic": [
+      "Reconnaissance"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1599",
+    "technique": "Network Boundary Bridging",
+    "url": "https://attack.mitre.org/techniques/T1599",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1599.001",
+    "technique": "Network Boundary Bridging: Network Address Translation Traversal",
+    "url": "https://attack.mitre.org/techniques/T1599/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1600",
+    "technique": "Weaken Encryption",
+    "url": "https://attack.mitre.org/techniques/T1600",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1600.001",
+    "technique": "Weaken Encryption: Reduce Key Space",
+    "url": "https://attack.mitre.org/techniques/T1600/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1600.002",
+    "technique": "Weaken Encryption: Disable Crypto Hardware",
+    "url": "https://attack.mitre.org/techniques/T1600/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1601",
+    "technique": "Modify System Image",
+    "url": "https://attack.mitre.org/techniques/T1601",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1601.001",
+    "technique": "Modify System Image: Patch System Image",
+    "url": "https://attack.mitre.org/techniques/T1601/001",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1601.002",
+    "technique": "Modify System Image: Downgrade System Image",
+    "url": "https://attack.mitre.org/techniques/T1601/002",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1602",
+    "technique": "Data from Configuration Repository",
+    "url": "https://attack.mitre.org/techniques/T1602",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1602.001",
+    "technique": "Data from Configuration Repository: SNMP (MIB Dump)",
+    "url": "https://attack.mitre.org/techniques/T1602/001",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1602.002",
+    "technique": "Data from Configuration Repository: Network Device Configuration Dump",
+    "url": "https://attack.mitre.org/techniques/T1602/002",
+    "tactic": [
+      "Collection"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Network"
+    ]
+  },
+  {
+    "technique_id": "T1603",
+    "technique": "Scheduled Task/Job",
+    "url": "https://attack.mitre.org/techniques/T1603",
+    "tactic": [
+      "Execution",
+      "Persistence"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
+    ]
+  },
+  {
+    "technique_id": "T1604",
+    "technique": "Proxy Through Victim",
+    "url": "https://attack.mitre.org/techniques/T1604",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "technique_id": "T1605",
+    "technique": "Command-Line Interface",
+    "url": "https://attack.mitre.org/techniques/T1605",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android",
+      "iOS"
+    ]
+  },
+  {
+    "technique_id": "T1606",
+    "technique": "Forge Web Credentials",
+    "url": "https://attack.mitre.org/techniques/T1606",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "SaaS",
+      "Windows",
+      "macOS",
+      "Linux",
+      "Azure AD",
+      "Office 365",
+      "Google Workspace",
+      "IaaS"
+    ]
+  },
+  {
+    "technique_id": "T1606.001",
+    "technique": "Forge Web Credentials: Web Cookies",
+    "url": "https://attack.mitre.org/techniques/T1606/001",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Linux",
+      "macOS",
+      "Windows",
+      "SaaS",
+      "IaaS"
+    ]
+  },
+  {
+    "technique_id": "T1606.002",
+    "technique": "Forge Web Credentials: SAML Tokens",
+    "url": "https://attack.mitre.org/techniques/T1606/002",
+    "tactic": [
+      "Credential Access"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Azure AD",
+      "SaaS",
+      "Windows",
+      "Office 365",
+      "Google Workspace",
+      "IaaS"
+    ]
+  },
+  {
+    "technique_id": "T1608",
+    "technique": "Stage Capabilities",
+    "url": "https://attack.mitre.org/techniques/T1608",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1608.001",
+    "technique": "Stage Capabilities: Upload Malware",
+    "url": "https://attack.mitre.org/techniques/T1608/001",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1608.002",
+    "technique": "Stage Capabilities: Upload Tool",
+    "url": "https://attack.mitre.org/techniques/T1608/002",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1608.003",
+    "technique": "Stage Capabilities: Install Digital Certificate",
+    "url": "https://attack.mitre.org/techniques/T1608/003",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1608.004",
+    "technique": "Stage Capabilities: Drive-by Target",
+    "url": "https://attack.mitre.org/techniques/T1608/004",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1608.005",
+    "technique": "Stage Capabilities: Link Target",
+    "url": "https://attack.mitre.org/techniques/T1608/005",
+    "tactic": [
+      "Resource Development"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "PRE"
+    ]
+  },
+  {
+    "technique_id": "T1609",
+    "technique": "Container Administration Command",
+    "url": "https://attack.mitre.org/techniques/T1609",
+    "tactic": [
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Containers"
+    ]
+  },
+  {
+    "technique_id": "T1610",
+    "technique": "Deploy Container",
+    "url": "https://attack.mitre.org/techniques/T1610",
+    "tactic": [
+      "Defense Evasion",
+      "Execution"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Containers"
+    ]
+  },
+  {
+    "technique_id": "T1611",
+    "technique": "Escape to Host",
+    "url": "https://attack.mitre.org/techniques/T1611",
+    "tactic": [
+      "Privilege Escalation"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "Containers"
+    ]
+  },
+  {
+    "technique_id": "T1612",
+    "technique": "Build Image on Host",
+    "url": "https://attack.mitre.org/techniques/T1612",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Containers"
+    ]
+  },
+  {
+    "technique_id": "T1613",
+    "technique": "Container and Resource Discovery",
+    "url": "https://attack.mitre.org/techniques/T1613",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Containers"
+    ]
+  },
+  {
+    "technique_id": "T1614",
+    "technique": "System Location Discovery",
+    "url": "https://attack.mitre.org/techniques/T1614",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS",
+      "IaaS"
+    ]
+  },
+  {
+    "technique_id": "T1614.001",
+    "technique": "System Location Discovery: System Language Discovery",
+    "url": "https://attack.mitre.org/techniques/T1614/001",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows",
+      "Linux",
+      "macOS"
+    ]
+  },
+  {
+    "technique_id": "T1615",
+    "technique": "Group Policy Discovery",
+    "url": "https://attack.mitre.org/techniques/T1615",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "Windows"
+    ]
+  },
+  {
+    "technique_id": "T1616",
+    "technique": "Call Control",
+    "url": "https://attack.mitre.org/techniques/T1616",
+    "tactic": [
+      "Collection",
+      "Impact",
+      "Command and Control"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "technique_id": "T1617",
+    "technique": "Hooking",
+    "url": "https://attack.mitre.org/techniques/T1617",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "technique_id": "T1618",
+    "technique": "User Evasion",
+    "url": "https://attack.mitre.org/techniques/T1618",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Mobile"
+    ],
+    "platform": [
+      "Android"
+    ]
+  },
+  {
+    "technique_id": "T1619",
+    "technique": "Cloud Storage Object Discovery",
+    "url": "https://attack.mitre.org/techniques/T1619",
+    "tactic": [
+      "Discovery"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "IaaS"
+    ]
+  },
+  {
+    "technique_id": "T1620",
+    "technique": "Reflective Code Loading",
+    "url": "https://attack.mitre.org/techniques/T1620",
+    "tactic": [
+      "Defense Evasion"
+    ],
+    "domain": [
+      "Enterprise"
+    ],
+    "platform": [
+      "macOS",
+      "Linux",
+      "Windows"
     ]
   }
 ]

--- a/tools/config/mitre/update_mitre.py
+++ b/tools/config/mitre/update_mitre.py
@@ -1,5 +1,5 @@
-# Updates the Mitre Tactics & Techniques from Mitre CTI Pre, Enterprise & Mobile Attack
-# Copyright 2020 Scott Dermott
+# Updates MITRE ATT&CK tactic, technique, group and software files from the enterprise, ics and mobile bundles
+# Copyright 2020-2022 Scott Dermott, Joel Perron-Langlois
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published by
@@ -14,114 +14,237 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import json
-import urllib.request 
+import urllib.request
 
-mitre_update_urls = [
-    'https://raw.githubusercontent.com/mitre/cti/master/pre-attack/pre-attack.json',
-    'https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/enterprise-attack.json',
-    'https://raw.githubusercontent.com/mitre/cti/master/mobile-attack/mobile-attack.json'
-]
-mitre_source_types = list([
-    'mitre-pre-attack',
-    'mitre-attack',
-    'mitre-mobile-attack'
-])
-tactics_list = []
-techniques_list = []
+mitre_source_names = frozenset(['mitre-attack', 'mitre-ics-attack', 'mitre-mobile-attack'])
+software_types = frozenset(["tool", "malware"])
+mitre_update_urls = dict(
+    Enterprise="https://raw.githubusercontent.com/mitre/cti/master/enterprise-attack/enterprise-attack.json",
+    ICS="https://raw.githubusercontent.com/mitre/cti/master/ics-attack/ics-attack.json",
+    Mobile="https://raw.githubusercontent.com/mitre/cti/master/mobile-attack/mobile-attack.json"
+)
 
-def get_external_id(obj):
-    return obj.get('external_id')
-    
-def get_technique_id(obj):
-    return obj.get('technique_id')
 
-def revoked_or_deprecated(entry):
-    if "revoked" in entry.keys() and entry['revoked'] or "x_mitre_deprecated" in entry.keys() and entry['x_mitre_deprecated']:
+def is_revoked_or_deprecated(obj: dict) -> bool:
+    """ Check if the STIX object is revoked or deprecated """
+    if obj.get('revoked') or obj.get('x_mitre_deprecated'):
         return True
     return False
 
-for url in mitre_update_urls:
-    with urllib.request.urlopen(url) as cti_json:
-        mitre_json = json.loads(cti_json.read().decode())
-        url_type = url.rsplit('/',1)[1].split('.')[0].title()
-        techniques = []
-        tactics = []
-        tactic_map = {}
-        technique_map = {}
 
-        # Map the tatics
-        for entry in mitre_json['objects']:
-            if not entry['type'] == "x-mitre-tactic" or revoked_or_deprecated(entry):
-                continue
-            for ref in entry['external_references']:
-                if ref['source_name'] in mitre_source_types:
-                    tactic_map[entry['x_mitre_shortname']] = entry['name']
-                    tactics.append({
-                        "external_id": ref['external_id'],
-                        "url": ref['url'],
-                        "tactic": entry['name']
-                    })
+def update_tactics(domain: str, mitre_attack: dict, tactics: dict) -> None:
+    """ Parse the STIX bundle and update the tactic dictionary """
+    # Map the tactics
+    for entry in mitre_attack.get('objects', {}):
+        if entry.get('type', "") == "x-mitre-tactic" and not is_revoked_or_deprecated(entry):
+            for ref in entry.get('external_references', []):
+                if isinstance(ref, dict) and ref.get('source_name', "") in mitre_source_names:
+                    # Initialize the tactic
+                    if not tactics.get(entry['x_mitre_shortname']):
+                        tactics[entry['x_mitre_shortname']] = {}
+                    # Append the domain to the tactic
+                    tactics[entry['x_mitre_shortname']][domain] = {
+                        'external_id': ref['external_id'],
+                        'tactic': entry['name'],
+                        'shortname': entry['x_mitre_shortname'],
+                        'url': ref['url'],
+                        'domain': [domain]
+                    }
                     break
 
-        # Map the techniques
-        for entry in mitre_json['objects']:
-            if not entry['type'] == "attack-pattern" or revoked_or_deprecated(entry):
-                continue
-            if "x_mitre_is_subtechnique" in entry.keys() and entry['x_mitre_is_subtechnique']:
-                continue
-            for ref in entry['external_references']:
-                if ref['source_name'] in mitre_source_types:
-                    technique_map[ref['external_id']] = entry['name']
-                    sub_tactics = []
-                    # Get Mitre Tactics (Kill-Chains)
-                    for tactic in entry['kill_chain_phases']:
-                        if tactic['kill_chain_name'] in mitre_source_types:
-                            # Map the short phase_name to tactic name
-                            sub_tactics.append(tactic_map[tactic['phase_name']])
-                    techniques.append({
-                        "technique_id": ref['external_id'],
-                        "technique": entry['name'],
-                        "url": ref['url'],
-                        "tactic" : sub_tactics
-                    })
-                    break
 
-        ## Map the sub-techniques
-        for entry in mitre_json['objects']:
-            if not entry['type'] == "attack-pattern" or revoked_or_deprecated(entry):
-                continue
-            if "x_mitre_is_subtechnique" in entry.keys() and entry['x_mitre_is_subtechnique']:
-                for ref in entry['external_references']:
-                    if ref['source_name'] in mitre_source_types:
-                        sub_technique_id = ref['external_id']
-                        sub_technique_name = entry['name']
-                        parent_technique_name = technique_map[sub_technique_id.split('.')[0]]
-                        sub_technique_name = '{} : {}'.format(parent_technique_name, sub_technique_name)
-                        techniques.append({
-                            "technique_id": ref['external_id'],
-                            "technique": sub_technique_name,
-                            "url": ref['url'],
-                        })
+def update_techniques(domain: str, mitre_attack: dict, tactics: dict, techniques: dict) -> None:
+    """ Parse the STIX bundle and update the technique dictionary """
+
+    for entry in mitre_attack.get('objects', {}):
+        if entry.get('type', "") == "attack-pattern" and not is_revoked_or_deprecated(entry):
+            for ref in entry.get('external_references', []):
+                if isinstance(ref, dict) and ref.get('source_name', "") in mitre_source_names:
+                    # Check if technique is already in the dictionary
+                    if techniques.get(ref['external_id']) and domain not in techniques[ref['external_id']]['domain']:
+                        techniques[ref['external_id']]['domain'].append(domain)
+                    elif techniques.get(ref['external_id']):
+                        break
+                    # Add technique to the dictionary
+                    else:
+                        # Get MITRE tactics
+                        sub_tactics = []
+                        for kc_phase in entry.get('kill_chain_phases', []):
+                            if kc_phase.get('kill_chain_name', "") in mitre_source_names:
+                                kc_phase_name = kc_phase.get('phase_name', "")
+                                sub_tactic = tactics[kc_phase_name][domain]['tactic']
+                                sub_tactics.append(sub_tactic)
+                        # Add the technique/sub-technique
+                        techniques[ref['external_id']] = {
+                            'technique_id': ref['external_id'],
+                            'technique': entry['name'],
+                            'url': ref['url'],
+                            'tactic': sub_tactics,
+                            'domain': [domain],
+                            'platform': entry.get('x_mitre_platforms', []),
+                        }
                         break
 
-        print("Updating from : {}".format(url))
-        print("{} Mitre Bundle ID : {} ".format(url_type, mitre_json['id']))
-        print("{} Tactics : {} ".format(url_type, len(tactic_map)))
-        print("{} Techniques : {} ".format(url_type, len(technique_map)))
-        print("{} Sub-Techniques : {} ".format(url_type, len(techniques) - len(technique_map)))
-        print("-------------------------------------------------")
-        tactics_list.extend(tactics)
-        techniques_list.extend(techniques)
 
-print("Total Mitre Tactics : {} ".format(len(tactics_list)))
-print("Total Mitre Techniques : {} ".format(len(techniques_list)))
-## Create the output files
-with open('tactics.json', 'w') as json_file:
-    tactics_list.sort(key=get_external_id)
-    json.dump(tactics_list, json_file, sort_keys=False, indent=2)
+def update_sub_technique_names(techniques: dict) -> None:
+    """ Update sub-technique names with parent name as prefix """
 
-with open('techniques.json', 'w') as json_file:
-    techniques_list.sort(key=get_technique_id)
-    json.dump(techniques_list, json_file, sort_keys=False, indent=2)
+    for technique in techniques.values():
+        t_ids = technique['technique_id'].split('.')
+        technique_id = t_ids[0] if len(t_ids) >= 1 else ""
+        sub_technique_id = t_ids[1] if len(t_ids) >= 2 else ""
+
+        if sub_technique_id:
+            parent_t_name = techniques[technique_id]['technique']
+
+            # Check that sub-technique name hasn't the parent name already
+            if not technique['technique'].startswith(parent_t_name):
+                technique['technique'] = f"{parent_t_name}: {technique['technique']}"
+            else:
+                print(technique['technique'])
+
+
+def update_groups(domain: str, mitre_attack: dict, groups: dict) -> None:
+    """ Parse the STIX bundle and update the group dictionary """
+
+    for entry in mitre_attack.get('objects', {}):
+        if entry.get('type', "") == "intrusion-set" and not is_revoked_or_deprecated(entry):
+            for ref in entry.get('external_references', []):
+                if isinstance(ref, dict) and ref.get('source_name', "") in mitre_source_names:
+                    # Check if group is already in the dictionary
+                    if groups.get(ref['external_id']) and domain not in groups[ref['external_id']]['domain']:
+                        groups[ref['external_id']]['domain'].append(domain)
+                    elif groups.get(ref['external_id']):
+                        break
+                    # Add group to the dictionary
+                    else:
+                        groups[ref['external_id']] = {
+                            'group_id': ref['external_id'],
+                            'group': entry['name'],
+                            'url': ref['url'],
+                            'domain': [domain]
+                        }
+                        break
+
+
+def update_software(domain: str, mitre_attack: dict, software: dict) -> None:
+    """ Parse the STIX bundle and update the software dictionary """
+
+    for entry in mitre_attack.get('objects', {}):
+        if entry.get('type', "") in software_types and not is_revoked_or_deprecated(entry):
+            for ref in entry.get('external_references', []):
+                if isinstance(ref, dict) and ref.get('source_name', "") in mitre_source_names:
+                    # Check if software is already in the dictionary
+                    if software.get(ref['external_id']) and \
+                            domain not in software[ref['external_id']]['domain']:
+                        software[ref['external_id']]['domain'].append(domain)
+                    elif software.get(ref['external_id']):
+                        break
+                    # Add software to the dictionary
+                    else:
+                        software[ref['external_id']] = {
+                            'software_id': ref['external_id'],
+                            'software': entry['name'],
+                            'type': entry['type'].capitalize(),
+                            'url': ref['url'],
+                            'domain': [domain],
+                            'platform': entry.get('x_mitre_platforms', [])
+                        }
+                        break
+
+
+def format_tactics_output(tactics: dict) -> list:
+    """ Format the tactic data for easier output """
+
+    tactics_formatted = []
+    for tactic in tactics.values():
+        for domain in tactic.values():
+            tactics_formatted.append(domain)
+
+    tactics_formatted.sort(key=lambda ta: ta['external_id'])
+    return tactics_formatted
+
+
+def format_output(sort_field: str, data: dict) -> list:
+    """ Format the MITRE ATT&CK data for easier output """
+    data_formatted = []
+    for entry in data.values():
+        data_formatted.append(entry)
+
+    data_formatted.sort(key=lambda s: s[sort_field])
+    return data_formatted
+
+
+def print_results(tactics: list, techniques: list, groups: list, software: list) -> None:
+    """ Count and print to console MITRE ATT&CK type count """
+
+    def _init_or_add_domain(dom: str, res: dict) -> None:
+        res[dom] = res[dom] + 1 if dom in res else 1
+
+    def _calc_results_per_domain(res: dict, data: list) -> None:
+        for entry in data:
+            for domain in entry['domain']:
+                _init_or_add_domain(dom=domain, res=res)
+
+    def _print_results_per_domain(mitre_type: str, data: list, res: dict) -> None:
+        print(f"Total unique MITRE ATT&CK {mitre_type}: {len(data)}")
+        for domain, count in res.items():
+            print(f"\tTotal MITRE ATT&CK - {domain} {mitre_type}: {count}")
+
+    # Count number of MITRE ATT&CK types
+    res_tactics, res_techniques, res_groups, res_software = {}, {}, {}, {}
+    _calc_results_per_domain(res=res_tactics, data=tactics)
+    _calc_results_per_domain(res=res_techniques, data=techniques)
+    _calc_results_per_domain(res=res_groups, data=groups)
+    _calc_results_per_domain(res=res_software, data=software)
+
+    # Print to console the results
+    _print_results_per_domain(mitre_type="tactics", data=tactics, res=res_tactics)
+    _print_results_per_domain(mitre_type="techniques and sub-techniques", data=techniques, res=res_techniques)
+    _print_results_per_domain(mitre_type="groups", data=groups, res=res_groups)
+    _print_results_per_domain(mitre_type="software", data=software, res=res_software)
+
+
+def create_output_file(filename: str, data: list) -> None:
+    """ Create JSON output file with the MITRE ATT&CK data """
+    with open(file=filename, mode='w') as json_file:
+        json.dump(obj=data, fp=json_file, sort_keys=False, indent=2)
+
+
+def main():
+    tactics, techniques, software, groups = {}, {}, {}, {}
+
+    # Download and parse MITRE ATT&CK STIX domain bundles
+    for domain, url in mitre_update_urls.items():
+        with urllib.request.urlopen(url) as cti_json:
+            mitre_json = json.loads(cti_json.read().decode())
+
+            # Parse MITRE ATT&CK STIX data and update the dictionaries
+            update_tactics(domain=domain, mitre_attack=mitre_json, tactics=tactics)
+            update_techniques(domain=domain, mitre_attack=mitre_json, tactics=tactics, techniques=techniques)
+            update_groups(domain=domain, mitre_attack=mitre_json, groups=groups)
+            update_software(domain=domain, mitre_attack=mitre_json, software=software)
+
+    # Add the technique names in front their sub-technique names
+    update_sub_technique_names(techniques=techniques)
+
+    # Create lists to output
+    formatted_tactics = format_tactics_output(tactics=tactics)
+    formatted_techniques = format_output(sort_field="technique_id", data=techniques)
+    formatted_groups = format_output(sort_field="group_id", data=groups)
+    formatted_software = format_output(sort_field="software_id", data=software)
+
+    # Print MITRE ATT&CK type count per domain
+    print_results(tactics=formatted_tactics, techniques=formatted_techniques,
+                  groups=formatted_groups, software=formatted_software)
+
+    # Output MITRE ATT&CK types to files
+    create_output_file(filename="tactics.json", data=formatted_tactics)
+    create_output_file(filename="techniques.json", data=formatted_techniques)
+    create_output_file(filename="groups.json", data=formatted_groups)
+    create_output_file(filename="software.json", data=formatted_software)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Updated MITRE ATT&CK tactics and techniques to v10.1;
- Added fields to the tactics and techniques such as the domains and the platforms;
- Creation of the group and software files;
- Added the ICS bundle;
- Removed the deprecated Pre-Attack bundle.