### PR TITLE
Updated Rules to use "OriginalFileName" Field (First Batch)

### DIFF
--- a/rules/windows/file_rename/file_rename_win_not_dll_to_dll.yml
+++ b/rules/windows/file_rename/file_rename_win_not_dll_to_dll.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1036/T1036.md#atomic-test-1---system-file-copied-to-unusual-location
 author: frack113
 date: 2022/02/19
-modified: 2022/03/13
+modified: 2022/05/13
 logsource:
     product: windows
     category: file_rename
@@ -15,10 +15,10 @@ detection:
     to_dll:
         TargetFilename|endswith: '.dll'
     filter_from_dll:
-        - OriginalFilename|endswith: 
+        - OriginalFilename|endswith:
             - '.dll'
             - '.tmp'  # VSCode FP
-        - OriginalFilename|contains: 
+        - OriginalFilename:
             - '.dll.'
             - '\SquirrelTemp\temp'
     filter_tiworker:

--- a/rules/windows/file_rename/file_rename_win_not_dll_to_dll.yml
+++ b/rules/windows/file_rename/file_rename_win_not_dll_to_dll.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1036/T1036.md#atomic-test-1---system-file-copied-to-unusual-location
 author: frack113
 date: 2022/02/19
-modified: 2022/05/13
+modified: 2022/03/13
 logsource:
     product: windows
     category: file_rename
@@ -18,7 +18,7 @@ detection:
         - OriginalFilename|endswith:
             - '.dll'
             - '.tmp'  # VSCode FP
-        - OriginalFilename:
+        - OriginalFilename|contains:
             - '.dll.'
             - '\SquirrelTemp\temp'
     filter_tiworker:

--- a/rules/windows/process_creation/proc_creation_win_creation_mavinject_dll.yml
+++ b/rules/windows/process_creation/proc_creation_win_creation_mavinject_dll.yml
@@ -3,6 +3,7 @@ id: 4f73421b-5a0b-4bbf-a892-5a7fb99bea66
 status: experimental
 author: frack113
 date: 2021/07/12
+modified: 2022/05/13
 description: Injects arbitrary DLL into running process specified by process ID. Requires Windows 10.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218/T1218.md
@@ -18,11 +19,11 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains|all: 
+        CommandLine|contains|all:
             - ' /INJECTRUNNING'
             - '.dll' # space some time in the end
-        OriginalFileName|contains: mavinject
-    condition: selection 
+        OriginalFileName: mavinject
+    condition: selection
 fields:
     - ComputerName
     - User

--- a/rules/windows/process_creation/proc_creation_win_creation_mavinject_dll.yml
+++ b/rules/windows/process_creation/proc_creation_win_creation_mavinject_dll.yml
@@ -22,7 +22,9 @@ detection:
         CommandLine|contains|all:
             - ' /INJECTRUNNING'
             - '.dll' # space some time in the end
-        OriginalFileName: mavinject
+        OriginalFileName:
+            - 'mavinject32.exe'
+            - 'mavinject64.exe'
     condition: selection
 fields:
     - ComputerName

--- a/rules/windows/process_creation/proc_creation_win_esentutl_webcache.yml
+++ b/rules/windows/process_creation/proc_creation_win_esentutl_webcache.yml
@@ -7,16 +7,19 @@ references:
     - https://redcanary.com/threat-detection-report/threats/qbot/
 author: frack113
 date: 2022/02/13
+modified: 2022/05/12
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        Image|endswith: \esentutl.exe
+    selection_img:
+        - Image|endswith: '\esentutl.exe'
+        - OriginalFileName: 'esentutl.exe'
+    selection_cli:
         CommandLine|contains|all:
             - '/r '
             - '\Windows\WebCache'
-    condition: selection
+    condition: all of selection*
 falsepositives:
     - Legitimate use
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_powershell_defender_exclusion.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_defender_exclusion.yml
@@ -11,13 +11,13 @@ tags:
     - attack.t1562.001
 author: Florian Roth
 date: 2021/04/29
-modified: 2022/03/04
+modified: 2022/05/12
 logsource:
     category: process_creation
     product: windows
 detection:
     selection1:
-        CommandLine|contains: 
+        CommandLine|contains:
             - 'Add-MpPreference '
             - 'Set-MpPreference '
     selection2:
@@ -25,6 +25,7 @@ detection:
             - ' -ExclusionPath '
             - ' -ExclusionExtension '
             - ' -ExclusionProcess '
+            - ' -ExclusionIpAddress '
     condition: all of selection*
 falsepositives:
     - Possible Admin Activity

--- a/rules/windows/process_creation/proc_creation_win_susp_advancedrun.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_advancedrun.yml
@@ -9,13 +9,13 @@ references:
     - https://www.winhelponline.com/blog/run-program-as-system-localsystem-account-windows/
 author: Florian Roth
 date: 2022/01/20
-modified: 2022/05/05
+modified: 2022/05/13
 logsource:
     product: windows
     category: process_creation
 detection:
     selection:
-        - OriginalFileName|contains: 'AdvancedRun.exe'
+        - OriginalFileName: 'AdvancedRun.exe'
         - CommandLine|contains|all:
             - ' /EXEFilename '
             - ' /Run'

--- a/rules/windows/process_creation/proc_creation_win_susp_ftp.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_ftp.yml
@@ -6,7 +6,7 @@ author: Victor Sergeev, oscd.community
 references:
   - https://github.com/LOLBAS-Project/LOLBAS/blob/master/yml/OSBinaries/Ftp.yml
 date: 2020/10/09
-modified: 2021/11/27
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
@@ -14,7 +14,7 @@ detection:
   ftp_path:
     Image|endswith: 'ftp.exe'
   ftp_metadata:
-    OriginalFileName|contains: 'ftp.exe'
+    OriginalFileName: 'ftp.exe'
   cmd_with_script_modifier:
     CommandLine|contains: '-s:'
   parent_path:

--- a/rules/windows/process_creation/proc_creation_win_susp_psloglist.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_psloglist.yml
@@ -8,6 +8,7 @@ references:
     - https://github.com/3CORESec/MAL-CL/tree/master/Descriptors/Sysinternals/PsLogList
 author: Nasreddine Bencherchali @nas_bench
 date: 2021/12/18
+modified: 2022/05/13
 tags:
     - attack.discovery
     - attack.t1087
@@ -18,7 +19,7 @@ logsource:
     product: windows
 detection:
     selection1:
