### PR TITLE
changed windows-bits-client Channel

### DIFF
--- a/tools/config/generic/windows-services.yml
+++ b/tools/config/generic/windows-services.yml
@@ -160,4 +160,4 @@ logsources:
         product: windows
         service: bits-client
         conditions:
-            Channel: 'WinEventlog:Microsoft-Windows-Bits-Client/Operational'
+            Channel: 'Microsoft-Windows-Bits-Client/Operational'


### PR DESCRIPTION
Fixed #2897 

windows-bits-client tag converted `WinEventlog:Microsoft-Windows-Bits-Client/Operational` but other channel is not add `WinEventLog:`.

Removed "WinEventlog:" to unify with other channel conversions.

ex: https://answers.microsoft.com/en-us/windows/forum/all/unknown-events-in-windowsbits-clientoperational/c0856f82-44a2-4998-9a3b-9d6eda328136