### PR TITLE
Rule Update (Batch 2)

### DIFF
--- a/rules/windows/file_event/file_event_win_powershell_exploit_scripts.yml
+++ b/rules/windows/file_event/file_event_win_powershell_exploit_scripts.yml
@@ -5,8 +5,10 @@ description: Detects the creation of known powershell scripts for exploitation
 author: Markus Neis
 references:
   - https://raw.githubusercontent.com/Neo23x0/sigma/f35c50049fa896dff91ff545cb199319172701e8/rules/windows/powershell/powershell_malicious_commandlets.yml
+  - https://github.com/PowerShellMafia/PowerSploit
+  - https://github.com/NetSPI/PowerUpSQL
 date: 2018/04/07
-modified: 2021/11/27
+modified: 2022/05/13
 logsource:
   category: file_event
   product: windows
@@ -108,6 +110,11 @@ detection:
       - '\Invoke-ReverseDNSLookup.ps1'
       - '\Invoke-SMBScanner.ps1'
       - '\Invoke-Mimikittenz.ps1'
+      - '\PowerUpSQL.ps1'
+      - '\Get-ComputerDetail.ps1'
+      - '\Find-AVSignature.ps1'
+      - '\Get-GPPAutologon.ps1'
+      - '\Get-MicrophoneAudio.ps1'
   condition: selection
 falsepositives:
   - Unknown

--- a/rules/windows/process_creation/proc_creation_win_certoc_download.yml
+++ b/rules/windows/process_creation/proc_creation_win_certoc_download.yml
@@ -19,4 +19,6 @@ detection:
 falsepositives:
     - Unknown
 level: high
-
+tags:
+    - attack.command_and_control
+    - attack.t1105

--- a/rules/windows/process_creation/proc_creation_win_certoc_download.yml
+++ b/rules/windows/process_creation/proc_creation_win_certoc_download.yml
@@ -15,7 +15,7 @@ detection:
         - OriginalFileName: 'CertOC.exe'
     selection_cli:
         CommandLine|contains: '-GetCACAPS'
-    condition: selection
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_certoc_download.yml
+++ b/rules/windows/process_creation/proc_creation_win_certoc_download.yml
@@ -1,0 +1,22 @@
+title: Suspicious File Download via CertOC.exe
+id: 70ad0861-d1fe-491c-a45f-fa48148a300d
+description: Detects when a user downloads file by using CertOC.exe
+status: experimental
+author: Nasreddine Bencherchali
+date: 2022/05/16
+references:
+- https://lolbas-project.github.io/lolbas/Binaries/Certoc/
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\certoc.exe'
+        - OriginalFileName: 'CertOC.exe'
+    selection_cli:
+        CommandLine|contains: '-GetCACAPS'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high
+

--- a/rules/windows/process_creation/proc_creation_win_certoc_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_certoc_execution.yml
@@ -4,25 +4,27 @@ description: Detects when a user installs certificates by using CertOC.exe to lo
 status: experimental
 author: Austin Songer @austinsonger
 date: 2021/10/23
+modified: 2022/05/16
 references:
 - https://twitter.com/sblmsrsn/status/1445758411803480072?s=20
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        Image|endswith: '\certoc.exe'
+    selection_img:
+        - Image|endswith: '\certoc.exe'
+        - OriginalFileName: 'CertOC.exe'
+    selection_cli:
         CommandLine|contains|all:
             - '-LoadDLL'
             - '.dll'
-    condition: selection
+    condition: all of selection*
 fields:
     - CommandLine
     - ParentCommandLine
 tags:
 - attack.defense_evasion
 - attack.t1218
-level: medium
 falsepositives:
-- Unknown
-
+    - Unknown
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_cmdkey_recon.yml
+++ b/rules/windows/process_creation/proc_creation_win_cmdkey_recon.yml
@@ -7,7 +7,7 @@ references:
     - https://technet.microsoft.com/en-us/library/cc754243(v=ws.11).aspx
 author: jmallette, Florian Roth
 date: 2019/01/16
-modified: 2022/04/21
+modified: 2022/05/16
 tags:
     - attack.credential_access
     - attack.t1003.005
@@ -15,12 +15,14 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        Image|endswith: '\cmdkey.exe'
+    selection_img:
+        - Image|endswith: '\cmdkey.exe'
+        - OriginalFileName: 'CertOC.exe'
+    selection_cli:
         CommandLine|contains:
             - ' /list'
             - ' -list'
