### PR TITLE
Update proc_creation_win_msdt.yml

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_msdt.yml
+++ b/rules/windows/process_creation/proc_creation_win_msdt.yml
@@ -7,6 +7,7 @@ references:
   - https://twitter.com/nao_sec/status/1530196847679401984
   - https://app.any.run/tasks/713f05d2-fe78-4b9d-a744-f7c133e3fafb/
 date: 2022/05/29
+modified: 2022/05/31
 logsource:
   category: process_creation
   product: windows
@@ -15,11 +16,8 @@ detection:
     ParentImage|endswith: '\WINWORD.exe'
     Image|endswith: '\msdt.exe'
   selection_cmd:
-    Image|endswith: '\msdt.exe'
-    CommandLine|contains|all:
-      - 'ms-msdt:/id'
-      - 'IT_BrowseForFile='
-      - 'IT_RebrowseForFile='
+    OriginalFileName: 'msdt.exe'
+    CommandLine|contains: 'IT_BrowseForFile='
   condition: 1 of selection*
 falsepositives:
   - Unknown


### PR DESCRIPTION
Quick update to take into consideration some new internal findings. Basically, you can execute the "follina" issue in one of the following forms.
- Using only the "IT_BrowseForFile"
`msdt ms-msdt:/id PCWDiagnostic /skip force /param "IT_LaunchMethod=ContextMenu IT_BrowseForFile=/../../$(calc).exe"`
- Or injecting the payload in the "IT_RebrowseForFile" but the "IT_BrowseForFile" must be there.
`msdt ms-msdt:/id PCWDiagnostic /skip force /param "IT_LaunchMethod=ContextMenu IT_RebrowseForFile=/../../$(calc).exe IT_BrowseForFile=?"`

During testing, we found that "IT_BrowseForFile" must be present for the payload to work hence the change. (If further research proves against this. We will change this rule).