### PR TITLE
VS Code Filter Fix - Undo the last commit

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_file_permission_modifications.yml
+++ b/rules/windows/process_creation/proc_creation_win_file_permission_modifications.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1222.001/T1222.001.md
     - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh750728(v=ws.11)
 date: 2019/10/23
-modified: 2022/09/03
+modified: 2022/09/13
 logsource:
     category: process_creation
     product: windows
@@ -30,8 +30,7 @@ detection:
             - 'ICACLS C:\ProgramData\dynatrace\gateway\config\config.properties /grant :r '
             - 'S-1-5-19:F'
     filter_programs:
-        - Image|contains: '\AppData\Local\Programs\Microsoft VS Code'
-        - Image|endswith: '\Microsoft VS Code\Code.exe'
+        CommandLine|contains: '\AppData\Local\Programs\Microsoft VS Code'
     condition: 1 of selection* and not 1 of filter*
 fields:
     - ComputerName

--- a/rules/windows/process_creation/proc_creation_win_file_permission_modifications.yml
+++ b/rules/windows/process_creation/proc_creation_win_file_permission_modifications.yml
@@ -30,7 +30,8 @@ detection:
             - 'ICACLS C:\ProgramData\dynatrace\gateway\config\config.properties /grant :r '
             - 'S-1-5-19:F'
     filter_programs:
-        CommandLine|contains: '\AppData\Local\Programs\Microsoft VS Code'
+        - CommandLine|contains: '\AppData\Local\Programs\Microsoft VS Code'
+        - ParentImage|endswith: '\Microsoft VS Code\Code.exe'
     condition: 1 of selection* and not 1 of filter*
 fields:
     - ComputerName


### PR DESCRIPTION
Previous Filter of Image was wrong. Image can't endsWith (Code.exe and attrib.exe) at the same time. Same condition with other scenario. CommandLine filter is good.

