### PR TITLE
Update win_applocker_file_was_not_allowed_to_run.yml

### DIFF
--- a/rules/windows/builtin/applocker/win_applocker_file_was_not_allowed_to_run.yml
+++ b/rules/windows/builtin/applocker/win_applocker_file_was_not_allowed_to_run.yml
@@ -17,6 +17,8 @@ detection:
     EventID:
       - 8004
       - 8007
+      - 8022
+      - 8024
   condition: selection
 fields:
   - PolicyName

--- a/rules/windows/builtin/applocker/win_applocker_file_was_not_allowed_to_run.yml
+++ b/rules/windows/builtin/applocker/win_applocker_file_was_not_allowed_to_run.yml
@@ -18,7 +18,7 @@ detection:
       - 8004
       - 8007
       - 8022
-      - 8024
+      - 8025
   condition: selection
 fields:
   - PolicyName


### PR DESCRIPTION
Hello,

I added the Event ID 8022 and 8025 that respectively indicate:

EID 8022: Packaged app disabled, Applocker Prevented the Packaged app (modern application) from running.
EID 8025: Packaged app installation disabled. Applocker Prevented the Packaged app (modern application) from being installed.

https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-application-control/applocker/using-event-viewer-with-applocker
