### PR TITLE
Updating azure federation modified rule

### DIFF
--- a/rules/cloud/azure/azure_federation_modified.yml
+++ b/rules/cloud/azure/azure_federation_modified.yml
@@ -4,6 +4,7 @@ description: Identifies when an user or application modified the federation sett
 author: Austin Songer
 status: experimental
 date: 2021/09/06
+modified: 2022/06/08
 references:
     - https://attack.mitre.org/techniques/T1078
     - https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-monitor-federation-changes

--- a/rules/cloud/azure/azure_federation_modified.yml
+++ b/rules/cloud/azure/azure_federation_modified.yml
@@ -6,12 +6,13 @@ status: experimental
 date: 2021/09/06
 references:
     - https://attack.mitre.org/techniques/T1078
+    - https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-monitor-federation-changes
 logsource:
   product: azure
-  service: signinlogs
+  service: auditlogs
 detection:
     selection:
-        properties.message: Set federation settings on domain
+        ActivityDisplayName: Set federation settings on domain
     condition: selection
 level: medium
 tags:


### PR DESCRIPTION
* Set logsource service to auditlogs instead of signinlogs
* Add reference to Microsoft documentation
* Set field name in selection to ActivityDisplayName instead of properties.message

The below query was confirmed on my company's environment.

https://docs.microsoft.com/en-us/azure/active-directory/hybrid/how-to-connect-monitor-federation-changes
```
AuditLogs 
 |  extend TargetResource = parse_json(TargetResources) 
 | where ActivityDisplayName contains "Set federation settings on domain" or ActivityDisplayName contains "Set domain authentication" 
 | project TimeGenerated, SourceSystem, TargetResource[0].displayName, AADTenantId, OperationName, InitiatedBy, Result, ActivityDisplayName, ActivityDateTime, Type
```