### PR TITLE
Remove some keywords

### DIFF
--- a/rules/windows/builtin/application/win_susp_msmpeng_crash.yml
+++ b/rules/windows/builtin/application/win_susp_msmpeng_crash.yml
@@ -7,7 +7,7 @@ tags:
     - attack.t1562.001
 status: experimental
 date: 2017/05/09
-modified: 2021/10/13
+modified: 2022/07/12
 references:
     - https://bugs.chromium.org/p/project-zero/issues/detail?id=1252&desc=5
     - https://technet.microsoft.com/en-us/library/security/4022344
@@ -15,6 +15,7 @@ author: Florian Roth
 logsource:
     product: windows
     service: application
+    # warning: The 'data' field used in the detection section is the container for the event data as a whole. You may have to adapt the rule for your backend accordingly
 detection:
     selection1:
         Provider_Name: 'Application Error'
@@ -22,10 +23,11 @@ detection:
     selection2:
         Provider_Name: 'Windows Error Reporting'
         EventID: 1001
-    keywords:
-        - 'MsMpEng.exe'
-        - 'mpengine.dll'
-    condition: 1 of selection* and all of keywords
+    malware_engine:
+        Data|contains|all:
+            - 'MsMpEng.exe'
+            - 'mpengine.dll'
+    condition: 1 of selection* and malware_engine
 falsepositives:
     - MsMpEng.exe can crash when C:\ is full
 level: high

--- a/rules/windows/builtin/application/win_vul_cve_2021_41379.yml
+++ b/rules/windows/builtin/application/win_vul_cve_2021_41379.yml
@@ -6,19 +6,20 @@ references:
     - https://github.com/klinix5/InstallerFileTakeOver
 author: Florian Roth
 date: 2021/11/22
+modified: 2022/07/12
 tags:
     - attack.initial_access
     - attack.t1190
 logsource:
     product: windows
     service: application
+    # warning: The 'data' field used in the detection section is the container for the event data as a whole. You may have to adapt the rule for your backend accordingly
 detection:
     selection:
         EventID: 1033
         Provider_Name: 'MsiInstaller'
-    keywords:
-        - 'test pkg'
-    condition: selection and keywords
+        Data|contains: 'test pkg'
+    condition: selection 
 falsepositives:
     - Other MSI packages for which your admins have used that name
 level: high

--- a/rules/windows/builtin/msexchange/win_exchange_cve_2021_42321.yml
+++ b/rules/windows/builtin/msexchange/win_exchange_cve_2021_42321.yml
@@ -6,18 +6,20 @@ references:
     - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-42321
 author: 'Florian Roth, @testanull'
 date: 2021/11/18
+modified: 2022/07/12
 logsource:
     product: windows
     service: msexchange-management
+    # warning: The 'data' field used in the detection section is the container for the event data as a whole. You may have to adapt the rule for your backend accordingly
 detection:
     selection:
         EventID: 
             - 6
             - 8
-    keywords:
-        - 'Cmdlet failed. Cmdlet Get-App, '
-        - 'Task Get-App throwing unhandled exception: System.InvalidCastException:'
-    condition: selection and keywords
+        Data|contains:
+            - 'Cmdlet failed. Cmdlet Get-App, '
+            - 'Task Get-App throwing unhandled exception: System.InvalidCastException:'
+    condition: selection
 falsepositives:
     - Unknown, please report false positives via https://github.com/SigmaHQ/sigma/issues
 level: high

--- a/rules/windows/builtin/msexchange/win_exchange_transportagent_failed.yml
+++ b/rules/windows/builtin/msexchange/win_exchange_transportagent_failed.yml
@@ -8,16 +8,18 @@ tags:
     - attack.persistence  
     - attack.t1505.002    
 author: Tobias Michalski  
-date: 2021/06/08  
+date: 2021/06/08
+modified: 2022/07/12
 logsource:        
     service: msexchange-management
     product: windows
+    # warning: The 'data' field used in the detection section is the container for the event data as a whole. You may have to adapt the rule for your backend accordingly
 detection:
     selection:
         EventID: 6 
-    keywords:
-        - 'Install-TransportAgent'
-    condition: selection and keywords
+        Data|contains:
+            - 'Install-TransportAgent'
+    condition: selection
 fields:
     - AssemblyPath
 falsepositives:

--- a/rules/windows/builtin/msexchange/win_exchange_transportagent_failed.yml
+++ b/rules/windows/builtin/msexchange/win_exchange_transportagent_failed.yml
@@ -17,8 +17,7 @@ logsource:
 detection:
     selection:
         EventID: 6 
-        Data|contains:
-            - 'Install-TransportAgent'
+        Data|contains: 'Install-TransportAgent'
     condition: selection
 fields:
     - AssemblyPath


### PR DESCRIPTION
For windows when it is `Data` in the ETW, I have update the rule.
Some use keywords while events have a field name, so more digging is needed.