-    condition: selection
+    condition: all of selection*
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/process_creation/proc_creation_win_cmdkey_recon.yml
+++ b/rules/windows/process_creation/proc_creation_win_cmdkey_recon.yml
@@ -17,7 +17,7 @@ logsource:
 detection:
     selection_img:
         - Image|endswith: '\cmdkey.exe'
-        - OriginalFileName: 'CertOC.exe'
+        - OriginalFileName: 'cmdkey.exe'
     selection_cli:
         CommandLine|contains:
             - ' /list'

--- a/rules/windows/process_creation/proc_creation_win_lolbas_configsecuritypolicy.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_configsecuritypolicy.yml
@@ -9,12 +9,15 @@ tags:
     - attack.t1567
 author: frack113
 date: 2021/11/26
+modified: 2022/05/16
 logsource:
     category: process_creation
     product: windows
 detection:
     lolbas:
-        CommandLine|contains: ConfigSecurityPolicy.exe
+        - CommandLine|contains: ConfigSecurityPolicy.exe
+        - Image|endswith: '\ConfigSecurityPolicy.exe'
+        - OriginalFileName: 'ConfigSecurityPolicy'
     remote:
         CommandLine|contains:
             - 'https://'

--- a/rules/windows/process_creation/proc_creation_win_lolbas_configsecuritypolicy.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_configsecuritypolicy.yml
@@ -17,7 +17,7 @@ detection:
     lolbas:
         - CommandLine|contains: ConfigSecurityPolicy.exe
         - Image|endswith: '\ConfigSecurityPolicy.exe'
-        - OriginalFileName: 'ConfigSecurityPolicy'
+        - OriginalFileName: 'ConfigSecurityPolicy.exe'
     remote:
         CommandLine|contains:
             - 'https://'

--- a/rules/windows/process_creation/proc_creation_win_lolbas_data_exfiltration_by_using_datasvcutil.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_data_exfiltration_by_using_datasvcutil.yml
@@ -2,13 +2,15 @@ title: LOLBAS Data Exfiltration by DataSvcUtil.exe
 id: e290b10b-1023-4452-a4a9-eb31a9013b3a
 status: experimental
 author: Ialle Teixeira @teixeira0xfffff, Austin Songer @austinsonger
-date: 2021/09/30 
 description: Detects when a user performs data exfiltration by using DataSvcUtil.exe
+date: 2021/09/30
+modified: 2022/05/16
 references:
     - https://gist.github.com/teixeira0xfffff/837e5bfed0d1b0a29a7cb1e5dbdd9ca6
     - https://docs.microsoft.com/en-us/dotnet/framework/data/wcf/wcf-data-service-client-utility-datasvcutil-exe
     - https://docs.microsoft.com/en-us/dotnet/framework/data/wcf/generating-the-data-service-client-library-wcf-data-services
     - https://docs.microsoft.com/en-us/dotnet/framework/data/wcf/how-to-add-a-data-service-reference-wcf-data-services
+    - https://lolbas-project.github.io/lolbas/Binaries/DataSvcUtil/
 tags:
     - attack.exfiltration
     - attack.t1567
@@ -16,12 +18,15 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        CommandLine|contains|all:
+    selection_cli:
+        CommandLine|contains:
             - '/in:'
             - '/out:'
-        Image|endswith: '\DataSvcUtil.exe'
-    condition: selection
+            - '/uri:'
+    selection_img:
+        - Image|endswith: '\DataSvcUtil.exe'
+        - OriginalFileName: 'DataSvcUtil.exe'
+    condition: all of selection*
 fields:
     - ComputerName
     - User

--- a/rules/windows/process_creation/proc_creation_win_lolbas_extexport.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_extexport.yml
@@ -4,18 +4,21 @@ status: experimental
 description: Extexport.exe loads dll and is execute from other folder the original path
 references:
     - https://lolbas-project.github.io/lolbas/Binaries/Extexport/
-tags:
-    - attack.defense_evasion
-    - attack.t1218
 author: frack113
 date: 2021/11/26
+modified: 2022/05/16
 logsource:
     category: process_creation
     product: windows
 detection:
     lolbas:
-        CommandLine|contains: Extexport.exe
-    condition: lolbas 
+        - CommandLine|contains: Extexport.exe
+        - Image|endswith: '\Extexport.exe'
+        - OriginalFileName: 'extexport.exe'
+    condition: lolbas
 falsepositives:
     - Unknown
 level: medium
+tags:
+    - attack.defense_evasion
+    - attack.t1218

--- a/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
@@ -25,7 +25,7 @@ detection:
             - /C
             - /Y
             - ' \\'
-condition: all of selection_*
+    condition: all of selection_*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
@@ -19,7 +19,7 @@ detection:
         - Image|endswith: '\extrac32.exe'
         - OriginalFileName: 'extrac32.exe'
     selection_archive:
