### PR TITLE
using deepcopy to clone previous rule

### DIFF
--- a/tools/sigma/parser/collection.py
+++ b/tools/sigma/parser/collection.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import copy
 import yaml
 from .exceptions import SigmaCollectionParseError
 from .rule import SigmaParser
@@ -61,7 +62,7 @@ class SigmaCollectionParser:
             elif action == "repeat":
                 if prevrule is None:
                     raise SigmaCollectionParseError("action 'repeat' is only applicable after first valid Sigma rule")
-                newrule = prevrule.copy()
+                newrule = copy.deepcopy(prevrule)
                 deep_update_dict(newrule, yamldoc)
                 if rulefilter is None or rulefilter is not None and not rulefilter.match(newrule):
                     self.parsers.append(SigmaParser(newrule, config))


### PR DESCRIPTION
SigmaCollectionParser should use deep copy to clone previous rule, otherwise the previously generated Sigma file would be affected.

```
$ ./tools/merge_sigma ./tests/collection_repeat.yml 
description: Test all features of Sigma collections
detection:
  condition: selection
  selection:
    CommandLine: cmd.exe
    EventID: 4688         <=== affected by 2nd Sigma
logsource:
  product: windows
  service: security       <=== affected by 2nd Sigma
title: Sigma Collection Test
---
description: Test all features of Sigma collections
detection:
  condition: selection
  selection:
    CommandLine: cmd.exe
    EventID: 4688
logsource:
  product: windows
  service: security
title: Sigma Collection Test
```

With deepcopy():
```
$ ./tools/merge_sigma ./tests/collection_repeat.yml 
description: Test all features of Sigma collections
detection:
  condition: selection
  selection:
    CommandLine: cmd.exe
    EventID: 1
logsource:
  product: windows
  service: sysmon
title: Sigma Collection Test
---
description: Test all features of Sigma collections
detection:
  condition: selection
  selection:
    CommandLine: cmd.exe
    EventID: 4688
logsource:
  product: windows
  service: security
title: Sigma Collection Test
```