### PR TITLE
Update proc_creation_win_susp_conhost_option.yml - Remove Empty Reference Line

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_conhost_option.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_conhost_option.yml
@@ -5,7 +5,6 @@ description: ForceV1 asks for information directly from the kernel space. Conhos
 references:
     - https://cybercryptosec.medium.com/covid-19-cyber-infection-c615ead7c29
     - https://thedfirreport.com/2022/04/04/stolen-images-campaign-ends-in-conti-ransomware/
-    - 
 author: frack113
 date: 2022/04/04
 logsource:


### PR DESCRIPTION
When converting the rule using Sigmac to an Elastic Security compatible rule, the empty line under the References section results in the Sigmac output for the rule having a `null` value as the last reference.

The command used to convert the rule is:
`tools/sigmac -t es-rule -c tools/config/generic/sysmon.yml -c tools/config/winlogbeat-modules-enabled.yml -r rules/windows/ --backend-option keyword_field=""`

The `references` portion of the output from the above command for that rule is:
`"references": ["https://cybercryptosec.medium.com/covid-19-cyber-infection-c615ead7c29", "https://thedfirreport.com/2022/04/04/stolen-images-campaign-ends-in-conti-ransomware/", null]}`

If the converted rule is uploaded to Elastic Security, the `Failed to import 1 rule` error is seen; The error message is `Invalid value "null" supplied to "references"`