### PR TITLE
Update proc_creation_win_susp_recon_activity.yml

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_recon_activity.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_recon_activity.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects suspicious command line activity on Windows systems
 author: Florian Roth, omkar72, @svch0st
 date: 2019/01/16
-modified: 2021/08/09
+modified: 2022/06/09
 references:
     - https://redcanary.com/blog/how-one-hospital-thwarted-a-ryuk-ransomware-outbreak/
     - https://thedfirreport.com/2020/10/18/ryuk-in-5-hours/

--- a/rules/windows/process_creation/proc_creation_win_susp_recon_activity.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_recon_activity.yml
@@ -18,9 +18,9 @@ logsource:
 detection:
     selection:
         CommandLine|contains:
-            - net group "domain admins" /do
+            - net group "domain admins"
             - net localgroup administrators
-            - net group "enterprise admins" /do
+            - net group "enterprise admins"
             - net accounts /do
     condition: selection
 fields:

--- a/rules/windows/process_creation/proc_creation_win_susp_recon_activity.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_recon_activity.yml
@@ -2,7 +2,7 @@ title: Suspicious Reconnaissance Activity
 id: d95de845-b83c-4a9a-8a6a-4fc802ebf6c0
 status: experimental
 description: Detects suspicious command line activity on Windows systems
-author: Florian Roth, omkar72
+author: Florian Roth, omkar72, @svch0st
 date: 2019/01/16
 modified: 2021/08/09
 references:
@@ -17,11 +17,11 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine:
-            - net group "domain admins" /dom
+        CommandLine|contains:
+            - net group "domain admins" /do
             - net localgroup administrators
-            - net group "enterprise admins" /dom
-            - net accounts /dom
+            - net group "enterprise admins" /do
+            - net accounts /do
     condition: selection
 fields:
     - CommandLine


### PR DESCRIPTION
Using "/do" is still a valid argument . looking for /dom will exclude this. 

Other option is to remove the "/do" argument and just look for cmdline contains:
- net group "domain admins"

https://twitter.com/TheDFIRReport/status/1534227586225684481