### PR TITLE
BloodHound Collection Files

### DIFF
--- a/rules/windows/file_event/file_event_bloodhound_collection.yml
+++ b/rules/windows/file_event/file_event_bloodhound_collection.yml
@@ -1,0 +1,40 @@
+title: BloodHound Collection Files
+id: 02773bed-83bf-469f-b7ff-e676e7d78bab
+description: Detects default file names outputted by the BloodHound collection tool SharpHound
+status: experimental
+author: C.J. May
+references:
+    - https://academy.hackthebox.com/course/preview/active-directory-bloodhound/bloodhound--data-collection
+date: 2022/08/09
+modified: 2022/08/09
+tags:
+  - attack.discovery
+  - attack.t1087.001
+  - attack.t1087.002
+  - attack.t1482
+  - attack.t1069.001
+  - attack.t1069.002
+  - attack.execution
+  - attack.t1059.001
+logsource:
+    product: windows
+    category: file_event
+detection:
+    selection1:
+        TargetFilename|endswith: 
+            - '\_BloodHound.zip'
+            - '\_computers.json'
+            - '\_containers.json'
+            - '\_domains.json'
+            - '\_gpos.json'
+            - '\_groups.json'
+            - '\_ous.json'
+            - '\_users.json'
+    selection2:
+        TargetFilename|contains|all:
+            - '\BloodHound'
+            - '.zip'
+    condition: 1 of selection*
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/file_event/file_event_bloodhound_collection.yml
+++ b/rules/windows/file_event/file_event_bloodhound_collection.yml
@@ -22,17 +22,17 @@ logsource:
 detection:
     selection1:
         TargetFilename|endswith: 
-            - '\_BloodHound.zip'
-            - '\_computers.json'
-            - '\_containers.json'
-            - '\_domains.json'
-            - '\_gpos.json'
-            - '\_groups.json'
-            - '\_ous.json'
-            - '\_users.json'
+            - '_BloodHound.zip'
+            - '_computers.json'
+            - '_containers.json'
+            - '_domains.json'
+            - '_gpos.json'
+            - '_groups.json'
+            - '_ous.json'
+            - '_users.json'
     selection2:
         TargetFilename|contains|all:
-            - '\BloodHound'
+            - 'BloodHound'
             - '.zip'
     condition: 1 of selection*
 falsepositives:


### PR DESCRIPTION
Similar idea to the [lsass dump detection rule](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/file_event/file_event_win_lsass_dump.yml), this rule detects default file names outputted by SharpHound.