### PR TITLE
filtering out dnsZoneScope

### DIFF
--- a/rules/windows/builtin/security/win_account_backdoor_dcsync_rights.yml
+++ b/rules/windows/builtin/security/win_account_backdoor_dcsync_rights.yml
@@ -4,7 +4,7 @@ description: backdooring domain object to grant the rights associated with DCSyn
     Extended Right cmdlet, will allow to re-obtain the pwd hashes of any user/computer
 status: experimental
 date: 2019/04/03
-modified: 2022/05/05
+modified: 2022/05/10
 author: Samir Bousseaden; Roberto Rodriguez @Cyb3rWard0g; oscd.community; Tim Shelton
 references:
     - https://twitter.com/menasec1/status/1111556090137903104
@@ -24,7 +24,9 @@ detection:
          - '1131f6aa-9c07-11d1-f79f-00c04fc2dcd2'
          - '89e95b76-444d-4c62-991a-0facbeda640c'
     filter1:
-        ObjectType: 'dnsNode'
+        ObjectType:
+         - 'dnsNode'
+         - 'dnsZoneScope'
     condition: selection and not 1 of filter*
 falsepositives:
     - New Domain Controller computer account, check user SIDs within the value attribute of event 5136 and verify if it's a regular user or DC computer account.


### PR DESCRIPTION
example, normal behavior when updating dns records from the field

```
2022-05-10 17:47:30 redacted.hostname Security-Auditing: 5136: A directory service object was modified. | OpCorrelationID={533af100-af63-4f8c-8369-80b9e23990ee} | AppCorrelationID=- | SubjectUserSid=S-1-5-18 | SubjectUserName=SYSTEM | SubjectDomainName=NT AUTHORITY | SubjectLogonId=0xa091d | DSName=REDACTED.com | DSType=Active Directory Domain Services | ObjectDN=cn=REDACTED,cn=ZoneScopeContainer,DC=REDACTED.com,cn=MicrosoftDNS,cn=System,DC=REDACTED,DC=com | ObjectGUID={a37d3707-8a78-47d9-854c-f0aae5ca3a75} | ObjectClass=dnsZoneScope | AttributeLDAPDisplayName=nTSecurityDescriptor | AttributeSyntaxOID=2.5.5.15 | AttributeValue= ....
```