### PR TITLE
workflow: add checks against Windows 2022 baseline

### DIFF
--- a/.github/workflows/sigma-test.yml
+++ b/.github/workflows/sigma-test.yml
@@ -12,6 +12,9 @@ on: # yamllint disable-line rule:truthy
       - master
       - oscd
 
+env:
+  EVTX_BASELINE_VERSION: v0.5
+
 jobs:
   test-sigma:
     runs-on: ubuntu-latest
@@ -42,10 +45,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Download evtx-sigma-checker
-      run: wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/latest/download/evtx-sigma-checker
+      run: wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/download/$EVTX_BASELINE_VERSION/evtx-sigma-checker
     - name: Download and extract Windows 7 32-bit baseline
       run: |
-        wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/latest/download/win7-x86.tgz
+        wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/download/$EVTX_BASELINE_VERSION/win7-x86.tgz
         tar xzf win7-x86.tgz
     - name: Remove deprecated rules
       run: 'grep -ERl "^status: deprecated" rules | xargs -r rm -v'
@@ -60,10 +63,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Download evtx-sigma-checker
-      run: wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/latest/download/evtx-sigma-checker
+      run: wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/download/$EVTX_BASELINE_VERSION/evtx-sigma-checker
     - name: Download and extract Windows 10 baseline
       run: |
-        wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/latest/download/win10-client.tgz
+        wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/download/$EVTX_BASELINE_VERSION/win10-client.tgz
         tar xzf win10-client.tgz
     - name: Remove deprecated rules
       run: 'grep -ERl "^status: deprecated" rules | xargs -r rm -v'
@@ -78,10 +81,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Download evtx-sigma-checker
-      run: wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/latest/download/evtx-sigma-checker
+      run: wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/download/$EVTX_BASELINE_VERSION/evtx-sigma-checker
     - name: Download and extract Windows 11 baseline
       run: |
-        wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/latest/download/win11-client.tgz
+        wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/download/$EVTX_BASELINE_VERSION/win11-client.tgz
         tar xzf win11-client.tgz
     - name: Remove deprecated rules
       run: 'grep -ERl "^status: deprecated" rules | xargs -r rm -v'
@@ -89,5 +92,23 @@ jobs:
       run: |
         chmod +x evtx-sigma-checker
         ./evtx-sigma-checker --log-source tools/config/thor.yml --evtx-path Logs_Win11/ --rule-path rules/windows/ > findings.json
+    - name: Show findings excluding known FPs
+      run: ./.github/workflows/matchgrep.sh findings.json .github/workflows/known-FPs.csv
+    check-baseline-win2022:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download evtx-sigma-checker
+      run: wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/download/$EVTX_BASELINE_VERSION/evtx-sigma-checker
+    - name: Download and extract Windows 2022 baseline
+      run: |
+        wget --no-verbose https://github.com/NextronSystems/evtx-baseline/releases/download/$EVTX_BASELINE_VERSION/win2022-evtx.tgz
+        tar xzf win2022-evtx.tgz
+    - name: Remove deprecated rules
+      run: 'grep -ERl "^status: deprecated" rules | xargs -r rm -v'
+    - name: Check for Sigma matches in baseline
+      run: |
+        chmod +x evtx-sigma-checker
+        ./evtx-sigma-checker --log-source tools/config/thor.yml --evtx-path win2022-evtx/ --rule-path rules/windows/ > findings.json
     - name: Show findings excluding known FPs
       run: ./.github/workflows/matchgrep.sh findings.json .github/workflows/known-FPs.csv

--- a/.github/workflows/sigma-test.yml
+++ b/.github/workflows/sigma-test.yml
@@ -94,7 +94,7 @@ jobs:
         ./evtx-sigma-checker --log-source tools/config/thor.yml --evtx-path Logs_Win11/ --rule-path rules/windows/ > findings.json
     - name: Show findings excluding known FPs
       run: ./.github/workflows/matchgrep.sh findings.json .github/workflows/known-FPs.csv
-    check-baseline-win2022:
+  check-baseline-win2022:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/rules/windows/builtin/firewall_as/win_firewall_as_add_rule.yml
+++ b/rules/windows/builtin/firewall_as/win_firewall_as_add_rule.yml
@@ -4,7 +4,7 @@ status: experimental
 description: A rule has been modified in the Windows Firewall exception list
 author: frack113
 date: 2022/02/19
-modified: 2022/04/06
+modified: 2022/04/07
 references:
     - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/dd364427(v=ws.10)
 logsource:
@@ -25,6 +25,7 @@ detection:
         - ModifyingApplication:
             - 'C:\Windows\SysWOW64\msiexec.exe'
             - 'C:\Windows\System32\svchost.exe'
+            - 'C:\Windows\System32\dllhost.exe'
             - 'C:\Program Files\Windows Defender\MsMpEng.exe'
     condition: selection and not 1 of filter_*
 level: medium

--- a/rules/windows/create_remote_thread/sysmon_suspicious_remote_thread.yml
+++ b/rules/windows/create_remote_thread/sysmon_suspicious_remote_thread.yml
@@ -7,7 +7,7 @@ notes:
     - MonitoringHost.exe is a process that loads .NET CLR by default and thus a favorite for process injection for .NET in-memory offensive tools.
 status: experimental
 date: 2019/10/27
