### PR TITLE
To account for SyncAppvPublishingServer bypass

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_lolbin_syncappvpublishingserver_vbs_execute_psh.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_syncappvpublishingserver_vbs_execute_psh.yml
@@ -19,8 +19,6 @@ detection:
     selection:
         CommandLine|contains:
             - '\SyncAppvPublishingServer.vbs'
-    selection2:
-        CommandLine|contains:
             - ';'  # at a minimum, a semi-colon is required
     condition: selection
 fields:

--- a/rules/windows/process_creation/proc_creation_win_lolbin_syncappvpublishingserver_vbs_execute_psh.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_syncappvpublishingserver_vbs_execute_psh.yml
@@ -17,7 +17,7 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains:
+        CommandLine|contains|all:
             - '\SyncAppvPublishingServer.vbs'
             - ';'  # at a minimum, a semi-colon is required
     condition: selection

--- a/rules/windows/process_creation/proc_creation_win_lolbin_syncappvpublishingserver_vbs_execute_psh.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_syncappvpublishingserver_vbs_execute_psh.yml
@@ -3,7 +3,7 @@ id: 36475a7d-0f6d-4dce-9b01-6aeb473bbaf1
 status: experimental
 author: frack113
 date: 2021/07/16
-modified: 2022/01/24
+modified: 2022/06/22
 description: Executes arbitrary PowerShell code using SyncAppvPublishingServer.vbs
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1216/T1216.md
@@ -17,9 +17,11 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains|all:
+        CommandLine|contains:
             - '\SyncAppvPublishingServer.vbs'
-            - '"\n;'
+    selection2:
+        CommandLine|contains:
+            - ';'  # at a minimum, a semi-colon is required
     condition: selection
 fields:
     - ComputerName


### PR DESCRIPTION
All format work:
```
- SyncAppvPublishingServer.vbs "\n;<code>"
- SyncAppvPublishingServer.vbs "n;<code>"
- SyncAppvPublishingServer.vbs ";<code>"
- SyncAppvPublishingServer.vbs "abc;<code>"
```