### PR TITLE
fix(rule): lnx_dd_file_overwrite /bin symlinks

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_dd_file_overwrite.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_dd_file_overwrite.yml
@@ -14,7 +14,9 @@ logsource:
    category: process_creation
 detection:
    selection1:
-      Image: '/bin/dd'
+      Image:
+         - '/bin/dd'
+         - '/usr/bin/dd'
    selection2:   
       CommandLine|contains: 'of='
    selection3:


### PR DESCRIPTION
This rule is subject to false negatives for *nix distros which symlink /bin to /usr/bin.
By including both /bin and /usr/bin we can handle both flavors

<img width="597" alt="Screen Shot 2022-06-06 at 9 23 32 AM" src="https://user-images.githubusercontent.com/7862144/172181335-8354582e-49d3-4108-9120-1ae9c6972fce.png">
