### PR TITLE
Filtering of ccm setup executables

### DIFF
--- a/rules/windows/file_event/file_event_win_susp_adsi_cache_usage.yml
+++ b/rules/windows/file_event/file_event_win_susp_adsi_cache_usage.yml
@@ -8,7 +8,7 @@ references:
   - https://blog.fox-it.com/2020/03/19/ldapfragger-command-and-control-over-ldap-attributes/
   - https://github.com/fox-it/LDAPFragger
 date: 2019/03/24
-modified: 2022/02/21
+modified: 2022/03/26
 logsource:
   product: windows
   category: file_event
@@ -16,7 +16,7 @@ detection:
   selection:
     TargetFilename|contains: '\Local\Microsoft\Windows\SchCache\'
     TargetFilename|endswith: '.sch'
-  filter:
+  filter_eq:
     Image:
       - 'C:\windows\system32\svchost.exe'
       - 'C:\windows\system32\dllhost.exe'
@@ -25,7 +25,9 @@ detection:
       - 'C:\Windows\CCM\CcmExec.exe'
       - 'C:\Program Files\Cylance\Desktop\CylanceSvc.exe'
       - 'C:\Windows\System32\wbem\WmiPrvSE.exe'
-  condition: selection and not filter
+  filter_begins|startswith:
+      - 'C:\Windows\ccmsetup\autoupgrade\ccmsetup' # C:\Windows\ccmsetup\autoupgrade\ccmsetup.TMC00002.40.exe
+  condition: selection and not 1 of filter*
 falsepositives:
   - Other legimate tools, which do ADSI (LDAP) operations, e.g. any remoting activity by MMC, Powershell, Windows etc.
 level: high

--- a/rules/windows/file_event/file_event_win_susp_adsi_cache_usage.yml
+++ b/rules/windows/file_event/file_event_win_susp_adsi_cache_usage.yml
@@ -26,8 +26,7 @@ detection:
       - 'C:\Program Files\Cylance\Desktop\CylanceSvc.exe'
       - 'C:\Windows\System32\wbem\WmiPrvSE.exe'
   filter_begins:
-    Image|startswith:
-      - 'C:\Windows\ccmsetup\autoupgrade\ccmsetup' # C:\Windows\ccmsetup\autoupgrade\ccmsetup.TMC00002.40.exe
+    Image|startswith: 'C:\Windows\ccmsetup\autoupgrade\ccmsetup' # C:\Windows\ccmsetup\autoupgrade\ccmsetup.TMC00002.40.exe
   condition: selection and not 1 of filter*
 falsepositives:
   - Other legimate tools, which do ADSI (LDAP) operations, e.g. any remoting activity by MMC, Powershell, Windows etc.

--- a/rules/windows/file_event/file_event_win_susp_adsi_cache_usage.yml
+++ b/rules/windows/file_event/file_event_win_susp_adsi_cache_usage.yml
@@ -25,7 +25,8 @@ detection:
       - 'C:\Windows\CCM\CcmExec.exe'
       - 'C:\Program Files\Cylance\Desktop\CylanceSvc.exe'
       - 'C:\Windows\System32\wbem\WmiPrvSE.exe'
-  filter_begins|startswith:
+  filter_begins:
+    Image|startswith:
       - 'C:\Windows\ccmsetup\autoupgrade\ccmsetup' # C:\Windows\ccmsetup\autoupgrade\ccmsetup.TMC00002.40.exe
   condition: selection and not 1 of filter*
 falsepositives:


### PR DESCRIPTION
Filter out ccm setup:

```
2022-03-26 15:03:15 redacted.host.name Sysmon: 11: File created | RuleName=technique_id=T1044,technique_name=File System Permissions Weakness | UtcTime=2022-03-26 15:03:15.958 | ProcessGuid={C493B211-2B32-623F-5310-000000008100} | ProcessId=5640 | Image=C:\Windows\ccmsetup\autoupgrade\ccmsetup.TMC00002.40.exe | TargetFilename=C:\Windows\SysWOW64\config\systemprofile\AppData\Local\Microsoft\Windows\SchCache\root.pvt.sch
```