### PR TITLE
Atlassian Confluence CVE 2022 26134

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
@@ -24,7 +24,16 @@ detection:
         ParentImage|startswith: '/opt/atlassian/confluence/'
         ParentImage|endswith: '/java'
         CommandLine|contains:
-            - '/bin/bash'
+            - '/bin/sh'
+            - 'bash'
+            - 'dash'
+            - 'ksh'
+            - 'zsh'
+            - 'csh'
+            - 'fish'
+            - 'curl'
+            - 'wget'
+            - 'python'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
@@ -20,7 +20,7 @@ logsource:
 detection:
     selection:
         # Monitor suspicious child processes spawned by Confluence
-        ParentImage|endswith: '/opt/atlassian\confluence\jre\bin\java.exe'
+        ParentImage|endswith: '/opt/atlassian/confluence/jre/bin/java.exe'
         CommandLine|contains: '/bin/bash'
     condition: selection
 falsepositives:

--- a/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
@@ -1,0 +1,29 @@
+title: Atlassian Confluence CVE-2022-26134
+id: 7fb14105-530e-4e2e-8cfb-99f7d8700b66
+status: experimental
+description: Detects spawning of suspicious child processes by Atlassian Confluence server which may indicate successful exploitation of CVE-2022-26134
+author: Nasreddine Bencherchali
+date: 2022/06/03
+related:
+    - id: 245f92e3-c4da-45f1-9070-bc552e06db11
+      type: derived
+references:
+    - https://www.volexity.com/blog/2022/06/02/zero-day-exploitation-of-atlassian-confluence/
+tags:
+    - attack.initial_access
+    - attack.execution
+    - attack.t1190
+    - attack.t1059
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection:
+        # Monitor suspicious child processes spawned by Confluence
+        ParentImage|endswith: '/opt/atlassian\confluence\jre\bin\java.exe'
+        CommandLine|contains:
+            - '/bin/bash'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
@@ -21,8 +21,7 @@ detection:
     selection:
         # Monitor suspicious child processes spawned by Confluence
         ParentImage|endswith: '/opt/atlassian\confluence\jre\bin\java.exe'
-        CommandLine|contains:
-            - '/bin/bash'
+        CommandLine|contains: '/bin/bash'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
@@ -14,13 +14,14 @@ tags:
     - attack.execution
     - attack.t1190
     - attack.t1059
+    - cve.2022.26134
 logsource:
     category: process_creation
     product: linux
 detection:
     selection:
         # Monitor suspicious child processes spawned by Confluence
-        ParentImage|endswith: '/opt/atlassian/confluence/jre/bin/java.exe'
+        ParentImage|endswith: '/opt/atlassian/confluence/jre/bin/java'
         CommandLine|contains: '/bin/bash'
     condition: selection
 falsepositives:

--- a/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_atlassian_confluence_cve_2022_26134.yml
@@ -21,9 +21,11 @@ logsource:
 detection:
     selection:
         # Monitor suspicious child processes spawned by Confluence
-        ParentImage|endswith: '/opt/atlassian/confluence/jre/bin/java'
-        CommandLine|contains: '/bin/bash'
+        ParentImage|startswith: '/opt/atlassian/confluence/'
+        ParentImage|endswith: '/java'
+        CommandLine|contains:
+            - '/bin/bash'
     condition: selection
 falsepositives:
     - Unknown
-level: high
+level: critical

--- a/rules/linux/process_creation/proc_creation_lnx_susp_java_children.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_susp_java_children.yml
@@ -1,0 +1,32 @@
+title: Suspicious Java Children Processes
+id: d292e0af-9a18-420c-9525-ec0ac3936892
+status: experimental
+description: Detects java process spawning suspicious children
+author: Nasreddine Bencherchali
+date: 2022/06/03
+references:
+    - https://www.tecmint.com/different-types-of-linux-shells/
+tags:
+    - attack.execution
+    - attack.t1059
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection:
+        ParentImage|endswith: '/java'
+        CommandLine|contains:
+            - '/bin/sh'
+            - 'bash'
+            - 'dash'
+            - 'ksh'
+            - 'zsh'
+            - 'csh'
+            - 'fish'
+            - 'curl'
+            - 'wget'
+            - 'python'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
- Rule to detect "Confluence" java process spawning "/bin/bash" CLI (Maybe related to CVE 2022 26134).
- I actually don't know if this is normal or not. This is directly based on the screenshot provided by Veloxity and their analysis of  CVE 2022 26134 (https://www.volexity.com/wp-content/uploads/2022/06/Figure1.png)
- Full Blog: https://www.volexity.com/blog/2022/06/02/zero-day-exploitation-of-atlassian-confluence/
- Will definitely add to it as things get revealed.