### PR TITLE
DFIR Report - SELECT XMRig FROM SQLServer (New Rules)

### DIFF
--- a/rules/windows/builtin/application/win_mssql_xp_cmdshell_audit_log.yml
+++ b/rules/windows/builtin/application/win_mssql_xp_cmdshell_audit_log.yml
@@ -11,6 +11,7 @@ logsource:
     product: windows
     service: application
     definition: MSSQL audit policy to monitor for 'xp_cmdshell' must be enabled in order to recieve this event in the application log (Follow this tutorial https://dba.stackexchange.com/questions/103183/is-there-any-way-to-monitor-execution-of-xp-cmdshell-in-sql-server-2012)
+    warning: The 'data' field used in the detection section is the container for the event data as a whole. You may have to adapt the rule for your backend accordingly
 detection:
     selection:
         Provider_Name: 'MSSQLSERVER'

--- a/rules/windows/builtin/application/win_mssql_xp_cmdshell_audit_log.yml
+++ b/rules/windows/builtin/application/win_mssql_xp_cmdshell_audit_log.yml
@@ -3,6 +3,9 @@ id: 7f103213-a04e-4d59-8261-213dddf22314
 status: experimental
 description: Detects when the MSSQL "xp_cmdshell" stored procedure is used to execute commands
 author: Nasreddine Bencherchali
+references:
+    - https://www.netspi.com/blog/technical/network-penetration-testing/sql-server-persistence-part-1-startup-stored-procedures/
+    - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/
 date: 2022/07/12
 logsource:
     product: windows

--- a/rules/windows/builtin/application/win_mssql_xp_cmdshell_audit_log.yml
+++ b/rules/windows/builtin/application/win_mssql_xp_cmdshell_audit_log.yml
@@ -1,0 +1,24 @@
+title: MSSQL XPCmdshell Suspicious Execution
+id: 7f103213-a04e-4d59-8261-213dddf22314
+status: experimental
+description: Detects when the MSSQL "xp_cmdshell" stored procedure is used to execute commands
+author: Nasreddine Bencherchali
+date: 2022/07/12
+logsource:
+    product: windows
+    service: application
+    definition: MSSQL audit policy to monitor for 'xp_cmdshell' must be enabled in order to recieve this event in the application log (Follow this tutorial https://dba.stackexchange.com/questions/103183/is-there-any-way-to-monitor-execution-of-xp-cmdshell-in-sql-server-2012)
+detection:
+    selection:
+        Provider_Name: 'MSSQLSERVER'
+        EventID: 33205
+        Data|contains|all:
+            # You can modify this to include specific commands
+            - 'object_name:xp_cmdshell'
+            - 'statement:EXEC'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high
+tags:
+    - attack.execution

--- a/rules/windows/builtin/application/win_mssql_xp_cmdshell_change.yml
+++ b/rules/windows/builtin/application/win_mssql_xp_cmdshell_change.yml
@@ -1,0 +1,21 @@
+title: MSSQL XPCmdshell Option Change
+id: d08dd86f-681e-4a00-a92c-1db218754417
+status: experimental
+description: Detects when the MSSQL "xp_cmdshell" stored procedure setting is changed
+author: Nasreddine Bencherchali
+date: 2022/07/12
+logsource:
+    product: windows
+    service: application
+detection:
+    selection:
+        Provider_Name: 'MSSQLSERVER'
+        EventID: 15457
+        Data|contains: 'xp_cmdshell'
+    condition: selection
+falsepositives:
+    - Legitimate enable/disable of the setting
+    - Note that since the event contain the change for both values. This means that this will trigger on both enable and disable
+level: high
+tags:
+    - attack.execution

--- a/rules/windows/builtin/application/win_mssql_xp_cmdshell_change.yml
+++ b/rules/windows/builtin/application/win_mssql_xp_cmdshell_change.yml
@@ -3,6 +3,9 @@ id: d08dd86f-681e-4a00-a92c-1db218754417
 status: experimental
 description: Detects when the MSSQL "xp_cmdshell" stored procedure setting is changed
 author: Nasreddine Bencherchali
+references:
+    - https://www.netspi.com/blog/technical/network-penetration-testing/sql-server-persistence-part-1-startup-stored-procedures/
+    - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/
 date: 2022/07/12
 logsource:
     product: windows

--- a/rules/windows/builtin/application/win_mssql_xp_cmdshell_change.yml
+++ b/rules/windows/builtin/application/win_mssql_xp_cmdshell_change.yml
@@ -10,6 +10,7 @@ date: 2022/07/12
 logsource:
     product: windows
     service: application
+    warning: The 'data' field used in the detection section is the container for the event data as a whole. You may have to adapt the rule for your backend accordingly
 detection:
     selection:
         Provider_Name: 'MSSQLSERVER'

--- a/rules/windows/process_creation/proc_creation_win_cmd_redirection_susp_folder.yml
+++ b/rules/windows/process_creation/proc_creation_win_cmd_redirection_susp_folder.yml
@@ -1,0 +1,28 @@
+title: Suspicious CMD Shell Redirect
+id: 8e0bb260-d4b2-4fff-bb8d-3f82118e6892
+status: experimental
+description: Detects inline windows shell commands redirecting output via the ">" symbol to a suspicous location
+author: Nasreddine Bencherchali
+references:
+    - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/
+date: 2022/07/12
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\cmd.exe'
+        CommandLine|contains|all:
+            # Add more suspicious locations as you find them
+            - ' > %USERPROFILE%\'
+            - ' > %APPDATA%\'
+            - ' > \Users\Public\'
+            - ' > C:\Users\Public\'
+            - ' > %TEMP%\'
+    condition: selection
+falsepositives:
+    - Legitimate admin scripts
+level: medium
+tags:
+    - attack.execution
+    - attack.t1218

--- a/rules/windows/process_creation/proc_creation_win_inline_base64_mz_header.yml
+++ b/rules/windows/process_creation/proc_creation_win_inline_base64_mz_header.yml
@@ -11,7 +11,12 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains: 'TVqQAAMAAAAEAAAA' # MZ..........
+        CommandLine|contains: 
+            - 'TVqQAAMAAAAEAAAA' # MZ..........
+            - 'TVpQAAIAAAAEAA8A'
+            - 'TVqAAAEAAAAEABAA'
+            - 'TVoAAAAAAAAAAAAA'
+            - 'TVpTAQEAAAAEAAAA'
     condition: selection
 falsepositives:
     - Unlikley

--- a/rules/windows/process_creation/proc_creation_win_inline_base64_mz_header.yml
+++ b/rules/windows/process_creation/proc_creation_win_inline_base64_mz_header.yml
@@ -1,0 +1,20 @@
+title: Base64 MZ Header In CommandLine
+id: 22e58743-4ac8-4a9f-bf19-00a0428d8c5f
+status: experimental
+description: Detects encoded base64 MZ header in the commandline
+author: Nasreddine Bencherchali
+references:
+    - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/
+date: 2022/07/12
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        CommandLine|contains: 'TVqQAAMAAAAEAAAA' # MZ..........
+    condition: selection
+falsepositives:
+    - Unlikley
+level: high
+tags:
+    - attack.execution

--- a/rules/windows/process_creation/proc_creation_win_net_user_add_never_expire.yml
+++ b/rules/windows/process_creation/proc_creation_win_net_user_add_never_expire.yml
@@ -1,0 +1,30 @@
+title: Net.exe User Account Creation - Never Expire
+id: b9f0e6f5-09b4-4358-bae4-08408705bd5c
+related:
+    - id: cd219ff3-fa99-45d4-8380-a7d15116c6dc
+      type: derived
+status: test
+description: Detects creation of local users via the net.exe command with the option "never expire"
+author: Nasreddine Bencherchali
+references:
+    - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/
+date: 2022/07/12
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith:
+            - '\net.exe'
+            - '\net1.exe'
+        CommandLine|contains|all:
+            - 'user'
+            - 'add'
+            - 'expires:never'
+    condition: selection
+falsepositives:
+    - Unlikley
+level: high
+tags:
+    - attack.persistence
+    - attack.t1136.001

--- a/rules/windows/process_creation/proc_creation_win_susp_mofcomp_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_mofcomp_execution.yml
@@ -1,0 +1,39 @@
+title: Suspicious Mofcomp Execution
+id: 1dd05363-104e-4b4a-b963-196a534b03a1
+status: experimental
+description: |
+    Detects execution of the "mofcomp" utility as a child of a suspicious shell or script running utility or by having a supsicious path in the commandline.
+    The "mofcomp" utility parses a file containing MOF statements and adds the classes and class instances defined in the file to the WMI repository.
+    Attackers abuse this utility to install malicious MOF scripts
+author: Nasreddine Bencherchali
+references:
+    - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/
+    - https://github.com/The-DFIR-Report/Sigma-Rules/blob/75260568a7ffe61b2458ca05f6f25914efb44337/win_mofcomp_execution.yml
+    - https://docs.microsoft.com/en-us/windows/win32/wmisdk/mofcomp
+date: 2022/07/12
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        Image|endswith: '\mofcomp.exe'
+    selection_case:
+        - ParentImage|endswith:
+            - '\cmd.exe'
+            - '\powershell.exe'
+            - '\wsl.exe'
+            - '\wscript.exe'
+            - '\cscript.exe'
+        - CommandLine|contains:
+            - '\AppData\Local\Temp'
+            - '\Users\Public\'
+            - '\WINDOWS\Temp\'
+            - '%temp%'
+            - '%appdata%'
+    condition: all of selection_*
+falsepositives:
+    - Unknown
+level: medium
+tags:
+    - attack.execution
+    - attack.t1218

--- a/rules/windows/registry/registry_set/registry_set_special_accounts.yml
+++ b/rules/windows/registry/registry_set/registry_set_special_accounts.yml
@@ -1,0 +1,23 @@
+title: Hide User Account Via Special Accounts Reg Key
+id: f8aebc67-a56d-4ec9-9fbe-7b0e8b7b4efd
+description: Detects when an attacker set the registry key "HKLM\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\Userlist" to "0" in order to hide user account.
+author: Nasreddine Bencherchali
+date: 2022/07/12
+status: experimental
+references:
+    - https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains: \SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList
+        Details: DWORD (0x00000000)
+    condition: selection
+falsepositives:
+    - Unknown
+level: high
+tags:
+  - attack.defense_evasion
+  - attack.t1564.002


### PR DESCRIPTION
This PR adds the following new rules based on the latest DFIR report (https://thedfirreport.com/2022/07/11/select-xmrig-from-sqlserver/) :

- Hide User Account Via Special Accounts Reg Key (f8aebc67-a56d-4ec9-9fbe-7b0e8b7b4efd)
- Net.exe User Account Creation - Never Expire (b9f0e6f5-09b4-4358-bae4-08408705bd5c) derived from (cd219ff3-fa99-45d4-8380-a7d15116c6dc)
- Base64 MZ Header In CommandLine (22e58743-4ac8-4a9f-bf19-00a0428d8c5f)
- Suspicious CMD Shell Redirect (8e0bb260-d4b2-4fff-bb8d-3f82118e6892)
- Suspicious Mofcomp Execution (1dd05363-104e-4b4a-b963-196a534b03a1)
- MSSQL XPCmdshell Suspicious Execution (7f103213-a04e-4d59-8261-213dddf22314)
- MSSQL XPCmdshell Option Change (d08dd86f-681e-4a00-a92c-1db218754417)