### PR TITLE
New Persistence Rules

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_psexex_paexec_escalate_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_psexex_paexec_escalate_system.yml
@@ -7,7 +7,7 @@ references:
     - https://www.poweradmin.com/paexec/
     - https://www.fireeye.com/blog/threat-research/2020/10/kegtap-and-singlemalt-with-a-ransomware-chaser.html
 author: Florian Roth
-date: 2021/11/237
+date: 2021/11/23
 modified: 2022/07/21
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_susp_psexex_paexec_escalate_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_psexex_paexec_escalate_system.yml
@@ -7,22 +7,22 @@ references:
     - https://www.poweradmin.com/paexec/
     - https://www.fireeye.com/blog/threat-research/2020/10/kegtap-and-singlemalt-with-a-ransomware-chaser.html
 author: Florian Roth
-date: 2021/11/23
+date: 2021/11/237
+modified: 2022/07/21
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection_cmd_to_system: # Escalation to LOCAL_SYSTEM
+    selection: # Escalation to LOCAL_SYSTEM
         CommandLine|endswith: ' -s cmd.exe'
-    selection_supporting_flags:
         CommandLine|contains:
             - 'PsExec'
             - 'PAExec'
             - 'accepteula'
             - 'cmd /c '
-    condition: selection_supporting_flags and selection_cmd_to_system 
+    condition: all of selection_*
 falsepositives:
-    - Admins that use PsExec or PAExec to escalate to the SYSTEM account for maintenance purposes (rare) 
+    - Admins that use PsExec or PAExec to escalate to the SYSTEM account for maintenance purposes (rare)
 level: high
 tags:
     - attack.develop_capabilities

--- a/rules/windows/process_creation/proc_creation_win_susp_psexex_paexec_escalate_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_psexex_paexec_escalate_system.yml
@@ -20,7 +20,7 @@ detection:
             - 'PAExec'
             - 'accepteula'
             - 'cmd /c '
-    condition: all of selection_*
+    condition: selection
 falsepositives:
     - Admins that use PsExec or PAExec to escalate to the SYSTEM account for maintenance purposes (rare)
 level: high

--- a/rules/windows/registry/registry_add/registry_add_amsi_providers_persistence.yml
+++ b/rules/windows/registry/registry_add/registry_add_amsi_providers_persistence.yml
@@ -1,0 +1,24 @@
+title: Persistence Via New AMSI Providers
+id: 33efc23c-6ea2-4503-8cfe-bdf82ce8f705
+status: experimental
+description: Detects when an attacker registers a new AMSI provider in order to achieve persistence
+author: Nasreddine Bencherchali
+references:
+    - https://persistence-info.github.io/Data/amsi.html
+    - https://github.com/gtworek/PSBits/blob/8d767892f3b17eefa4d0668f5d2df78e844f01d8/FakeAMSI/FakeAMSI.c
+date: 2022/07/21
+logsource:
+    category: registry_add
+    product: windows
+detection:
+    selection:
+        EventType: CreateKey
+        TargetObject|contains:
+            - '\SOFTWARE\Microsoft\AMSI\Providers\'
+            - '\SOFTWARE\WOW6432Node\Microsoft\AMSI\Providers\'
+    condition: selection
+falsepositives:
+    - Legitimate security products adding their own AMSI providers
+level: high
+tags:
+    - attack.persistence

--- a/rules/windows/registry/registry_add/registry_add_amsi_providers_persistence.yml
+++ b/rules/windows/registry/registry_add/registry_add_amsi_providers_persistence.yml
@@ -16,7 +16,9 @@ detection:
         TargetObject|contains:
             - '\SOFTWARE\Microsoft\AMSI\Providers\'
             - '\SOFTWARE\WOW6432Node\Microsoft\AMSI\Providers\'
-    condition: selection
+    filter:
+        Image|startswith: 'C:\Program Files'
+    condition: selection and not filter
 falsepositives:
     - Legitimate security products adding their own AMSI providers
 level: high

