### PR TITLE
Update Children Of Web Shell Rules

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_webshell_detection.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_webshell_detection.yml
@@ -45,7 +45,7 @@ detection:
             - '/netstat'
             - '/pwd'
             - '/route'
-    condition: 1 selection_* and sub_processes
+    condition: 1 of selection_* and sub_processes
 falsepositives:
     - Web applications that invoke Linux command line tools
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_webshell_detection.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_webshell_detection.yml
@@ -3,41 +3,49 @@ id: 818f7b24-0fba-4c49-a073-8b755573b9c7
 status: experimental
 description: Detects suspicious sub processes of web server processes
 references:
-   - https://www.acunetix.com/blog/articles/web-shells-101-using-php-introduction-web-shells-part-2/
+    - https://www.acunetix.com/blog/articles/web-shells-101-using-php-introduction-web-shells-part-2/
+    - https://media.defense.gov/2020/Jun/09/2002313081/-1/-1/0/CSI-DETECT-AND-PREVENT-WEB-SHELL-MALWARE-20200422.PDF
 date: 2021/10/15
-modified: 2022/06/03
-author: Florian Roth
+modified: 2022/08/01
+author: Florian Roth, Nasreddine Bencherchali (update)
 tags:
     - attack.persistence
     - attack.t1505.003
 logsource:
-   product: linux
-   category: process_creation
+    product: linux
+    category: process_creation
 detection:
-   selection_general:
-      ParentImage|endswith:
-         - '/httpd'
-         - '/lighttpd'
-         - '/nginx'
-         - '/apache2'
-         - '/node'
-         - '/caddy'
-   selection_tomcat:
-      ParentCommandLine|contains|all:
-         - '/bin/java'
-         - 'tomcat'
-   selection_websphere:  # ? just guessing
-      ParentCommandLine|contains|all:
-         - '/bin/java'
-         - 'websphere'
-   selection_sub_processes:
-      Image|endswith:
-         - '/whoami'
-         - '/ifconfig'
-         - '/usr/bin/ip'
-         - '/bin/uname'
-   condition: selection_sub_processes and ( selection_general or selection_tomcat or selection_websphere)
+    selection_general:
+        ParentImage|endswith:
+            - '/httpd'
+            - '/lighttpd'
+            - '/nginx'
+            - '/apache2'
+            - '/node'
+            - '/caddy'
+    selection_tomcat:
+        ParentCommandLine|contains|all:
+            - '/bin/java'
+            - 'tomcat'
+    selection_websphere:  # ? just guessing
+        ParentCommandLine|contains|all:
+            - '/bin/java'
+            - 'websphere'
+    sub_processes:
+        Image|endswith:
+            - '/whoami'
+            - '/ifconfig'
+            - '/usr/bin/ip'
+            - '/usr/sbin/ip'
+            - '/bin/uname'
+            - '/bin/cat'
+            - '/bin/crontab'
+            - '/hostname'
+            - '/iptables'
+            - '/netstat'
+            - '/pwd'
+            - '/route'
+    condition: 1 selection_* and sub_processes
 falsepositives:
-   - Web applications that invoke Linux command line tools
+    - Web applications that invoke Linux command line tools
 level: high
-

--- a/rules/windows/process_creation/proc_creation_win_webshell_spawn.yml
+++ b/rules/windows/process_creation/proc_creation_win_webshell_spawn.yml
@@ -2,9 +2,11 @@ title: Shells Spawned by Web Servers
 id: 8202070f-edeb-4d31-a010-a26c72ac5600
 status: test
 description: Detects web servers that spawn shell processes which could be the result of a successfully placed web shell or another attack
-author: Thomas Patzke, Florian Roth, Zach Stanford @svch0st, Tim Shelton
+author: Thomas Patzke, Florian Roth, Zach Stanford @svch0st, Tim Shelton, Nasreddine Bencherchali (update)
 date: 2019/01/16
-modified: 2022/07/25
+modified: 2022/08/01
+references:
+    - https://media.defense.gov/2020/Jun/09/2002313081/-1/-1/0/CSI-DETECT-AND-PREVENT-WEB-SHELL-MALWARE-20200422.PDF
 tags:
     - attack.persistence
     - attack.t1505.003
@@ -46,6 +48,43 @@ detection:
             - '\powershell.exe'
             - '\pwsh.exe'
             - '\bitsadmin.exe'
+            - '\arp.exe'
+            - '\at.exe'
+            - '\certutil.exe'
+            - '\dsget.exe'
+            - '\dsquery.exe'
+            - '\find.exe'
+            - '\findstr.exe'
+            - '\fsutil.exe'
+            - '\hostname.exe'
+            - '\ipconfig.exe'
+            - '\nbtstat.exe'
+            - '\net.exe'
+            - '\net1.exe'
+            - '\netdom.exe'
+            - '\netsh.exe'
+            - '\netstat.exe'
+            - '\nltest.exe'
+            - '\nslookup.exe'
+            - '\ntdutil.exe'
+            - '\pathping.exe'
+            - '\ping.exe'
+            - '\qprocess.exe'
+            - '\query.exe'
+            - '\qwinsta.exe'
+            - '\reg.exe'
+            - '\rundll32.exe'
+            - '\sc.exe'
+            - '\schtasks.exe'
+            - '\systeminfo.exe'
+            - '\tasklist.exe'
+            - '\tracert.exe'
+            - '\ver.exe'
+            - '\vssadmin.exe'
+            - '\wevtutil.exe'
+            - '\whoami.exe'
+            - '\wmic.exe'
+            - '\wusa.exe'
     false_positive1:
         CommandLine|endswith: 'Windows\system32\cmd.exe /c C:\ManageEngine\ADManager "Plus\ES\bin\elasticsearch.bat -Enode.name=RMP-NODE1 -pelasticsearch-pid.txt'
     condition: 1 of selection* and anomaly_children and not 1 of false_positive*


### PR DESCRIPTION
Updated these two rules following the NSA link provided in this tweet https://twitter.com/securepeacock/status/1554220498917228544

- Shells Spawned by Web Servers (8202070f-edeb-4d31-a010-a26c72ac5600)
- Linux Webshell Indicators (818f7b24-0fba-4c49-a073-8b755573b9c7)

NSA Link: https://media.defense.gov/2020/Jun/09/2002313081/-1/-1/0/CSI-DETECT-AND-PREVENT-WEB-SHELL-MALWARE-20200422.PDF