-        OriginalFileName|contains: 'psloglist'
+        OriginalFileName: 'psloglist'
     selection2:
         Image|endswith:
           - '\psloglist.exe'
@@ -32,7 +33,7 @@ detection:
           - '-s'
           - '/s'
     other:
-        CommandLine|contains|all: 
+        CommandLine|contains|all:
             - 'security'
             - 'accepteula'
     condition: (1 of selection*) or (flags and other)

--- a/rules/windows/process_creation/proc_creation_win_susp_trolleyexpress_procdump.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_trolleyexpress_procdump.yml
@@ -26,7 +26,7 @@ detection:
   renamed:
     Image|endswith: '\TrolleyExpress.exe'
   filter_renamed:
-    OriginalFileName: 'CtxInstall'
+    OriginalFileName|contains: 'CtxInstall'
   filter_empty:
     OriginalFileName: null
   condition: selection or ( renamed and not 1 of filter* )

--- a/rules/windows/process_creation/proc_creation_win_susp_trolleyexpress_procdump.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_trolleyexpress_procdump.yml
@@ -7,6 +7,7 @@ references:
   - https://twitter.com/_xpn_/status/1491557187168178176
   - https://www.youtube.com/watch?v=Ie831jF0bb0
 date: 2022/02/10
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
@@ -25,7 +26,7 @@ detection:
   renamed:
     Image|endswith: '\TrolleyExpress.exe'
   filter_renamed:
-    OriginalFileName|contains: 'CtxInstall'
+    OriginalFileName: 'CtxInstall'
   filter_empty:
     OriginalFileName: null
   condition: selection or ( renamed and not 1 of filter* )

--- a/rules/windows/process_creation/proc_creation_win_susp_vaultcmd.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_vaultcmd.yml
@@ -4,7 +4,7 @@ status: experimental
 description: List credentials currently stored in Windows Credential Manager via the native Windows utility vaultcmd.exe 
 author: frack113
 date: 2022/04/08
-modified: 2022/05/12
+modified: 2022/05/13
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1555.004/T1555.004.md#atomic-test-1---access-saved-credentials-via-vaultcmd
 logsource:
@@ -13,7 +13,7 @@ logsource:
 detection:
     selection_img:
         - Image|endswith: '\VaultCmd.exe'
-        - OriginalFileName|contains: 'VAULTCMD.EXE'
+        - OriginalFileName: 'VAULTCMD.EXE'
     selection_cli:
         CommandLine|contains: '/listcreds:'
     condition: all of selection*

--- a/rules/windows/process_creation/proc_creation_win_susp_vaultcmd.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_vaultcmd.yml
@@ -4,16 +4,19 @@ status: experimental
 description: List credentials currently stored in Windows Credential Manager via the native Windows utility vaultcmd.exe 
 author: frack113
 date: 2022/04/08
+modified: 2022/05/12
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1555.004/T1555.004.md#atomic-test-1---access-saved-credentials-via-vaultcmd
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        Image|endswith: '\VaultCmd.exe'
+    selection_img:
+        - Image|endswith: '\VaultCmd.exe'
+        - OriginalFileName|contains: 'VAULTCMD.EXE'
+    selection_cli:
         CommandLine|contains: '/listcreds:'
-    condition: selection
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_susp_webdav_client_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_webdav_client_execution.yml
@@ -7,14 +7,14 @@ references:
   - https://github.com/OTRF/detection-hackathon-apt29/issues/17
   - https://threathunterplaybook.com/evals/apt29/detections/7.B.4_C10730EA-6345-4934-AA0F-B0EFCA0C4BA6.html
 date: 2020/05/02
-modified: 2022/05/15
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
 detection:
   selection_img:
     - Image|endswith: '\rundll32.exe'
-    - OriginalFileName|contains: 'RUNDLL32.EXE'
+    - OriginalFileName: 'RUNDLL32.EXE'
   selection_cli:
     CommandLine|contains: 'C:\windows\system32\davclnt.dll,DavSetCookie'
   condition: all of selection*

--- a/rules/windows/process_creation/proc_creation_win_susp_webdav_client_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_webdav_client_execution.yml
@@ -7,15 +7,17 @@ references:
   - https://github.com/OTRF/detection-hackathon-apt29/issues/17
   - https://threathunterplaybook.com/evals/apt29/detections/7.B.4_C10730EA-6345-4934-AA0F-B0EFCA0C4BA6.html
 date: 2020/05/02
-modified: 2021/11/27
+modified: 2022/05/15
 logsource:
   category: process_creation
   product: windows
 detection:
-  selection:
-    Image|endswith: '\rundll32.exe'
+  selection_img:
+    - Image|endswith: '\rundll32.exe'
+    - OriginalFileName|contains: 'RUNDLL32.EXE'
+  selection_cli:
     CommandLine|contains: 'C:\windows\system32\davclnt.dll,DavSetCookie'
-  condition: selection
+  condition: all of selection*
 falsepositives:
   - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_susp_where_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_where_execution.yml
@@ -9,12 +9,14 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1217/T1217.md
 author: frack113
 date: 2021/12/13
+modified: 2022/05/12
 logsource:
     category: process_creation
     product: windows
 detection:
     where_exe:
-        Image|endswith: '\where.exe'
+        - Image|endswith: '\where.exe'
+        - OriginalFileName|contains: 'where.exe'
     where_opt:
         CommandLine|contains:
             - 'Bookmarks'

--- a/rules/windows/process_creation/proc_creation_win_susp_where_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_where_execution.yml
@@ -9,14 +9,14 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1217/T1217.md
 author: frack113
 date: 2021/12/13
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
     category: process_creation
     product: windows
 detection:
     where_exe:
         - Image|endswith: '\where.exe'
-        - OriginalFileName|contains: 'where.exe'
+        - OriginalFileName: 'where.exe'
     where_opt:
         CommandLine|contains:
             - 'Bookmarks'

--- a/rules/windows/process_creation/proc_creation_win_susp_whoami.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_whoami.yml
@@ -7,13 +7,14 @@ references:
   - https://brica.de/alerts/alert/public/1247926/agent-tesla-keylogger-delivered-inside-a-power-iso-daa-archive/
   - https://app.any.run/tasks/7eaba74e-c1ea-400f-9c17-5e30eee89906/
 date: 2018/08/13
-modified: 2021/11/27
+modified: 2022/05/12
 logsource:
   category: process_creation
   product: windows
 detection:
   selection:
-    Image|endswith: '\whoami.exe'
+    - Image|endswith: '\whoami.exe'
+    - OriginalFileName|contains: 'whoami.exe'
   condition: selection
 falsepositives:
   - Admin activity

