### PR TITLE
Update proc_creation_win_commandline_path_traversal_evasion.yml

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_commandline_path_traversal_evasion.yml
+++ b/rules/windows/process_creation/proc_creation_win_commandline_path_traversal_evasion.yml
@@ -25,8 +25,8 @@ detection:
         CommandLine|contains: '.exe\..\'
     filter:
         CommandLine|contains:
-            -  '\Google\Drive\googledrivesync.exe\..\'
-            -  '\Citrix\Virtual Smart Card\Citrix.Authentication.VirtualSmartcard.Launcher.exe\..\'
+            - '\Google\Drive\googledrivesync.exe\..\'
+            - '\Citrix\Virtual Smart Card\Citrix.Authentication.VirtualSmartcard.Launcher.exe\..\'
     condition: 1 of selection* and not filter
 falsepositives:
     - Google Drive

--- a/rules/windows/process_creation/proc_creation_win_commandline_path_traversal_evasion.yml
+++ b/rules/windows/process_creation/proc_creation_win_commandline_path_traversal_evasion.yml
@@ -3,7 +3,7 @@ status: experimental
 id: 1327381e-6ab0-4f38-b583-4c1b8346a56b
 author: Christian Burkard
 date: 2021/10/26
-modified: 2022/02/02
+modified: 2022/09/20
 description: Detects the attempt to evade or obfuscate the executed command on the CommandLine using bogus path traversal
 references:
     - https://twitter.com/hexacorn/status/1448037865435320323
@@ -24,8 +24,9 @@ detection:
     selection2:
         CommandLine|contains: '.exe\..\'
     filter:
-        - CommandLine|contains: '\Google\Drive\googledrivesync.exe\..\'
-        - CommandLine|contains: '\Citrix\Virtual Smart Card\Citrix.Authentication.VirtualSmartcard.Launcher.exe\..\'
+        CommandLine|contains:
+            -  '\Google\Drive\googledrivesync.exe\..\'
+            -  '\Citrix\Virtual Smart Card\Citrix.Authentication.VirtualSmartcard.Launcher.exe\..\'
     condition: 1 of selection* and not filter
 falsepositives:
     - Google Drive

--- a/rules/windows/process_creation/proc_creation_win_commandline_path_traversal_evasion.yml
+++ b/rules/windows/process_creation/proc_creation_win_commandline_path_traversal_evasion.yml
@@ -24,8 +24,10 @@ detection:
     selection2:
         CommandLine|contains: '.exe\..\'
     filter:
-        CommandLine|contains: '\Google\Drive\googledrivesync.exe\..\'
+        - CommandLine|contains: '\Google\Drive\googledrivesync.exe\..\'
+        - CommandLine|contains: '\Citrix\Virtual Smart Card\Citrix.Authentication.VirtualSmartcard.Launcher.exe\..\'
     condition: 1 of selection* and not filter
 falsepositives:
     - Google Drive
+    - Citrix
 level: high


### PR DESCRIPTION
Citrix hits this rule.  I propose adding the specific Citrix commandline to the filter.  

```
Image: 
C:\Program Files\Citrix\Virtual Smart Card\Citrix.Authentication.VirtualSmartcard.exe
CommandLine: 
"C:\Program Files\Citrix\Virtual Smart Card\Citrix.Authentication.VirtualSmartcard.Launcher.exe\..\Citrix.Authentication.VirtualSmartcard.exe"
```