--- a/rules/windows/registry/registry_add/registry_set_disk_cleanup_handler_new_entry_persistence.yml
+++ b/rules/windows/registry/registry_add/registry_set_disk_cleanup_handler_new_entry_persistence.yml
@@ -10,11 +10,11 @@ references:
     - https://persistence-info.github.io/Data/diskcleanuphandler.html
     - https://www.hexacorn.com/blog/2018/09/02/beyond-good-ol-run-key-part-86/
 logsource:
-    category: registry_set
     product: windows
+    category: registry_add
 detection:
     selection:
-        EventType: SetValue
+        EventType: CreateKey
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_add/registry_set_disk_cleanup_handler_new_entry_persistence.yml
+++ b/rules/windows/registry/registry_add/registry_set_disk_cleanup_handler_new_entry_persistence.yml
@@ -16,7 +16,42 @@ detection:
     selection:
         EventType: CreateKey
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\'
-    condition: selection
+    filter:
+        # Default Keys
+        TargetObject|endswith:
+            - '\Active Setup Temp Folders'
+            - '\BranchCache'
+            - '\Content Indexer Cleaner'
+            - '\D3D Shader Cache'
+            - '\Delivery Optimization Files'
+            - '\Device Driver Packages'
+            - '\Diagnostic Data Viewer database files'
+            - '\Downloaded Program Files'
+            - '\DownloadsFolder'
+            - '\Feedback Hub Archive log files'
+            - '\Internet Cache Files'
+            - '\Language Pack'
+            - '\Microsoft Office Temp Files'
+            - '\Offline Pages Files'
+            - '\Old ChkDsk Files'
+            - '\Previous Installations'
+            - '\Recycle Bin'
+            - '\RetailDemo Offline Content'
+            - '\Setup Log Files'
+            - '\System error memory dump files'
+            - '\System error minidump files'
+            - '\Temporary Files'
+            - '\Temporary Setup Files'
+            - '\Temporary Sync Files'
+            - '\Thumbnail Cache'
+            - '\Update Cleanup'
+            - '\Upgrade Discarded Files'
+            - '\User file versions'
+            - '\Windows Defender'
+            - '\Windows Error Reporting Files'
+            - '\Windows ESD installation files'
+            - '\Windows Upgrade Log Files'
+    condition: selection and not filter
 falsepositives:
     - Legitimate new entry added by windows
 level: medium

--- a/rules/windows/registry/registry_set/registry_set_aedebug_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_aedebug_persistence.yml
@@ -1,0 +1,25 @@
+title: Add Debugger Entry To AeDebug For Persistence
+id: 092af964-4233-4373-b4ba-d86ea2890288
+description: Detects when an attacker adds a new "Debugger" value to the "AeDebug" key in order to achieve persistence which will get invoked when an application crashes
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/aedebug.html
+    - https://docs.microsoft.com/en-us/windows/win32/debug/configuring-automatic-debugging
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug\Debugger'
+        Details|endswith: '.dll'
+    filter:
+        Details: '"C:\WINDOWS\system32\vsjitdebugger.exe" -p %ld -e %ld -j 0x%p'
+    condition: selection and not filter
+falsepositives:
+    - Legitimate use of the key to setup a debugger. Which is often the case on developers machines
+level: medium
+tags:
+  - attack.persistence

--- a/rules/windows/registry/registry_set/registry_set_chm_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_chm_persistence.yml
@@ -1,0 +1,24 @@
+title: CHM Helper DLL Persistence
+id: 976dd1f2-a484-45ec-aa1d-0e87e882262b
+description: Detects when an attacker modifies the registry key "HtmlHelp Author" to achieve persistence
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/htmlhelpauthor.html
+    - https://www.hexacorn.com/blog/2018/04/22/beyond-good-ol-run-key-part-76/
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains:
+            - '\Software\Microsoft\HtmlHelp Author\Location'
+            - '\Software\WOW6432Node\Microsoft\HtmlHelp Author\Location'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high
+tags:
+  - attack.persistence