--- a/rules/windows/process_creation/proc_creation_win_susp_whoami.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_whoami.yml
@@ -7,14 +7,14 @@ references:
   - https://brica.de/alerts/alert/public/1247926/agent-tesla-keylogger-delivered-inside-a-power-iso-daa-archive/
   - https://app.any.run/tasks/7eaba74e-c1ea-400f-9c17-5e30eee89906/
 date: 2018/08/13
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
 detection:
   selection:
     - Image|endswith: '\whoami.exe'
-    - OriginalFileName|contains: 'whoami.exe'
+    - OriginalFileName: 'whoami.exe'
   condition: selection
 falsepositives:
   - Admin activity

--- a/rules/windows/process_creation/proc_creation_win_susp_whoami_anomaly.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_whoami_anomaly.yml
@@ -7,7 +7,7 @@ references:
     - https://app.any.run/tasks/7eaba74e-c1ea-400f-9c17-5e30eee89906/
 author: Florian Roth
 date: 2021/08/12
-modified: 2021/08/26
+modified: 2021/05/12
 tags:
     - attack.discovery
     - attack.t1033
@@ -17,9 +17,10 @@ logsource:
     product: windows
 detection:
     selection:
-        Image|endswith: '\whoami.exe'
+        - Image|endswith: '\whoami.exe'
+        - OriginalFileName|contains: 'whoami.exe'
     filter1:
-        ParentImage|endswith: 
+        ParentImage|endswith:
             - '\cmd.exe'
             - '\powershell.exe'
     filter2:

--- a/rules/windows/process_creation/proc_creation_win_susp_whoami_anomaly.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_whoami_anomaly.yml
@@ -7,7 +7,7 @@ references:
     - https://app.any.run/tasks/7eaba74e-c1ea-400f-9c17-5e30eee89906/
 author: Florian Roth
 date: 2021/08/12
-modified: 2021/05/12
+modified: 2022/05/13
 tags:
     - attack.discovery
     - attack.t1033
@@ -18,7 +18,7 @@ logsource:
 detection:
     selection:
         - Image|endswith: '\whoami.exe'
-        - OriginalFileName|contains: 'whoami.exe'
+        - OriginalFileName: 'whoami.exe'
     filter1:
         ParentImage|endswith:
             - '\cmd.exe'

--- a/rules/windows/process_creation/proc_creation_win_susp_winrm_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_winrm_execution.yml
@@ -7,14 +7,14 @@ references:
   - https://twitter.com/bohops/status/994405551751815170
   - https://redcanary.com/blog/lateral-movement-winrm-wmi/
 date: 2020/10/07
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
 detection:
   selection_img:
     - Image|endswith: '\cscript.exe'
-    - OriginalFileName|contains: 'cscript.exe'
+    - OriginalFileName: 'cscript.exe'
   selection_cli:
     CommandLine|contains|all:
       - 'winrm'

--- a/rules/windows/process_creation/proc_creation_win_susp_winrm_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_winrm_execution.yml
@@ -7,18 +7,20 @@ references:
   - https://twitter.com/bohops/status/994405551751815170
   - https://redcanary.com/blog/lateral-movement-winrm-wmi/
 date: 2020/10/07
-modified: 2021/11/27
+modified: 2022/05/12
 logsource:
   category: process_creation
   product: windows
 detection:
-  selection:
-    Image|endswith: '\cscript.exe'
+  selection_img:
+    - Image|endswith: '\cscript.exe'
+    - OriginalFileName|contains: 'cscript.exe'
+  selection_cli:
     CommandLine|contains|all:
       - 'winrm'
       - 'invoke Create wmicimv2/Win32_'
       - '-r:http'
-  condition: selection
+  condition: all of selection*
 falsepositives:
   - Legitimate use for administartive purposes. Unlikely
 

--- a/rules/windows/process_creation/proc_creation_win_susp_wmi_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wmi_execution.yml
@@ -8,14 +8,14 @@ references:
   - https://www.hybrid-analysis.com/sample/4be06ecd234e2110bd615649fe4a6fa95403979acf889d7e45a78985eb50acf9?environmentId=1
   - https://blog.malwarebytes.com/threat-analysis/2016/04/rokku-ransomware/
 date: 2019/01/16
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
 detection:
   selection:
     - Image|endswith: '\wmic.exe'
-    - OriginalFileName|contains: 'wmic.exe'
+    - OriginalFileName: 'wmic.exe'
   selection2:
     CommandLine|contains|all:
       - 'process'

--- a/rules/windows/process_creation/proc_creation_win_susp_wmi_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wmi_execution.yml
@@ -8,13 +8,14 @@ references:
   - https://www.hybrid-analysis.com/sample/4be06ecd234e2110bd615649fe4a6fa95403979acf889d7e45a78985eb50acf9?environmentId=1
   - https://blog.malwarebytes.com/threat-analysis/2016/04/rokku-ransomware/
 date: 2019/01/16
-modified: 2022/01/07
+modified: 2022/05/12
 logsource:
   category: process_creation
   product: windows
 detection:
   selection:
-    Image|endswith: '\wmic.exe'
+    - Image|endswith: '\wmic.exe'
+    - OriginalFileName|contains: 'wmic.exe'
   selection2:
     CommandLine|contains|all:
       - 'process'

--- a/rules/windows/process_creation/proc_creation_win_susp_wsl_lolbin.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wsl_lolbin.yml
@@ -6,17 +6,19 @@ author: 'oscd.community, Zach Stanford @svch0st'
 references:
   - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Wsl/
 date: 2020/10/05
-modified: 2021/11/27
+modified: 2022/05/12
 logsource:
   category: process_creation
   product: windows
 detection:
-  selection:
-    Image|endswith: '\wsl.exe'
+  selection_img:
+    - Image|endswith: '\wsl.exe'
+    - OriginalFileName|contains: 'wsl.exe'
+  selection_cli:
     CommandLine|contains:
       - ' -e '
       - ' --exec '
-  condition: selection
+  condition: all of selection*
 falsepositives:
   - Automation and orchestration scripts may use this method execute scripts etc
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_susp_wsl_lolbin.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wsl_lolbin.yml
@@ -6,14 +6,14 @@ author: 'oscd.community, Zach Stanford @svch0st'
 references:
   - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Wsl/
 date: 2020/10/05
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
 detection:
   selection_img:
     - Image|endswith: '\wsl.exe'
