### PR TITLE
Fix False-Positives In Testing

### DIFF
--- a/rules/windows/file_event/file_event_win_notepad_plus_plus_persistence.yml
+++ b/rules/windows/file_event/file_event_win_notepad_plus_plus_persistence.yml
@@ -6,7 +6,7 @@ author: Nasreddine Bencherchali
 references:
     - https://pentestlab.blog/2022/02/14/persistence-notepad-plugins/
 date: 2022/06/10
-modified: 2022/06/21
+modified: 2022/09/20
 logsource:
     product: windows
     category: file_event
@@ -20,7 +20,9 @@ detection:
         # This filter is for Sigma dataset you could remove it or change when using the rule in your own env
         Image|startswith: 'C:\Users\'
         Image|contains: '\AppData\Local\Temp\'
-        Image|endswith: '\target.exe'
+        Image|endswith:
+            - '\target.exe'
+            - 'Installer.x64.exe'
     condition: selection and not 1 of filter*
 falsepositives:
     - Possible FPs during first installation of Notepad++

--- a/rules/windows/image_load/image_load_side_load_from_non_system_location.yml
+++ b/rules/windows/image_load/image_load_side_load_from_non_system_location.yml
@@ -421,6 +421,9 @@ detection:
     filter_appvpolicy:
         ImageLoaded: C:\Program Files\Common Files\microsoft shared\ClickToRun\AppVPolicy.dll
         Image: C:\Program Files\Common Files\microsoft shared\ClickToRun\OfficeClickToRun.exe
+    filter_dell:
+        Image: 'C:\Windows\System32\backgroundTaskHost.exe'
+        ImageLoaded|startswith: 'C:\Program Files\WindowsApps\DellInc.DellSupportAssistforPCs'
     condition: selection and not 1 of filter_*
 falsepositives:
     - Legitimate applications loading their own versions of the DLLs mentioned in this rule

--- a/rules/windows/image_load/image_load_uipromptforcreds_dlls.yml
+++ b/rules/windows/image_load/image_load_uipromptforcreds_dlls.yml
@@ -3,7 +3,7 @@ id: 9ae01559-cf7e-4f8e-8e14-4c290a1b4784
 description: Detects potential use of UIPromptForCredentials functions by looking for some of the DLLs needed for it.
 status: experimental
 date: 2020/10/20
-modified: 2022/08/13
+modified: 2022/09/20
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 tags:
     - attack.credential_access
@@ -27,18 +27,23 @@ detection:
     filter_start:
         Image|startswith:
             - 'C:\Windows\System32\'
-            - 'C:\Windows\explorer.exe'
+            - 'C:\Windows\SysWOW64\'
             - 'C:\Program Files\'
             - 'C:\Program Files (x86)\'
     filter_end:
         Image|endswith: '\opera_autoupdate.exe'
     filter_full:
-        Image: 'C:\Windows\ImmersiveControlPanel\SystemSettings.exe'
+        Image:
+            - 'C:\Windows\ImmersiveControlPanel\SystemSettings.exe'
+            - 'C:\Windows\explorer.exe'
     filter_user:
         Image|startswith: 'C:\Users\'
-        Image|endswith: '\AppData\Roaming\Spotify\Spotify.exe'
-    filter_path:    
-        Image|contains: '\Local\Microsoft\OneDrive\'
+        Image|endswith:
+            - '\AppData\Roaming\Spotify\Spotify.exe'
+            - '\AppData\Local\Microsoft\Teams\current\Teams.exe'
+    filter_contains:
+        Image|startswith: 'C:\Users\'
+        Image|contains: '\AppData\Local\Microsoft\OneDrive\'
     condition: selection and not 1 of filter_*
 falsepositives:
     - Other legitimate processes loading those DLLs in your environment.

--- a/rules/windows/process_access/proc_access_win_direct_syscall_ntopenprocess.yml
+++ b/rules/windows/process_access/proc_access_win_direct_syscall_ntopenprocess.yml
@@ -6,7 +6,7 @@ references:
 status: experimental
 author: Christian Burkard, Tim Shelton
 date: 2021/07/28
-modified: 2022/09/18
+modified: 2022/09/20
 logsource:
     category: process_access
     product: windows
@@ -32,6 +32,18 @@ detection:
     falsepositive6:
         TargetImage|endswith: 'C:\Program Files\Mozilla Firefox\firefox.exe'
         SourceImage|endswith: 'C:\Program Files\Mozilla Firefox\firefox.exe'
