### PR TITLE
Azure Activity Logs - operationName Field

### DIFF
--- a/rules/cloud/azure/azure_application_gateway_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_application_gateway_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer
 date: 2021/08/16
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_application_gateway_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_application_gateway_modified_or_deleted.yml
@@ -1,24 +1,24 @@
 title: Azure Application Gateway Modified or Deleted
 id: ad87d14e-7599-4633-ba81-aeb60cfe8cd6
-description: Identifies when a application gateway is modified or deleted.
-author: Austin Songer
 status: experimental
-date: 2021/08/16
+description: Identifies when a application gateway is modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer
+date: 2021/08/16
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.NETWORK/APPLICATIONGATEWAYS/WRITE
-            - MICROSOFT.NETWORK/APPLICATIONGATEWAYS/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/APPLICATIONGATEWAYS/WRITE
+      - MICROSOFT.NETWORK/APPLICATIONGATEWAYS/DELETE
+  condition: selection
 falsepositives:
- - Application gateway being modified or deleted may be performed by a system administrator. 
- - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Application gateway modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Application gateway being modified or deleted may be performed by a system administrator.
+  - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Application gateway modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_application_security_group_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_application_security_group_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer
 date: 2021/08/16
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_application_security_group_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_application_security_group_modified_or_deleted.yml
@@ -1,24 +1,24 @@
 title: Azure Application Security Group Modified or Deleted
 id: 835747f1-9329-40b5-9cc3-97d465754ce6
-description: Identifies when a application security group is modified or deleted.
-author: Austin Songer
 status: experimental
-date: 2021/08/16
+description: Identifies when a application security group is modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer
+date: 2021/08/16
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.NETWORK/APPLICATIONSECURITYGROUPS/WRITE
-            - MICROSOFT.NETWORK/APPLICATIONSECURITYGROUPS/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/APPLICATIONSECURITYGROUPS/WRITE
+      - MICROSOFT.NETWORK/APPLICATIONSECURITYGROUPS/DELETE
+  condition: selection
 falsepositives:
- - Application security group being modified or deleted may be performed by a system administrator. 
- - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Application security group modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Application security group being modified or deleted may be performed by a system administrator.
+  - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Application security group modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_container_registry_created_or_deleted.yml
+++ b/rules/cloud/azure/azure_container_registry_created_or_deleted.yml
@@ -10,6 +10,7 @@ references:
   - https://attack.mitre.org/matrices/enterprise/cloud/
 author: Austin Songer @austinsonger
 date: 2021/08/07
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_container_registry_created_or_deleted.yml
+++ b/rules/cloud/azure/azure_container_registry_created_or_deleted.yml
@@ -1,27 +1,27 @@
 title: Azure Container Registry Created or Deleted
 id: 93e0ef48-37c8-49ed-a02c-038aab23628e
-description: Detects when a Container Registry is created or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/07
+description: Detects when a Container Registry is created or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
-    - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
-    - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
-    - https://attack.mitre.org/matrices/enterprise/cloud/
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
+  - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
+  - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
+  - https://attack.mitre.org/matrices/enterprise/cloud/
+author: Austin Songer @austinsonger
+date: 2021/08/07
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.CONTAINERREGISTRY/REGISTRIES/WRITE
-            - MICROSOFT.CONTAINERREGISTRY/REGISTRIES/DELETE
-    condition: selection
-level: low
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.CONTAINERREGISTRY/REGISTRIES/WRITE
+      - MICROSOFT.CONTAINERREGISTRY/REGISTRIES/DELETE
+  condition: selection
 falsepositives:
- - Container Registry being created or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
- - Container Registry created or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Container Registry being created or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Container Registry created or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: low

--- a/rules/cloud/azure/azure_dns_zone_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_dns_zone_modified_or_deleted.yml
@@ -12,10 +12,10 @@ logsource:
   service: activitylogs
 detection:
   selection:
+    operationName|startswith: MICROSOFT.NETWORK/DNSZONES
     operationName|endswith:
       - /WRITE
       - /DELETE
-    operationName|startswith: MICROSOFT.NETWORK/DNSZONES
   condition: selection
 falsepositives:
   - DNS zone modified and deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.

--- a/rules/cloud/azure/azure_dns_zone_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_dns_zone_modified_or_deleted.yml
@@ -1,24 +1,24 @@
 title: Azure DNS Zone Modified or Deleted
 id: af6925b0-8826-47f1-9324-337507a0babd
-description: Identifies when DNS zone is modified or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/08
+description: Identifies when DNS zone is modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+author: Austin Songer @austinsonger
+date: 2021/08/08
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message|startswith: MICROSOFT.NETWORK/DNSZONES
-        properties.message|endswith:
-            - /WRITE
-            - /DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName|endswith:
+      - /WRITE
+      - /DELETE
+    operationName|startswith: MICROSOFT.NETWORK/DNSZONES
+  condition: selection
 falsepositives:
- - DNS zone modified and deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - DNS zone modification from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - DNS zone modified and deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - DNS zone modification from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_dns_zone_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_dns_zone_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
 author: Austin Songer @austinsonger
 date: 2021/08/08
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_firewall_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_firewall_modified_or_deleted.yml
@@ -1,23 +1,23 @@
 title: Azure Firewall Modified or Deleted
 id: 512cf937-ea9b-4332-939c-4c2c94baadcd
-description: Identifies when a firewall is created, modified, or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/08
+description: Identifies when a firewall is created, modified, or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/08
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.NETWORK/AZUREFIREWALLS/WRITE
-            - MICROSOFT.NETWORK/AZUREFIREWALLS/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/AZUREFIREWALLS/WRITE
+      - MICROSOFT.NETWORK/AZUREFIREWALLS/DELETE
+  condition: selection
 falsepositives:
- - Firewall being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Firewall modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Firewall being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Firewall modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_firewall_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_firewall_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/08
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_firewall_rule_collection_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_firewall_rule_collection_modified_or_deleted.yml
@@ -1,27 +1,27 @@
 title: Azure Firewall Rule Collection Modified or Deleted
 id: 025c9fe7-db72-49f9-af0d-31341dd7dd57