-    - OriginalFileName|contains: 'wsl.exe'
+    - OriginalFileName: 'wsl.exe'
   selection_cli:
     CommandLine|contains:
       - ' -e '

--- a/rules/windows/process_creation/proc_creation_win_susp_wuauclt.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wuauclt.yml
@@ -6,7 +6,7 @@ references:
     - https://dtm.uk/wuauclt/
 author: FPT.EagleEye Team
 date: 2020/10/17
-modified: 2021/11/18
+modified: 2022/05/12
 tags:
     - attack.command_and_control
     - attack.execution
@@ -16,17 +16,19 @@ logsource:
     product: windows
     category: process_creation
 detection:
-    selection:
+    selection_cli:
         CommandLine|contains|all:
             - '/UpdateDeploymentProvider'
             - '/RunHandlerComServer'
             - '.dll'
-        Image|endswith: '\wuauclt.exe'
+    selection_img:
+        - Image|endswith: '\wuauclt.exe'
+        - OriginalFileName|contains: 'wuauclt.exe'
     filter:
         CommandLine|contains:
             - ' /ClassId '
             - ' wuaueng.dll '
-    condition: selection and not filter
+    condition: all of selection* and not filter
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_susp_wuauclt.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wuauclt.yml
@@ -6,7 +6,7 @@ references:
     - https://dtm.uk/wuauclt/
 author: FPT.EagleEye Team
 date: 2020/10/17
-modified: 2022/05/12
+modified: 2022/05/13
 tags:
     - attack.command_and_control
     - attack.execution
@@ -23,7 +23,7 @@ detection:
             - '.dll'
     selection_img:
         - Image|endswith: '\wuauclt.exe'
-        - OriginalFileName|contains: 'wuauclt.exe'
+        - OriginalFileName: 'wuauclt.exe'
     filter:
         CommandLine|contains:
             - ' /ClassId '

--- a/rules/windows/process_creation/proc_creation_win_susp_wuauclt_cmdline.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wuauclt_cmdline.yml
@@ -6,14 +6,14 @@ author: Florian Roth
 references:
     - https://redcanary.com/blog/blackbyte-ransomware/
 date: 2022/02/26
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
     category: process_creation
     product: windows
 detection:
     selection_img:
         - Image|endswith: '\Wuauclt.exe'
-        - OriginalFileName|contains: 'Wuauclt.exe'
+        - OriginalFileName: 'Wuauclt.exe'
     selection_cli:
         CommandLine|endswith: '\Wuauclt.exe'
     condition: all of selection*

--- a/rules/windows/process_creation/proc_creation_win_susp_wuauclt_cmdline.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wuauclt_cmdline.yml
@@ -6,14 +6,17 @@ author: Florian Roth
 references:
     - https://redcanary.com/blog/blackbyte-ransomware/
 date: 2022/02/26
+modified: 2022/05/12
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        Image|endswith: '\Wuauclt.exe'
-        CommandLine|endswith: '\Wuauclt.exe' 
-    condition: selection
+    selection_img:
+        - Image|endswith: '\Wuauclt.exe'
+        - OriginalFileName|contains: 'Wuauclt.exe'
+    selection_cli:
+        CommandLine|endswith: '\Wuauclt.exe'
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_suspicious_ad_reco.yml
+++ b/rules/windows/process_creation/proc_creation_win_suspicious_ad_reco.yml
@@ -9,14 +9,17 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1069.001/T1069.001.md
 author: frack113
 date: 2021/12/12
+modified: 2022/05/12
 logsource:
     product: windows
     category: process_creation
 detection:
-    test_5:
-        Image|endswith: '\wmic.exe'
+    selection_img:
+        - Image|endswith: '\wmic.exe'
+        - OriginalFileName|contains: 'wmic.exe'
+    selection_cli:
         CommandLine|contains: ' group'
-    condition: test_5
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: low

--- a/rules/windows/process_creation/proc_creation_win_suspicious_ad_reco.yml
+++ b/rules/windows/process_creation/proc_creation_win_suspicious_ad_reco.yml
@@ -9,14 +9,14 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1069.001/T1069.001.md
 author: frack113
 date: 2021/12/12
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
     product: windows
     category: process_creation
 detection:
     selection_img:
         - Image|endswith: '\wmic.exe'
-        - OriginalFileName|contains: 'wmic.exe'
+        - OriginalFileName: 'wmic.exe'
     selection_cli:
         CommandLine|contains: ' group'
     condition: all of selection*

--- a/rules/windows/process_creation/proc_creation_win_tool_nircmd.yml
+++ b/rules/windows/process_creation/proc_creation_win_tool_nircmd.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects the use of NirCmd tool for command execution, which could be the result of legitimate administrative activity
 author: 'Florian Roth, Nasreddine Bencherchali @nas_bench'
 date: 2022/01/24
-modified: 2022/05/06
+modified: 2022/05/13
 references:
     - https://www.nirsoft.net/utils/nircmd.html
     - https://www.winhelponline.com/blog/run-program-as-system-localsystem-account-windows/
@@ -18,7 +18,7 @@ logsource:
     product: windows
 detection:
     selection_org:
-        OriginalFileName|contains: 'NirCmd.exe'
+        OriginalFileName: 'NirCmd.exe'
     combo_exec:
         CommandLine|contains:
             - ' exec '

--- a/rules/windows/process_creation/proc_creation_win_uac_cmstp.yml
+++ b/rules/windows/process_creation/proc_creation_win_uac_cmstp.yml
@@ -7,17 +7,19 @@ references:
   - https://eqllib.readthedocs.io/en/latest/analytics/e584f1a1-c303-4885-8a66-21360c90995b.html
   - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1191/T1191.md
 date: 2019/10/24
-modified: 2021/11/27
+modified: 2022/05/12
 logsource:
   category: process_creation
   product: windows
 detection:
-  selection:
-    Image|endswith: '\cmstp.exe'
+  selection_img:
+    - Image|endswith: '\cmstp.exe'
+    - OriginalFileName|contains: 'CMSTP.EXE'
+  selection_cli:
     CommandLine|contains:
       - '/s'
       - '/au'
-  condition: selection
+  condition: all of selection*
 fields:
   - ComputerName
   - User

--- a/rules/windows/process_creation/proc_creation_win_uac_cmstp.yml
+++ b/rules/windows/process_creation/proc_creation_win_uac_cmstp.yml
@@ -7,14 +7,14 @@ references:
   - https://eqllib.readthedocs.io/en/latest/analytics/e584f1a1-c303-4885-8a66-21360c90995b.html
   - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1191/T1191.md
 date: 2019/10/24
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
 detection:
   selection_img:
     - Image|endswith: '\cmstp.exe'
