### PR TITLE
Support alternate case for OriginalFileName.

### DIFF
--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -126,6 +126,7 @@ _allFieldMappings = {
                 "ParentCommandLine": "event/PARENT/COMMAND_LINE",
                 "User": "event/USER_NAME",
                 "OriginalFileName": "event/ORIGINAL_FILE_NAME",
+                "OriginalFilename": "event/ORIGINAL_FILE_NAME",
                 # Custom field names coming from somewhere unknown.
                 "NewProcessName": "event/FILE_PATH",
                 "ProcessCommandLine": "event/COMMAND_LINE",
@@ -237,6 +238,7 @@ _allFieldMappings = {
                 "ParentCommandLine": "event/PARENT/COMMAND_LINE",
                 "User": "event/USER_NAME",
                 "OriginalFileName": "event/ORIGINAL_FILE_NAME",
+                "OriginalFilename": "event/ORIGINAL_FILE_NAME",
                 # Custom field names coming from somewhere unknown.
                 "NewProcessName": "event/FILE_PATH",
                 "ProcessCommandLine": "event/COMMAND_LINE",


### PR DESCRIPTION
In LimaCharlie backend, support the alternate case for `OriginalFileName` since it's used with a lower case `Name` in various rules.