-description: Identifies when Rule Collections (Application, NAT, and Network) is being modified or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/08
+description: Identifies when Rule Collections (Application, NAT, and Network) is being modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/08
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.NETWORK/AZUREFIREWALLS/APPLICATIONRULECOLLECTIONS/WRITE
-            - MICROSOFT.NETWORK/AZUREFIREWALLS/APPLICATIONRULECOLLECTIONS/DELETE
-            - MICROSOFT.NETWORK/AZUREFIREWALLS/NATRULECOLLECTIONS/WRITE
-            - MICROSOFT.NETWORK/AZUREFIREWALLS/NATRULECOLLECTIONS/DELETE
-            - MICROSOFT.NETWORK/AZUREFIREWALLS/NETWORKRULECOLLECTIONS/WRITE
-            - MICROSOFT.NETWORK/AZUREFIREWALLS/NETWORKRULECOLLECTIONS/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/AZUREFIREWALLS/APPLICATIONRULECOLLECTIONS/WRITE
+      - MICROSOFT.NETWORK/AZUREFIREWALLS/APPLICATIONRULECOLLECTIONS/DELETE
+      - MICROSOFT.NETWORK/AZUREFIREWALLS/NATRULECOLLECTIONS/WRITE
+      - MICROSOFT.NETWORK/AZUREFIREWALLS/NATRULECOLLECTIONS/DELETE
+      - MICROSOFT.NETWORK/AZUREFIREWALLS/NETWORKRULECOLLECTIONS/WRITE
+      - MICROSOFT.NETWORK/AZUREFIREWALLS/NETWORKRULECOLLECTIONS/DELETE
+  condition: selection
 falsepositives:
- - Rule Collections (Application, NAT, and Network) being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Rule Collections (Application, NAT, and Network) modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Rule Collections (Application, NAT, and Network) being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Rule Collections (Application, NAT, and Network) modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_firewall_rule_collection_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_firewall_rule_collection_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/08
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_keyvault_key_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_keyvault_key_modified_or_deleted.yml
@@ -1,34 +1,34 @@
 title: Azure Keyvault Key Modified or Deleted
 id: 80eeab92-0979-4152-942d-96749e11df40
-description: Identifies when a Keyvault Key is modified or deleted in Azure.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/16
+description: Identifies when a Keyvault Key is modified or deleted in Azure.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/16
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.KEYVAULT/VAULTS/KEYS/UPDATE/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/KEYS/CREATE
-            - MICROSOFT.KEYVAULT/VAULTS/KEYS/CREATE/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/KEYS/IMPORT/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/KEYS/RECOVER/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/KEYS/RESTORE/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/KEYS/DELETE
-            - MICROSOFT.KEYVAULT/VAULTS/KEYS/BACKUP/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/KEYS/PURGE/ACTION
-    condition: selection
-level: medium
-tags:
-    - attack.impact
-    - attack.credential_access
-    - attack.t1552
-    - attack.t1552.001
+  selection:
+    operationName:
+      - MICROSOFT.KEYVAULT/VAULTS/KEYS/UPDATE/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/KEYS/CREATE
+      - MICROSOFT.KEYVAULT/VAULTS/KEYS/CREATE/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/KEYS/IMPORT/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/KEYS/RECOVER/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/KEYS/RESTORE/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/KEYS/DELETE
+      - MICROSOFT.KEYVAULT/VAULTS/KEYS/BACKUP/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/KEYS/PURGE/ACTION
+  condition: selection
 falsepositives:
- - Key being modified or deleted may be performed by a system administrator. 
- - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Key modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Key being modified or deleted may be performed by a system administrator.
+  - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Key modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+  - attack.credential_access
+  - attack.t1552
+  - attack.t1552.001
+level: medium

--- a/rules/cloud/azure/azure_keyvault_key_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_keyvault_key_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/16
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_keyvault_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_keyvault_modified_or_deleted.yml
@@ -1,29 +1,29 @@
 title: Azure Key Vault Modified or Deleted
 id: 459a2970-bb84-4e6a-a32e-ff0fbd99448d
-description: Identifies when a key vault is modified or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/16
+description: Identifies when a key vault is modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/16
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message:
-            - MICROSOFT.KEYVAULT/VAULTS/WRITE
-            - MICROSOFT.KEYVAULT/VAULTS/DELETE
-            - MICROSOFT.KEYVAULT/VAULTS/DEPLOY/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/ACCESSPOLICIES/WRITE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
-    - attack.credential_access
-    - attack.t1552
-    - attack.t1552.001
+  selection:
+    operationName:
+      - MICROSOFT.KEYVAULT/VAULTS/WRITE
+      - MICROSOFT.KEYVAULT/VAULTS/DELETE
+      - MICROSOFT.KEYVAULT/VAULTS/DEPLOY/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/ACCESSPOLICIES/WRITE
+  condition: selection
 falsepositives:
- - Key Vault being modified or deleted may be performed by a system administrator. 
- - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Key Vault modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Key Vault being modified or deleted may be performed by a system administrator.
+  - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Key Vault modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+  - attack.credential_access
+  - attack.t1552
+  - attack.t1552.001
+level: medium

--- a/rules/cloud/azure/azure_keyvault_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_keyvault_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/16
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_keyvault_secrets_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_keyvault_secrets_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/16
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_keyvault_secrets_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_keyvault_secrets_modified_or_deleted.yml
@@ -1,33 +1,33 @@
 title: Azure Keyvault Secrets Modified or Deleted
 id: b831353c-1971-477b-abb6-2828edc3bca1
-description: Identifies when secrets are modified or deleted in Azure.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/16
+description: Identifies when secrets are modified or deleted in Azure.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/16
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.KEYVAULT/VAULTS/SECRETS/WRITE
-            - MICROSOFT.KEYVAULT/VAULTS/SECRETS/DELETE
-            - MICROSOFT.KEYVAULT/VAULTS/SECRETS/BACKUP/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/SECRETS/PURGE/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/SECRETS/UPDATE/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/SECRETS/RECOVER/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/SECRETS/RESTORE/ACTION
-            - MICROSOFT.KEYVAULT/VAULTS/SECRETS/SETSECRET/ACTION
-    condition: selection
-level: medium
-tags:
-    - attack.impact
-    - attack.credential_access
-    - attack.t1552
-    - attack.t1552.001
+  selection:
+    operationName:
+      - MICROSOFT.KEYVAULT/VAULTS/SECRETS/WRITE
+      - MICROSOFT.KEYVAULT/VAULTS/SECRETS/DELETE
+      - MICROSOFT.KEYVAULT/VAULTS/SECRETS/BACKUP/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/SECRETS/PURGE/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/SECRETS/UPDATE/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/SECRETS/RECOVER/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/SECRETS/RESTORE/ACTION
+      - MICROSOFT.KEYVAULT/VAULTS/SECRETS/SETSECRET/ACTION
+  condition: selection
 falsepositives:
- - Secrets being modified or deleted may be performed by a system administrator. 
- - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Secrets modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Secrets being modified or deleted may be performed by a system administrator.
+  - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Secrets modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+  - attack.credential_access
+  - attack.t1552
+  - attack.t1552.001
+level: medium

--- a/rules/cloud/azure/azure_kubernetes_admission_controller.yml
+++ b/rules/cloud/azure/azure_kubernetes_admission_controller.yml
@@ -1,34 +1,34 @@
 title: Azure Kubernetes Admission Controller
 id: a61a3c56-4ce2-4351-a079-88ae4cbd2b58
-description: Identifies when an admission controller is executed in Azure Kubernetes. A Kubernetes Admission controller intercepts, and possibly modifies, requests to the Kubernetes API server. The behavior of this admission controller is determined by an admission webhook (MutatingAdmissionWebhook or ValidatingAdmissionWebhook) that the user deploys in the cluster. An adversary can use such webhooks as the MutatingAdmissionWebhook for obtaining persistence in the cluster. For example, attackers can intercept and modify the pod creation operations in the cluster and add their malicious container to every created pod. An adversary can use the webhook ValidatingAdmissionWebhook, which could be used to obtain access credentials. An adversary could use the webhook to intercept the requests to the API server, record secrets, and other sensitive information.
-author: Austin Songer @austinsonger
 status: experimental
+description: Identifies when an admission controller is executed in Azure Kubernetes. A Kubernetes Admission controller intercepts, and possibly modifies, requests to the Kubernetes API server. The behavior of this admission controller is determined by an admission webhook (MutatingAdmissionWebhook or ValidatingAdmissionWebhook) that the user deploys in the cluster. An adversary can use such webhooks as the MutatingAdmissionWebhook for obtaining persistence in the cluster. For example, attackers can intercept and modify the pod creation operations in the cluster and add their malicious container to every created pod. An adversary can use the webhook ValidatingAdmissionWebhook, which could be used to obtain access credentials. An adversary could use the webhook to intercept the requests to the API server, record secrets, and other sensitive information.
+references:
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+author: Austin Songer @austinsonger
 date: 2021/11/25
 modified: 2021/11/26
-references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection1:
-          properties.message|startswith: MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/ADMISSIONREGISTRATION.K8S.IO
-          properties.message|endswith:
-            - /MUTATINGWEBHOOKCONFIGURATIONS/WRITE
-            - /VALIDATINGWEBHOOKCONFIGURATIONS/WRITE
-    selection2:
-          properties.message|startswith: MICROSOFT.CONTAINERSERVICE/MANAGEDCLUSTERS/ADMISSIONREGISTRATION.K8S.IO
-          properties.message|endswith:
-            - /MUTATINGWEBHOOKCONFIGURATIONS/WRITE
-            - /VALIDATINGWEBHOOKCONFIGURATIONS/WRITE
-    condition: selection1 or selection2
-level: medium
-tags:
-    - attack.persistence
-    - attack.t1078
-    - attack.credential_access
-    - attack.t1552
-    - attack.t1552.007
+  selection1:
+    operationName|startswith: MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/ADMISSIONREGISTRATION.K8S.IO
+    operationName|endswith:
+      - /MUTATINGWEBHOOKCONFIGURATIONS/WRITE
+      - /VALIDATINGWEBHOOKCONFIGURATIONS/WRITE
+  selection2:
+    operationName|startswith: MICROSOFT.CONTAINERSERVICE/MANAGEDCLUSTERS/ADMISSIONREGISTRATION.K8S.IO
+    operationName|endswith:
+      - /MUTATINGWEBHOOKCONFIGURATIONS/WRITE
+      - /VALIDATINGWEBHOOKCONFIGURATIONS/WRITE
+  condition: selection1 or selection2
 falsepositives:
-- Azure Kubernetes Admissions Controller may be done by a system administrator. 
-- If known behavior is causing false positives, it can be exempted from the rule.
+  - Azure Kubernetes Admissions Controller may be done by a system administrator.
+  - If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.persistence
+  - attack.t1078
+  - attack.credential_access
+  - attack.t1552
+  - attack.t1552.007
+level: medium

--- a/rules/cloud/azure/azure_kubernetes_admission_controller.yml
+++ b/rules/cloud/azure/azure_kubernetes_admission_controller.yml
@@ -6,7 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
 author: Austin Songer @austinsonger
 date: 2021/11/25
-modified: 2021/11/26
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_kubernetes_cluster_created_or_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_cluster_created_or_deleted.yml
@@ -10,6 +10,7 @@ references:
   - https://attack.mitre.org/matrices/enterprise/cloud/
 author: Austin Songer @austinsonger
 date: 2021/08/07
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_kubernetes_cluster_created_or_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_cluster_created_or_deleted.yml
@@ -1,28 +1,27 @@
 title: Azure Kubernetes Cluster Created or Deleted
 id: 9541f321-7cba-4b43-80fc-fbd1fb922808
-description: Detects when a Azure Kubernetes Cluster is created or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/07
+description: Detects when a Azure Kubernetes Cluster is created or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
-    - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
-    - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
-    - https://attack.mitre.org/matrices/enterprise/cloud/
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
+  - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
+  - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
+  - https://attack.mitre.org/matrices/enterprise/cloud/
+author: Austin Songer @austinsonger
+date: 2021/08/07
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/WRITE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/DELETE
-    condition: selection
-level: low
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/DELETE
+  condition: selection
 falsepositives:
- - Kubernetes cluster being created or  deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
- - Kubernetes cluster created or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
- 
+  - Kubernetes cluster being created or  deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Kubernetes cluster created or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: low

