### PR TITLE
new rule for the winpeas tool

### DIFF
--- a/rules/windows/process_creation/proc_creation_detect_execution_of_winPEAS.yml
+++ b/rules/windows/process_creation/proc_creation_detect_execution_of_winPEAS.yml
@@ -1,0 +1,57 @@
+title: Detect Execution of winPEAS 
+id: 98b53e78-ebaf-46f8-be06-421aafd176d9
+status: experimental
+description: WinPEAS is a script that search for possible paths to escalate privileges on Windows hosts. The checks are explained on book.hacktricks.xyz
+author: Georg Lauenstein
+date: 2022/09/19
+references:
+     - https://github.com/carlospolop/PEASS-ng
+     - https://book.hacktricks.xyz/windows-hardening/windows-local-privilege-escalation
+tags:
+    - attack.privilege_escalation
+    - attack.t1082
+    - attack.t1087
+    - attack.t1046
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith:
+            - '\winPEASany.exe'
+            - '\winPEASany_ofs.exe'
+            - '\winPEASx64.exe'
+            - '\winPEASx64_ofs.exe'
+            - '\winPEASx86.exe'
+            - '\winPEASx86_ofs.exe'
+        - OriginalFileName:
+            - 'winPEAS.exe' # always the same
+    selection_cmd_args:
+        - CommandLine|contains:
+            - 'domain'         # Enumerate domain information
+            - 'systeminfo'     # Search system information
+            - 'userinfo'       # Search user information
+            - 'processinfo'    # Search processes information
+            - 'serviceinfo'    # Search services information
+            - 'applicationsinfo' # Search installed applications information
+            - 'networkinfo'   # Search network information
+            - 'windowscreds'  # Search windows credentials
+            - 'browserinfo '  # Search browser information
+            - 'filesinfo '    # Search generic files that can contains credentials
+            - 'fileanalysis'  # Search specific files that can contains credentials and for regexes inside files
+            - 'eventsinfo'    # Display interesting events information
+    filter_sysinfo:
+        - Image|endswith:
+            - '\systeminfo.exe' # due to option "systeminfo" via winPEAS
+        - OriginalFileName:
+            - 'sysinfo.exe'
+    condition: (selection_img or selection_cmd_args) and not filter_sysinfo
+fields:
+    - Image
+    - User
+    - CommandLine
+    - ParentCommandLine
+    - CurrentDirectory
+falsepositives:
+    - Pentesting
+level: high

--- a/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
+++ b/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
@@ -25,7 +25,7 @@ detection:
             - '\winPEASx86.exe'
             - '\winPEASx86_ofs.exe'
     selection_pe:
-        	OriginalFileName: 'winPEAS.exe'
+        OriginalFileName: 'winPEAS.exe'
     selection_option:
         - CommandLine|endswith:
             - 'serviceinfo'    # Search services information

--- a/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
+++ b/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
@@ -24,8 +24,7 @@ detection:
             - '\winPEASx64_ofs.exe'
             - '\winPEASx86.exe'
             - '\winPEASx86_ofs.exe'
-        - OriginalFileName:
-            - 'winPEAS.exe' # always the same
+        - OriginalFileName: 'winPEAS.exe' # always the same
     selection_cmd_args:
         - CommandLine|contains:
             - 'domain'         # Enumerate domain information
@@ -41,10 +40,8 @@ detection:
             - 'fileanalysis'  # Search specific files that can contains credentials and for regexes inside files
             - 'eventsinfo'    # Display interesting events information
     filter_sysinfo:
-        - Image|endswith:
-            - '\systeminfo.exe' # due to option "systeminfo" via winPEAS
-        - OriginalFileName:
-            - 'sysinfo.exe'
+        - Image|endswith: '\systeminfo.exe' # due to option "systeminfo" via winPEAS
+        - OriginalFileName: 'sysinfo.exe'
     condition: (selection_img or selection_cmd_args) and not filter_sysinfo
 fields:
     - Image
@@ -53,5 +50,5 @@ fields:
     - ParentCommandLine
     - CurrentDirectory
 falsepositives:
-    - Pentesting
+    - Should not be any as administrators do not use this tool
 level: high

