### PR TITLE
Fix wrong field mapping of Windows Audit Log EventID 4688

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_bootconf_mod.yml
+++ b/rules/windows/process_creation/proc_creation_win_bootconf_mod.yml
@@ -1,6 +1,6 @@
 title: Modification of Boot Configuration
 id: 1444443e-6757-43e4-9ea4-c8fc705f79a2
-status: test
+status: stable
 description: Identifies use of the bcdedit command to delete boot configuration data. This tactic is sometimes used as by malware or an attacker as a destructive technique.
 author: E.M. Anhaus (originally from Atomic Blue Detections, Endgame), oscd.community
 references:

--- a/rules/windows/process_creation/proc_creation_win_cobaltstrike_load_by_rundll32.yml
+++ b/rules/windows/process_creation/proc_creation_win_cobaltstrike_load_by_rundll32.yml
@@ -1,5 +1,5 @@
 title: CobaltStrike Load by Rundll32
-status: experimental
+status: test
 id: ae9c6a7c-9521-42a6-915e-5aaa8689d529
 author: Wojciech Lesicki
 date: 2021/06/01
@@ -20,7 +20,7 @@ detection:
         CommandLine|contains|all:
             - 'rundll32.exe'
             - '.dll'
-        CommandLine|endswith: 
+        CommandLine|endswith:
             - ' StartW'
             - ',StartW'
     condition: selection

--- a/rules/windows/process_creation/proc_creation_win_conti_cmd_ransomware.yml
+++ b/rules/windows/process_creation/proc_creation_win_conti_cmd_ransomware.yml
@@ -1,6 +1,6 @@
 title: Conti Ransomware Execution
 id: 689308fc-cfba-4f72-9897-796c1dc61487
-status: experimental
+status: test
 author: frack113
 date: 2021/10/12
 description: Conti ransomware command line ioc
@@ -23,7 +23,7 @@ detection:
             - '-nomutex '
             - '-p \\'
             - '$'
-    condition: selection 
+    condition: selection
 falsepositives:
-    - Unknown should be low
+    - Unlikely
 level: critical

--- a/rules/windows/process_creation/proc_creation_win_crime_maze_ransomware.yml
+++ b/rules/windows/process_creation/proc_creation_win_crime_maze_ransomware.yml
@@ -1,6 +1,6 @@
 title: Maze Ransomware
 id: 29fd07fc-9cfd-4331-b7fd-cc18dfa21052
-status: experimental
+status: test
 description: Detects specific process characteristics of Maze ransomware word document droppers
 references:
     - https://www.fireeye.com/blog/threat-research/2020/05/tactics-techniques-procedures-associated-with-maze-ransomware-incidents.html
@@ -31,7 +31,7 @@ detection:
         ParentImage|contains: '\Temp\'
         CommandLine|endswith: 'shadowcopy delete'
     # Specific Pattern
-    selection3: 
+    selection3:
         CommandLine|endswith: 'shadowcopy delete'
         CommandLine|contains: '\..\..\system32'
     condition: 1 of selection*

--- a/rules/windows/process_creation/proc_creation_win_crime_snatch_ransomware.yml
+++ b/rules/windows/process_creation/proc_creation_win_crime_snatch_ransomware.yml
@@ -1,6 +1,6 @@
 title: Snatch Ransomware
 id: 5325945e-f1f0-406e-97b8-65104d393fff
-status: test
+status: stable
 description: Detects specific process characteristics of Snatch ransomware word document droppers
 author: Florian Roth
 references:

--- a/rules/windows/process_creation/proc_creation_win_delete_systemstatebackup.yml
+++ b/rules/windows/process_creation/proc_creation_win_delete_systemstatebackup.yml
@@ -1,6 +1,6 @@
 title: Wbadmin Delete Systemstatebackup
 id: 89f75308-5b1b-4390-b2d8-d6b2340efaf8
-status: experimental
+status: test
 description: |
   Deletes the Windows systemstatebackup using wbadmin.exe.
   This technique is used by numerous ransomware families.
@@ -14,7 +14,7 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    wbadmin_exe: 
+    wbadmin_exe:
         - Image|endswith: \wbadmin.exe
         - CommandLine|contains: wbadmin
     wbadmin_cmd:

--- a/rules/windows/process_creation/proc_creation_win_mal_darkside_ransomware.yml
+++ b/rules/windows/process_creation/proc_creation_win_mal_darkside_ransomware.yml
@@ -3,7 +3,7 @@ id: 965fff6c-1d7e-4e25-91fd-cdccd75f7d2c
 author: Florian Roth
 date: 2021/05/14
 description: Detects DarkSide Ransomware and helpers
-status: experimental
+status: test
 references:
     - https://www.fireeye.com/blog/threat-research/2021/05/shining-a-light-on-darkside-ransomware-operations.html
     - https://app.any.run/tasks/8b9a571b-bcc1-4783-ba32-df4ba623b9c0/

