### PR TITLE
fix: Comma in title seems to break splunk search

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_sticky_keys_unauthenticated_privileged_cmd_access.yml
+++ b/rules/windows/process_creation/proc_creation_win_sticky_keys_unauthenticated_privileged_cmd_access.yml
@@ -1,4 +1,4 @@
-title: Using Sticky-keys To Obtain Unauthenticated and Privileged Console Access
+title: Sticky-Key Backdoor Copy Cmd.exe
 id: 1070db9a-3e5d-412e-8e7b-7183b616e1b3
 description: By replacing the sticky keys executable with the local admins CMD executable, an attacker is able to access a privileged windows console session without authenticating to the system. When the sticky keys are "activated" the privilleged shell is launched.
 references:

--- a/rules/windows/process_creation/proc_creation_win_sticky_keys_unauthenticated_privileged_cmd_access.yml
+++ b/rules/windows/process_creation/proc_creation_win_sticky_keys_unauthenticated_privileged_cmd_access.yml
@@ -1,4 +1,4 @@
-title: Using Sticky-keys To Obtain Unauthenticated, Privileged Console Access
+title: Using Sticky-keys To Obtain Unauthenticated and Privileged Console Access
 id: 1070db9a-3e5d-412e-8e7b-7183b616e1b3
 description: By replacing the sticky keys executable with the local admins CMD executable, an attacker is able to access a privileged windows console session without authenticating to the system. When the sticky keys are "activated" the privilleged shell is launched.
 references:
@@ -6,7 +6,7 @@ references:
     - https://www.clearskysec.com/wp-content/uploads/2020/02/ClearSky-Fox-Kitten-Campaign-v1.pdf
 status: experimental
 date: 2020/02/18
-modified: 2022/01/11
+modified: 2022/04/19
 author: Sreeman
 tags:
     - attack.t1546.008


### PR DESCRIPTION
Most likely it comes from a bad parsing by Sigma2Splunkalert but since it is unmaintained and this is the only rule with a comma in title, this is the easy fix. 

Error in 'inputlookup' command: Invalid argument:
'_Privileged_Console_Access_whitelist.csv'

[| inputlookup "Using_Sticky-keys_To_Obtain_Unauthenticated,_Privileged_Console_Access_whitelist.csv]