--- a/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
+++ b/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
@@ -1,4 +1,4 @@
-title: Detect Execution of winPEAS 
+title: Detect Execution of winPEAS
 id: 98b53e78-ebaf-46f8-be06-421aafd176d9
 status: experimental
 description: WinPEAS is a script that search for possible paths to escalate privileges on Windows hosts. The checks are explained on book.hacktricks.xyz

--- a/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
+++ b/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
@@ -5,8 +5,8 @@ description: WinPEAS is a script that search for possible paths to escalate priv
 author: Georg Lauenstein
 date: 2022/09/19
 references:
-     - https://github.com/carlospolop/PEASS-ng
-     - https://book.hacktricks.xyz/windows-hardening/windows-local-privilege-escalation
+    - https://github.com/carlospolop/PEASS-ng
+    - https://book.hacktricks.xyz/windows-hardening/windows-local-privilege-escalation
 tags:
     - attack.privilege_escalation
     - attack.t1082
@@ -17,16 +17,15 @@ logsource:
     product: windows
 detection:
     winpeas_basic:
-          Image|endswith:
+        Image|endswith:
             - '\winPEASany.exe'
             - '\winPEASany_ofs.exe'
             - '\winPEASx64.exe'
             - '\winPEASx64_ofs.exe'
             - '\winPEASx86.exe'
             - '\winPEASx86_ofs.exe'
-          OriginalFileName: 'winPEAS.exe' # always the same
     winpeas_option:
-          CommandLine|contains:
+        CommandLine|contains:
             - 'systeminfo'     # Search system information
             - 'userinfo'       # Search user information
             - 'processinfo'    # Search processes information
@@ -39,8 +38,7 @@ detection:
             - 'fileanalysis'  # Search specific files that can contains credentials and for regexes inside files
             - 'eventsinfo'    # Display interesting events information
     filter_sysinfo:
-          Image|endswith: '\systeminfo.exe' # due to option "systeminfo" via winPEAS
-          OriginalFileName: 'sysinfo.exe'
+        Image|endswith: '\systeminfo.exe' # due to option "systeminfo" via winPEAS
     condition: 1 of winpeas_* and not filter_sysinfo
 fields:
     - Image
@@ -49,5 +47,5 @@ fields:
     - ParentCommandLine
     - CurrentDirectory
 falsepositives:
-    - Should not be any as administrators do not use this tool
+    - Unlikely
 level: high

--- a/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
+++ b/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
@@ -16,7 +16,7 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection_img:
+    winpeas_basic:
         - Image|endswith:
             - '\winPEASany.exe'
             - '\winPEASany_ofs.exe'
@@ -25,7 +25,7 @@ detection:
             - '\winPEASx86.exe'
             - '\winPEASx86_ofs.exe'
         - OriginalFileName: 'winPEAS.exe' # always the same
-    selection_cmd_args:
+    winpeas_option:
         - CommandLine|contains:
             - 'systeminfo'     # Search system information
             - 'userinfo'       # Search user information
@@ -41,7 +41,7 @@ detection:
     filter_sysinfo:
         - Image|endswith: '\systeminfo.exe' # due to option "systeminfo" via winPEAS
         - OriginalFileName: 'sysinfo.exe'
-    condition: (selection_img or selection_cmd_args) and not filter_sysinfo
+    condition: 1 of winpeas_* and not filter_sysinfo
 fields:
     - Image
     - User

--- a/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
+++ b/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
@@ -16,7 +16,7 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    winpeas_basic:
+    selection_basic:
         Image|endswith:
             - '\winPEASany.exe'
             - '\winPEASany_ofs.exe'
@@ -24,28 +24,17 @@ detection:
             - '\winPEASx64_ofs.exe'
             - '\winPEASx86.exe'
             - '\winPEASx86_ofs.exe'
-    winpeas_option:
-        CommandLine|contains:
-            - 'systeminfo'     # Search system information
-            - 'userinfo'       # Search user information
-            - 'processinfo'    # Search processes information
+    selection_pe:
+        	OriginalFileName: 'winPEAS.exe'
+    selection_option:
+        - CommandLine|endswith:
             - 'serviceinfo'    # Search services information
             - 'applicationsinfo' # Search installed applications information
