### PR TITLE
Create win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml

### DIFF
--- a/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
+++ b/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
@@ -1,11 +1,11 @@
-title: Suspicious usage of CVE 2022_21919 or CVE_2021_34484
+title: Suspicious Usage of CVE_2021_34484 or CVE 2022_21919
 id: 52a85084-6989-40c3-8f32-091e12e13f09
 status: Experimental
-description: During exploitation of this vuln, It appears when the directory \Users\TEMP is created, two logs (providername:Microsoft-Windows-User Profiles Service) with eventid 1511 and 1515 are created. Viewed on 2008 Server
+description: During exploitation of this vuln, two logs (providername:Microsoft-Windows-User Profiles Service) with eventid 1511 and 1515 (maybe lot of false positives with this event) are created. Moreover, it appears the directory \Users\TEMP is created may be created during the exploitation.Viewed on 2008 Server
 author: Sorcha
 references:
   - https://packetstormsecurity.com/files/166692/Windows-User-Profile-Service-Privlege-Escalation.html
-date: 22/08/16
+date: 2022/08/16
 logsource:
   product: windows
   service: application
@@ -13,6 +13,7 @@ detection:
       EventID:
           - 1511                      
       ProviderName: 'Microsoft-Windows-User Profiles Service'
+condition: selection
 falsepositives:
   - Unknown
 level: high

--- a/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
+++ b/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
@@ -11,8 +11,7 @@ logsource:
   service: application
 detection:    
   selection:
-      EventID:
-          - 1511                      
+      EventID: 1511                      
       ProviderName: 'Microsoft-Windows-User Profiles Service'
   condition: selection
 falsepositives:

--- a/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
+++ b/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
@@ -1,8 +1,8 @@
 title: Suspicious Usage of CVE_2021_34484 or CVE 2022_21919
-id: 52a85084-6989-40c3-8f32-091e12e13f09
-status: Experimental
+id: 52a85084-6989-40c3-8f32-091e12e17692
+status: experimental
 description: During exploitation of this vuln, two logs (providername:Microsoft-Windows-User Profiles Service) with eventid 1511 and 1515 (maybe lot of false positives with this event) are created. Moreover, it appears the directory \Users\TEMP is created may be created during the exploitation.Viewed on 2008 Server
-author: Sorcha
+author: Cybex
 references:
   - https://packetstormsecurity.com/files/166692/Windows-User-Profile-Service-Privlege-Escalation.html
 date: 2022/08/16
@@ -10,10 +10,11 @@ logsource:
   product: windows
   service: application
 detection:    
+  selection:
       EventID:
           - 1511                      
       ProviderName: 'Microsoft-Windows-User Profiles Service'
-condition: selection
+  condition: selection
 falsepositives:
   - Unknown
 level: high

--- a/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
+++ b/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
@@ -1,0 +1,21 @@
+title: Suspicious usage of CVE 2022_21919 or CVE_2021_34484
+id: 52a85084-6989-40c3-8f32-091e12e13f09
+status: test
+description: During exploitation of this vuln, It appears when the directory \Users\TEMP is created, two logs (providername:Microsoft-Windows-User Profiles Service) with eventid 1511 and 1515 are created. Viewed on 2008 Server
+author: Sorcha
+references:
+  - https://packetstormsecurity.com/files/166692/Windows-User-Profile-Service-Privlege-Escalation.html
+date: 22/08/16
+logsource:
+  product: windows
+  service: Profile Service
+detection:    
+      EventID:
+          - 1511   
+          - 1515                      
+      System.ProviderName: 'Microsoft-Windows-User Profiles Service'
+falsepositives:
+  - Unknown
+level: high
+tags:  
+  - attack.execution

--- a/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
+++ b/rules/windows/builtin/system/win_susp_vuln_cve_2022_21919_or_cve_2021_34484.yml
@@ -1,6 +1,6 @@
 title: Suspicious usage of CVE 2022_21919 or CVE_2021_34484
 id: 52a85084-6989-40c3-8f32-091e12e13f09
-status: test
+status: Experimental
 description: During exploitation of this vuln, It appears when the directory \Users\TEMP is created, two logs (providername:Microsoft-Windows-User Profiles Service) with eventid 1511 and 1515 are created. Viewed on 2008 Server
 author: Sorcha
 references:
@@ -8,12 +8,11 @@ references:
 date: 22/08/16
 logsource:
   product: windows
-  service: Profile Service
+  service: application
 detection:    
       EventID:
-          - 1511   
-          - 1515                      
-      System.ProviderName: 'Microsoft-Windows-User Profiles Service'
+          - 1511                      
+      ProviderName: 'Microsoft-Windows-User Profiles Service'
 falsepositives:
   - Unknown
 level: high


### PR DESCRIPTION
During exploitation of this vuln, It appears when the directory \Users\TEMP is created, two logs (providername:Microsoft-Windows-User Profiles Service) with eventid 1511 and 1515 are created. Viewed on 2008 Server