### PR TITLE
chore: Change subrepo from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/cti"]
 	path = tests/cti
-	url = git@github.com:mitre/cti.git
+	url = https://github.com/mitre/cti.git


### PR DESCRIPTION
Many Firewalls allow HTTPS but block SSH. 
This also allows cloning without auth which makes processes easier.