### PR TITLE
The "NewValue" field for Windows Defender should be "New Value"

### DIFF
--- a/rules/windows/builtin/windefend/win_defender_exclusions.yml
+++ b/rules/windows/builtin/windefend/win_defender_exclusions.yml
@@ -16,7 +16,7 @@ logsource:
 detection:
     selection1:
         EventID: 5007
-        New Value|contains: '\Microsoft\Windows Defender\Exclusions'
+        New_Value|contains: '\Microsoft\Windows Defender\Exclusions'
     condition: selection1
 falsepositives:
     - Administrator actions

--- a/rules/windows/builtin/windefend/win_defender_exclusions.yml
+++ b/rules/windows/builtin/windefend/win_defender_exclusions.yml
@@ -16,7 +16,7 @@ logsource:
 detection:
     selection1:
         EventID: 5007
-        NewValue|contains: '\Microsoft\Windows Defender\Exclusions'
+        New Value|contains: '\Microsoft\Windows Defender\Exclusions'
     condition: selection1
 falsepositives:
     - Administrator actions

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -254,7 +254,8 @@ fieldmappings:
     LogonId: winlog.event_data.LogonId
     NewName: winlog.event_data.NewName
     NewValue: winlog.event_data.NewValue
-    New Value: winlog.event_data.New Value
+    New_Value: winlog.event_data.New\ Value
+    Old_Value: winlog.event_data.Old\ Value
     ObjectServer: winlog.event_data.ObjectServer
     PasswordLastSet: winlog.event_data.PasswordLastSet
     PrivilegeList: winlog.event_data.PrivilegeList

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -254,6 +254,7 @@ fieldmappings:
     LogonId: winlog.event_data.LogonId
     NewName: winlog.event_data.NewName
     NewValue: winlog.event_data.NewValue
+    New Value: winlog.event_data.New Value
     ObjectServer: winlog.event_data.ObjectServer
     PasswordLastSet: winlog.event_data.PasswordLastSet
     PrivilegeList: winlog.event_data.PrivilegeList


### PR DESCRIPTION
The detection of Windows Defender Exclusions within `windows/builtin/windefend/win_defender_exclusions.yml` fails since it uses the `NewValue` field instead of `New Value`.