### PR TITLE
Restore ruamel in sigmac to allow output in YAML

### DIFF
--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -18,7 +18,7 @@
 import sys
 import argparse
 import yaml
-#import ruamel.yaml
+import ruamel.yaml
 import json
 import pathlib
 import itertools


### PR DESCRIPTION
This commit definitely fix the #3337 issue. The commit #3349 restored the commented lines but the ruamel import was not in it.