### PR TITLE
Fix issue with using `source:` on Zeek `files` log

### DIFF
--- a/tools/config/splunk-zeek.yml
+++ b/tools/config/splunk-zeek.yml
@@ -404,7 +404,7 @@ fieldmappings:
     - query
     - server_name
   service.response_code: status_code
-  source: id.orig_h
+#  source: id.orig_h
   SourceAddr: id.orig_h
   SourceAddress: id.orig_h
   SourceIP: id.orig_h


### PR DESCRIPTION
Line 407 was `source: id.orig_h` so that people could use the word `source` as an alias to `id.orig_h`, however there is a literal field with the name `source` in the `files.log` for Zeek, so having a Sigma query with something like `source: 'SMTP'` would yield `id.orig_h='SMTP'` in the resulting Splunk translation, which is incorrect. It should be `source='SMTP'`

Commenting out line 407 fixes this.