### PR TITLE
Reducing the level of Account Tampering - Suspicious Failed Logon Reasons

### DIFF
--- a/rules/windows/builtin/security/win_susp_failed_logon_reasons.yml
+++ b/rules/windows/builtin/security/win_susp_failed_logon_reasons.yml
@@ -5,7 +5,7 @@ description: This method uses uncommon error codes on failed logons to determine
 status: experimental
 author: Florian Roth
 date: 2017/02/19
-modified: 2021/10/29
+modified: 2022/06/29
 references:
     - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4625
     - https://twitter.com/SBousseaden/status/1101431884540710913
@@ -35,4 +35,4 @@ detection:
     condition: selection and not filter
 falsepositives:
     - User using a disabled account
-level: high
+level: medium


### PR DESCRIPTION
This behavior happens too often in a normal enviornment, with day to day activity and no definitive threat.  I believe a different rule, detecting a larger volume of this behavior would warrant a high level rating.

Examples:

```
2022-06-29 12:37:08 REDACTED Security-Auditing: 4776: The computer attempted to validate the credentials for an account. | PackageName=MICROSOFT_AUTHENTICATION_PACKAGE_V1_0 | TargetUserName=JS0XXXXXXXXQP2$ | Workstation=JS0XXXXXXXXQP2 | Status=0xc0000072 | pid=684 | level=0 | sys_version=0 | category=Credential Validation | op=Info | Security=true | key=0x8010000000000000 | id=1359729128 | app="C:\Windows\System32\lsass.exe" | tid=1588 | channel="Security" | type=audit failure(0)
```