### PR TITLE
Create proc_creation_win_rundll32_parent_explorer.yml

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
+++ b/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
@@ -12,6 +12,8 @@ detection:
     selection:
         Image|endswith: '\rundll32.exe'
         ParentImage|endswith: '\explorer.exe'
+    filter:
+         CommandLine|contains: '\shell32.dll,OpenAs_RunDLL'
     condition: selection
 fields:
     - Image

--- a/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
+++ b/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
@@ -1,0 +1,23 @@
+title: Rundll32 With Suspicious Parent Process
+description: Detects suspicious start of rundll32.exe with a parent process of Explorer.exe. Variant of Raspberry Robin, as first reported by Red Canary.
+status: experimental
+references:
+    - https://redcanary.com/blog/raspberry-robin/
+author: CD_ROM_
+date: 2022/05/21
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\rundll32.exe'
+        ParentImage|endswith: '\explorer.exe'
+    condition: selection
+fields:
+    - Image
+    - ParentImage
+falsepositives:
+    - Unknown
+level: medium
+tags:
+    - attack.defense_evasion 

--- a/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
+++ b/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
@@ -14,7 +14,7 @@ detection:
         ParentImage|endswith: '\explorer.exe'
     filter:
          CommandLine|contains: '\shell32.dll,OpenAs_RunDLL'
-    condition: selection
+    condition: selection and not filter
 fields:
     - Image
     - ParentImage

--- a/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
+++ b/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
@@ -1,4 +1,5 @@
 title: Rundll32 With Suspicious Parent Process
+id: 1723e720-616d-4ddc-ab02-f7e3685a4713
 description: Detects suspicious start of rundll32.exe with a parent process of Explorer.exe. Variant of Raspberry Robin, as first reported by Red Canary.
 status: experimental
 references:


### PR DESCRIPTION
Rule to detect Rundll32.exe with a parent process of explorer.exe. Identified as a variant of Raspberry Robin activity, originally reported by Red Canary: https://redcanary.com/blog/raspberry-robin/