### PR TITLE
False positive when box app uses regsvr32

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_regsvr32_anomalies.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_regsvr32_anomalies.yml
@@ -2,9 +2,9 @@ title: Regsvr32 Anomaly
 id: 8e2b24c9-4add-46a0-b4bb-0057b4e6187d
 status: experimental
 description: Detects various anomalies in relation to regsvr32.exe
-author: Florian Roth, oscd.community
+author: Florian Roth, oscd.community, Tim Shelton
 date: 2019/01/16
-modified: 2022/07/14
+modified: 2022/07/20
 references:
     - https://subt0x10.blogspot.de/2017/04/bypass-application-whitelisting-script.html
     - https://app.any.run/tasks/34221348-072d-4b70-93f3-aa71f6ebecad/
@@ -66,11 +66,14 @@ detection:
             - '.tmp'
             - '.temp'
             - '.txt'
-    filter:
+    filter1:
         CommandLine|contains:
             - '\AppData\Local\Microsoft\Teams'
             - '\AppData\Local\WebEx\WebEx64\Meetings\atucfobj.dll'
-    condition: 1 of selection* and not filter
+    filter2:
+        ParentImage: 'C:\Program Files\Box\Box\FS\streem.exe'
+        CommandLine|contains: '\Program Files\Box\Box\Temp\'
+    condition: 1 of selection* and not 1 of filter*
 fields:
     - CommandLine
     - ParentCommandLine


### PR DESCRIPTION
Example:

```
2022-07-20 18:18:51 REDACTED Sysmon: 1: Process Create | RuleName=technique_id=T1117,technique_name=Regsvr32 | UtcTime=2022-07-20 18:18:51.084 | ProcessGuid={77295911-470B-62D8-5152-000000000402} | ProcessId=14752 | Image=C:\Windows\SysWOW64\regsvr32.exe | FileVersion=10.0.14393.1378 (rs1_release.170620-2008) | Description=Microsoft(C) Register Server | Company=Microsoft Corporation | OriginalFileName=REGSVR32.EXE | OriginalCommandLine="C:\Windows\SysWOW64\regsvr32.exe" /n /s /i:"cbfsconnect2017-Box" "C:\Program Files\Box\Box\Temp\cbfsconnect2017-Box\i386\cbfsconnectMntNtf2017.dll" | CommandLine=C:\Windows\SysWOW64\regsvr32.exe /n /s /i:cbfsconnect2017-Box "C:\Program Files\Box\Box\Temp\cbfsconnect2017-Box\i386\cbfsconnectMntNtf2017.dll" | CurrentDirectory=C:\Windows\Installer\MSI66A5.tmp-\ | User=NT AUTHORITY\SYSTEM | LogonGuid={77295911-AA84-62D2-E703-000000000000} | LogonId=0x3e7 | TerminalSessionId=1 | IntegrityLevel=System | Hashes=SHA1=B087C89832B883CB54278BB72538E87303B8557D,MD5=56CF190F4143DC68800C4125D6001B07,SHA256=F72ED4D11C9971A9B7CE0A5681EE35968A6B4CCDC2F2B3A9F3E81418605FA467,IMPHASH=D053774A49BA83FF54C68888CB687C6C | ParentProcessGuid={77295911-4709-62D8-5052-000000000402} | ParentProcessId=16656 | ParentImage=C:\Program Files\Box\Box\FS\streem.exe | OriginalParentCommandLine="C:\Program Files\Box\Box\FS\streem.exe" --install-cbfs --cbfs-cab-path "C:\Program Files\Box\Box\FS\cbfsconnect.cab" | ParentCommandLine="C:\Program Files\Box\Box\FS\streem.exe" --install-cbfs --cbfs-cab-path "C:\Program Files\Box\Box\FS\cbfsconnect.cab" | ParentUser=NT AUTHORITY\SYSTEM | pid=18232 | level=29 | sys_version=5 | category=Process Create (rule: ProcessCreate) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=326220 | app="C:\Windows\sysmon64.exe" | tid=13744 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) 
```