### PR TITLE
Adding security services and defender options

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_tamper_defender.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_tamper_defender.yml
@@ -4,7 +4,7 @@ related:
     - id: ec19ebab-72dc-40e1-9728-4c0b805d722c
       type: derived
 status: experimental
-description: Attempting to disable scheduled scanning and other parts of windows defender atp.
+description: Attempting to disable scheduled scanning and other parts of windows defender atp. Or set default actions to allow.
 author: frack113, elhoim
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1562.001/T1562.001.md

--- a/rules/windows/powershell/powershell_script/posh_ps_tamper_defender.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_tamper_defender.yml
@@ -5,17 +5,19 @@ related:
       type: derived
 status: experimental
 description: Attempting to disable scheduled scanning and other parts of windows defender atp.
-author: frack113
+author: frack113, elhoim
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1562.001/T1562.001.md
     - https://docs.microsoft.com/en-us/powershell/module/defender/set-mppreference?view=windowsserver2022-ps
+    - https://bidouillesecurity.com/disable-windows-defender-in-powershell/
 date: 2022/01/16
+modified: 2022/05/05
 logsource:
     product: windows
     category: ps_script
     definition: Script block logging must be enabled
 detection:
-    selection:
+    selection_options_disabling:
         ScriptBlockText|contains|all:
             - 'Set-MpPreference'
             - ' 1'
@@ -23,9 +25,22 @@ detection:
             - DisableRealtimeMonitoring
             - DisableBehaviorMonitoring
             - DisableScriptScanning
+            - DisableArchiveScanning
             - DisableBlockAtFirstSeen
             - DisableIOAVProtection
-    condition: selection
+            - DisableIntrusionPreventionSystem
+            - DisableRemovableDriveScanning
+            - DisableScanningMappedNetworkDrivesForFullScan
+            - DisableScanningNetworkFiles
+    selection_default_actions_allow:
+        ScriptBlockText|contains|all:
+            - 'Set-MpPreference'
+            - Allow
+        ScriptBlockText|contains:
+            - LowThreatDefaultAction
+            - ModerateThreatDefaultAction
+            - HighThreatDefaultAction
+    condition: selection_options_disabling or selection_default_actions_allow
 falsepositives:
     - Legitimate PowerShell scripts
 level: high

--- a/rules/windows/process_creation/proc_creation_win_susp_reg_disable_sec_services.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_reg_disable_sec_services.yml
@@ -22,17 +22,17 @@ detection:
             - ' /v Start'
     selection_services:
         CommandLine|contains:
-            - '\Sense '
+            - '\Sense'
             - '\WinDefend'
             - '\MsMpSvc'
             - '\NisSrv'
-            - '\WdBoot '
+            - '\WdBoot'
             - '\WdNisDrv'
             - '\WdNisSvc'
-            - '\wscsvc '
+            - '\wscsvc'
             - '\SecurityHealthService'
             - '\wuauserv'
-            - '\UsoSvc '
+            - '\UsoSvc'
             - '\WdFilter'
             - '\AppIDSvc'
     condition: selection_reg and selection_services

--- a/rules/windows/process_creation/proc_creation_win_susp_reg_disable_sec_services.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_reg_disable_sec_services.yml
@@ -4,6 +4,7 @@ description: Detects a suspicious reg.exe invocation that looks as if it would d
 status: experimental
 references:
     - https://twitter.com/JohnLaTwC/status/1415295021041979392
+    - https://github.com/gordonbay/Windows-On-Reins/blob/master/wor.ps1
 author: Florian Roth, John Lambert (idea)
 date: 2021/07/14
 tags:
@@ -32,6 +33,8 @@ detection:
             - '\SecurityHealthService'
             - '\wuauserv'
             - '\UsoSvc '
+            - '\WdFilter'
+            - '\AppIDSvc'
     condition: selection_reg and selection_services
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_susp_reg_disable_sec_services.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_reg_disable_sec_services.yml
@@ -5,8 +5,11 @@ status: experimental
 references:
     - https://twitter.com/JohnLaTwC/status/1415295021041979392
     - https://github.com/gordonbay/Windows-On-Reins/blob/master/wor.ps1
-author: Florian Roth, John Lambert (idea)
+    - https://vms.drweb.fr/virus/?i=24144899
+    - https://bidouillesecurity.com/disable-windows-defender-in-powershell/
+author: Florian Roth, John Lambert (idea), elhoim
 date: 2021/07/14
+modified: 2022/05/05
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -14,13 +17,15 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection_reg:
+    selection_reg_add:
         CommandLine|contains|all:
             - 'reg'
             - 'add'
+    selection_reg_start:
+        CommandLine|contains|all:
             - ' /d 4'
             - ' /v Start'
-    selection_services:
+    selection_start_services:
         CommandLine|contains:
             - '\Sense'
             - '\WinDefend'
@@ -35,7 +40,32 @@ detection:
             - '\UsoSvc'
             - '\WdFilter'
             - '\AppIDSvc'
-    condition: selection_reg and selection_services
+    selection_reg_disable_defender:
+        CommandLine|contains|all:
+            - ' /d 1'
+            - 'Windows Defender'
+    selection_reg_disable_defender_values:
+        CommandLine|contains:
+            - 'DisableIOAVProtection'
+            - 'DisableOnAccessProtection'
+            - 'DisableRoutinelyTakingAction'
+            - 'DisableScanOnRealtimeEnable'
+            - 'DisableBlockAtFirstSeen'
+            - 'DisableBehaviorMonitoring'
+            - 'DisableEnhancedNotifications'
+            - 'DisableAntiSpyware'
+            - 'DisableAntiSpywareRealtimeProtection'
+            - 'DisableConfig'
+            - 'DisablePrivacyMode'
+            - 'SignatureDisableUpdateOnStartupWithoutEngine'
+            - 'DisableArchiveScanning'
+            - 'DisableIntrusionPreventionSystem'
+            - 'DisableScriptScanning'
+    condition: selection_reg_add and (
+            (selection_reg_start and selection_start_services)
+            or
+            (selection_reg_disable_defender and selection_reg_disable_defender_values)
+            )
 falsepositives:
     - Unknown
     - Other security solution installers


### PR DESCRIPTION
In proc_creation_win_susp_reg_disable_sec_services.yml
- Added two services
- Removed trailing spaces at the end of service names (is that correct that there should not be any? Or is there an obscure reason?)

In powershell_script/posh_ps_tamper_defender.yml
- Added other Defender options that can be disabled
- Added setting of default actions to allow