### PR TITLE
Quick Updates and Fixes

### DIFF
--- a/rules/windows/file_event/file_event_win_powershell_exploit_scripts.yml
+++ b/rules/windows/file_event/file_event_win_powershell_exploit_scripts.yml
@@ -7,6 +7,7 @@ references:
   - https://raw.githubusercontent.com/Neo23x0/sigma/f35c50049fa896dff91ff545cb199319172701e8/rules/windows/powershell/powershell_malicious_commandlets.yml
   - https://github.com/PowerShellMafia/PowerSploit
   - https://github.com/NetSPI/PowerUpSQL
+  - https://github.com/CsEnox/EventViewer-UACBypass
 date: 2018/04/07
 modified: 2022/05/13
 logsource:
@@ -115,6 +116,7 @@ detection:
       - '\Find-AVSignature.ps1'
       - '\Get-GPPAutologon.ps1'
       - '\Get-MicrophoneAudio.ps1'
+      - '\Invoke-EventViewer.ps1'
   condition: selection
 falsepositives:
   - Unknown

--- a/rules/windows/process_creation/proc_creation_win_susp_taskkill.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_taskkill.yml
@@ -12,12 +12,12 @@ logsource:
     product: windows
 detection:
     selection_img:
-        - Image|endswith: \taskkill.exe
+        - Image|endswith: '\taskkill.exe'
         - OriginalFileName: 'taskkill.exe'
     selection_cli:
         CommandLine|contains|all:
-            - /f
-            - /im
+            - ' /f'
+            - ' /im '
     condition: all of selection*
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_susp_taskkill.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_taskkill.yml
@@ -6,16 +6,19 @@ author: frack113
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1489/T1489.md#atomic-test-3---windows---stop-service-by-killing-process
 date: 2021/12/26
+modified: 2022/05/17
 logsource:
     category: process_creation
     product: windows
 detection:
-    taskkill:
-        Image|endswith: \taskkill.exe
-        CommandLine|contains|all: 
-            - /f 
+    selection_img:
+        - Image|endswith: \taskkill.exe
+        - OriginalFileName: 'taskkill.exe'
+    selection_cli:
+        CommandLine|contains|all:
+            - /f
             - /im
-    condition: taskkill
+    condition: all of selection*
 falsepositives:
     - Unknown
 level: low

--- a/rules/windows/process_creation/proc_creation_win_winword_lolbin.yml
+++ b/rules/windows/process_creation/proc_creation_win_winword_lolbin.yml
@@ -1,0 +1,28 @@
+title: Winword LOLBIN Usage
+id: 4ae3e30b-b03f-43aa-87e3-b622f4048eed
+status: experimental
+description: Winword can be abused as a LOLBIN to download arbitary file or load arbitary DLLs
+author: Nasreddine Bencherchali
+references:
+    - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Winword/
+    - https://github.com/D4Vinci/One-Lin3r/blob/master/one_lin3r/core/liners/windows/cmd/dll_loader_word.py
+date: 2022/05/17
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\WINWORD.exe'
+        - OriginalFileName: 'WinWord.exe'
+    selection_cli_http:
+        CommandLine|contains:
+            - 'http://'
+            - 'https://'
+    selection_cli_dll:
+        CommandLine|contains:
+            - '/l '
+            - '.dll'
+    condition: selection_img and 1 of selection_cli*
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
This has the following addition/updates:

- Added "Invoke-EventViewer.ps1" script to the rule "file_event_win_powershell_exploit_scripts"
- Added "OriginalFileName" to "proc_creation_win_susp_taskkill"
- Created rule for "winword" being used as a LOLBIN to download and load arbitrary DLLs