--- a/rules/cloud/azure/azure_kubernetes_cronjob.yml
+++ b/rules/cloud/azure/azure_kubernetes_cronjob.yml
@@ -1,34 +1,34 @@
 title: Azure Kubernetes CronJob
 id: 1c71e254-6655-42c1-b2d6-5e4718d7fc0a
-description: Identifies when a Azure Kubernetes CronJob runs in Azure Cloud. Kubernetes Job is a controller that creates one or more pods and ensures that a specified number of them successfully terminate. Kubernetes Job can be used to run containers that perform finite tasks for batch jobs. Kubernetes CronJob is used to schedule Jobs. An Adversary may use Kubernetes CronJob for scheduling execution of malicious code that would run as a container in the cluster.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/11/22
+description: Identifies when a Azure Kubernetes CronJob runs in Azure Cloud. Kubernetes Job is a controller that creates one or more pods and ensures that a specified number of them successfully terminate. Kubernetes Job can be used to run containers that perform finite tasks for batch jobs. Kubernetes CronJob is used to schedule Jobs. An Adversary may use Kubernetes CronJob for scheduling execution of malicious code that would run as a container in the cluster.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
-    - https://kubernetes.io/docs/concepts/workloads/controllers/job/
-    - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
+  - https://kubernetes.io/docs/concepts/workloads/controllers/job/
+  - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
+author: Austin Songer @austinsonger
+date: 2021/11/22
 logsource:
-    product: azure
-    service: activitylogs
+  product: azure
+  service: activitylogs
 detection:
-    selection1:
-          properties.message|startswith: MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/BATCH
-          properties.message|endswith:
-            - /CRONJOBS/WRITE
-            - /JOBS/WRITE
-    selection2:
-          properties.message|startswith: MICROSOFT.CONTAINERSERVICE/MANAGEDCLUSTERS/BATCH
-          properties.message|endswith:
-            - /CRONJOBS/WRITE
-            - /JOBS/WRITE
-    condition: selection1 or selection2
-level: medium
-tags:
-    - attack.persistence
-    - attack.privilege_escalation
-    - attack.execution
+  selection1:
+    operationName|startswith: MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/BATCH
+    operationName|endswith:
+      - /CRONJOBS/WRITE
+      - /JOBS/WRITE
+  selection2:
+    operationName|startswith: MICROSOFT.CONTAINERSERVICE/MANAGEDCLUSTERS/BATCH
+    operationName|endswith:
+      - /CRONJOBS/WRITE
+      - /JOBS/WRITE
+  condition: selection1 or selection2
 falsepositives:
-    - Azure Kubernetes CronJob/Job may be done by a system administrator.
-    - If known behavior is causing false positives, it can be exempted from the rule.
+  - Azure Kubernetes CronJob/Job may be done by a system administrator.
+  - If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.persistence
+  - attack.privilege_escalation
+  - attack.execution
+level: medium

--- a/rules/cloud/azure/azure_kubernetes_cronjob.yml
+++ b/rules/cloud/azure/azure_kubernetes_cronjob.yml
@@ -9,6 +9,7 @@ references:
   - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
 author: Austin Songer @austinsonger
 date: 2021/11/22
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_kubernetes_events_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_events_deleted.yml
@@ -1,24 +1,23 @@
 title: Azure Kubernetes Events Deleted
 id: 225d8b09-e714-479c-a0e4-55e6f29adf35
-description: Detects when Events are deleted in Azure Kubernetes. An adversary may delete events in Azure Kubernetes in an attempt to evade detection.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/07/24
+description: Detects when Events are deleted in Azure Kubernetes. An adversary may delete events in Azure Kubernetes in an attempt to evade detection.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://github.com/elastic/detection-rules/blob/da3852b681cf1a33898b1535892eab1f3a76177a/rules/integrations/azure/defense_evasion_kubernetes_events_deleted.toml
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://github.com/elastic/detection-rules/blob/da3852b681cf1a33898b1535892eab1f3a76177a/rules/integrations/azure/defense_evasion_kubernetes_events_deleted.toml
+author: Austin Songer @austinsonger
+date: 2021/07/24
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection_operation_name:
-          properties.message: MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/EVENTS.K8S.IO/EVENTS/DELETE
-    condition: selection_operation_name
-level: medium
-tags:
-    - attack.defense_evasion
-    - attack.t1562
-    - attack.t1562.001
+  selection:
+    operationName: MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/EVENTS.K8S.IO/EVENTS/DELETE
+  condition: selection
 falsepositives:
-- Event deletions may be done by a system or network administrator. Verify whether the username, hostname, and/or resource name should be making changes in your environment. Events deletions from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
-
+  - Event deletions may be done by a system or network administrator. Verify whether the username, hostname, and/or resource name should be making changes in your environment. Events deletions from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.defense_evasion
+  - attack.t1562
+  - attack.t1562.001
+level: medium

--- a/rules/cloud/azure/azure_kubernetes_events_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_events_deleted.yml
@@ -7,6 +7,7 @@ references:
   - https://github.com/elastic/detection-rules/blob/da3852b681cf1a33898b1535892eab1f3a76177a/rules/integrations/azure/defense_evasion_kubernetes_events_deleted.toml
 author: Austin Songer @austinsonger
 date: 2021/07/24
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_kubernetes_network_policy_change.yml
+++ b/rules/cloud/azure/azure_kubernetes_network_policy_change.yml
@@ -10,6 +10,7 @@ references:
   - https://attack.mitre.org/matrices/enterprise/cloud/
 author: Austin Songer @austinsonger
 date: 2021/08/07
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_kubernetes_network_policy_change.yml
+++ b/rules/cloud/azure/azure_kubernetes_network_policy_change.yml
@@ -1,30 +1,30 @@
 title: Azure Kubernetes Network Policy Change
 id: 08d6ac24-c927-4469-b3b7-2e422d6e3c43