+    falsepositive7: # VsCode
+        TargetImage|endswith: '\AppData\Local\Programs\Microsoft VS Code\Code.exe'
+        SourceImage|endswith: '\AppData\Local\Programs\Microsoft VS Code\Code.exe'
+    falsepositive8: # Google Chrome
+        TargetImage|endswith: 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+        SourceImage|endswith: 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+    falsepositive9: # Google Chrome Update
+        TargetImage|endswith: 'C:\Program Files (x86)\Google\Update\GoogleUpdate.exe'
+        SourceImage|endswith: 'C:\Program Files (x86)\Google\Update\GoogleUpdate.exe'
+    falsepositive10: # MS Teams
+        TargetImage|endswith: '\AppData\Local\Microsoft\Teams\current\Teams.exe'
+        SourceImage|endswith: '\AppData\Local\Microsoft\Teams\current\Teams.exe'
     falsepositive_kerneltrace_edge:  # Cases in which the CallTrace is just e.g. 'UNKNOWN(19290435374)' from Microsoft-Windows-Kernel-Audit-API-Calls provider
         Provider_Name: 'Microsoft-Windows-Kernel-Audit-API-Calls'
     condition: selection and not 1 of falsepositive*

--- a/rules/windows/process_creation/proc_creation_win_cobaltstrike_process_patterns.yml
+++ b/rules/windows/process_creation/proc_creation_win_cobaltstrike_process_patterns.yml
@@ -7,34 +7,39 @@ references:
     - https://hausec.com/2021/07/26/cobalt-strike-and-tradecraft/
     - https://thedfirreport.com/2021/08/29/cobalt-strike-a-defenders-guide/
 date: 2021/07/27
-modified: 2022/03/05
+modified: 2022/09/20
 tags:
     - attack.execution
-    - attack.t1059 
+    - attack.t1059
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection1: 
+    selection1:
         CommandLine|contains: '\cmd.exe /C whoami'
         ParentImage|startswith: 'C:\Temp'
     selection2:
-        CommandLine|contains: 'conhost.exe 0xffffffff -ForceV1'
-        ParentCommandLine|contains: 
-            - '/C whoami'
-            - 'cmd.exe /C echo'
-            - ' > \\\\.\\pipe'
-    selection3:
-        CommandLine|contains: 
+        CommandLine|contains:
             - 'cmd.exe /c echo'
             - '> \\\\.\\pipe'
             - '\whoami.exe'
         ParentImage|endswith: '\dllhost.exe'
-    selection4:
+    selection3:
         Image|endswith: '\cmd.exe'
         ParentImage|endswith: '\runonce.exe'
         ParentCommandLine|endswith: '\runonce.exe'
-    condition: 1 of selection*
+    selection_special1:
+        CommandLine|contains: 'conhost.exe 0xffffffff -ForceV1'
+        ParentCommandLine|contains:
+            - '/C whoami'
+            - 'cmd.exe /C echo'
+            - ' > \\\\.\\pipe'
+    filter_special1:
+        # Internet Download Manager - Chrome Extension
+        ParentCommandLine|contains:
+            - 'C:\Program Files (x86)\Internet Download Manager\IDMMsgHost.exe'
+            - 'chrome-extension://'
+    condition: 1 of selection* and (selection_special1 and not filter_special1)
 falsepositives:
     - Other programs that cause these patterns (please report)
 level: high

--- a/rules/windows/process_creation/proc_creation_win_mstsc.yml
+++ b/rules/windows/process_creation/proc_creation_win_mstsc.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1021.001/T1021.001.md#t1021001---remote-desktop-protocol
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/mstsc
 date: 2022/01/07
-modified: 2022/06/12
+modified: 2022/09/20
 logsource:
     category: process_creation
     product: windows
@@ -25,7 +25,9 @@ detection:
             - ' /g'
             - ' /u'
             - ' /p'
-    condition: all of selection_mstsc* or all of selection_cmdkey*
+    filter_mstsc_1:
+        ParentImage: 'C:\Windows\System32\lxss\wslhost.exe'
+    condition: all of selection_mstsc* and not 1 of filter_mstsc_* or all of selection_cmdkey*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_ntfs_short_name_path_use_cli.yml
+++ b/rules/windows/process_creation/proc_creation_win_ntfs_short_name_path_use_cli.yml
@@ -11,7 +11,7 @@ references:
     - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc959352(v=technet.10)?redirectedfrom=MSDN
     - https://twitter.com/frack113/status/1555830623633375232
 date: 2022/08/07
-modified: 2022/09/12
+modified: 2022/09/20
 logsource:
     category: process_creation
     product: windows
@@ -22,8 +22,9 @@ detection:
             - '~2\'
     filter:
         - ParentImage:
-            - C:\Windows\System32\Dism.exe
-            - C:\Windows\System32\cleanmgr.exe
+            - 'C:\Windows\System32\Dism.exe'
+            - 'C:\Windows\System32\cleanmgr.exe'
+            - 'C:\Program Files\GPSoftware\Directory Opus\dopus.exe'
         - ParentImage|endswith:
             - '\WebEx\WebexHost.exe'
             - '\thor\thor64.exe'

