### PR TITLE
Filter out FP of dnsZone

### DIFF
--- a/rules/windows/builtin/security/win_account_backdoor_dcsync_rights.yml
+++ b/rules/windows/builtin/security/win_account_backdoor_dcsync_rights.yml
@@ -4,8 +4,8 @@ description: Backdooring domain object to grant the rights associated with DCSyn
     Extended Right cmdlet, will allow to re-obtain the pwd hashes of any user/computer
 status: experimental
 date: 2019/04/03
-modified: 2022/08/10
-author: Samir Bousseaden; Roberto Rodriguez @Cyb3rWard0g; oscd.community; Tim Shelton
+modified: 2022/08/16
+author: Samir Bousseaden; Roberto Rodriguez @Cyb3rWard0g; oscd.community; Tim Shelton; Maxence Fossat
 references:
     - https://twitter.com/menasec1/status/1111556090137903104
     - https://www.specterops.io/assets/resources/an_ace_up_the_sleeve.pdf
@@ -27,6 +27,7 @@ detection:
         ObjectClass:
             - 'dnsNode'
             - 'dnsZoneScope'
+            - 'dnsZone'
     condition: selection and not 1 of filter*
 falsepositives:
     - New Domain Controller computer account, check user SIDs within the value attribute of event 5136 and verify if it's a regular user or DC computer account.


### PR DESCRIPTION
In an hybrid environment (Azure AD + on-premises), we can see false positives on objects with the "**dnsZone**" ObjectClass. Specifically, we've seen:

```
DN :	DC=privatelink.blob.core.windows.net,cn=MicrosoftDNS,DC=ForestDnsZones,DC=redacted,DC=com
DN :	DC=privatelink.azurewebsites.net,cn=MicrosoftDNS,DC=ForestDnsZones,DC=redacted,DC=com
DN :	DC=privatelink.vaultcore.azure.net,cn=MicrosoftDNS,DC=ForestDnsZones,DC=redacted,DC=com
DN :	DC=privatelink.prod.migration.windowsazure.com,cn=MicrosoftDNS,DC=ForestDnsZones,DC=redacted,DC=com
DN :	DC=privatelink.siterecovery.windowsazure.com,cn=MicrosoftDNS,DC=ForestDnsZones,DC=redacted,DC=com
```

We can see references to these domain names at: https://docs.microsoft.com/en-us/azure/migrate/troubleshoot-network-connectivity#confirm-that-the-required-private-dns-zone-resource-exists