### PR TITLE
Update selection_source for AWS ec2 startup script rule

### DIFF
--- a/rules/cloud/aws/aws_ec2_startup_script_change.yml
+++ b/rules/cloud/aws/aws_ec2_startup_script_change.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects changes to the EC2 instance startup script. The shell script will be executed as root/SYSTEM every time the specific instances are booted up.
 author: faloker
 date: 2020/02/12
-modified: 2021/08/09
+modified: 2022/06/07
 references:
     - https://github.com/RhinoSecurityLabs/pacu/blob/master/modules/ec2__startup_shell_script/main.py#L9
 logsource:
@@ -13,7 +13,7 @@ logsource:
 detection:
     selection_source:
         eventSource: ec2.amazonaws.com
-        requestParameters.userData: '*'
+        requestParameters.attribute: 'userData'
         eventName: ModifyInstanceAttribute
     condition: selection_source
 falsepositives:


### PR DESCRIPTION
The JSON payload for `ModifyInstanceAttribute` event currently looks like:
```
"requestParameters": {
  "attribute": "userData",
  ...
},
```

Updating the selection_source from `requestParameters.userData: "*"` to `requestParameters.attribute: "userData"` accordingly.

Signed-off-by: Rachel Rice <rachel.rice@lacework.net>