-description: Identifies when a Azure Kubernetes network policy is modified or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/07
+description: Identifies when a Azure Kubernetes network policy is modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
-    - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
-    - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
-    - https://attack.mitre.org/matrices/enterprise/cloud/
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
+  - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
+  - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
+  - https://attack.mitre.org/matrices/enterprise/cloud/
+author: Austin Songer @austinsonger
+date: 2021/08/07
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/NETWORKING.K8S.IO/NETWORKPOLICIES/WRITE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/NETWORKING.K8S.IO/NETWORKPOLICIES/DELETE 
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/EXTENSIONS/NETWORKPOLICIES/WRITE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/EXTENSIONS/NETWORKPOLICIES/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
-    - attack.credential_access
+  selection:
+    operationName:
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/NETWORKING.K8S.IO/NETWORKPOLICIES/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/NETWORKING.K8S.IO/NETWORKPOLICIES/DELETE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/EXTENSIONS/NETWORKPOLICIES/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/EXTENSIONS/NETWORKPOLICIES/DELETE
+  condition: selection
 falsepositives:
- - Network Policy being modified and deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
- - Network Policy being modified and deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Network Policy being modified and deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Network Policy being modified and deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+  - attack.credential_access
+level: medium

--- a/rules/cloud/azure/azure_kubernetes_pods_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_pods_deleted.yml
@@ -7,6 +7,7 @@ references:
   - https://github.com/elastic/detection-rules/blob/065bf48a9987cd8bd826c098a30ce36e6868ee46/rules/integrations/azure/impact_kubernetes_pod_deleted.toml
 author: Austin Songer @austinsonger
 date: 2021/07/24
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_kubernetes_pods_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_pods_deleted.yml
@@ -1,22 +1,22 @@
 title: Azure Kubernetes Pods Deleted
 id: b02f9591-12c3-4965-986a-88028629b2e1
-description: Identifies the deletion of Azure Kubernetes Pods.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/07/24
+description: Identifies the deletion of Azure Kubernetes Pods.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://github.com/elastic/detection-rules/blob/065bf48a9987cd8bd826c098a30ce36e6868ee46/rules/integrations/azure/impact_kubernetes_pod_deleted.toml
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://github.com/elastic/detection-rules/blob/065bf48a9987cd8bd826c098a30ce36e6868ee46/rules/integrations/azure/impact_kubernetes_pod_deleted.toml
+author: Austin Songer @austinsonger
+date: 2021/07/24
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection_operation_name:
-          properties.message: MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/PODS/DELETE
-    condition: selection_operation_name
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName: MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/PODS/DELETE
+  condition: selection
 falsepositives:
-- Pods may be deleted by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
-- Pods deletions from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Pods may be deleted by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Pods deletions from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_kubernetes_role_access.yml
+++ b/rules/cloud/azure/azure_kubernetes_role_access.yml
@@ -1,33 +1,33 @@
 title: Azure Kubernetes Sensitive Role Access
 id: 818fee0c-e0ec-4e45-824e-83e4817b0887
-description: Identifies when ClusterRoles/Roles are being modified or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/07
+description: Identifies when ClusterRoles/Roles are being modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
-    - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
-    - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
-    - https://attack.mitre.org/matrices/enterprise/cloud/
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
+  - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
+  - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
+  - https://attack.mitre.org/matrices/enterprise/cloud/
+author: Austin Songer @austinsonger
+date: 2021/08/07
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/WRITE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/DELETE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/BIND/ACTION
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/ESCALATE/ACTION
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLES/WRITE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLES/DELETE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLES/BIND/ACTION
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLES/ESCALATE/ACTION
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationname:
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/DELETE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/BIND/ACTION
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/ESCALATE/ACTION
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLES/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLES/DELETE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLES/BIND/ACTION
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLES/ESCALATE/ACTION
+  condition: selection
 falsepositives:
- - ClusterRoles/Roles being modified and deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
- - ClusterRoles/Roles modification from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - ClusterRoles/Roles being modified and deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - ClusterRoles/Roles modification from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_kubernetes_role_access.yml
+++ b/rules/cloud/azure/azure_kubernetes_role_access.yml
@@ -10,12 +10,13 @@ references:
   - https://attack.mitre.org/matrices/enterprise/cloud/
 author: Austin Songer @austinsonger
 date: 2021/08/07
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs
 detection:
   selection:
-    operationname:
+    operationName:
       - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/WRITE
       - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/DELETE
       - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLES/BIND/ACTION

--- a/rules/cloud/azure/azure_kubernetes_rolebinding_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_rolebinding_modified_or_deleted.yml
@@ -10,6 +10,7 @@ references:
   - https://attack.mitre.org/matrices/enterprise/cloud/
 author: Austin Songer @austinsonger
 date: 2021/08/07
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_kubernetes_rolebinding_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_rolebinding_modified_or_deleted.yml
@@ -1,31 +1,30 @@
 title: Azure Kubernetes RoleBinding/ClusterRoleBinding Modified and Deleted
 id: 25cb259b-bbdc-4b87-98b7-90d7c72f8743
-description: Detects the creation or patching of potential malicious RoleBinding/ClusterRoleBinding.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/07
+description: Detects the creation or patching of potential malicious RoleBinding/ClusterRoleBinding.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
-    - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
-    - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
-    - https://attack.mitre.org/matrices/enterprise/cloud/
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
+  - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
+  - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
+  - https://attack.mitre.org/matrices/enterprise/cloud/
+author: Austin Songer @austinsonger
+date: 2021/08/07
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLEBINDINGS/WRITE 
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLEBINDINGS/DELETE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLEBINDINGS/WRITE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLEBINDINGS/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
-    - attack.credential_access
+  selection:
+    operationName:
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLEBINDINGS/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLEBINDINGS/DELETE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLEBINDINGS/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLEBINDINGS/DELETE
+  condition: selection
 falsepositives:
- - RoleBinding/ClusterRoleBinding being modified and deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - RoleBinding/ClusterRoleBinding modification from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
- 
+  - RoleBinding/ClusterRoleBinding being modified and deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - RoleBinding/ClusterRoleBinding modification from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+  - attack.credential_access
+level: medium

--- a/rules/cloud/azure/azure_kubernetes_secret_or_config_object_access.yml
+++ b/rules/cloud/azure/azure_kubernetes_secret_or_config_object_access.yml
@@ -10,6 +10,7 @@ references:
   - https://attack.mitre.org/matrices/enterprise/cloud/
 author: Austin Songer @austinsonger
 date: 2021/08/07
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_kubernetes_secret_or_config_object_access.yml
+++ b/rules/cloud/azure/azure_kubernetes_secret_or_config_object_access.yml
@@ -1,28 +1,28 @@
 title: Azure Kubernetes Secret or Config Object Access
 id: 7ee0b4aa-d8d4-4088-b661-20efdf41a04c