--- a/rules/windows/registry/registry_set/registry_set_disk_cleanup_handler_autorun_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_disk_cleanup_handler_autorun_persistence.yml
@@ -1,0 +1,43 @@
+title: Persistence Via Disk Cleanup Handler - Autorun
+id: d4e2745c-f0c6-4bde-a3ab-b553b3f693cc
+description: |
+    Detects when an attacker modifies values of the Disk Cleanup Handler in the registry to achieve persistence via autorun.
+    The disk cleanup manager is part of the operating system. It displays the dialog box […] The user has the option of enabling or disabling individual handlers by selecting or clearing their check box in the disk cleanup manager's UI. Although Windows comes with a number of disk cleanup handlers, they aren't designed to handle files produced by other applications. Instead, the disk cleanup manager is designed to be flexible and extensible by enabling any developer to implement and register their own disk cleanup handler. Any developer can extend the available disk cleanup services by implementing and registering a disk cleanup handler.
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/diskcleanuphandler.html
+    - https://www.hexacorn.com/blog/2018/09/02/beyond-good-ol-run-key-part-86/
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    root:
+        EventType: SetValue
+        TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\'
+    selection_autorun:
+        TargetObject|contains: '\Autorun'
+        Details: 'DWORD (0x00000001)'
+    selection_pre_after:
+        Targetobject|contains:
+            - '\CleanupString'
+            - '\PreCleanupString'
+        Details|contains:
+            # Add more as you see fit
+            - 'cmd'
+            - 'powershell'
+            - 'rundll32'
+            - 'mshta'
+            - 'cscript'
+            - 'wscript'
+            - 'wsl'
+            - '\Users\Public\'
+            - '\Windows\TEMP\'
+            - '\Microsoft\Windows\Start Menu\Programs\Startup\'
+    condition: root and 1 of selection_*
+falsepositives:
+    - Unlikely
+level: high
+tags:
+  - attack.persistence

--- a/rules/windows/registry/registry_set/registry_set_disk_cleanup_handler_autorun_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_disk_cleanup_handler_autorun_persistence.yml
@@ -17,6 +17,7 @@ detection:
         EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\'
     selection_autorun:
+        # Launching PreCleanupString / CleanupString programs w/o gui, i.e. while using e.g. /autoclean
         TargetObject|contains: '\Autorun'
         Details: 'DWORD (0x00000001)'
     selection_pre_after:
@@ -37,7 +38,7 @@ detection:
             - '\Microsoft\Windows\Start Menu\Programs\Startup\'
     condition: root and 1 of selection_*
 falsepositives:
-    - Unlikely
-level: high
+    - Unknown
+level: medium
 tags:
   - attack.persistence

--- a/rules/windows/registry/registry_set/registry_set_disk_cleanup_handler_new_entry_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_disk_cleanup_handler_new_entry_persistence.yml
@@ -1,0 +1,24 @@
+title: Persistence Via Disk Cleanup Handler - NewEntry
+id: d4f4e0be-cf12-439f-9e25-4e2cdcf7df5a
+description: |
+    Detects when an attacker modifies values of the Disk Cleanup Handler in the registry to achieve persistence.
+    The disk cleanup manager is part of the operating system. It displays the dialog box […] The user has the option of enabling or disabling individual handlers by selecting or clearing their check box in the disk cleanup manager's UI. Although Windows comes with a number of disk cleanup handlers, they aren't designed to handle files produced by other applications. Instead, the disk cleanup manager is designed to be flexible and extensible by enabling any developer to implement and register their own disk cleanup handler. Any developer can extend the available disk cleanup services by implementing and registering a disk cleanup handler.
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/diskcleanuphandler.html
+    - https://www.hexacorn.com/blog/2018/09/02/beyond-good-ol-run-key-part-86/
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\'
+    condition: selection
+falsepositives:
+    - Legitimate new entry added by windows
+level: medium
+tags:
+  - attack.persistence

