### PR TITLE
String 2 Int for EventIDs

### DIFF
--- a/rules/windows/builtin/system/win_possible_zerologon_exploitation_using_wellknown_tools.yml
+++ b/rules/windows/builtin/system/win_possible_zerologon_exploitation_using_wellknown_tools.yml
@@ -17,8 +17,8 @@ logsource:
 detection:
     selection:
         EventID:
-            - '5805'
-            - '5723'
+            - 5805
+            - 5723
     keywords:
         - kali
         - mimikatz


### PR DESCRIPTION
Help PySigma with integer types instead of string.