### PR TITLE
proxy_ua_bitsadmin_susp_tld.yml fp filter

### DIFF
--- a/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
+++ b/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects Bitsadmin connections to domains with uncommon TLDs - https://twitter.com/jhencinski/status/1102695118455349248 - https://isc.sans.edu/forums/diary/Investigating+Microsoft+BITS+Activity/23281/
 author: Florian Roth, Tim Shelton
 date: 2019/03/07
-modified: 2022/05/09
+modified: 2022/08/16
 logsource:
     category: proxy
 detection:
@@ -16,6 +16,7 @@ detection:
             - '.net' 
             - '.org' 
             - '.scdn.co' # spotify streaming
+            - '.sfx.ms' # Microsoft domain, example request: https://oneclient.sfx.ms/PreSignInSettings/Prod/2022-08-15-21-xx-xx/PreSignInSettingsConfig.json
     condition: selection and not falsepositives
 fields:
     - ClientIP


### PR DESCRIPTION
Observed false-positive traffic towards `.sfx.ms` for proxy_ua_bitsadmin_susp_tld.yml so updated the rule filter.