### PR TITLE
proxy_ua_bitsadmin_susp_ip.yml falsepositive fix

### DIFF
--- a/rules/proxy/proxy_ua_bitsadmin_susp_ip.yml
+++ b/rules/proxy/proxy_ua_bitsadmin_susp_ip.yml
@@ -4,12 +4,13 @@ status: experimental
 description: Detects Bitsadmin connections to IP addresses instead of FQDN names
 author: Florian Roth
 date: 2022/06/10
+modified: 2022/08/24
 logsource:
     category: proxy
 detection:
     selection:
         c-useragent|startswith: 'Microsoft BITS/'
-        cs-host|startswith: 
+        cs-host|endswith: 
             - '1'
             - '2'
             - '3'


### PR DESCRIPTION
Change to endswith instead of startswith to avoid matching subdomains which starts with digits, example one: `3.au.download.windowsupdate.com`