-    - OriginalFileName|contains: 'CMSTP.EXE'
+    - OriginalFileName: 'CMSTP.EXE'
   selection_cli:
     CommandLine|contains:
       - '/s'

--- a/rules/windows/process_creation/proc_creation_win_uac_wsreset.yml
+++ b/rules/windows/process_creation/proc_creation_win_uac_wsreset.yml
@@ -6,7 +6,7 @@ author: E.M. Anhaus (originally from Atomic Blue Detections, Tony Lambert), oscd
 references:
   - https://eqllib.readthedocs.io/en/latest/analytics/532b5ed4-7930-11e9-8f5c-d46d6d62a49e.html
 date: 2019/10/24
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
@@ -14,7 +14,8 @@ detection:
   selection:
     ParentImage|endswith: '\wsreset.exe'
   filter:
-    OriginalFileName|contains: 'CONHOST.EXE'
+    - Image|endswith: '\conhost.exe'
+    - OriginalFileName: 'CONHOST.EXE'
   condition: selection and not filter
 falsepositives:
   - Unknown

--- a/rules/windows/process_creation/proc_creation_win_uac_wsreset.yml
+++ b/rules/windows/process_creation/proc_creation_win_uac_wsreset.yml
@@ -6,7 +6,7 @@ author: E.M. Anhaus (originally from Atomic Blue Detections, Tony Lambert), oscd
 references:
   - https://eqllib.readthedocs.io/en/latest/analytics/532b5ed4-7930-11e9-8f5c-d46d6d62a49e.html
 date: 2019/10/24
-modified: 2021/11/27
+modified: 2022/05/12
 logsource:
   category: process_creation
   product: windows
@@ -14,7 +14,7 @@ detection:
   selection:
     ParentImage|endswith: '\wsreset.exe'
   filter:
-    Image|endswith: '\conhost.exe'
+    OriginalFileName|contains: 'CONHOST.EXE'
   condition: selection and not filter
 falsepositives:
   - Unknown

--- a/rules/windows/process_creation/proc_creation_win_using_sc_to_hide_sevices.yml
+++ b/rules/windows/process_creation/proc_creation_win_using_sc_to_hide_sevices.yml
@@ -7,12 +7,14 @@ references:
   - https://blog.talosintelligence.com/2021/10/threat-hunting-in-large-datasets-by.html
   - https://www.sans.org/blog/red-team-tactics-hiding-windows-services/
 date: 2021/12/20
+modified: 2022/05/12
 logsource:
   category: process_creation
   product: windows
 detection:
   sc:
-    Image|endswith: '\sc.exe'
+    - Image|endswith: '\sc.exe'
+    - OriginalFileName|contains: 'sc.exe'
   cli:
     CommandLine|contains|all:
       - 'sdset'

--- a/rules/windows/process_creation/proc_creation_win_using_sc_to_hide_sevices.yml
+++ b/rules/windows/process_creation/proc_creation_win_using_sc_to_hide_sevices.yml
@@ -7,14 +7,14 @@ references:
   - https://blog.talosintelligence.com/2021/10/threat-hunting-in-large-datasets-by.html
   - https://www.sans.org/blog/red-team-tactics-hiding-windows-services/
 date: 2021/12/20
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
 detection:
   sc:
     - Image|endswith: '\sc.exe'
-    - OriginalFileName|contains: 'sc.exe'
+    - OriginalFileName: 'sc.exe'
   cli:
     CommandLine|contains|all:
       - 'sdset'

--- a/rules/windows/process_creation/proc_creation_win_vmtoolsd_susp_child_process.yml
+++ b/rules/windows/process_creation/proc_creation_win_vmtoolsd_susp_child_process.yml
@@ -8,7 +8,7 @@ tags:
     - attack.t1059
 author: behops, Bhabesh Raj
 date: 2021/10/08
-modified: 2021/10/10
+modified: 2022/05/12
 references:
     - https://bohops.com/2021/10/08/analyzing-and-detecting-a-vmtools-persistence-technique/
 fields:
@@ -24,13 +24,13 @@ logsource:
 detection:
     selection:
         ParentImage|endswith: '\vmtoolsd.exe'
-        Image|endswith:
-            - '\cmd.exe'
-            - '\powershell.exe'
-            - '\rundll32.exe'
-            - '\regsvr32.exe'
-            - '\wscript.exe'
-            - '\cscript.exe'
+        OriginalFileName|contains:
+            - 'Cmd.Exe'
+            - 'PowerShell.EXE'
+            - 'RUNDLL32.EXE'
+            - 'REGSVR32.EXE'
+            - 'wscript.exe'
+            - 'cscript.exe'
     filter:
         CommandLine|contains:
             - '\VMware\VMware Tools\poweron-vm-default.bat'

--- a/rules/windows/process_creation/proc_creation_win_vmtoolsd_susp_child_process.yml
+++ b/rules/windows/process_creation/proc_creation_win_vmtoolsd_susp_child_process.yml
@@ -8,7 +8,7 @@ tags:
     - attack.t1059
 author: behops, Bhabesh Raj
 date: 2021/10/08
-modified: 2022/05/12
+modified: 2022/05/13
 references:
     - https://bohops.com/2021/10/08/analyzing-and-detecting-a-vmtools-persistence-technique/
 fields:
@@ -22,9 +22,17 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
+    selection_parent:
         ParentImage|endswith: '\vmtoolsd.exe'
-        OriginalFileName|contains:
+    selection_img:
+        - Image|endswith:
+            - '\cmd.exe'
+            - '\powershell.exe'
+            - '\rundll32.exe'
+            - '\regsvr32.exe'
+            - '\wscript.exe'
+            - '\cscript.exe'
+        - OriginalFileName:
             - 'Cmd.Exe'
             - 'PowerShell.EXE'
             - 'RUNDLL32.EXE'
@@ -37,4 +45,4 @@ detection:
             - '\VMware\VMware Tools\poweroff-vm-default.bat'
             - '\VMware\VMware Tools\resume-vm-default.bat'
             - '\VMware\VMware Tools\suspend-vm-default.bat'
-    condition: selection and not filter
+    condition: all of selection* and not filter

