### PR TITLE
Avast vuln driver

### DIFF
--- a/rules/windows/driver_load/driver_load_susp_temp_use.yml
+++ b/rules/windows/driver_load/driver_load_susp_temp_use.yml
@@ -6,16 +6,16 @@ author: Florian Roth
 date: 2017/02/12
 modified: 2021/11/27
 logsource:
-  category: driver_load
-  product: windows
+    category: driver_load
+    product: windows
 detection:
-  selection:
-    ImageLoaded|contains: '\Temp\'
-  condition: selection
+    selection:
+        ImageLoaded|contains: '\Temp\'
+    condition: selection
 falsepositives:
-  - There is a relevant set of false positives depending on applications in the environment
+    - There is a relevant set of false positives depending on applications in the environment
 level: high
 tags:
-  - attack.persistence
-  - attack.privilege_escalation
-  - attack.t1543.003
+    - attack.persistence
+    - attack.privilege_escalation
+    - attack.t1543.003

--- a/rules/windows/driver_load/driver_load_vuln_avast_anti_rootkit_driver.yml
+++ b/rules/windows/driver_load/driver_load_vuln_avast_anti_rootkit_driver.yml
@@ -1,0 +1,33 @@
+title: Vulnerable AVAST Anti Rootkit Driver Load
+id: 7c676970-af4f-43c8-80af-ec9b49952852
+status: experimental
+description: Detects the load of a signed and vulnerable AVAST Anti Rootkit driver often used by threat actors or malware for stopping and disabling AV and EDR products
+author: Nasreddine Bencherchali
+references:
+    - https://www.aon.com/cyber-solutions/aon_cyber_labs/yours-truly-signed-av-driver-weaponizing-an-antivirus-driver/
+date: 2022/07/28
+logsource:
+    product: windows
+    category: driver_load
+detection:
+    selection_sysmon:
+        Hashes|contains:
+            - 'MD5=a179c4093d05a3e1ee73f6ff07f994aa'
+            - 'SHA1=5d6b9e80e12bfc595d4d26f6afb099b3cb471dd4'
+            - 'SHA256=4b5229b3250c8c08b98cb710d6c056144271de099a57ae09f5d2097fc41bd4f1'
+    selection_other:
+        - MD5: 'a179c4093d05a3e1ee73f6ff07f994aa'
+        - SHA1: '5d6b9e80e12bfc595d4d26f6afb099b3cb471dd4'
+        - SHA256: '4b5229b3250c8c08b98cb710d6c056144271de099a57ae09f5d2097fc41bd4f1'
+    driver_img:
+        ImageLoaded|endswith: '\aswArPot.sys'
+    driver_status:
+        - Signed: false
+        - SignatureStatus: Expired
+    condition: 1 of selection* or all of driver_*
+falsepositives:
+    - Unknown
+level: high
+tags:
+    - attack.privilege_escalation
+    - attack.t1543.003

--- a/rules/windows/process_creation/proc_creation_win_susp_new_kernel_driver_via_sc.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_new_kernel_driver_via_sc.yml
@@ -1,0 +1,29 @@
+title: New Kernel Driver Via SC.EXE
+id: 431a1fdb-4799-4f3b-91c3-a683b003fc49
+status: experimental
+description: Detects creation of a new service (kernel driver) with the type "kernel"
+author: Nasreddine Bencherchali
+references:
+    - https://www.aon.com/cyber-solutions/aon_cyber_labs/yours-truly-signed-av-driver-weaponizing-an-antivirus-driver/
+date: 2022/07/14
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\sc.exe'
+        CommandLine|contains:
+            - 'create'
+            - 'config'
+        CommandLine|contains|all:
+            - 'binPath='
+            - 'type='
+            - 'kernel'
+    condition: selection
+falsepositives:
+    - Legitimate installation of drivers via sc.exe
+level: medium
+tags:
+    - attack.persistence
+    - attack.privilege_escalation
+    - attack.t1543.003


### PR DESCRIPTION
Added new rules based on this https://www.aon.com/cyber-solutions/aon_cyber_labs/yours-truly-signed-av-driver-weaponizing-an-antivirus-driver/

- Detect vuln avast driver mentioned in the article via its HASH
- Rule to detect the installation of new drivers via "sc type=kernel"