--- a/rules/windows/process_creation/proc_creation_win_reg_add_run_key.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_add_run_key.yml
@@ -12,13 +12,15 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains|all: 
+        CommandLine|contains|all:
             - 'reg'
             - ' ADD '
             - 'Software\Microsoft\Windows\CurrentVersion\Run'
     condition: selection
 falsepositives:
-    - Unknown
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reasons.
+    - Legitimate administrator sets up autorun keys for legitimate reasons.
+    - Discord
 level: medium
 tags:
     - attack.persistence

--- a/rules/windows/process_creation/proc_creation_win_susp_curl_download.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_curl_download.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/pr0xylife/Qakbot/blob/4f0795d79dabee5bc9dd69f17a626b48852e7869/Qakbot_AA_23.06.2022.txt
     - https://www.volexity.com/blog/2022/07/28/sharptongue-deploys-clever-mail-stealing-browser-extension-sharpext/
 date: 2020/07/03
-modified: 2022/09/13
+modified: 2022/09/20
 logsource:
     category: process_creation
     product: windows
@@ -41,7 +41,16 @@ detection:
             - ' -O'  # covers the alias for --remote-name and --output
             - '--remote-name'
             - '--output'
-    condition: selection_curl and 1 of selection_susp*
+    filter_git_windows:
+        ParentImage: 'C:\Program Files\Git\usr\bin\sh.exe'
+        ParentCommandLine|contains|all:
+            - 'git-update-git-for-windows'
+            - '--quiet --gui'
+        Image: 'C:\Program Files\Git\mingw64\bin\curl.exe'
+        CommandLine|contains|all:
+            - '--silent --show-error --output '
+            - 'gfw-httpget-'
+    condition: selection_curl and 1 of selection_susp* and not 1 of filter_*
 fields:
     - CommandLine
     - ParentCommandLine

--- a/rules/windows/process_creation/proc_creation_win_susp_direct_asep_reg_keys_modification.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_direct_asep_reg_keys_modification.yml
@@ -29,6 +29,7 @@ fields:
 falsepositives:
     - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reasons.
     - Legitimate administrator sets up autorun keys for legitimate reasons.
+    - Discord
 level: medium
 tags:
     - attack.persistence

--- a/rules/windows/process_creation/proc_creation_win_susp_explorer_break_proctree.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_explorer_break_proctree.yml
@@ -2,21 +2,26 @@ title: Explorer Process Tree Break
 id: 949f1ffb-6e85-4f00-ae1e-c3c5b190d605
 status: test
 description: Detects a command line process that uses explorer.exe to launch arbitrary commands or binaries, which is similar to cmd.exe /c, only it breaks the process tree and makes its parent a new instance of explorer spawning from "svchost"
-author: Florian Roth, Nasreddine Bencherchali
+author: 'Florian Roth, Nasreddine Bencherchali, @gott_cyber'
 references:
     - https://twitter.com/CyberRaiju/status/1273597319322058752
     - https://twitter.com/bohops/status/1276357235954909188?s=12
     - https://twitter.com/nas_bench/status/1535322450858233858
     - https://securityboulevard.com/2019/09/deobfuscating-ostap-trickbots-34000-line-javascript-downloader/
 date: 2019/06/29
-modified: 2022/06/14
+modified: 2022/09/20
 logsource:
     category: process_creation
     product: windows
 detection:
     selection:
         # See CLSID_SeparateMultipleProcessExplorerHost in the registry for reference
-        CommandLine|contains: '/factory,{75dff2b7-6936-4c06-a8bb-676a7b00b24b}'
+        - CommandLine|contains: '/factory,{75dff2b7-6936-4c06-a8bb-676a7b00b24b}' # This will catch, the new explorer spawning which indicates a process/tree break. But you won't be able to catch the executing process. For that you need historical data
+        # There is exists almost infinite possibilities to spawn from explorer. The "/root" flag is just an example
+        # It's better to have the ability to look at the process tree and look for explorer processes with "weird" flags to be able to catch this technique.
+        - CommandLine|contains|all:
+            - 'explorer.exe'
+            - ' /root,'
     condition: selection
 falsepositives:
     - Unknown how many legitimate software products use that method

--- a/rules/windows/process_creation/proc_creation_win_susp_image_missing.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_image_missing.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Checks whether the image specified in a process creation event is not a full, absolute path (caused by process ghosting or other unorthodox methods to start a process)
 author: Max Altgelt
 date: 2021/12/09
