### PR TITLE
Add rule: msdt with an smb answer file

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_msdt_smb_path.yml
+++ b/rules/windows/process_creation/proc_creation_win_msdt_smb_path.yml
@@ -1,0 +1,27 @@
+title: MSDT.EXE With SMB Answers File
+id: c577e607-8f6f-4e33-8767-a8f263b326a1
+status: experimental
+description: Detects when "msdt.exe" is executed with an answers file from an SMB share
+references:
+  - https://twitter.com/nao_sec/status/1530196847679401984
+  - https://app.any.run/tasks/713f05d2-fe78-4b9d-a744-f7c133e3fafb/
+  - https://twitter.com/ImpetuousDanny/status/1531650953082023936
+date: 2022/06/09
+author: Matt Ehrnschwender
+logsource:
+  category: process_creation
+  product: windows
+detection:
+  image:
+    - Image|endswith: '\msdt.exe'
+    - OriginalFileName: 'msdt.exe'
+  af_with_smb:
+    CommandLine|contains:
+      - '/af \\\\'
+      - '-af \\\\'
+  condition: image and af_with_smb
+falsepositives:
+  - Unknown
+level: high
+tags:
+  - attack.defense_evasion


### PR DESCRIPTION
CVE 2022-30190 (Follina) allows msdt.exe to execute code with a malicious "IT_BrowseForFile" command line argument. This command line argument can be put in an `answer.xml` file allowing the exploit to be triggered by referencing that xml file through the `/af` or `-af` command line argument. It is common for windows to invoke msdt.exe with the `/af` or `-af` argument through normal troubleshooting; however, it is uncommon for msdt.exe to reference an `answer.xml` file from an SMB share.

This rule will flag if CVE 2022-30190 is triggered through a remote answer.xml file from an SMB share.

https://www.binarydefense.com/detecting-follina-exploits-using-a-remote-answer-file/