--- a/rules/windows/process_creation/proc_creation_win_webshell_detection.yml
+++ b/rules/windows/process_creation/proc_creation_win_webshell_detection.yml
@@ -7,7 +7,7 @@ references:
     - https://www.fireeye.com/blog/threat-research/2013/08/breaking-down-the-china-chopper-web-shell-part-ii.html
     - https://unit42.paloaltonetworks.com/bumblebee-webshell-xhunt-campaign/
 date: 2017/01/01
-modified: 2021/03/17
+modified: 2022/05/13
 tags:
     - attack.persistence
     - attack.t1505.003
@@ -41,7 +41,7 @@ detection:
             - 'catalina.jar'
             - 'CATALINA_HOME'
     susp_net_utility:
-        OriginalFileName|contains:
+        OriginalFileName:
             - 'net.exe'
             - 'net1.exe'
         CommandLine|contains:
@@ -49,14 +49,14 @@ detection:
             - ' use '
             - ' group '
     susp_ping_utility:
-        OriginalFileName|contains: 'ping.exe'
+        OriginalFileName: 'ping.exe'
         CommandLine|contains: ' -n '
     susp_change_dir:
         CommandLine|contains:
             - '&cd&echo'  # china chopper web shell
             - 'cd /d '  # https://www.computerhope.com/cdhlp.htm
     susp_wmic_utility:
-        OriginalFileName|contains: 'wmic.exe'
+        OriginalFileName: 'wmic.exe'
         CommandLine|contains: ' /node:'
     susp_misc_discovery_binaries:
         - Image|endswith:
@@ -71,7 +71,7 @@ detection:
             - '\vssadmin.exe'
             - '\wevtutil.exe'
             - '\tasklist.exe'
-        - OriginalFileName|contains:
+        - OriginalFileName:
             - 'whoami.exe'
             - 'sysinfo.exe'
             - 'quser.exe'

--- a/rules/windows/process_creation/proc_creation_win_webshell_detection.yml
+++ b/rules/windows/process_creation/proc_creation_win_webshell_detection.yml
@@ -27,50 +27,62 @@ detection:
             - '\caddy.exe'
             - '\ws_tomcatservice.exe'
     selection_webserver_characteristics_tomcat1:
-        ParentImage|endswith: 
+        ParentImage|endswith:
             - '\java.exe'
             - '\javaw.exe'
-        ParentImage|contains: 
+        ParentImage|contains:
             - '-tomcat-'
             - '\tomcat'
     selection_webserver_characteristics_tomcat2:
-        ParentImage|endswith: 
+        ParentImage|endswith:
             - '\java.exe'
             - '\javaw.exe'
-        CommandLine|contains: 
+        CommandLine|contains:
             - 'catalina.jar'
             - 'CATALINA_HOME'
     susp_net_utility:
-        Image|endswith:
-            - '\net.exe'
-            - '\net1.exe'
+        OriginalFileName|contains:
+            - 'net.exe'
+            - 'net1.exe'
         CommandLine|contains:
             - ' user '
             - ' use '
             - ' group '
     susp_ping_utility:
-        Image|endswith: '\ping.exe'
+        OriginalFileName|contains: 'ping.exe'
         CommandLine|contains: ' -n '
     susp_change_dir:
         CommandLine|contains:
             - '&cd&echo'  # china chopper web shell
             - 'cd /d '  # https://www.computerhope.com/cdhlp.htm
     susp_wmic_utility:
-        Image|endswith: '\wmic.exe'
-        CommandLine|contains: ' /node:' 
+        OriginalFileName|contains: 'wmic.exe'
+        CommandLine|contains: ' /node:'
     susp_misc_discovery_binaries:
-        Image|endswith:
+        - Image|endswith:
             - '\whoami.exe'
             - '\systeminfo.exe'
             - '\quser.exe'
-            - '\ipconfig.exe' 
-            - '\pathping.exe' 
-            - '\tracert.exe' 
-            - '\netstat.exe' 
-            - '\schtasks.exe' 
-            - '\vssadmin.exe' 
-            - '\wevtutil.exe' 
-            - '\tasklist.exe' 
+            - '\ipconfig.exe'
+            - '\pathping.exe'
+            - '\tracert.exe'
+            - '\netstat.exe'
+            - '\schtasks.exe'
+            - '\vssadmin.exe'
+            - '\wevtutil.exe'
+            - '\tasklist.exe'
+        - OriginalFileName|contains:
+            - 'whoami.exe'
+            - 'sysinfo.exe'
+            - 'quser.exe'
+            - 'ipconfig.exe'
+            - 'pathping.exe'
+            - 'tracert.exe'
+            - 'netstat.exe'
+            - 'schtasks.exe'
+            - 'VSSADMIN.EXE'
+            - 'wevtutil.exe'
+            - 'tasklist.exe'
     susp_misc_discovery_commands:
         CommandLine|contains:
             - ' Test-NetConnection '

--- a/rules/windows/process_creation/proc_creation_win_whoami_as_priv_user.yml
+++ b/rules/windows/process_creation/proc_creation_win_whoami_as_priv_user.yml
@@ -7,7 +7,7 @@ references:
     - https://nsudo.m2team.org/en-us/
 author: Florian Roth
 date: 2022/01/28
-modified: 2022/05/12
+modified: 2022/05/13
 tags:
     - attack.privilege_escalation
     - attack.discovery
@@ -19,7 +19,7 @@ detection:
     selection_user:
         User|contains: 'TrustedInstaller'
     selection_img:
-        - OriginalFileName|contains: 'whoami.exe'
+        - OriginalFileName: 'whoami.exe'
         - Image|endswith: '\whoami.exe'
     condition: all of selection*
 falsepositives:

--- a/rules/windows/process_creation/proc_creation_win_whoami_as_priv_user.yml
+++ b/rules/windows/process_creation/proc_creation_win_whoami_as_priv_user.yml
@@ -7,6 +7,7 @@ references:
     - https://nsudo.m2team.org/en-us/
 author: Florian Roth
 date: 2022/01/28
+modified: 2022/05/12
 tags:
     - attack.privilege_escalation
     - attack.discovery
@@ -15,10 +16,12 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
+    selection_user:
         User|contains: 'TrustedInstaller'
-        Image|endswith: '\whoami.exe'
-    condition: selection
+    selection_img:
+        - OriginalFileName|contains: 'whoami.exe'
+        - Image|endswith: '\whoami.exe'
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_whoami_as_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_whoami_as_system.yml
@@ -6,7 +6,7 @@ references:
     - https://speakerdeck.com/heirhabarov/hunting-for-privilege-escalation-in-windows-environment
 author: Teymur Kheirkhabarov, Florian Roth
 date: 2019/10/23
