### PR TITLE
proxy_empire_ua_uri_combos.yml: Change cs-uri-query to cs-uri to enable matching

### DIFF
--- a/rules/proxy/proxy_empire_ua_uri_combos.yml
+++ b/rules/proxy/proxy_empire_ua_uri_combos.yml
@@ -6,13 +6,13 @@ author: Florian Roth
 references:
   - https://github.com/BC-SECURITY/Empire
 date: 2020/07/13
-modified: 2021/11/27
+modified: 2022/08/05
 logsource:
   category: proxy
 detection:
   selection:
     c-useragent: 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko'
-    cs-uri-query:
+    cs-uri:
       - '/admin/get.php'
       - '/news.php'
       - '/login/process.php'


### PR DESCRIPTION
Rule should be applied on uri and not the uri-query