### PR TITLE
Fixing selection_user to match NT AUTHORITY\SYSTEM

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_schtasks_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_system.yml
@@ -21,7 +21,7 @@ detection:
     selection_user:
         CommandLine|contains:
             - 'NT AUT'
-            - ' SYSTEM '
+            - 'SYSTEM'
     filter:
         # FP from test set in SIGMA
         ParentImage|contains|all:


### PR DESCRIPTION
This should be 'SYSTEM' not ' SYSTEM ' - these leading/trailing spaces are making this detection invalid since the /RU parameter value will be "NT AUTHORITY\SYSTEM".