### PR TITLE
Update win_impacket_psexec.yml

### DIFF
--- a/rules/windows/builtin/security/win_impacket_psexec.yml
+++ b/rules/windows/builtin/security/win_impacket_psexec.yml
@@ -6,7 +6,7 @@ author: Bhabesh Raj
 references:
   - https://blog.menasec.net/2019/02/threat-hunting-3-detecting-psexec.html
 date: 2020/12/14
-modified: 2022/08/11
+modified: 2022/09/22
 logsource:
   product: windows
   service: security

--- a/rules/windows/builtin/security/win_impacket_psexec.yml
+++ b/rules/windows/builtin/security/win_impacket_psexec.yml
@@ -16,9 +16,9 @@ detection:
     EventID: 5145
     ShareName: '\\\\\*\\IPC$' # looking for the string \\*\IPC$
     RelativeTargetName|contains:
-      - 'RemCom_stdint'
-      - 'RemCom_stdoutt'
-      - 'RemCom_stderrt'
+      - 'RemCom_stdin'
+      - 'RemCom_stdout'
+      - 'RemCom_stderr'
   condition: selection1
 falsepositives:
   - Unknown


### PR DESCRIPTION
Based on recent tests, the original RelativeTargetName from this rule are not accurate. The last "t" from each selection must be deleted in order to detect the predefined impacket psexec behavior.