-            - 'networkinfo'   # Search network information
             - 'windowscreds'  # Search windows credentials
             - 'browserinfo '  # Search browser information
-            - 'filesinfo '    # Search generic files that can contains credentials
             - 'fileanalysis'  # Search specific files that can contains credentials and for regexes inside files
-            - 'eventsinfo'    # Display interesting events information
-    filter_sysinfo:
-        Image|endswith: '\systeminfo.exe' # due to option "systeminfo" via winPEAS
-    condition: 1 of winpeas_* and not filter_sysinfo
-fields:
-    - Image
-    - User
-    - CommandLine
-    - ParentCommandLine
-    - CurrentDirectory
+        - CommandLine|contains: '.exe browserinfo '  # Search browser information
+    condition: 1 of selection*
 falsepositives:
-    - Unlikely
+    - Other programs that use the same command line flags
 level: high

--- a/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
+++ b/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
@@ -27,7 +27,6 @@ detection:
         - OriginalFileName: 'winPEAS.exe' # always the same
     selection_cmd_args:
         - CommandLine|contains:
-            - 'domain'         # Enumerate domain information
             - 'systeminfo'     # Search system information
             - 'userinfo'       # Search user information
             - 'processinfo'    # Search processes information

--- a/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
+++ b/rules/windows/process_creation/proc_creation_win_winpeas_tool.yml
@@ -17,16 +17,16 @@ logsource:
     product: windows
 detection:
     winpeas_basic:
-        - Image|endswith:
+          Image|endswith:
             - '\winPEASany.exe'
             - '\winPEASany_ofs.exe'
             - '\winPEASx64.exe'
             - '\winPEASx64_ofs.exe'
             - '\winPEASx86.exe'
             - '\winPEASx86_ofs.exe'
-        - OriginalFileName: 'winPEAS.exe' # always the same
+          OriginalFileName: 'winPEAS.exe' # always the same
     winpeas_option:
-        - CommandLine|contains:
+          CommandLine|contains:
             - 'systeminfo'     # Search system information
             - 'userinfo'       # Search user information
             - 'processinfo'    # Search processes information
@@ -39,8 +39,8 @@ detection:
             - 'fileanalysis'  # Search specific files that can contains credentials and for regexes inside files
             - 'eventsinfo'    # Display interesting events information
     filter_sysinfo:
-        - Image|endswith: '\systeminfo.exe' # due to option "systeminfo" via winPEAS
-        - OriginalFileName: 'sysinfo.exe'
+          Image|endswith: '\systeminfo.exe' # due to option "systeminfo" via winPEAS
+          OriginalFileName: 'sysinfo.exe'
     condition: 1 of winpeas_* and not filter_sysinfo
 fields:
     - Image


### PR DESCRIPTION
Hey,

I created a rule for our "magic" tool winPEAS :)

SPL test via Splunk

```
index=main AND EventCode=1 
Image IN ("*\\winPEASany.exe", "*\\winPEASany_ofs.exe", "*\\winPEASx64.exe", "*\\winPEASx64_ofs.exe", "*\\winPEASx86.exe", "*\\winPEASx86_ofs.exe")
OR OriginalFileName="winPEAS.exe"
OR CommandLine IN ("*domain*", "*systeminfo*", "*userinfo*", "*processinfo*", "*serviceinfo*", "*applicationsinfo*", "*networkinfo*", "*windowscreds*", "*browserinfo *", 
"*filesinfo *", "*fileanalysis*", "*eventsinfo*") 
NOT (Image="*\\systeminfo.exe" OR OriginalFileName="sysinfo.exe")
| fields Image CurrentDirectory dest User ParentImage OriginalFileName CommandLine ParentCommandLine 
| table _time Image  CurrentDirectory dest User ParentImage OriginalFileName CommandLine ParentCommandLine
| sort - _time
```
![grafik](https://user-images.githubusercontent.com/89155053/191089008-caadf389-600c-407d-a20c-e4c46901c032.png)

Regards,
