### PR TITLE
ProviderName seems to be wrong

### DIFF
--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -216,6 +216,7 @@ fieldmappings:
     NewEngineState: winlog.event_data.NewEngineState
     PreviousEngineState: winlog.event_data.PreviousEngineState
     NewProviderState: winlog.event_data.NewProviderState
+    ProviderName: winlog.event_data.ProviderName
     Provider_Name: winlog.provider_name
     HostId: winlog.event_data.HostId
     HostApplication: winlog.event_data.HostApplication

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -216,7 +216,7 @@ fieldmappings:
     NewEngineState: winlog.event_data.NewEngineState
     PreviousEngineState: winlog.event_data.PreviousEngineState
     NewProviderState: winlog.event_data.NewProviderState
-    ProviderName: winlog.provider_name
+    Provider_Name: winlog.provider_name
     HostId: winlog.event_data.HostId
     HostApplication: winlog.event_data.HostApplication
     HostName: winlog.event_data.HostName

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -216,7 +216,7 @@ fieldmappings:
     NewEngineState: winlog.event_data.NewEngineState
     PreviousEngineState: winlog.event_data.PreviousEngineState
     NewProviderState: winlog.event_data.NewProviderState
-    ProviderName: winlog.event_data.ProviderName
+    ProviderName: winlog.provider_name
     HostId: winlog.event_data.HostId
     HostApplication: winlog.event_data.HostApplication
     HostName: winlog.event_data.HostName


### PR DESCRIPTION
`ProviderName: winlog.event_data.ProviderName` seems to be wrong (at least in our case). Actually, the mapping from the `winlogbeat-modules-enabled.yml` would be correct (which I have applied in this pull request), but we definitely don't use the modules (the other mappings don't apply). Maybe the two got mixed up? Can't verify it for the winlogbeat-modules case, but at least the `winlogbeat.yml` does seem to have this mapping wrong.

Also: The mapping identifier `ProviderName` doesn't occur in any windows rule (except one: `powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml`).

Instead, the identifier `Provider_Name` is used. 