-modified: 2022/04/06
+modified: 2022/04/07
 author: Perez Diego (@darkquassar), oscd.community
 references:
     - Personal research, statistical analysis
@@ -72,14 +72,12 @@ detection:
             - '\wscript.exe'
     filter1:
         SourceImage|contains: 'Visual Studio'
-    filter2: # happens on Windows 7
-        StartModule: 'C:\Windows\SYSTEM32\ntdll.dll'
-        StartFunction: 'EtwpNotificationThread'
+    filter2:
         SourceImage: 'C:\Windows\System32\winlogon.exe'
         TargetImage:
-            - 'C:\Windows\System32\services.exe'
-            - 'C:\Windows\System32\wininit.exe'
-            - 'C:\Windows\System32\csrss.exe'
+            - 'C:\Windows\System32\services.exe' # happens on Windows 7
+            - 'C:\Windows\System32\wininit.exe' # happens on Windows 7
+            - 'C:\Windows\System32\csrss.exe' # multiple OS
     condition: selection and not 1 of filter*
 fields:
     - ComputerName

--- a/rules/windows/registry/registry_set/registry_set_disabled_tamper_protection_on_microsoft_defender.yml
+++ b/rules/windows/registry/registry_set/registry_set_disabled_tamper_protection_on_microsoft_defender.yml
@@ -3,7 +3,7 @@ id: 93d298a1-d28f-47f1-a468-d971e7796679
 description: Detects disabling Windows Defender Tamper Protection
 status: experimental
 date: 2021/08/04
-modified: 2022/03/26
+modified: 2022/04/07
 author: Austin Songer @austinsonger
 references:
     - https://www.tenforums.com/tutorials/123792-turn-off-tamper-protection-microsoft-defender-antivirus.html
@@ -13,9 +13,12 @@ logsource:
 detection:
     selection:
         EventType: SetValue
-        TargetObject|contains: 'HKLM\SOFTWARE\Microsoft\Windows Defender\Features\TamperProtection'
+        TargetObject|contains: '\Microsoft\Windows Defender\Features\TamperProtection'
         Details: DWORD (0x00000000)
-    condition: selection
+    filter_msmpeng: # only disabled temporarily during updates
+        Image|startswith: 'C:\ProgramData\Microsoft\Windows Defender\Platform\'
+        Image|endswith: '\MsMpEng.exe'
+    condition: selection and not filter_msmpeng
 falsepositives:
     - Unknown
 level: medium

--- a/tests/check-baseline-local.sh
+++ b/tests/check-baseline-local.sh
@@ -69,7 +69,7 @@ wget --no-verbose --progress=bar --show-progress https://github.com/NextronSyste
 echo "Extract Windows 7 32-bit baseline events"
 tar xzf win7-x86.tgz
 echo
-echo "Check for Sigma matches in Windows 7 32-bit baseline (this takes at least 2 minutes)"
+echo "Check for Sigma matches in Windows 7 32-bit baseline"
 ./evtx-sigma-checker --log-source "${SIGMA}"/tools/config/thor.yml --evtx-path win7_x86/ --rule-path windows/ > findings-win7.json
 
 # Windows 10
@@ -91,6 +91,15 @@ tar xzf win11-client.tgz
 echo
 echo "Check for Sigma matches in Windows 11 baseline (this takes at least 6 minutes)"
 ./evtx-sigma-checker --log-source "${SIGMA}"/tools/config/thor.yml --evtx-path Logs_Win11/ --rule-path windows/ > findings-win11.json
+ Windows 2022
+echo
+echo "Download Windows 2022 baseline events"
+wget --no-verbose --progress=bar --show-progress https://github.com/NextronSystems/evtx-baseline/releases/latest/download/win2022-evtx.tgz
+echo "Extract Windows 2022 baseline events"
+tar xzf win2022-evtx.tgz
+echo
+echo "Check for Sigma matches in Windows 2022 baseline (this takes around 1 minute)"
+./evtx-sigma-checker --log-source "${SIGMA}"/tools/config/thor.yml --evtx-path win2022-evtx/ --rule-path windows/ > findings-win2022.json
 
 
 echo
@@ -104,6 +113,9 @@ echo "Windows 10:"
 echo
 echo "Windows 11:"
 "${SIGMA}"/.github/workflows/matchgrep.sh findings-win11.json "${SIGMA}"/.github/workflows/known-FPs.csv
+echo
+echo "Windows 2022:"
+"${SIGMA}"/.github/workflows/matchgrep.sh findings-win2022.json "${SIGMA}"/.github/workflows/known-FPs.csv
 
 echo
 read -p  "Removing temporary directory ${TMP}. Press Enter to continue." -s


### PR DESCRIPTION
Also changed the workflow action to use a fixed version of evtx-baseline again. Can be tweaked using the variable `EVTX_BASELINE_VERSION`. This makes it possible to make upstream changes to existing baselines without breaking the GitHub actions of SigmaHQ.