-description: Identifies when a Kubernetes account access a sensitive objects such as configmaps or secrets.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/07
+description: Identifies when a Kubernetes account access a sensitive objects such as configmaps or secrets.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
-    - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
-    - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
-    - https://attack.mitre.org/matrices/enterprise/cloud/
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
+  - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
+  - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
+  - https://attack.mitre.org/matrices/enterprise/cloud/
+author: Austin Songer @austinsonger
+date: 2021/08/07
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/CONFIGMAPS/WRITE 
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/CONFIGMAPS/DELETE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SECRETS/WRITE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SECRETS/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/CONFIGMAPS/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/CONFIGMAPS/DELETE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SECRETS/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SECRETS/DELETE
+  condition: selection
 falsepositives:
- - Sensitive objects may be accessed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. Sensitive objects accessed from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Sensitive objects may be accessed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. Sensitive objects accessed from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_kubernetes_service_account_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_service_account_modified_or_deleted.yml
@@ -10,6 +10,7 @@ references:
   - https://attack.mitre.org/matrices/enterprise/cloud/
 author: Austin Songer @austinsonger
 date: 2021/08/07
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_kubernetes_service_account_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_kubernetes_service_account_modified_or_deleted.yml
@@ -1,28 +1,28 @@
 title: Azure Kubernetes Service Account Modified or Deleted
 id: 12d027c3-b48c-4d9d-8bb6-a732200034b2
-description: Identifies when a service account is modified or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/07
+description: Identifies when a service account is modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
-    - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
-    - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
-    - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
-    - https://attack.mitre.org/matrices/enterprise/cloud/
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftkubernetes
+  - https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/
+  - https://www.microsoft.com/security/blog/2020/04/02/attack-matrix-kubernetes/
+  - https://medium.com/mitre-engenuity/att-ck-for-containers-now-available-4c2359654bf1
+  - https://attack.mitre.org/matrices/enterprise/cloud/
+author: Austin Songer @austinsonger
+date: 2021/08/07
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SERVICEACCOUNTS/WRITE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SERVICEACCOUNTS/DELETE
-            - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SERVICEACCOUNTS/IMPERSONATE/ACTION
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SERVICEACCOUNTS/WRITE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SERVICEACCOUNTS/DELETE
+      - MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/SERVICEACCOUNTS/IMPERSONATE/ACTION
+  condition: selection
 falsepositives:
- - Service account being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
- - Service account modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Service account being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Service account modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_network_firewall_policy_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_firewall_policy_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/09/02
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_network_firewall_policy_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_firewall_policy_modified_or_deleted.yml
@@ -1,25 +1,25 @@
 title: Azure Network Firewall Policy Modified or Deleted
 id: 83c17918-746e-4bd9-920b-8e098bf88c23
-description: Identifies when a Firewall Policy is Modified or Deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/09/02
+description: Identifies when a Firewall Policy is Modified or Deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/09/02
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: 
-            - MICROSOFT.NETWORK/FIREWALLPOLICIES/WRITE
-            - MICROSOFT.NETWORK/FIREWALLPOLICIES/JOIN/ACTION
-            - MICROSOFT.NETWORK/FIREWALLPOLICIES/CERTIFICATES/ACTION
-            - MICROSOFT.NETWORK/FIREWALLPOLICIES/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/FIREWALLPOLICIES/WRITE
+      - MICROSOFT.NETWORK/FIREWALLPOLICIES/JOIN/ACTION
+      - MICROSOFT.NETWORK/FIREWALLPOLICIES/CERTIFICATES/ACTION
+      - MICROSOFT.NETWORK/FIREWALLPOLICIES/DELETE
+  condition: selection
 falsepositives:
- - Firewall Policy being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Firewall Policy modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Firewall Policy being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Firewall Policy modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_network_firewall_rule_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_firewall_rule_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/08
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_network_firewall_rule_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_firewall_rule_modified_or_deleted.yml
@@ -1,25 +1,25 @@
 title: Azure Firewall Rule Configuration Modified or Deleted
 id: 2a7d64cf-81fa-4daf-ab1b-ab80b789c067
-description: Identifies when a Firewall Rule Configuration is Modified or Deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/08
+description: Identifies when a Firewall Rule Configuration is Modified or Deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/08
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message:
-            - MICROSOFT.NETWORK/FIREWALLPOLICIES/RULECOLLECTIONGROUPS/WRITE
-            - MICROSOFT.NETWORK/FIREWALLPOLICIES/RULECOLLECTIONGROUPS/DELETE
-            - MICROSOFT.NETWORK/FIREWALLPOLICIES/RULEGROUPS/WRITE
-            - MICROSOFT.NETWORK/FIREWALLPOLICIES/RULEGROUPS/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/FIREWALLPOLICIES/RULECOLLECTIONGROUPS/WRITE
+      - MICROSOFT.NETWORK/FIREWALLPOLICIES/RULECOLLECTIONGROUPS/DELETE
+      - MICROSOFT.NETWORK/FIREWALLPOLICIES/RULEGROUPS/WRITE
+      - MICROSOFT.NETWORK/FIREWALLPOLICIES/RULEGROUPS/DELETE
+  condition: selection
 falsepositives:
- - Firewall Rule Configuration being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Firewall Rule Configuration modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Firewall Rule Configuration being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Firewall Rule Configuration modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_network_p2s_vpn_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_p2s_vpn_modified_or_deleted.yml
@@ -1,27 +1,27 @@
 title: Azure Point-to-site VPN Modified or Deleted
 id: d9557b75-267b-4b43-922f-a775e2d1f792