--- a/rules/windows/registry/registry_set/registry_set_hangs_debugger_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_hangs_debugger_persistence.yml
@@ -1,0 +1,22 @@
+title: Add Debugger Entry To Hangs Key For Persistence
+id: 833ef470-fa01-4631-a79b-6f291c9ac498
+description: Detects when an attacker adds a new "Debugger" value to the "Hangs" key in order to achieve persistence which will get invoked when an application crashes
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/wer_debugger.html
+    - https://www.hexacorn.com/blog/2019/09/20/beyond-good-ol-run-key-part-116/
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains: '\SOFTWARE\Microsoft\Windows\Windows Error Reporting\Hangs\Debugger'
+    condition: selection
+falsepositives:
+    - This value is not set by default but could be rarly used by administrators
+level: high
+tags:
+  - attack.persistence

--- a/rules/windows/registry/registry_set/registry_set_hhctrl_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_hhctrl_persistence.yml
@@ -1,0 +1,24 @@
+title: Persistence Via Hhctrl.ocx
+id: f10ed525-97fe-4fed-be7c-2feecca941b1
+description: Detects when an attacker modifies the registry value of the "hhctrl" to point to a custom binary
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/hhctrl.html
+    - https://www.hexacorn.com/blog/2018/04/23/beyond-good-ol-run-key-part-77/
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains: '\CLSID\{52A2AAAE-085D-4187-97EA-8C30DB990436}\InprocServer32\(Default)'
+    filter:
+        Details: 'C:\Windows\System32\hhctrl.ocx'
+    condition: selection and not filter
+falsepositives:
+    - Unlikely
+level: high
+tags:
+  - attack.persistence

--- a/rules/windows/registry/registry_set/registry_set_ifilter_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_ifilter_persistence.yml
@@ -1,0 +1,34 @@
+title: Register New IFiltre For Persistence
+id: b23818c7-e575-4d13-8012-332075ec0a2b
+description: Detects when an attacker register a new IFilter for an exntesion. Microsoft Windows Search uses filters to extract the content of items for inclusion in a full-text index. You can extend Windows Search to index new or proprietary file types by writing filters to extract the content, and property handlers to extract the properties of files
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/ifilters.html
+    - https://twitter.com/0gtweet/status/1468548924600459267
+    - https://github.com/gtworek/PSBits/tree/master/IFilter
+    - https://github.com/gtworek/PSBits/blob/8d767892f3b17eefa4d0668f5d2df78e844f01d8/IFilter/Dll.cpp#L281-L308
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection_ext:
+        # This selection focuses on the extension assoc
+        EventType: SetValue
+        TargetObject|startswith:
+            - 'HKLM\SOFTWARE\Classes\.'
+            - 'HKEY_LOCAL_MACHINE\SOFTWARE\Classes\.'
+        TargetObject|contains: '\PersistentHandler'
+    selection_ext:
+        EventType: SetValue
+        TargetObject|startswith:
+            - 'HKLM\SOFTWARE\Classes\CLSID'
+            - 'HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID'
+        TargetObject|contains: '\PersistentAddinsRegistered\{89BCB740-6119-101A-BCB7-00DD010655AF}'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate registration of IFilters by the OS or software
+level: medium
+tags:
+  - attack.persistence

--- a/rules/windows/registry/registry_set/registry_set_ifilter_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_ifilter_persistence.yml
@@ -14,19 +14,18 @@ logsource:
     product: windows
 detection:
     selection_ext:
-        # This selection focuses on the extension assoc
         EventType: SetValue
         TargetObject|startswith:
             - 'HKLM\SOFTWARE\Classes\.'
             - 'HKEY_LOCAL_MACHINE\SOFTWARE\Classes\.'
         TargetObject|contains: '\PersistentHandler'
-    selection_ext:
+    selection_clsid:
         EventType: SetValue
         TargetObject|startswith:
             - 'HKLM\SOFTWARE\Classes\CLSID'
             - 'HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID'
         TargetObject|contains: '\PersistentAddinsRegistered\{89BCB740-6119-101A-BCB7-00DD010655AF}'
-    condition: all of selection_*
+    condition: 1 of selection_*
 falsepositives:
     - Legitimate registration of IFilters by the OS or software
 level: medium

