### PR TITLE
Change ATT&CK technique

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
@@ -5,8 +5,8 @@ description: Download or Copy file with Extrac32
 references:
     - https://lolbas-project.github.io/lolbas/Binaries/Extrac32/
 tags:
-    - attack.defense_evasion
-    - attack.t1564.004 
+    - attack.command_and_control
+    - attack.t1105
 author: frack113
 date: 2021/11/26
 logsource:


### PR DESCRIPTION
Per source reference, the ADS rule is T1564.004 BUT copying/downloading files is T1105 (hwich in turn is C&C, not defense evasion"