### PR TITLE
Update fields for EID 5156 rules

### DIFF
--- a/rules/windows/builtin/security/win_global_catalog_enumeration.yml
+++ b/rules/windows/builtin/security/win_global_catalog_enumeration.yml
@@ -4,7 +4,7 @@ status: experimental
 author: Chakib Gzenayi (@Chak092), Hosni Mribah
 id: 619b020f-0fd7-4f23-87db-3f51ef837a34
 date: 2020/05/11
-modified: 2021/06/01
+modified: 2022/08/15
 references:
     - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-5156
 tags:
@@ -17,7 +17,7 @@ logsource:
 detection:
     selection:
         EventID: 5156
-        DestinationPort:
+        DestPort:
         - 3268
         - 3269
     timeframe: 1h

--- a/rules/windows/builtin/security/win_susp_outbound_kerberos_connection.yml
+++ b/rules/windows/builtin/security/win_susp_outbound_kerberos_connection.yml
@@ -6,16 +6,16 @@ author: Ilyas Ochkov, oscd.community
 references:
   - https://github.com/GhostPack/Rubeus
 date: 2019/10/24
-modified: 2021/11/27
+modified: 2022/08/15
 logsource:
   product: windows
   service: security
 detection:
   selection:
     EventID: 5156
-    DestinationPort: 88
+    DestPort: 88
   filter:
-    Image|endswith:
+    Application|endswith:
       - '\lsass.exe'
       - '\opera.exe'
       - '\chrome.exe'


### PR DESCRIPTION
Update to keep field names consistent for all rules which use EID 5156:
1. DestPort instead of DestinationPort
2. Application instead of Image

Current List:
[/rules/windows/builtin/security/win_global_catalog_enumeration.yml - Changed](https://github.com/SigmaHQ/sigma/blob/eded7e479db631f72ceef8d2960efae018048735/rules/windows/builtin/security/win_global_catalog_enumeration.yml)
[/rules/windows/builtin/security/win_rdp_reverse_tunnel.yml](https://github.com/SigmaHQ/sigma/blob/eded7e479db631f72ceef8d2960efae018048735/rules/windows/builtin/security/win_rdp_reverse_tunnel.yml)
[/rules/windows/builtin/security/win_remote_powershell_session.yml](https://github.com/SigmaHQ/sigma/blob/eded7e479db631f72ceef8d2960efae018048735/rules/windows/builtin/security/win_remote_powershell_session.yml)
[/rules/windows/builtin/security/win_susp_outbound_kerberos_connection.yml - Changed](https://github.com/SigmaHQ/sigma/blob/eded7e479db631f72ceef8d2960efae018048735/rules/windows/builtin/security/win_susp_outbound_kerberos_connection.yml)