### PR TITLE
fix: FP fix

### DIFF
--- a/rules/windows/file_access/file_access_win_browser_credential_stealing.yml
+++ b/rules/windows/file_access/file_access_win_browser_credential_stealing.yml
@@ -39,15 +39,6 @@ detection:
         Image|endswith:
             - '\MsMpEng.exe'
             - '\MpCopyAccelerator.exe'
-    filter_service:
-        ParentImage: 'C:\Windows\System32\services.exe'
-        TargetFilename|endswith: '\APPDATA\LOCAL\MICROSOFT\WINDOWS\WEBCACHE\WEBCACHEV01.DAT'
-    filter_windows:
-        - Image: 'C:\Windows\System32\dllhost.exe'
-        - CommandLine|contains: '\svchost.exe -k DcomLaunch -p'
-    filter_scheduler:
-        - Image: 'C:\Windows\System32\taskhostw.exe'
-        - ParentImage: 'C:\Windows\System32\svchost.exe'
     condition: selection and not 1 of filter_*
 falsepositives:
     - Antivirus, Anti-Spyware, Anti-Malware Software

--- a/rules/windows/file_access/file_access_win_browser_credential_stealing.yml
+++ b/rules/windows/file_access/file_access_win_browser_credential_stealing.yml
@@ -34,6 +34,7 @@ detection:
         Image|startswith:
             - 'C:\Program Files\'
             - 'C:\Program Files (x86)\'
+            - 'C:\WINDOWS\system32\'
     filter_antimalware:
         Image|endswith:
             - '\MsMpEng.exe'


### PR DESCRIPTION
hi @frack113 ,

found the rule "**Browser Credential Store Access - 91cb43db-302a-47e3-b3c8-7ede481e27bf**" matching on:
![image](https://user-images.githubusercontent.com/28906717/176687369-403ebbb1-f854-4600-8e56-bf1fc68f748f.png)
![image](https://user-images.githubusercontent.com/28906717/176687430-6dfbcafd-e88b-4f18-b11a-b597d376c1a0.png)
![image](https://user-images.githubusercontent.com/28906717/176688085-6fc400d6-41c3-4acd-8699-5e74869a750b.png)

maybe "C:\WINDOWS\system32\" should be excluded as well?