--- a/rules/windows/registry/registry_set/registry_set_lsa_extension_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_lsa_extension_persistence.yml
@@ -1,0 +1,24 @@
+title: Persistence Via LSA Extensions
+id: 41f6531d-af6e-4c6e-918f-b946f2b85a36
+description: |
+    Detects when an attacker modifies the "REG_MULTI_SZ" value named "Extensions" to include a custom DLL to achieve persistence via lsass.
+    The "Extensions" list contains filenames of DLLs being automatically loaded by lsass.exe. Each DLL has its InitializeLsaExtension() method called after loading.
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/lsaaextension.html
+    - https://twitter.com/0gtweet/status/1476286368385019906
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|contains: '\SYSTEM\CurrentControlSet\Control\LsaExtensionConfig\LsaSrv\Extensions'
+    condition: selection
+falsepositives:
+    - Unlikely
+level: high
+tags:
+  - attack.persistence

--- a/rules/windows/registry/registry_set/registry_set_mpnotify_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_mpnotify_persistence.yml
@@ -11,7 +11,7 @@ logsource:
     category: registry_set
     product: windows
 detection:
-    selection_root:
+    selection:
         EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\mpnotify'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_mpnotify_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_mpnotify_persistence.yml
@@ -1,0 +1,23 @@
+title: Persistence Via Mpnotify
+id: 92772523-d9c1-4c93-9547-b0ca500baba3
+description: Detects when an attacker register a new SIP provider for persistence and defense evasion
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/mpnotify.html
+    - https://www.youtube.com/watch?v=ggY3srD9dYs&ab_channel=GrzegorzTworek
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection_root:
+        EventType: SetValue
+        TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\mpnotify'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high
+tags:
+  - attack.persistence
+

--- a/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
@@ -23,6 +23,8 @@ detection:
         TargetObject|contains:
             - '\Dll'
             - '\$DLL'
+    filter:
+        Image|endswith: '\Microsoft Office\root\integration\integrator.exe'
     condition: all of selection_*
 falsepositives:
     - Legitimate SIP being registered by the OS or different software.

--- a/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
@@ -1,0 +1,33 @@
+title: Persistence Via New SIP Provider
+id: 5a2b21ee-6aaa-4234-ac9d-59a59edf90a1
+description: Detects when an attacker register a new SIP provider for persistence and defense evasion
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/codesigning.html
+    - https://github.com/gtworek/PSBits/tree/master/SIP
+    - https://specterops.io/assets/resources/SpecterOps_Subverting_Trust_in_Windows.pdf
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection_root:
+        EventType: SetValue
+        TargetObject|contains:
+            - '\SOFTWARE\Microsoft\Cryptography\Providers\'
+            - '\SOFTWARE\Microsoft\Cryptography\OID\EncodingType'
+            - '\SOFTWARE\WOW6432Node\Microsoft\Cryptography\Providers\'
+            - '\SOFTWARE\WOW6432Node\Microsoft\Cryptography\OID\EncodingType'
+    selection_dll:
+        TargetObject|contains:
+            - '\Dll'
+            - '\$DLL'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate SIP being registered by the OS or different software.
+level: medium
+tags:
+  - attack.persistence
+  - attack.defense_evasion
+  - attack.t1553.003

--- a/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
@@ -25,7 +25,7 @@ detection:
             - '\$DLL'
     filter:
         Image|endswith: '\Microsoft Office\root\integration\integrator.exe'
-    condition: all of selection_*
+    condition: all of selection_* and not filter
 falsepositives:
     - Legitimate SIP being registered by the OS or different software.
 level: medium

--- a/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
@@ -24,7 +24,10 @@ detection:
             - '\Dll'
             - '\$DLL'
     filter:
-        Image|endswith: '\Microsoft Office\root\integration\integrator.exe'
+        Details:
+            # Add more legitimate SIP providers according to your env
+            - WINTRUST.DLL
+            - mso.dll
     condition: all of selection_* and not filter
 falsepositives:
     - Legitimate SIP being registered by the OS or different software.

