### PR TITLE
Replace commandline by parentcommandline and add fp

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
@@ -31,7 +31,7 @@ detection:
         ParentImage|endswith: ':\Windows\System32\cmd.exe'
         ParentCommandLine|contains: ' C:\Program Files\SplunkUniversalForwarder\'
     filter_localserver_fp:
-        CommandLine|endswith: ' -localserver '
+        CommandLine|contains: ' -localserver '
     condition: selection and not 1 of filter*
 fields:
     - Image

--- a/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
@@ -4,9 +4,9 @@ status: experimental
 description: Detects the execution of rundll32 with a command line that doesn't contain a .dll file
 references:
     - https://twitter.com/mrd0x/status/1481630810495139841?s=12
-author: Tim Shelton, Florian Roth
+author: Tim Shelton, Florian Roth, Yassine Oukessou (fix + fp)
 date: 2022/01/13
-modified: 2022/06/30
+modified: 2022/07/27
 logsource:
     category: process_creation
     product: windows
@@ -23,13 +23,15 @@ detection:
         CommandLine|contains: '.cpl'
     filter_msiexec_syswow64:
         ParentImage|endswith: ':\Windows\SysWOW64\msiexec.exe'
-        CommandLine|startswith: 'C:\Windows\syswow64\MsiExec.exe -Embedding'
+        ParentCommandLine|startswith: 'C:\Windows\syswow64\MsiExec.exe -Embedding'
     filter_msiexec_system32:
         ParentImage|endswith: ':\Windows\System32\msiexec.exe'
-        CommandLine|startswith: 'C:\Windows\system32\MsiExec.exe -Embedding'
+        ParentCommandLine|startswith: 'C:\Windows\system32\MsiExec.exe -Embedding'
     filter_splunk_ufw:
         ParentImage|endswith: ':\Windows\System32\cmd.exe'
         ParentCommandLine|contains: ' C:\Program Files\SplunkUniversalForwarder\'
+    filter_localserver_fp:
+        CommandLine|endswith: ' -localserver 22d8c27b-47a1-48d1-ad08-7da7abd79617'
     condition: selection and not 1 of filter*
 fields:
     - Image

--- a/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/proc_creation_win_run_executable_invalid_extension.yml
@@ -31,7 +31,7 @@ detection:
         ParentImage|endswith: ':\Windows\System32\cmd.exe'
         ParentCommandLine|contains: ' C:\Program Files\SplunkUniversalForwarder\'
     filter_localserver_fp:
-        CommandLine|endswith: ' -localserver 22d8c27b-47a1-48d1-ad08-7da7abd79617'
+        CommandLine|endswith: ' -localserver '
     condition: selection and not 1 of filter*
 fields:
     - Image


### PR DESCRIPTION
I believe those CommandLine fields are errors and should be ParentCommandLine

The FP was added based on real client environments, they generate a lot of alerts