### PR TITLE
Rule for HandleKatz

### DIFF
--- a/rules/windows/process_access/proc_access_win_handlekatz_lsass_access.yml
+++ b/rules/windows/process_access/proc_access_win_handlekatz_lsass_access.yml
@@ -1,0 +1,30 @@
+title: HandleKatz Duplicating LSASS Handle
+id: b1bd3a59-c1fd-4860-9f40-4dd161a7d1f5
+description: Detects HandleKatz opening LSASS to duplicate its handle to later dump the memory without opening any new handles
+references:
+    - https://github.com/codewhitesec/HandleKatz
+status: experimental
+author: Bhabesh Raj (rule), @thefLinkk
+date: 2022/06/27
+logsource:
+    category: process_access
+    product: windows
+detection:
+    selection:
+        TargetImage|endswith: '\lsass.exe' # Theoretically, can be any benign process holding handle to LSASS
+        GrantedAccess: '0x1440' # Only PROCESS_DUP_HANDLE, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_QUERY_INFORMATION
+        CallTrace|contains: '|UNKNOWN('
+    filter:
+        CallTrace|contains:
+          - '\KERNEL32.DLL+'
+          - '\KERNELBASE.DLL+'
+          - '\WOW64.DLL+'
+    condition: selection and not filter
+falsepositives:
+    - Unknown
+level: high
+tags:
+    - attack.execution
+    - attack.t1106
+    - attack.defense_evasion
+    - attack.t1003.001

--- a/rules/windows/process_access/proc_access_win_handlekatz_lsass_access.yml
+++ b/rules/windows/process_access/proc_access_win_handlekatz_lsass_access.yml
@@ -13,13 +13,12 @@ detection:
     selection:
         TargetImage|endswith: '\lsass.exe' # Theoretically, can be any benign process holding handle to LSASS
         GrantedAccess: '0x1440' # Only PROCESS_DUP_HANDLE, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_QUERY_INFORMATION
+    
+    call_trace:  # C:\Windows\SYSTEM32\ntdll.dll+9d234\|UNKNOWN(00000000001C119B)
+        CallTrace|startswith: 'C:\Windows\System32\ntdll.dll+' 
         CallTrace|contains: '|UNKNOWN('
-    filter:
-        CallTrace|contains:
-          - '\KERNEL32.DLL+'
-          - '\KERNELBASE.DLL+'
-          - '\WOW64.DLL+'
-    condition: selection and not filter
+        CallTrace|endswith: ')'
+    condition: selection and call_trace
 falsepositives:
     - Unknown
 level: high


### PR DESCRIPTION
@Neo23x0 Can you check false positives on this? May need to add additional filters.

The exact call trace is:
```
C:\Windows\SYSTEM32\ntdll.dll+9d234\|UNKNOWN(00000000001C119B)
```

I am using the below regex pattern but I suspect many backends may not support "_re_" so I didn't include it.
```
(?i)^C:\\Windows\\System32\\ntdll\.dll\+[a-z0-9]+\|UNKNOWN\([A-Z0-9]+\)$
```

This rule has a "false negative" scenario when adversaries use HandleKatz to duplicate LSASS handle by opening a benign process that has a handle to LSASS. In this way, LSASS is not touched. However, it is rare to find these benign processes and the writers of HandleKatz have said that this occurs in servers. 
Adversaries can skip this and directly target LSASS since it has a handle to itself.