-modified: 2022/05/12
+modified: 2022/05/13
 tags:
     - attack.privilege_escalation
     - attack.discovery
@@ -20,7 +20,7 @@ detection:
             - 'AUTHORI'
             - 'AUTORI'
     selection_img:
-        - OriginalFileName|contains: 'whoami.exe'
+        - OriginalFileName: 'whoami.exe'
         - Image|endswith: '\whoami.exe'
     condition: all of selection*
 falsepositives:

--- a/rules/windows/process_creation/proc_creation_win_whoami_as_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_whoami_as_system.yml
@@ -6,21 +6,23 @@ references:
     - https://speakerdeck.com/heirhabarov/hunting-for-privilege-escalation-in-windows-environment
 author: Teymur Kheirkhabarov, Florian Roth
 date: 2019/10/23
-modified: 2022/01/28
+modified: 2022/05/12
 tags:
     - attack.privilege_escalation
-    - attack.discovery    
+    - attack.discovery
     - attack.t1033
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
+    selection_user:
         User|contains: # covers many language settings
             - 'AUTHORI'
             - 'AUTORI'
-        Image|endswith: '\whoami.exe'
-    condition: selection
+    selection_img:
+        - OriginalFileName|contains: 'whoami.exe'
+        - Image|endswith: '\whoami.exe'
+    condition: all of selection*
 falsepositives:
     - Possible name overlap with NT AUHTORITY substring to cover all languages
 level: high

--- a/rules/windows/process_creation/proc_creation_win_whoami_priv.yml
+++ b/rules/windows/process_creation/proc_creation_win_whoami_priv.yml
@@ -6,6 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/whoami
 author: Florian Roth
 date: 2021/05/05
+modified: 2022/05/12
 tags:
     - attack.privilege_escalation
     - attack.discovery
@@ -14,10 +15,12 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        Image|endswith: '\whoami.exe'
+    selection_img:
+        - Image|endswith: '\whoami.exe'
+        - OriginalFileName|contains: 'whoami.exe'
+    selection_cli:
         CommandLine|contains: '/priv'
-    condition: selection
+    condition: all of selection*
 falsepositives:
     - Administrative activity (rare lookups on current privileges)
 level: high

--- a/rules/windows/process_creation/proc_creation_win_whoami_priv.yml
+++ b/rules/windows/process_creation/proc_creation_win_whoami_priv.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/whoami
 author: Florian Roth
 date: 2021/05/05
-modified: 2022/05/12
+modified: 2022/05/13
 tags:
     - attack.privilege_escalation
     - attack.discovery
@@ -17,7 +17,7 @@ logsource:
 detection:
     selection_img:
         - Image|endswith: '\whoami.exe'
-        - OriginalFileName|contains: 'whoami.exe'
+        - OriginalFileName: 'whoami.exe'
     selection_cli:
         CommandLine|contains: '/priv'
     condition: all of selection*

--- a/rules/windows/process_creation/proc_creation_win_win10_sched_task_0day.yml
+++ b/rules/windows/process_creation/proc_creation_win_win10_sched_task_0day.yml
@@ -6,19 +6,21 @@ author: Olaf Hartong
 references:
   - https://github.com/SandboxEscaper/polarbearrepo/tree/master/bearlpe
 date: 2019/05/22
-modified: 2021/11/27
+modified: 2022/05/12
 logsource:
   category: process_creation
   product: windows
 detection:
-  selection:
+  selection_img:
     Image|endswith: '\schtasks.exe'
+    OriginalFileName|contains: 'schtasks.exe'
+  selection_cli:
     CommandLine|contains|all:
       - '/change'
       - '/TN'
       - '/RU'
       - '/RP'
-  condition: selection
+  condition: all of selection*
 falsepositives:
   - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_win10_sched_task_0day.yml
+++ b/rules/windows/process_creation/proc_creation_win_win10_sched_task_0day.yml
@@ -6,14 +6,14 @@ author: Olaf Hartong
 references:
   - https://github.com/SandboxEscaper/polarbearrepo/tree/master/bearlpe
 date: 2019/05/22
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
 detection:
   selection_img:
     Image|endswith: '\schtasks.exe'
-    OriginalFileName|contains: 'schtasks.exe'
+    OriginalFileName: 'schtasks.exe'
   selection_cli:
     CommandLine|contains|all:
       - '/change'

--- a/rules/windows/process_creation/proc_creation_win_wmi_spwns_powershell.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmi_spwns_powershell.yml
@@ -7,7 +7,7 @@ references:
     - https://any.run/report/68bc255f9b0db6a0d30a8f2dadfbee3256acfe12497bf93943bc1eab0735e45e/a2385d6f-34f7-403c-90d3-b1f9d2a90a5e
 author: Markus Neis / @Karneades
 date: 2019/04/03
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
     category: process_creation
     product: windows
@@ -16,7 +16,7 @@ detection:
         ParentImage|endswith: '\wmiprvse.exe'
     selection_img:
         - Image|endswith: '\powershell.exe'
-        - OriginalFileName|contains: 'PowerShell.EXE'
+        - OriginalFileName: 'PowerShell.EXE'
     filter_null1:
         CommandLine: 'null'
     filter_null2:  # some backends need the null value in a separate expression

--- a/rules/windows/process_creation/proc_creation_win_wmi_spwns_powershell.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmi_spwns_powershell.yml
@@ -7,19 +7,21 @@ references:
     - https://any.run/report/68bc255f9b0db6a0d30a8f2dadfbee3256acfe12497bf93943bc1eab0735e45e/a2385d6f-34f7-403c-90d3-b1f9d2a90a5e
 author: Markus Neis / @Karneades
 date: 2019/04/03
-modified: 2021/02/24
+modified: 2022/05/12
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
+    selection_parent:
         ParentImage|endswith: '\wmiprvse.exe'
-        Image|endswith: '\powershell.exe'
+    selection_img:
+        - Image|endswith: '\powershell.exe'
+        - OriginalFileName|contains: 'PowerShell.EXE'
     filter_null1:
         CommandLine: 'null'
     filter_null2:  # some backends need the null value in a separate expression
         CommandLine: null
-    condition: selection and not filter_null1 and not filter_null2
+    condition: all of selection* and not filter_null1 and not filter_null2
 falsepositives:
     - AppvClient
     - CCM

