### PR TITLE
posh_ps_disable_psreadline_command_history

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_disable_psreadline_command_history.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_disable_psreadline_command_history.yml
@@ -1,0 +1,22 @@
+title: Disable Powershell Command History 
+id: 602f5669-6927-4688-84db-0d4b7afb2150
+status: experimental
+description: Powershell command history can be disabled by removing psreadline module 
+references:
+    - https://twitter.com/DissectMalware/status/1062879286749773824
+author: Ali Alwashali
+date: 2022/08/21
+logsource:
+    product: windows
+    category: ps_script
+    definition: Script block logging must be enabled
+detection:
+    selection:
+        ScriptBlockText|contains: 'Remove-Module psreadline'
+    condition: selection
+falsepositives:
+    - Legitimate script
+level: medium
+tags:
+    - attack.lateral_movement
+    - attack.t1021.006

--- a/rules/windows/powershell/powershell_script/posh_ps_disable_psreadline_command_history.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_disable_psreadline_command_history.yml
@@ -1,4 +1,4 @@
-title: Disable Powershell Command History 
+title: Disable Powershell Command History
 id: 602f5669-6927-4688-84db-0d4b7afb2150
 status: experimental
 description: Powershell command history can be disabled by removing psreadline module 
@@ -12,11 +12,13 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection:
-        ScriptBlockText|contains: 'Remove-Module psreadline'
+        ScriptBlockText|contains|all:
+            - Remove-Module 
+            - psreadline
     condition: selection
 falsepositives:
     - Legitimate script
 level: medium
 tags:
-    - attack.lateral_movement
-    - attack.t1021.006
+    - attack.defense_evasion
+    - attack.t1070.003

--- a/rules/windows/powershell/powershell_script/posh_ps_disable_psreadline_command_history.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_disable_psreadline_command_history.yml
@@ -1,7 +1,7 @@
 title: Disable Powershell Command History
 id: 602f5669-6927-4688-84db-0d4b7afb2150
 status: experimental
-description: Powershell command history can be disabled by removing psreadline module 
+description: Detects scripts or commands that disabled the Powershell command history by removing psreadline module
 references:
     - https://twitter.com/DissectMalware/status/1062879286749773824
 author: Ali Alwashali
@@ -13,12 +13,12 @@ logsource:
 detection:
     selection:
         ScriptBlockText|contains|all:
-            - Remove-Module 
+            - Remove-Module
             - psreadline
     condition: selection
 falsepositives:
-    - Legitimate script
-level: medium
+    - Legitimate script that disables the command history
+level: high
 tags:
     - attack.defense_evasion
     - attack.t1070.003


### PR DESCRIPTION
Powershell command history can be disabled by removing psreadline module 