### PR TITLE
Submit a rule for ECS Backdoor Task Definition

### DIFF
--- a/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
+++ b/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
@@ -1,0 +1,27 @@
+title: AWS ECS Backdoor Task Definition
+id: b94bf91e-c2bf-4047-9c43-c6810f43baad
+status: experimental
+description: Detects when an Elastic Container Service (ECS) Task Definition has been modified and run. This can indicate an adversary adding a backdoor to establish persistence or escalate privileges. This rule is based on examining events created upon execution of Rhino Security Lab's Pacu in a lab environment.
+author: Darin Smith
+date: 2022/06/07
+references:
+    - https://github.com/RhinoSecurityLabs/pacu/blob/master/pacu/modules/ecs__backdoor_task_def/main.py
+    - https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RegisterTaskDefinition.html
+    - https://attack.mitre.org/techniques/T1525
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: ecs.amazonaws.com
+        eventName:
+            - DescribeTaskDefinition
+            - RegisterTaskDefinition
+            - RunTask
+    condition: selection
+level: medium
+tags:
+    - attack.persistence
+    - attack.t1525
+falsepositives:
+ - Task Definition being modified for valid reasons

--- a/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
+++ b/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
@@ -19,9 +19,9 @@ detection:
             - RegisterTaskDefinition
             - RunTask
     filter:
-      - requestParameters.containerDefinitions.command|contains|all:
-          - '169.254'
-          - '$AWS_CONTAINER_CREDENTIALS'
+      requestParameters.containerDefinitions.command|contains|all:
+        - '169.254'
+        - '$AWS_CONTAINER_CREDENTIALS'
     condition: selection_source and filter
 level: medium
 tags:

--- a/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
+++ b/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
@@ -12,13 +12,15 @@ logsource:
     product: aws
     service: cloudtrail
 detection:
-    selection:
+    selection_source:
         eventSource: ecs.amazonaws.com
         eventName:
             - DescribeTaskDefinition
             - RegisterTaskDefinition
             - RunTask
-    condition: selection
+        filter:
+          requestParameters.containerDefinitions.command|contains: '169.254.170.2$AWS_CONTAINER_CREDENTIALS'
+    condition: selection_source
 level: medium
 tags:
     - attack.persistence

--- a/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
+++ b/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
@@ -12,17 +12,16 @@ logsource:
     product: aws
     service: cloudtrail
 detection:
-    selection_source:
+    selection:
         eventSource: ecs.amazonaws.com
         eventName:
             - DescribeTaskDefinition
             - RegisterTaskDefinition
             - RunTask
-    filter:
-      requestParameters.containerDefinitions.command|contains|all:
-        - '169.254'
-        - '$AWS_CONTAINER_CREDENTIALS'
-    condition: selection_source and filter
+        requestParameters.containerDefinitions.command|contains|all:
+            - '169.254'
+            - '$AWS_CONTAINER_CREDENTIALS'
+    condition: selection
 level: medium
 tags:
     - attack.persistence

--- a/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
+++ b/rules/cloud/aws/aws_ecs_task_definition_backdoor.yml
@@ -18,12 +18,14 @@ detection:
             - DescribeTaskDefinition
             - RegisterTaskDefinition
             - RunTask
-        filter:
-          requestParameters.containerDefinitions.command|contains: '169.254.170.2$AWS_CONTAINER_CREDENTIALS'
-    condition: selection_source
+    filter:
+      - requestParameters.containerDefinitions.command|contains|all:
+          - '169.254'
+          - '$AWS_CONTAINER_CREDENTIALS'
+    condition: selection_source and filter
 level: medium
 tags:
     - attack.persistence
     - attack.t1525
 falsepositives:
- - Task Definition being modified for valid reasons
+ - Task Definition being modified to request credentials from the Task Metadata Service for valid reasons


### PR DESCRIPTION
This is a rule to detect the behavior performed by Rhino Security Labs Pacu's module ecs__backdoor_task_def. 