--- a/rules/windows/process_creation/proc_creation_win_wmi_spwns_powershell.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmi_spwns_powershell.yml
@@ -21,7 +21,7 @@ detection:
         CommandLine: 'null'
     filter_null2:  # some backends need the null value in a separate expression
         CommandLine: null
-    condition: all of selection* and not filter_null*
+    condition: all of selection* and not filter_null1 and not filter_null2
 falsepositives:
     - AppvClient
     - CCM

--- a/rules/windows/process_creation/proc_creation_win_wmi_spwns_powershell.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmi_spwns_powershell.yml
@@ -21,7 +21,7 @@ detection:
         CommandLine: 'null'
     filter_null2:  # some backends need the null value in a separate expression
         CommandLine: null
-    condition: all of selection* and not filter_null1 and not filter_null2
+    condition: all of selection* and not filter_null*
 falsepositives:
     - AppvClient
     - CCM

--- a/rules/windows/process_creation/proc_creation_win_wmic_reconnaissance.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_reconnaissance.yml
@@ -7,14 +7,14 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1047/T1047.md
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/wmic
 date: 2022/01/01
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
     category: process_creation
     product: windows
 detection:
     selection_img:
         - Image|endswith: \WMIC.exe
-        - OriginalFileName|contains: 'wmic.exe'
+        - OriginalFileName: 'wmic.exe'
     selection_cli:
         CommandLine|contains:
             - process

--- a/rules/windows/process_creation/proc_creation_win_wmic_reconnaissance.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_reconnaissance.yml
@@ -7,20 +7,23 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1047/T1047.md
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/wmic
 date: 2022/01/01
+modified: 2022/05/12
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        Image|endswith: \WMIC.exe
-        CommandLine|contains: 
-            - process 
+    selection_img:
+        - Image|endswith: \WMIC.exe
+        - OriginalFileName|contains: 'wmic.exe'
+    selection_cli:
+        CommandLine|contains:
+            - process
             - qfe
     filter:
         CommandLine|contains|all: #rule id 526be59f-a573-4eea-b5f7-f0973207634d for `wmic process call create #{process_to_execute}` 
             - call
-            - create 
-    condition: selection and not filter
+            - create
+    condition: all of selection* and not filter
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_wmic_remote_command.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_remote_command.yml
@@ -7,21 +7,24 @@ references:
     - https://securelist.com/moonbounce-the-dark-side-of-uefi-firmware/105468/
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/wmic
 date: 2022/03/13
+modified: 2022/05/12
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        Image|endswith: \WMIC.exe
+    selection_img:
+        - Image|endswith: \WMIC.exe
+        - OriginalFileName|contains: 'wmic.exe'
+    selection_cli:
         CommandLine|contains|all:
             - '/node:'
             - process
             - call
-            - create 
-    condition: selection
+            - create
+    condition: all of selection*
 falsepositives:
     - Unknown
-level: medium 
+level: medium
 tags:
     - attack.execution
     - attack.t1047

--- a/rules/windows/process_creation/proc_creation_win_wmic_remote_command.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_remote_command.yml
@@ -7,14 +7,14 @@ references:
     - https://securelist.com/moonbounce-the-dark-side-of-uefi-firmware/105468/
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/wmic
 date: 2022/03/13
-modified: 2022/05/12
+modified: 2022/05/13
 logsource:
     category: process_creation
     product: windows
 detection:
     selection_img:
         - Image|endswith: \WMIC.exe
-        - OriginalFileName|contains: 'wmic.exe'
+        - OriginalFileName: 'wmic.exe'
     selection_cli:
         CommandLine|contains|all:
             - '/node:'

--- a/rules/windows/process_creation/proc_creation_win_wmic_remote_service.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_remote_service.yml
@@ -7,18 +7,18 @@ description: |
   A common feedback message is that "No instance(s) Available" if the service queried is not running.
   A common error message is "Node - (provided IP or default) ERROR Description =The RPC server is unavailable" if the provided remote host is unreacheable
 author: frack113
-modified: 2022/05/12
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1047/T1047.md
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/wmic
 date: 2022/01/01
+modified: 2022/05/13
 logsource:
     category: process_creation
     product: windows
 detection:
     selection_img:
         - Image|endswith: \WMIC.exe
-        - OriginalFileName|contains: 'wmic.exe'
+        - OriginalFileName: 'wmic.exe'
     selection_cli:
         CommandLine|contains|all:
             - '/node:'

--- a/rules/windows/process_creation/proc_creation_win_wmic_remote_service.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_remote_service.yml
@@ -7,6 +7,7 @@ description: |
   A common feedback message is that "No instance(s) Available" if the service queried is not running.
   A common error message is "Node - (provided IP or default) ERROR Description =The RPC server is unavailable" if the provided remote host is unreacheable
 author: frack113
+modified: 2022/05/12
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1047/T1047.md
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/wmic
@@ -15,12 +16,14 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        Image|endswith: \WMIC.exe
+    selection_img:
+        - Image|endswith: \WMIC.exe
+        - OriginalFileName|contains: 'wmic.exe'
+    selection_cli:
         CommandLine|contains|all:
             - '/node:'
-            - service 
-    condition: selection
+            - service
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_wmic_remove_application.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_remove_application.yml
@@ -6,13 +6,14 @@ author: frac113
 references:
   - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1047/T1047.md#atomic-test-10---application-uninstall-using-wmic
 date: 2022/01/28
+modified: 2022/05/13
 logsource:
   category: process_creation
   product: windows
 detection:
   selection_img:
     - Image|endswith: \WMIC.exe
-    - OriginalFileName|contains: 'wmic.exe'
+    - OriginalFileName: 'wmic.exe'
   selection_cli:
     CommandLine|contains: call uninstall
   condition: all of selection*

--- a/rules/windows/process_creation/proc_creation_win_wmic_remove_application.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_remove_application.yml
@@ -10,10 +10,12 @@ logsource:
   category: process_creation
   product: windows
 detection:
-  selection:
-    Image|endswith: \WMIC.exe
+  selection_img:
+    - Image|endswith: \WMIC.exe
+    - OriginalFileName|contains: 'wmic.exe'
+  selection_cli:
     CommandLine|contains: call uninstall
-  condition: selection
+  condition: all of selection*
 falsepositives:
   - Unknown
 level: medium


### PR DESCRIPTION
- Updated some process_creation rules to use both Image and OriginalFileName as increased accuracy.
- Added another option for the rule "proc_creation_win_powershell_defender_exclusion"
- I'm planning to modify the rest of the rules in small batches if this PR gets approved :)