### PR TITLE
False positive when print dll times out when attempting to register

### DIFF
--- a/rules/windows/builtin/printservice/win_exploit_cve_2021_1675_printspooler.yml
+++ b/rules/windows/builtin/printservice/win_exploit_cve_2021_1675_printspooler.yml
@@ -1,7 +1,7 @@
 title: Possible CVE-2021-1675 Print Spooler Exploitation
 id: 4e64668a-4da1-49f5-a8df-9e2d5b866718
 description: Detects events of driver load errors in print service logs that could be a sign of successful exploitation attempts of print spooler vulnerability CVE-2021-1675
-author: Florian Roth, KevTheHermit, fuzzyf10w
+author: Florian Roth, KevTheHermit, fuzzyf10w, Tim Shelton
 status: experimental
 level: high
 references:
@@ -9,7 +9,7 @@ references:
     - https://github.com/afwu/PrintNightmare
     - https://twitter.com/fuzzyf10w/status/1410202370835898371
 date: 2021/06/30
-modified: 2021/07/08
+modified: 2022/06/22
 tags:
     - attack.execution
     - attack.t1569    
@@ -36,7 +36,9 @@ detection:
         - '\main64.dll'
         - '\mimilib.dll'
         - '\mimispool.dll'
-    condition: selection or keywords
+    falsepositive:
+        - ' registration timed out' # ex: The print spooler failed to load a plug-in module PrintConfig registration timed out
+    condition: (selection or keywords) and not falsepositive
 fields:
     - PluginDllName
 falsepositives:


### PR DESCRIPTION
example:
```
2022-06-18 08:51:28 REDACTED PrintService: 808: The print spooler failed to load a plug-in module PrintConfig registration timed out: C:\Windows\system32\regsvr32.exe /s "C:\Windows\system32\spool\drivers\x64\3\PrintConfig.dll", error code 0x1. See the event user data for context information. | pid=1700 | level=0 | sys_version=0 | category=Initializing | op=Spooler Operation Failed | SPOOLER_KEYWORD=true | Microsoft-Windows-PrintService/Admin=true | key=0x8000000000020000 | id=81 | app="?" | tid=4344 | channel="Microsoft-Windows-PrintService/Admin" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=error(2) 
```