### PR TITLE
Rule: Follina and DogWalk exploit msdt.exe loading sdiageng.dll

### DIFF
--- a/rules/windows/image_load/image_load_msdt_sdiageng.yml
+++ b/rules/windows/image_load/image_load_msdt_sdiageng.yml
@@ -1,0 +1,28 @@
+title: MSDT.exe loading Diagnostic Library
+id: ec8c4047-fad9-416a-8c81-0f479353d7f6
+status: experimental
+description: Detects both of CVE-2022-30190 and DogWalk vulnerability exploiting "msdt.exe" binary to load "sdiageng.dll" library. 
+author: Greg (rule)
+references:
+  - https://twitter.com/j00sean/status/1534115332830507008
+  - https://twitter.com/nas_bench/status/1531944240271568896?t=z0hjfsgRgNb9c4NCLk-bHg&s=19
+  - https://www.securonix.com/blog/detecting-microsoft-msdt-dogwalk/
+date: 2022/06/09
+modified: 2022/06/27
+logsource:
+  category: image_load
+  product: windows
+detection:
+  selection_img:
+    Image|endswith: '\msdt.exe'
+  selection_load:
+    ImageLoaded|endswith: 'sdiageng.dll'
+  condition: all of selection*
+falsepositives:
+  - Unknown
+level: high
+tags:
+  - attack.defense_evasion
+  - attack.t1202
+  - cve.2022.30190
+

--- a/rules/windows/image_load/image_load_msdt_sdiageng.yml
+++ b/rules/windows/image_load/image_load_msdt_sdiageng.yml
@@ -1,12 +1,11 @@
 title: MSDT.exe Loading Diagnostic Library
 id: ec8c4047-fad9-416a-8c81-0f479353d7f6
 status: experimental
-description: Detects both of CVE-2022-30190 and DogWalk vulnerability exploiting "msdt.exe" binary to load "sdiageng.dll" binary. 
+description: Detects both of CVE-2022-30190 / Follina and DogWalk vulnerability exploiting msdt.exe binary to load sdiageng.dll binary 
 author: Greg (rule)
 references:
   - https://www.securonix.com/blog/detecting-microsoft-msdt-dogwalk/
-date: 2022/06/09
-modified: 2022/06/17
+date: 2022/06/17
 logsource:
   category: image_load
   product: windows
@@ -23,4 +22,3 @@ tags:
   - attack.defense_evasion
   - attack.t1202
   - cve.2022.30190
-

--- a/rules/windows/image_load/image_load_msdt_sdiageng.yml
+++ b/rules/windows/image_load/image_load_msdt_sdiageng.yml
@@ -1,14 +1,14 @@
 title: MSDT.exe loading Diagnostic Library
 id: ec8c4047-fad9-416a-8c81-0f479353d7f6
 status: experimental
-description: Detects both of CVE-2022-30190 and DogWalk vulnerability exploiting "msdt.exe" binary to load "sdiageng.dll" library. 
+description: Detects both of CVE-2022-30190 and DogWalk vulnerability exploiting "msdt.exe" binary to load "sdiageng.dll" binary. 
 author: Greg (rule)
 references:
   - https://twitter.com/j00sean/status/1534115332830507008
   - https://twitter.com/nas_bench/status/1531944240271568896?t=z0hjfsgRgNb9c4NCLk-bHg&s=19
   - https://www.securonix.com/blog/detecting-microsoft-msdt-dogwalk/
 date: 2022/06/09
-modified: 2022/06/27
+modified: 2022/06/17
 logsource:
   category: image_load
   product: windows

--- a/rules/windows/image_load/image_load_msdt_sdiageng.yml
+++ b/rules/windows/image_load/image_load_msdt_sdiageng.yml
@@ -13,7 +13,7 @@ detection:
   selection_img:
     Image|endswith: '\msdt.exe'
   selection_load:
-    ImageLoaded|endswith: 'sdiageng.dll'
+    ImageLoaded|endswith: '\sdiageng.dll'
   condition: all of selection*
 falsepositives:
   - Unknown

--- a/rules/windows/image_load/image_load_msdt_sdiageng.yml
+++ b/rules/windows/image_load/image_load_msdt_sdiageng.yml
@@ -4,8 +4,6 @@ status: experimental
 description: Detects both of CVE-2022-30190 and DogWalk vulnerability exploiting "msdt.exe" binary to load "sdiageng.dll" binary. 
 author: Greg (rule)
 references:
-  - https://twitter.com/j00sean/status/1534115332830507008
-  - https://twitter.com/nas_bench/status/1531944240271568896?t=z0hjfsgRgNb9c4NCLk-bHg&s=19
   - https://www.securonix.com/blog/detecting-microsoft-msdt-dogwalk/
 date: 2022/06/09
 modified: 2022/06/17

--- a/rules/windows/image_load/image_load_msdt_sdiageng.yml
+++ b/rules/windows/image_load/image_load_msdt_sdiageng.yml
@@ -1,4 +1,4 @@
-title: MSDT.exe loading Diagnostic Library
+title: MSDT.exe Loading Diagnostic Library
 id: ec8c4047-fad9-416a-8c81-0f479353d7f6
 status: experimental
 description: Detects both of CVE-2022-30190 and DogWalk vulnerability exploiting "msdt.exe" binary to load "sdiageng.dll" binary. 


### PR DESCRIPTION
Hello, 
I close the old pull request: process creation of  "sdiagnhost.exe". Detecting "sdiageng.dll" is more precise. Besides, this rule is able to detect both Follina and DogWalk attack. 