### PR TITLE
Feat. adds helper script to run sigmac against only those rules that …

### DIFF
--- a/contrib/sigmac-convert-updates.sh
+++ b/contrib/sigmac-convert-updates.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright 2022 Tim Shelton
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+if [ $# -ne 3 ]; then
+    echo "Usage: $0 <target> <target config> <output file>"
+    echo "Ex: $0 hawk ./tools/config/hawk.yml output.txt"
+    exit 1
+fi
+
+FILEDIFF=$(git fetch && git diff --name-only ..origin | egrep "rules/" )
+cd ..
+echo "Updating ${FILEDIFF}"
+git pull origin master
+python3 ./tools/sigmac --target $1 -c $2 ${FILEDIFF} > $3
+E=$(pwd)
+cd -
+
+echo "Output file can be found in $E"


### PR DESCRIPTION
…changed

Example usage:

```
[tjs@dev-03 contrib]$ git status
On branch master
Your branch is behind 'origin/master' by 8 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
```
```
[tjs@dev-03 contrib]$ ./sigmac-convert-updates.sh hawk ./tools/config/hawk.yml output.txt
Updating rules/windows/file_event/file_event_win_powershell_exploit_scripts.yml
rules/windows/powershell/powershell_script/posh_ps_malicious_commandlets.yml
rules/windows/process_creation/proc_creation_win_lolbas_cl_loadassembly.yml
rules/windows/process_creation/proc_creation_win_lolbas_cl_mutexverifiers.yml
rules/windows/process_creation/proc_creation_win_system_exe_anomaly.yml
From https://github.com/redsand/sigma
 * branch                master     -> FETCH_HEAD
Updating c7b90f108..b80eb411a
Fast-forward
 rules/windows/file_event/file_event_win_powershell_exploit_scripts.yml        | 89 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--
 rules/windows/powershell/powershell_script/posh_ps_malicious_commandlets.yml  | 79 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--
 rules/windows/process_creation/proc_creation_win_lolbas_cl_loadassembly.yml   | 24 ++++++++++++++++++++++++
 rules/windows/process_creation/proc_creation_win_lolbas_cl_mutexverifiers.yml | 23 +++++++++++++++++++++++
 rules/windows/process_creation/proc_creation_win_system_exe_anomaly.yml       |  5 +----
 5 files changed, 212 insertions(+), 8 deletions(-)
 create mode 100644 rules/windows/process_creation/proc_creation_win_lolbas_cl_loadassembly.yml
 create mode 100644 rules/windows/process_creation/proc_creation_win_lolbas_cl_mutexverifiers.yml
/home/tjs/dev/sigma/contrib
Output file can be found in /home/tjs/dev/sigma
```