-       - CommandLine|contains: '.cab'
+       ommandLine|contains: '.cab'
     selection_options:
        CommandLine|contains:
             - /C

--- a/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
@@ -9,14 +9,17 @@ tags:
     - attack.t1105
 author: frack113
 date: 2021/11/26
+modified: 2022/05/16
 logsource:
     category: process_creation
     product: windows
 detection:
     lolbas:
-        CommandLine|contains|all:
+        - CommandLine|contains|all:
             - extrac32.exe
             - .cab
+        - Image|endswith: '\extrac32.exe'
+        - OriginalFileName: 'extrac32.exe'
     options:
         CommandLine|contains:
             - /C

--- a/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_extrac32.yml
@@ -14,18 +14,18 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    lolbas:
-        - CommandLine|contains|all:
-            - extrac32.exe
-            - .cab
+    selection_lolbas:
+        - CommandLine|contains: extrac32.exe
         - Image|endswith: '\extrac32.exe'
         - OriginalFileName: 'extrac32.exe'
-    options:
-        CommandLine|contains:
+    selection_archive:
+       - CommandLine|contains: '.cab'
+    selection_options:
+       CommandLine|contains:
             - /C
             - /Y
             - ' \\'
-    condition: lolbas and options
+condition: all of selection_*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbas_ieexec_download.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbas_ieexec_download.yml
@@ -1,0 +1,23 @@
+title: Abusing IEExec To Download Payloads
+id: 9801abb8-e297-4dbf-9fbd-57dde0e830ad
+status: experimental
+description: Detects execution of the IEExec utility to download payloads
+references:
+    - https://lolbas-project.github.io/lolbas/Binaries/Ieexec/
+author: Nasreddine Bencherchali
+date: 2022/05/16
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    lolbas:
+        - Image|endswith: '\IEExec.exe'
+        - OriginalFileName: 'IEExec.exe'
+    remote:
+        CommandLine|contains:
+            - 'https://'
+            - 'http://'
+    condition: lolbas and remote
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/process_creation/proc_creation_win_lolbin_gpscript.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_gpscript.yml
@@ -6,17 +6,19 @@ references:
     - https://oddvar.moe/2018/04/27/gpscript-exe-another-lolbin-to-the-list/
     - https://lolbas-project.github.io/lolbas/Binaries/Gpscript/
 author: frack113
-date: 2022/05/02
+date: 2022/05/16
 logsource:
     product: windows
     category: process_creation
 detection:
-    selection:
-        Image|endswith: '\gpscript.exe'
-        CommandLine|contains: 
+    selection_img:
+        - Image|endswith: '\gpscript.exe'
+        - OriginalFileName: 'GPSCRIPT.EXE'
+    selection_cli:
+        CommandLine|contains:
             - ' /logon'
             - ' /startup'
-    condition: selection 
+    condition: all of selection*
 falsepositives:
     - Legitimate uses of logon scripts distributed via group policy
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_ie4uinit.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_ie4uinit.yml
@@ -7,12 +7,14 @@ references:
     - https://bohops.com/2018/03/10/leveraging-inf-sct-fetch-execute-techniques-for-bypass-evasion-persistence-part-2/
 author: frack113
 date: 2022/05/07
+modified: 2022/05/16
 logsource:
     product: windows
     category: process_creation
 detection:
     lolbin:
-        Image|endswith: '\ie4uinit.exe'
+        - Image|endswith: '\ie4uinit.exe'
+        - OriginalFileName: 'IE4UINIT.EXE'
     filter_correct:
         CurrentDirectory:
             - 'c:\windows\system32\'

--- a/rules/windows/process_creation/proc_creation_win_lolbin_ilasm.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_ilasm.yml
@@ -7,13 +7,15 @@ references:
     - https://www.echotrail.io/insights/search/ilasm.exe
 author: frack113
 date: 2022/05/07
+modified: 2022/05/16
 logsource:
     product: windows
     category: process_creation
 detection:
     selection:
-        Image|endswith: '\Ilasm.exe'
-    condition: selection 
+        - Image|endswith: '\ilasm.exe'
+        - OriginalFileName: 'ilasm.exe'
+    condition: selection
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_shadow_copies_deletion.yml
+++ b/rules/windows/process_creation/proc_creation_win_shadow_copies_deletion.yml
@@ -47,8 +47,8 @@ detection:
             - catalog
             - quiet # will match -quiet or /quiet
     selection3_img:
-        Image|endswith: '\vssadmin.exe'
-        OriginalFileName: 'VSSADMIN.EXE'
+        - Image|endswith: '\vssadmin.exe'
+        - OriginalFileName: 'VSSADMIN.EXE'
     selection3_cli:
         CommandLine|contains|all:
             - resize

--- a/rules/windows/process_creation/proc_creation_win_shadow_copies_deletion.yml
+++ b/rules/windows/process_creation/proc_creation_win_shadow_copies_deletion.yml
@@ -4,7 +4,7 @@ status: stable
 description: Shadow Copies deletion using operating systems utilities
 author: Florian Roth, Michael Haag, Teymur Kheirkhabarov, Daniil Yugoslavskiy, oscd.community, Andreas Hunkeler (@Karneades)
 date: 2019/10/22
-modified: 2021/10/24
+modified: 2022/05/16
 references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
     - https://blog.talosintelligence.com/2017/05/wannacry.html
@@ -23,28 +23,38 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection1:
-        Image|endswith:
+    selection1_img:
+        - Image|endswith:
             - '\powershell.exe'
             - '\wmic.exe'
             - '\vssadmin.exe'
             - '\diskshadow.exe'
+        - OriginalFileName:
+            - 'PowerShell.EXE'
+            - 'wmic.exe'
+            - 'VSSADMIN.EXE'
+            - 'diskshadow.exe'
+    selection1_cli:
         CommandLine|contains|all:
             - shadow  # will match "delete shadows" and "shadowcopy delete" and "shadowstorage"
             - delete
-    selection2:
-        Image|endswith: '\wbadmin.exe'
+    selection2_img:
+        - Image|endswith: '\wbadmin.exe'
+        - OriginalFileName: 'WBADMIN.EXE'
+    selection2_cli:
         CommandLine|contains|all:
             - delete
             - catalog
             - quiet # will match -quiet or /quiet
-    selection3:
+    selection3_img:
         Image|endswith: '\vssadmin.exe'
+        OriginalFileName: 'VSSADMIN.EXE'
+    selection3_cli:
         CommandLine|contains|all:
             - resize
             - shadowstorage
             - unbounded
-    condition: 1 of selection*
+    condition: (all of selection1*) or (all of selection2*) or (all of selection3*)
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/process_creation/proc_creation_win_susp_findstr.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_findstr.yml
@@ -8,13 +8,15 @@ references:
   - https://oddvar.moe/2018/04/11/putting-data-in-alternate-data-streams-and-how-to-execute-it-part-2/
   - https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 date: 2020/10/05
-modified: 2021/11/27
+modified: 2022/05/16
 logsource:
   category: process_creation
   product: windows
 detection:
   selectionFindstr:
-    CommandLine|contains: findstr
+    - CommandLine|contains: findstr
+    - Image|endswith: 'findstr.exe'
+    - OriginalFileName: 'FINDSTR.EXE'
   selection_V_L:
     CommandLine|contains|all:
       - /V

--- a/rules/windows/process_creation/proc_creation_win_uac_cmstp.yml
+++ b/rules/windows/process_creation/proc_creation_win_uac_cmstp.yml
@@ -1,13 +1,14 @@
 title: Bypass UAC via CMSTP
 id: e66779cc-383e-4224-a3a4-267eeb585c40
 status: test
-description: Detect child processes of automatically elevated instances of Microsoft Connection Manager Profile Installer (cmstp.exe).
+description: Detect commandline usage of Microsoft Connection Manager Profile Installer (cmstp.exe) to install specially formatted local .INF files
 author: E.M. Anhaus (originally from Atomic Blue Detections, Endgame), oscd.community
 references:
   - https://eqllib.readthedocs.io/en/latest/analytics/e584f1a1-c303-4885-8a66-21360c90995b.html
   - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1191/T1191.md
+  - https://lolbas-project.github.io/lolbas/Binaries/Cmstp/
 date: 2019/10/24
-modified: 2022/05/13
+modified: 2022/05/16
 logsource:
   category: process_creation
   product: windows
@@ -19,6 +20,7 @@ detection:
     CommandLine|contains:
       - '/s'
       - '/au'
+      - '/ni'
   condition: all of selection*
 fields:
   - ComputerName


### PR DESCRIPTION
- Added 5 more PowerShell scripts for the rule "file_event_win_powershell_exploit_scripts.yml"
- Created a new rule for "certoc" lolbin to cover the "Download" option as described in the LOLBAS project
- Created a specific rule for the "IEExec" lolbin to cover the "Download" option as described in the LOLBAS Project
- Updated some rules to use "OriginalFileName" in addition to the "Image" selection
- Updated some rules to increase coverage.