### PR TITLE
Narrowing the detection due to false positive matches of webresource.axd

### DIFF
--- a/rules/web/web_cve_2020_10148_solarwinds_exploit.yml
+++ b/rules/web/web_cve_2020_10148_solarwinds_exploit.yml
@@ -2,27 +2,31 @@ title: CVE-2020-10148 SolarWinds Orion API Auth Bypass
 id: 5a35116f-43bc-4901-b62d-ef131f42a9af
 status: test
 description: Detects CVE-2020-10148 SolarWinds Orion API authentication bypass attempts
-author: Bhabesh Raj
+author: Bhabesh Raj, Tim Shelton
 references:
   - https://kb.cert.org/vuls/id/843464
 date: 2020/12/27
-modified: 2022/01/07
+modified: 2022/08/02
 logsource:
   category: webserver
 detection:
   selection:
     c-uri|contains:
-      - 'WebResource.axd'
-      - 'ScriptResource.axd'
-      - 'i18n.ashx'
-      - 'Skipi18n'
+      - '/WebResource.axd'
+      - '/ScriptResource.axd'
+      - '/i18n.ashx'
+      - '/Skipi18n'
+  selection2:
+    c-uri|contains:
+      - '/SolarWinds/'
+      - '/api/'
   valid_request_1:
     c-uri|contains: 'Orion/Skipi18n/Profiler/'
   valid_request_2:
     c-uri|contains:
       - 'css.i18n.ashx'
       - 'js.i18n.ashx'
-  condition: selection and not valid_request_1 and not valid_request_2
+  condition: selection* and not valid_request_1 and not valid_request_2
 falsepositives:
   - Unknown
 level: critical

--- a/rules/web/web_cve_2020_10148_solarwinds_exploit.yml
+++ b/rules/web/web_cve_2020_10148_solarwinds_exploit.yml
@@ -26,7 +26,7 @@ detection:
     c-uri|contains:
       - 'css.i18n.ashx'
       - 'js.i18n.ashx'
-  condition: selection* and not valid_request_1 and not valid_request_2
+  condition: selection and selection2 and not valid_request_1 and not valid_request_2
 falsepositives:
   - Unknown
 level: critical

--- a/rules/web/web_cve_2020_10148_solarwinds_exploit.yml
+++ b/rules/web/web_cve_2020_10148_solarwinds_exploit.yml
@@ -26,7 +26,7 @@ detection:
     c-uri|contains:
       - 'css.i18n.ashx'
       - 'js.i18n.ashx'
-  condition: selection and selection2 and not valid_request_1 and not valid_request_2
+  condition: all of selection* and not 1 of valid_request_*
 falsepositives:
   - Unknown
 level: critical


### PR DESCRIPTION
FP: /webresource.axd?d=<REDACTED>1&t=637823185705833095



Adds /api or /SolarWinds/ path check