-description: Identifies when a Point-to-site VPN is Modified or Deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/08
+description: Identifies when a Point-to-site VPN is Modified or Deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/08
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message:
-            - MICROSOFT.NETWORK/P2SVPNGATEWAYS/WRITE
-            - MICROSOFT.NETWORK/P2SVPNGATEWAYS/DELETE
-            - MICROSOFT.NETWORK/P2SVPNGATEWAYS/RESET/ACTION
-            - MICROSOFT.NETWORK/P2SVPNGATEWAYS/GENERATEVPNPROFILE/ACTION
-            - MICROSOFT.NETWORK/P2SVPNGATEWAYS/DISCONNECTP2SVPNCONNECTIONS/ACTION
-            - MICROSOFT.NETWORK/P2SVPNGATEWAYS/PROVIDERS/MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/WRITE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/P2SVPNGATEWAYS/WRITE
+      - MICROSOFT.NETWORK/P2SVPNGATEWAYS/DELETE
+      - MICROSOFT.NETWORK/P2SVPNGATEWAYS/RESET/ACTION
+      - MICROSOFT.NETWORK/P2SVPNGATEWAYS/GENERATEVPNPROFILE/ACTION
+      - MICROSOFT.NETWORK/P2SVPNGATEWAYS/DISCONNECTP2SVPNCONNECTIONS/ACTION
+      - MICROSOFT.NETWORK/P2SVPNGATEWAYS/PROVIDERS/MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/WRITE
+  condition: selection
 falsepositives:
- - Point-to-site VPN being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Point-to-site VPN modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Point-to-site VPN being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Point-to-site VPN modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_network_p2s_vpn_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_p2s_vpn_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/08
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_network_security_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_security_modified_or_deleted.yml
@@ -1,27 +1,27 @@
 title: Azure Network Security Configuration Modified or Deleted
 id: d22b4df4-5a67-4859-a578-8c9a0b5af9df
-description: Identifies when a network security configuration is modified or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/08
+description: Identifies when a network security configuration is modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/08
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message:
-            - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/WRITE
-            - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/DELETE
-            - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/SECURITYRULES/WRITE
-            - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/SECURITYRULES/DELETE
-            - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/JOIN/ACTION
-            - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/PROVIDERS/MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/WRITE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/WRITE
+      - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/DELETE
+      - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/SECURITYRULES/WRITE
+      - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/SECURITYRULES/DELETE
+      - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/JOIN/ACTION
+      - MICROSOFT.NETWORK/NETWORKSECURITYGROUPS/PROVIDERS/MICROSOFT.INSIGHTS/DIAGNOSTICSETTINGS/WRITE
+  condition: selection
 falsepositives:
- - Network Security Configuration being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Network Security Configuration modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Network Security Configuration being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Network Security Configuration modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_network_security_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_security_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/08
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_network_virtual_device_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_virtual_device_modified_or_deleted.yml
@@ -1,32 +1,32 @@
 title: Azure Virtual Network Device Modified or Deleted
 id: 15ef3fac-f0f0-4dc4-ada0-660aa72980b3
-description: Identifies when a virtual network device is being modified or deleted. This can be a network interface, network virtual appliance, virtual hub, or virtual router.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/08
+description: Identifies when a virtual network device is being modified or deleted. This can be a network interface, network virtual appliance, virtual hub, or virtual router.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/08
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message:
-            - MICROSOFT.NETWORK/NETWORKINTERFACES/TAPCONFIGURATIONS/WRITE
-            - MICROSOFT.NETWORK/NETWORKINTERFACES/TAPCONFIGURATIONS/DELETE
-            - MICROSOFT.NETWORK/NETWORKINTERFACES/WRITE
-            - MICROSOFT.NETWORK/NETWORKINTERFACES/JOIN/ACTION
-            - MICROSOFT.NETWORK/NETWORKINTERFACES/DELETE
-            - MICROSOFT.NETWORK/NETWORKVIRTUALAPPLIANCES/DELETE
-            - MICROSOFT.NETWORK/NETWORKVIRTUALAPPLIANCES/WRITE
-            - MICROSOFT.NETWORK/VIRTUALHUBS/DELETE
-            - MICROSOFT.NETWORK/VIRTUALHUBS/WRITE
-            - MICROSOFT.NETWORK/VIRTUALROUTERS/WRITE
-            - MICROSOFT.NETWORK/VIRTUALROUTERS/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/NETWORKINTERFACES/TAPCONFIGURATIONS/WRITE
+      - MICROSOFT.NETWORK/NETWORKINTERFACES/TAPCONFIGURATIONS/DELETE
+      - MICROSOFT.NETWORK/NETWORKINTERFACES/WRITE
+      - MICROSOFT.NETWORK/NETWORKINTERFACES/JOIN/ACTION
+      - MICROSOFT.NETWORK/NETWORKINTERFACES/DELETE
+      - MICROSOFT.NETWORK/NETWORKVIRTUALAPPLIANCES/DELETE
+      - MICROSOFT.NETWORK/NETWORKVIRTUALAPPLIANCES/WRITE
+      - MICROSOFT.NETWORK/VIRTUALHUBS/DELETE
+      - MICROSOFT.NETWORK/VIRTUALHUBS/WRITE
+      - MICROSOFT.NETWORK/VIRTUALROUTERS/WRITE
+      - MICROSOFT.NETWORK/VIRTUALROUTERS/DELETE
+  condition: selection
 falsepositives:
- - Virtual Network Device being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Virtual Network Device modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Virtual Network Device being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Virtual Network Device modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_network_virtual_device_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_network_virtual_device_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/08
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_new_cloudshell_created.yml
+++ b/rules/cloud/azure/azure_new_cloudshell_created.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer
 date: 2021/09/21
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_new_cloudshell_created.yml
+++ b/rules/cloud/azure/azure_new_cloudshell_created.yml
@@ -1,22 +1,21 @@
 title: Azure New CloudShell Created
 id: 72af37e2-ec32-47dc-992b-bc288a2708cb
-description: Identifies when a new cloudshell is created inside of Azure portal.
-author: Austin Songer
 status: experimental
-date: 2021/09/21
+description: Identifies when a new cloudshell is created inside of Azure portal.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer
+date: 2021/09/21
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: MICROSOFT.PORTAL/CONSOLES/WRITE
-    condition: selection
-level: medium
-tags:
-    - attack.execution
-    - attack.t1059
+  selection:
+    operationName: MICROSOFT.PORTAL/CONSOLES/WRITE
+  condition: selection
 falsepositives:
- - A new cloudshell may be created by a system administrator. 
- 
+  - A new cloudshell may be created by a system administrator.
+tags:
+  - attack.execution
+  - attack.t1059
+level: medium