-modified: 2022/03/08
+modified: 2022/09/20
 references:
     - https://pentestlaboratories.com/2021/12/08/process-ghosting/
 tags:
@@ -25,9 +25,11 @@ detection:
         - Image:
             - 'Registry'
             - 'MemCompression'
+            - 'vmmem'
         - CommandLine:
             - 'Registry'
             - 'MemCompression'
+            - 'vmmem'
     condition: not image_absolute_path and not 1 of filter*
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_susp_non_exe_image.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_non_exe_image.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Checks whether the image specified in a process creation event doesn't refer to an .exe file (caused by process ghosting or other unorthodox methods to start a process)
 author: Max Altgelt
 date: 2021/12/09
-modified: 2022/06/20
+modified: 2022/09/20
 references:
     - https://pentestlaboratories.com/2021/12/08/process-ghosting/
 tags:
@@ -23,6 +23,7 @@ detection:
         Image:
             - 'Registry'
             - 'MemCompression'
+            - 'vmmem'
     filter_empty:
         Image:
             - '-'

--- a/rules/windows/process_creation/proc_creation_win_susp_squirrel_lolbin.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_squirrel_lolbin.yml
@@ -11,7 +11,7 @@ tags:
     - attack.t1218
 author: Karneades / Markus Neis, Jonhnathan Ribeiro, oscd.community
 date: 2019/11/12
-modified: 2022/08/23
+modified: 2022/09/20
 logsource:
     category: process_creation
     product: windows
@@ -32,6 +32,9 @@ detection:
         - CommandLine|contains|all:
             - 'C:\Users\'
             - '\AppData\Local\GitHubDesktop\Update.exe --createShortcut GitHubDesktop.exe'
+        - CommandLine|contains|all:
+            - 'C:\Users\'
+            - '\AppData\Local\GitHubDesktop\Update.exe --processStartAndWait GitHubDesktop.exe'
         - CommandLine|contains|all:
             - 'C:\Users\'
             - '\AppData\Local\Microsoft\Teams\Update.exe" --processStart "Teams.exe"'

--- a/rules/windows/process_creation/proc_creation_win_system_exe_anomaly.yml
+++ b/rules/windows/process_creation/proc_creation_win_system_exe_anomaly.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/GelosSnake/status/934900723426439170
 author: Florian Roth, Patrick Bareiss, Anton Kutepov, oscd.community, Nasreddine Bencherchali
 date: 2017/11/27
-modified: 2022/09/07
+modified: 2022/09/20
 tags:
     - attack.defense_evasion
     - attack.t1036
@@ -71,7 +71,9 @@ detection:
             - 'C:\Windows\WinSxS\'
             # - 'C:\avast! sandbox'
         - Image|contains: '\SystemRoot\System32\'
-        - Image: 'C:\Windows\explorer.exe'
+        - Image:
+            - 'C:\Windows\explorer.exe'
+            - 'C:\Program Files\PowerShell\7\pwsh.exe'
     condition: selection and not filter
 fields:
     - ComputerName

--- a/rules/windows/process_creation/proc_creation_win_windows_terminal_susp_children.yml
+++ b/rules/windows/process_creation/proc_creation_win_windows_terminal_susp_children.yml
@@ -47,6 +47,10 @@ detection:
         CommandLine|contains|all:
             - '\AppData\Local\Packages\Microsoft.WindowsTerminal_'
             - '\LocalState\settings.json'
+    filter_vsdevcmd:
+        CommandLine|contains|all:
+            - 'C:\Program Files\Microsoft Visual Studio\'
+            - '\Common7\Tools\VsDevCmd.bat'
     condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Other legitimate "Windows Terminal" profiles

--- a/rules/windows/registry/registry_event/registry_event_runonce_persistence.yml
+++ b/rules/windows/registry/registry_event/registry_event_runonce_persistence.yml
@@ -17,7 +17,7 @@ detection:
         TargetObject|endswith: '\StubPath'
     filter_chrome:
         Details|startswith: '"C:\Program Files\Google\Chrome\Application\'
-        Details|endswith: '\Installer\chrmstp.exe" --configure-user-settings --verbose-logging --system-level'
+        Details|contains: '\Installer\chrmstp.exe" --configure-user-settings --verbose-logging --system-level' # In some cases the Details will contain an additional flag called "--channel=stable" at the end
     filter_edge:
         Details|startswith:
             - '"C:\Program Files (x86)\Microsoft\Edge\Application\'


### PR DESCRIPTION
- This PR fixes some FP found in testing
- It also adds/reverts a change proposed in #3129 - After some testing, I think it's best to add the most known case of "/root," since most people don't have process history logs to be able to determine the source. For that, I left both options to be able to catch the initiating process and the results of an "explorer.exe" breaking the tree.