### PR TITLE
proxy_susp_flash_download_loc.yml: c-uri inst. of c-uri-query and r-dns inst of c-uri-stem, proxy_ua_susp.yml: Avoid adobe false positives

### DIFF
--- a/rules/proxy/proxy_susp_flash_download_loc.yml
+++ b/rules/proxy/proxy_susp_flash_download_loc.yml
@@ -11,10 +11,10 @@ logsource:
   category: proxy
 detection:
   selection:
-    - c-uri-query|contains: '/flash_install.php'
-    - c-uri-query|endswith: '/install_flash_player.exe'
+    - c-uri|contains: '/flash_install.php'
+    - c-uri|endswith: '/install_flash_player.exe'
   filter:
-    c-uri-stem|contains: '.adobe.com/'
+    r-dns|endswith: '.adobe.com'
   condition: selection and not filter
 falsepositives:
   - Unknown flash download locations

--- a/rules/proxy/proxy_susp_flash_download_loc.yml
+++ b/rules/proxy/proxy_susp_flash_download_loc.yml
@@ -1,4 +1,4 @@
-title: Flashtest
+title: Flash Player Update from Suspicious Location
 id: 6743-4fc2-8e81-144374280997
 status: test
 description: Detects a flashplayer update from an unofficial location

--- a/rules/proxy/proxy_susp_flash_download_loc.yml
+++ b/rules/proxy/proxy_susp_flash_download_loc.yml
@@ -1,5 +1,5 @@
 title: Flash Player Update from Suspicious Location
-id: 6743-4fc2-8e81-144374280997
+id: 4922a5dd-6743-4fc2-8e81-144374280997
 status: test
 description: Detects a flashplayer update from an unofficial location
 author: Florian Roth

--- a/rules/proxy/proxy_susp_flash_download_loc.yml
+++ b/rules/proxy/proxy_susp_flash_download_loc.yml
@@ -1,12 +1,12 @@
-title: Flash Player Update from Suspicious Location
-id: 4922a5dd-6743-4fc2-8e81-144374280997
+title: Flashtest
+id: 6743-4fc2-8e81-144374280997
 status: test
 description: Detects a flashplayer update from an unofficial location
 author: Florian Roth
 references:
   - https://gist.github.com/roycewilliams/a723aaf8a6ac3ba4f817847610935cfb
 date: 2017/10/25
-modified: 2022/01/07
+modified: 2022/08/08
 logsource:
   category: proxy
 detection:

--- a/rules/proxy/proxy_susp_flash_download_loc.yml
+++ b/rules/proxy/proxy_susp_flash_download_loc.yml
@@ -14,7 +14,7 @@ detection:
     - c-uri|contains: '/flash_install.php'
     - c-uri|endswith: '/install_flash_player.exe'
   filter:
-    r-dns|endswith: '.adobe.com'
+    cs-host|endswith: '.adobe.com'
   condition: selection and not filter
 falsepositives:
   - Unknown flash download locations

--- a/rules/proxy/proxy_ua_susp.yml
+++ b/rules/proxy/proxy_ua_susp.yml
@@ -34,7 +34,7 @@ detection:
             - 'HTTPS'  # https://twitter.com/stvemillertime/status/1204437531632250880
     falsepositives:
         - c-useragent: 'Mozilla/3.0 * Acrobat *'  # Acrobat with linked content
-        - r-dns|endswith: # Adobe product traffic, example: Mozilla/3.0 (compatible; Adobe Synchronizer 10.12.20000)
+        - cs-host|endswith: # Adobe product traffic, example: Mozilla/3.0 (compatible; Adobe Synchronizer 10.12.20000)
           - '.acrobat.com'
           - '.adobe.com'
           - '.adobe.io'
@@ -43,6 +43,7 @@ fields:
     - ClientIP
     - c-uri
     - c-useragent
+    - cs-host
 falsepositives:
     - Unknown
 level: high

--- a/rules/proxy/proxy_ua_susp.yml
+++ b/rules/proxy/proxy_ua_susp.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects suspicious malformed user agent strings in proxy logs
 author: Florian Roth
 date: 2017/07/08
-modified: 2022/07/07
+modified: 2022/08/08
 references:
     - https://github.com/fastly/waf_testbed/blob/8bfc406551f3045e418cbaad7596cff8da331dfc/templates/default/scanners-user-agents.data.erb
 logsource:
@@ -33,7 +33,11 @@ detection:
             - 'Mozilla/5.0 (Windows NT 6.3; WOW64; rv:28.0) Gecko/20100101 Firefox/28.0'  # used by APT28 malware https://threatvector.cylance.com/en_us/home/inside-the-apt28-dll-backdoor-blitz.html
             - 'HTTPS'  # https://twitter.com/stvemillertime/status/1204437531632250880
     falsepositives:
-        c-useragent: 'Mozilla/3.0 * Acrobat *'  # Acrobat with linked content
+        - c-useragent: 'Mozilla/3.0 * Acrobat *'  # Acrobat with linked content
+        - r-dns|endswith: # Adobe product traffic, example: Mozilla/3.0 (compatible; Adobe Synchronizer 10.12.20000)
+          - '.acrobat.com'
+          - '.adobe.com'
+          - '.adobe.io'
     condition: 1 of selection* and not falsepositives
 fields:
     - ClientIP


### PR DESCRIPTION
proxy_susp_flash_download_loc:
* Change to c-uri inst of c-uri-query so we actually match on the path and not the query.
* r-dns instead of c-uri-stem as it appears cleaner in this case.

proxy_ua_susp.yml:
* Filter to avoid false positive traffic towards Adobe sites from Adobe products