--- a/rules/windows/process_creation/proc_creation_win_mal_lockergoga_ransomware.yml
+++ b/rules/windows/process_creation/proc_creation_win_mal_lockergoga_ransomware.yml
@@ -1,6 +1,6 @@
 title: LockerGoga Ransomware
 id: 74db3488-fd28-480a-95aa-b7af626de068
-status: test
+status: stable
 description: Detects LockerGoga Ransomware command line.
 author: Vasiliy Burov, oscd.community
 references:

--- a/rules/windows/process_creation/proc_creation_win_mal_ryuk.yml
+++ b/rules/windows/process_creation/proc_creation_win_mal_ryuk.yml
@@ -1,6 +1,6 @@
 title: Ryuk Ransomware
 id: 0acaad27-9f02-4136-a243-c357202edd74
-status: test
+status: stable
 description: Detects Ryuk Ransomware command lines
 author: Vasiliy Burov
 references:

--- a/rules/windows/process_creation/proc_creation_win_malware_conti.yml
+++ b/rules/windows/process_creation/proc_creation_win_malware_conti.yml
@@ -3,7 +3,7 @@ id: 7b30e0a7-c675-4b24-8a46-82fa67e2433d
 description: Detects a command used by conti to find volume shadow backups
 author: Max Altgelt, Tobias Michalski
 date: 2021/08/09
-status: experimental
+status: test
 references:
     - https://twitter.com/vxunderground/status/1423336151860002816?s=20
     - https://www.virustotal.com/gui/file/03e9b8c2e86d6db450e5eceec057d7e369ee2389b9daecaf06331a95410aa5f8/detection

--- a/rules/windows/process_creation/proc_creation_win_malware_emotet.yml
+++ b/rules/windows/process_creation/proc_creation_win_malware_emotet.yml
@@ -1,6 +1,6 @@
 title: Emotet Process Creation
 id: d02e8cf5-6099-48cf-9bfc-1eec2d0c7b18
-status: test
+status: stable
 description: Detects all Emotet like process executions that are not covered by the more generic rules
 author: Florian Roth
 date: 2019/09/30

--- a/rules/windows/process_creation/proc_creation_win_malware_ryuk.yml
+++ b/rules/windows/process_creation/proc_creation_win_malware_ryuk.yml
@@ -1,6 +1,6 @@
 title: Ryuk Ransomware
 id: c37510b8-2107-4b78-aa32-72f251e7a844
-status: test
+status: stable
 description: Detects Ryuk ransomware activity
 author: Florian Roth
 references:

--- a/rules/windows/process_creation/proc_creation_win_office_from_proxy_executing_regsvr32_payload.yml
+++ b/rules/windows/process_creation/proc_creation_win_office_from_proxy_executing_regsvr32_payload.yml
@@ -13,7 +13,7 @@ tags:
     - attack.defense_evasion
 status: experimental
 date: 2021/08/23
-modified: 2021/11/09
+modified: 2022/03/30
 logsource:
   product: windows
   category: process_creation
@@ -21,7 +21,7 @@ detection:
   #useful_information: add more LOLBins to the rules logic of your choice.
   selection1:
     - Image|endswith: '\wbem\WMIC.exe'
-    - ParentCommandLine|contains: 'wmic '
+    - CommandLine|contains: 'wmic '
     - OriginalFileName: 'wmic.exe'
     - Description: 'WMI Commandline Utility'
   selection2:
@@ -37,7 +37,7 @@ detection:
       - excel.exe
       - powerpnt.exe
   selection4:
-    ParentCommandLine|contains|all: 
+    CommandLine|contains|all:
       - 'process'
       - 'create'
       - 'call'

--- a/rules/windows/process_creation/proc_creation_win_office_from_proxy_executing_regsvr32_payload2.yml
+++ b/rules/windows/process_creation/proc_creation_win_office_from_proxy_executing_regsvr32_payload2.yml
@@ -13,32 +13,32 @@ tags:
     - attack.defense_evasion
 status: experimental
 date: 2021/08/23
-modified: 2021/11/09
+modified: 2022/03/30
 logsource:
   product: windows
   category: process_creation
 detection:
   #useful_information: add more LOLBins to the rules logic of your choice.
   selection1:
-    ParentCommandLine:
-      - '*regsvr32*'
-      - '*rundll32*'
-      - '*msiexec*'
-      - '*mshta*'
-      - '*verclsid*'
+    CommandLine|contains:
+      - 'regsvr32'
+      - 'rundll32'
+      - 'msiexec'
+      - 'mshta'
+      - 'verclsid'
   selection2:
     - Image|endswith: '\wbem\WMIC.exe'
-    - ParentCommandLine|contains: 'wmic '
+    - CommandLine|contains: 'wmic '
   selection3:
     ParentImage|endswith:
       - winword.exe
       - excel.exe
       - powerpnt.exe
   selection4:
-    ParentCommandLine|contains|all: 
+    CommandLine|contains|all:
       - 'process'
       - 'create'