--- a/rules/windows/registry/registry_set/registry_set_winlogon_notify_key.yml
+++ b/rules/windows/registry/registry_set/registry_set_winlogon_notify_key.yml
@@ -1,8 +1,8 @@
 title: Winlogon Notify Key Logon Persistence
 id: bbf59793-6efb-4fa1-95ca-a7d288e52c88
 description: |
-  Adversaries may abuse features of Winlogon to execute DLLs and/or executables when a user logs in.
-  Winlogon.exe is a Windows component responsible for actions at logon/logoff as well as the secure attention sequence (SAS) triggered by Ctrl-Alt-Delete.
+    Adversaries may abuse features of Winlogon to execute DLLs and/or executables when a user logs in.
+    Winlogon.exe is a Windows component responsible for actions at logon/logoff as well as the secure attention sequence (SAS) triggered by Ctrl-Alt-Delete.
 author: frack113
 date: 2021/12/30
 modified: 2022/03/26

--- a/rules/windows/registry/registry_set/regsitry_set_natural_language_persistence.yml
+++ b/rules/windows/registry/registry_set/regsitry_set_natural_language_persistence.yml
@@ -1,0 +1,32 @@
+title: Add DLLPathOverride Entry For Persistence
+id: a1b1fd53-9c4a-444c-bae0-34a330fc7aa8
+description: Detects when an attacker adds a new "DLLPathOverride" value to the "Natural Language" key in order to achieve persistence which will get invoked by "SearchIndexer.exe" process
+author: Nasreddine Bencherchali
+date: 2022/07/21
+status: experimental
+references:
+    - https://persistence-info.github.io/Data/naturallanguage6.html
+    - https://www.hexacorn.com/blog/2018/12/30/beyond-good-ol-run-key-part-98/
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection_root:
+        EventType: SetValue
+        # The path can be for multiple languages
+        # Example:  HKLM\System\CurrentControlSet\Control\ContentIndex\Language\English_UK
+        #           HKLM\System\CurrentControlSet\Control\ContentIndex\Language\English_US
+        #           HKLM\System\CurrentControlSet\Control\ContentIndex\Language\Neutral
+        TargetObject|contains: '\SYSTEM\CurrentControlSet\Control\ContentIndex\Language\'
+    selection_values:
+        TargetObject|contains:
+            - '\StemmerDLLPathOverride'
+            - '\WBDLLPathOverride'
+            - '\StemmerClass'
+            - '\WBreakerClass'
+    condition: all of selection_*
+falsepositives:
+    - Unknown
+level: high
+tags:
+  - attack.persistence


### PR DESCRIPTION
This PR covers missing persistence techniques based on this repo https://persistence-info.github.io/

I added the following rules:

- Persistence Via AMSI Providers (33efc23c-6ea2-4503-8cfe-bdf82ce8f705)
- Persistence Via AeDebug value (092af964-4233-4373-b4ba-d86ea2890288)
- Persistence Via CHM Helper DLL (976dd1f2-a484-45ec-aa1d-0e87e882262b)
- Persistence Via DiskCleanup Handler (d4e2745c-f0c6-4bde-a3ab-b553b3f693cc) + (d4f4e0be-cf12-439f-9e25-4e2cdcf7df5a)
- Persistence Via Hangs Key (833ef470-fa01-4631-a79b-6f291c9ac498)
- Persistence Via "Hhctrl.ocx" (f10ed525-97fe-4fed-be7c-2feecca941b1)
- Persistence Via IFilters (b23818c7-e575-4d13-8012-332075ec0a2b)
- Persistence Via LSA Extensions (41f6531d-af6e-4c6e-918f-b946f2b85a36)
- Persistence Via Mpnotify (92772523-d9c1-4c93-9547-b0ca500baba3)
- Persistence Via SIP Providers (5a2b21ee-6aaa-4234-ac9d-59a59edf90a1)
- Persistence Via DLLPathOverride (5a2b21ee-6aaa-4234-ac9d-59a59edf90a1)

I also updated the selection for the (8834e2f7-6b4b-4f09-8906-d2276470ee23)