### PR TITLE
Backend with hardcoded  new registry category

### DIFF
--- a/tools/sigma/backends/cim.py
+++ b/tools/sigma/backends/cim.py
@@ -117,7 +117,11 @@ default_datamodels = {
                     "vendor_product": []
                 },
                 "mapping": {
-                    "category": "registry_event"
+                    "category": "registry_event",
+                    "category": "registry_add",
+                    "category": "registry_delete",
+                    "category": "registry_set",
+                    "category": "registry_rename"
                 }
             }
         }

--- a/tools/sigma/backends/mdatp.py
+++ b/tools/sigma/backends/mdatp.py
@@ -263,6 +263,18 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
         elif (self.category, self.product, self.service) == ("registry_event", "windows", None):
             self.tables.append("DeviceRegistryEvents")
             self.current_table = "DeviceRegistryEvents"
+        elif (self.category, self.product, self.service) == ("registry_add", "windows", None):
+            self.tables.append("DeviceRegistryEvents")
+            self.current_table = "DeviceRegistryEvents"
+        elif (self.category, self.product, self.service) == ("registry_delete", "windows", None):
+            self.tables.append("DeviceRegistryEvents")
+            self.current_table = "DeviceRegistryEvents"
+        elif (self.category, self.product, self.service) == ("registry_set", "windows", None):
+            self.tables.append("DeviceRegistryEvents")
+            self.current_table = "DeviceRegistryEvents"
+        elif (self.category, self.product, self.service) == ("registry_rename", "windows", None):
+            self.tables.append("DeviceRegistryEvents")
+            self.current_table = "DeviceRegistryEvents"    
         elif (self.category, self.service) == ("file_event", None) and self.product in ['windows', 'linux', 'macos']:
             self.tables.append("DeviceFileEvents")
             self.current_table = "DeviceFileEvents"

--- a/tools/sigma/backends/uberagent.py
+++ b/tools/sigma/backends/uberagent.py
@@ -367,7 +367,23 @@ class uberAgentBackend(SingleTextQueryBackend):
         "registry_event": {
             "targetobject": "Reg.Key.Target",
             "newname": "Reg.Key.Path.New"
-        }
+        },
+        "registry_add": {
+            "targetobject": "Reg.Key.Target",
+            "newname": "Reg.Key.Path.New"
+        },
+        "registry_delete": {
+            "targetobject": "Reg.Key.Target",
+            "newname": "Reg.Key.Path.New"
+        },
+        "registry_set": {
+            "targetobject": "Reg.Key.Target",
+            "newname": "Reg.Key.Path.New"
+        },
+        "registry_rename": {
+            "targetobject": "Reg.Key.Target",
+            "newname": "Reg.Key.Path.New"
+        } 
     }
 
     # We ignore some fields that we don't support yet but we don't want them to

--- a/tools/sigma/backends/uberagent.py
+++ b/tools/sigma/backends/uberagent.py
@@ -42,7 +42,11 @@ def convert_sigma_category_to_uberagent_event_type(category):
         "network_connection": "Net.Any",
         "firewall": "Net.Any",
         "create_remote_thread": "Process.CreateRemoteThread",
-        "registry_event": "Reg.Any"
+        "registry_event": "Reg.Any",
+        "registry_add": "Reg.Any",
+        "registry_delete": "Reg.Any",
+        "registry_set": "Reg.Any",
+        "registry_rename": "Reg.Any"
     }
 
     if category in categories:


### PR DESCRIPTION
A new category in hardcoded backend.
As I don't use these backends I added the new categories as best I could.

- cim.py  (splunkdm) tests with sigmac seem to be ok
- mdatp.py  tests with sigmac seem to be ok
- uberagent.py tests with sigmac  seem to be ok 