-      - 'call' 
+      - 'call'
   condition: selection1 and selection2 and selection3 and selection4
 falsepositives:
 - Unknown

--- a/rules/windows/process_creation/proc_creation_win_office_spawning_wmi_commandline.yml
+++ b/rules/windows/process_creation/proc_creation_win_office_spawning_wmi_commandline.yml
@@ -13,7 +13,7 @@ tags:
     - attack.defense_evasion
 status: experimental
 date: 2021/08/23
-modified: 2021/11/09
+modified: 2022/03/30
 logsource:
   product: windows
   category: process_creation
@@ -21,7 +21,7 @@ detection:
  #useful_information: Add more office applications to the rule logic of choice
   selection1:
     - Image|endswith: '\wbem\WMIC.exe'
-    - ParentCommandLine|contains: 'wmic '
+    - CommandLine|contains: 'wmic '
   selection2:
     ParentImage:
       - winword.exe

--- a/rules/windows/process_creation/proc_creation_win_susp_emotet_rundll32_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_emotet_rundll32_execution.yml
@@ -1,8 +1,8 @@
 title: Emotet RunDLL32 Process Creation
 id: 54e57ce3-0672-46eb-a402-2c0948d5e3e9
 description: Detecting Emotet DLL loading by looking for rundll32.exe processes with command lines ending in ,RunDLL or ,Control_RunDLL
-author: FPT.EagleEye 
-status: experimental
+author: FPT.EagleEye
+status: test
 date: 2020/12/25
 modified: 2021/11/17
 references:

--- a/rules/windows/process_creation/proc_creation_win_susp_eventlog_clear.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_eventlog_clear.yml
@@ -1,6 +1,6 @@
 title: Suspicious Eventlog Clear or Configuration Using Wevtutil
 id: cc36992a-4671-4f21-a91d-6c2b72a2edf5
-status: test
+status: stable
 description: Detects clearing or configuration of eventlogs using wevtutil, powershell and wmic. Might be used by ransomwares during the attack (seen by NotPetya and others).
 author: Ecco, Daniil Yugoslavskiy, oscd.community
 references:

--- a/rules/windows/process_creation/proc_creation_win_susp_fsutil_usage.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_fsutil_usage.yml
@@ -1,6 +1,6 @@
 title: Fsutil Suspicious Invocation
 id: add64136-62e5-48ea-807e-88638d02df1e
-status: test
+status: stable
 description: Detects suspicious parameters of fsutil (deleting USN journal, configuring it with small size, etc). Might be used by ransomwares during the attack (seen by NotPetya and others).
 author: Ecco, E.M. Anhaus, oscd.community
 references:

--- a/rules/windows/process_creation/proc_creation_win_susp_powershell_enc_cmd.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_powershell_enc_cmd.yml
@@ -1,7 +1,7 @@
 title: Suspicious Encoded PowerShell Command Line
 id: ca2092a1-c273-4878-9b4b-0d60115bf5ea
 description: Detects suspicious powershell process starts with base64 encoded commands (e.g. Emotet)
-status: experimental
+status: test
 references:
     - https://app.any.run/tasks/6217d77d-3189-4db2-a957-8ab239f3e01e
 author: Florian Roth, Markus Neis, Jonhnathan Ribeiro, Daniil Yugoslavskiy, Anton Kutepov, oscd.community

--- a/rules/windows/process_creation/proc_creation_win_susp_system_user_anomaly.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_system_user_anomaly.yml
@@ -1,6 +1,6 @@
 title: Suspicious SYSTEM User Process Creation
 id: 2617e7ed-adb7-40ba-b0f3-8f9945fe6c09
-status: experimental
+status: test
 description: Detects a suspicious process creation as SYSTEM user (suspicious program or command line parameter)
 references:
     - Internal Research

--- a/rules/windows/process_creation/proc_creation_win_susp_wuauclt.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wuauclt.yml
@@ -17,11 +17,11 @@ logsource:
     category: process_creation
 detection:
     selection:
-        CommandLine|contains|all: 
+        CommandLine|contains|all:
             - '/UpdateDeploymentProvider'
             - '/RunHandlerComServer'
             - '.dll'
-        Image|endswith: 
+        Image|endswith:
             - '\wuauclt.exe'
     filter:
         CommandLine|contains:

--- a/tools/config/generic/windows-audit.yml
+++ b/tools/config/generic/windows-audit.yml
@@ -44,5 +44,5 @@ fieldmappings:
     Image: NewProcessName
     ParentImage: ParentProcessName
     Details: NewValue
-    ParentCommandLine: ProcessCommandLine
+    #CommandLine: ProcessCommandLine  # No need to map, as real name of ProcessCommandLine is already CommandLine
     LogonId: SubjectLogonId


### PR DESCRIPTION
- reverts some changes introduced by commit c5fa73c328acd5fac5c89c84f2a71c94efc65827
    - removes the unnecessary/wrong field mapping
    - fixes the rules to apply to CommandLine instead of ParentCommandLine as the author probably intended
- promotion of the status of some rules.