### PR TITLE
Change MITRE ATT&CK tactic ID

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_lolbas_execution_of_wuauclt.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_execution_of_wuauclt.yml
@@ -29,4 +29,4 @@ level: medium
 tags:
     - attack.defense_evasion
     - attack.execution
-    - attack.t1218.011
+    - attack.t1218


### PR DESCRIPTION
The subtechnique `.011` is  specific to RunDLL32 proxy execution. There is no existing sub-technique specific to wuauclt.exe so only the top level technique should be referenced.