### PR TITLE
Adds allow for spotify streaming, which uses this service

### DIFF
--- a/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
+++ b/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
@@ -2,9 +2,9 @@ title: Bitsadmin to Uncommon TLD
 id: 9eb68894-7476-4cd6-8752-23b51f5883a7
 status: experimental
 description: Detects Bitsadmin connections to domains with uncommon TLDs - https://twitter.com/jhencinski/status/1102695118455349248 - https://isc.sans.edu/forums/diary/Investigating+Microsoft+BITS+Activity/23281/
-author: Florian Roth
+author: Florian Roth, Tim Shelton
 date: 2019/03/07
-modified: 2021/08/09
+modified: 2022/05/09
 logsource:
     category: proxy
 detection:
@@ -15,6 +15,7 @@ detection:
             - '.com' 
             - '.net' 
             - '.org' 
+            - '.scdn.co' # spotify streaming
     condition: selection and not falsepositives
 fields:
     - ClientIP


### PR DESCRIPTION
example
```
May 09 20:24:58 zscaler-nss CEF:0|Zscaler|NSSWeblog|5.0|Allowed|Allowed|3|act=Allowed app=HTTPS cat=Music and Audio Streaming dhost=i.scdn.co dst=151.101.70.248 src=redacted in=28636 outcome=206 out=204 request=i.scdn.co/image/ab67706f0000000281ef3ccc8db1d1868f24d0e9 rt=May 09 2022 20:24:58 sourceTranslatedAddress=redacted requestClientApplication=Microsoft BITS/7.8 requestMethod=GET suser=redacted_username spriv=Road Warrior externalId=7095835291257602051 fileType=Jpeg Files reason=Allowed destinationServiceName=Spotify cn1=0 cn1Label=riskscore cs1=HDG - Real Estate Ops cs1Label=dept cs2=Entertainment/Recreation cs2Label=urlsupercat cs3=Streaming Media cs3Label=appclass cs4=None cs4Label=malwarecat cs5=None cs5Label=threatname cs6=None cs6Label=dlpeng ZscalerNSSWeblogURLClass=Bandwidth Loss ZscalerNSSWeblogDLPDictionaries=None requestContext=None
```