### PR TITLE
Update Cmdkey

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_local_system_owner_account_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_local_system_owner_account_discovery.yml
@@ -24,7 +24,7 @@ detection:
       CommandLine|contains: ' /l'
     - Image|endswith: '\cmd.exe'
       CommandLine|contains|all:
-        - '/c'
+        - ' /c'
         - 'dir '
         - '\Users\'
   filter_1:

--- a/rules/windows/process_creation/proc_creation_win_local_system_owner_account_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_local_system_owner_account_discovery.yml
@@ -21,7 +21,7 @@ detection:
         - '\quser.exe'
         - '\qwinsta.exe'
     - Image|endswith: '\cmdkey.exe'
-      CommandLine|contains: '/l'
+      CommandLine|contains: ' /l'
     - Image|endswith: '\cmd.exe'
       CommandLine|contains|all:
         - '/c'

--- a/rules/windows/process_creation/proc_creation_win_local_system_owner_account_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_local_system_owner_account_discovery.yml
@@ -6,7 +6,7 @@ author: Timur Zinniatullin, Daniil Yugoslavskiy, oscd.community
 references:
   - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1033/T1033.md
 date: 2019/10/21
-modified: 2021/11/27
+modified: 2022/06/12
 logsource:
   category: process_creation
   product: windows
@@ -21,7 +21,7 @@ detection:
         - '\quser.exe'
         - '\qwinsta.exe'
     - Image|endswith: '\cmdkey.exe'
-      CommandLine|contains: '/list'
+      CommandLine|contains: '/l'
     - Image|endswith: '\cmd.exe'
       CommandLine|contains|all:
         - '/c'

--- a/rules/windows/process_creation/proc_creation_win_mstsc.yml
+++ b/rules/windows/process_creation/proc_creation_win_mstsc.yml
@@ -7,6 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1021.001/T1021.001.md#t1021001---remote-desktop-protocol
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/mstsc
 date: 2022/01/07
+modified: 2022/06/12
 logsource:
     category: process_creation
     product: windows
@@ -21,9 +22,9 @@ detection:
         - OriginalFileName: 'cmdkey.exe'
     selection_cmdkey_cli:
         CommandLine|contains|all:
-            - '/generic:'
-            - '/user:'
-            - '/pass:'
+            - '/g'
+            - '/u'
+            - '/p'
     condition: all of selection_mstsc* or all of selection_cmdkey*
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_mstsc.yml
+++ b/rules/windows/process_creation/proc_creation_win_mstsc.yml
@@ -22,9 +22,9 @@ detection:
         - OriginalFileName: 'cmdkey.exe'
     selection_cmdkey_cli:
         CommandLine|contains|all:
-            - '/g'
-            - '/u'
-            - '/p'
+            - ' /g'
+            - ' /u'
+            - ' /p'
     condition: all of selection_mstsc* or all of selection_cmdkey*
 falsepositives:
     - Unknown


### PR DESCRIPTION
Cmdkey option can be shorted to only 1 caracter

![image](https://user-images.githubusercontent.com/62423083/173240715-e6b61c47-b723-4a50-ac01-18d007c49fc4.png)

But `cmdkey /a:server03 /usersssssssss:mikedan /p:Kleo` works too 😟 

cc: @nasbench