--- a/rules/cloud/azure/azure_subscription_permissions_elevation_via_activitylogs.yml
+++ b/rules/cloud/azure/azure_subscription_permissions_elevation_via_activitylogs.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftauthorization
 author: Austin Songer @austinsonger
 date: 2021/11/26
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_subscription_permissions_elevation_via_activitylogs.yml
+++ b/rules/cloud/azure/azure_subscription_permissions_elevation_via_activitylogs.yml
@@ -1,21 +1,21 @@
 title: Azure Subscription Permission Elevation Via ActivityLogs
 id: 09438caa-07b1-4870-8405-1dbafe3dad95
 status: experimental
-author: Austin Songer @austinsonger
-date: 2021/11/26
 description: Detects when a user has been elevated to manage all Azure Subscriptions. This change should be investigated immediately if it isn't planned. This setting could allow an attacker access to Azure subscriptions in your environment.
 references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftauthorization
+author: Austin Songer @austinsonger
+date: 2021/11/26
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection1:
-        properties.message: MICROSOFT.AUTHORIZATION/ELEVATEACCESS/ACTION
-    condition: selection1
-level: high
+  selection:
+    operationName: MICROSOFT.AUTHORIZATION/ELEVATEACCESS/ACTION
+  condition: selection
 falsepositives:
   - If this was approved by System Administrator.
 tags:
   - attack.initial_access
   - attack.t1078
+level: high

--- a/rules/cloud/azure/azure_suppression_rule_created.yml
+++ b/rules/cloud/azure/azure_suppression_rule_created.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer
 date: 2021/08/16
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_suppression_rule_created.yml
+++ b/rules/cloud/azure/azure_suppression_rule_created.yml
@@ -1,22 +1,22 @@
 title: Azure Suppression Rule Created
 id: 92cc3e5d-eb57-419d-8c16-5c63f325a401
-description: Identifies when a suppression rule is created in Azure. Adversary's could attempt this to evade detection.
-author: Austin Songer
 status: experimental
-date: 2021/08/16
+description: Identifies when a suppression rule is created in Azure. Adversary's could attempt this to evade detection.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer
+date: 2021/08/16
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message: MICROSOFT.SECURITY/ALERTSSUPPRESSIONRULES/WRITE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName: MICROSOFT.SECURITY/ALERTSSUPPRESSIONRULES/WRITE
+  condition: selection
 falsepositives:
- - Suppression Rule being created may be performed by a system administrator.
- - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
- - Suppression Rule created from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Suppression Rule being created may be performed by a system administrator.
+  - Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Suppression Rule created from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_virtual_network_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_virtual_network_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/08
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs

--- a/rules/cloud/azure/azure_virtual_network_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_virtual_network_modified_or_deleted.yml
@@ -1,26 +1,26 @@
 title: Azure Virtual Network Modified or Deleted
 id: bcfcc962-0e4a-4fd9-84bb-a833e672df3f
-description: Identifies when a Virtual Network is modified or deleted in Azure.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/08
+description: Identifies when a Virtual Network is modified or deleted in Azure.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/08
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message|startswith:
-            - MICROSOFT.NETWORK/VIRTUALNETWORKGATEWAYS/
-            - MICROSOFT.NETWORK/VIRTUALNETWORKS/
-        properties.message|endswith:
-            - /WRITE
-            - /DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName|startswith:
+      - MICROSOFT.NETWORK/VIRTUALNETWORKGATEWAYS/
+      - MICROSOFT.NETWORK/VIRTUALNETWORKS/
+    operationName|endswith:
+      - /WRITE
+      - /DELETE
+  condition: selection
 falsepositives:
- - Virtual Network being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - Virtual Network modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - Virtual Network being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - Virtual Network modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_vpn_connection_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_vpn_connection_modified_or_deleted.yml
@@ -1,23 +1,23 @@
 title: Azure VPN Connection Modified or Deleted
 id: 61171ffc-d79c-4ae5-8e10-9323dba19cd3
-description: Identifies when a VPN connection is modified or deleted.
-author: Austin Songer @austinsonger
 status: experimental
-date: 2021/08/08
+description: Identifies when a VPN connection is modified or deleted.
 references:
-    - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+  - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
+author: Austin Songer @austinsonger
+date: 2021/08/08
 logsource:
   product: azure
   service: activitylogs
 detection:
-    selection:
-        properties.message:
-            - MICROSOFT.NETWORK/VPNGATEWAYS/VPNCONNECTIONS/WRITE
-            - MICROSOFT.NETWORK/VPNGATEWAYS/VPNCONNECTIONS/DELETE
-    condition: selection
-level: medium
-tags:
-    - attack.impact
+  selection:
+    operationName:
+      - MICROSOFT.NETWORK/VPNGATEWAYS/VPNCONNECTIONS/WRITE
+      - MICROSOFT.NETWORK/VPNGATEWAYS/VPNCONNECTIONS/DELETE
+  condition: selection
 falsepositives:
- - VPN Connection being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. 
- - VPN Connection modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+  - VPN Connection being modified or deleted may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
+  - VPN Connection modified or deleted from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+tags:
+  - attack.impact
+level: medium

--- a/rules/cloud/azure/azure_vpn_connection_modified_or_deleted.yml
+++ b/rules/cloud/azure/azure_vpn_connection_modified_or_deleted.yml
@@ -6,6 +6,7 @@ references:
   - https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations
 author: Austin Songer @austinsonger
 date: 2021/08/08
+modified: 2022/08/23
 logsource:
   product: azure
   service: activitylogs


### PR DESCRIPTION
All of these Azure rules are using what seems to be a custom field name of `properties.message` instead of the default log field name of `operationName`. Per Microsoft's documentation as well as my own testing with raw Azure Activity Logs sent to an external SIEM through EventHub, the default log field name is indeed `operationName`. 
Having this as `properties.message` means that any transform rules written for the default log field names will not properly transform these rules into queries.

My IDE also automatically reformatted these to match sigma standard field order and YAML spacing.
No other changes to the detection logic other than the renaming of the field `properties.message` to `operationName`.
I have not updated any of the `id` fields for these rules as I was not sure what a triggering event for that would be. 
I have added today's date into the `modified` field since this is an update to the `detection` field. 