### PR TITLE
add diagnosis-scripted to windows services file

### DIFF
--- a/tools/config/generic/windows-services.yml
+++ b/tools/config/generic/windows-services.yml
@@ -166,3 +166,8 @@ logsources:
         service: bits-client
         conditions:
             Channel: 'Microsoft-Windows-Bits-Client/Operational'
+    windows-diagnosis-scripted:
+        product: windows
+        service: diagnosis-scripted
+        conditions:
+            Channel: 'Microsoft-Windows-Diagnosis-Scripted/Operational'

--- a/tools/config/generic/windows-services.yml
+++ b/tools/config/generic/windows-services.yml
@@ -171,3 +171,8 @@ logsources:
         service: diagnosis-scripted
         conditions:
             Channel: 'Microsoft-Windows-Diagnosis-Scripted/Operational'
+    windows-shell-core:
+        product: windows
+        service: shell-core
+        conditions:
+            Channel: 'Microsoft-Windows-Shell-Core/Operational'


### PR DESCRIPTION
The following rule
```
title: Loading Diagcab Package From Remote Path
id: 50cb47b8-2c33-4b23-a2e9-4600657d9746
```
uses `service: diagnosis-scripted` in its log source but `diagnosis-scripted` is not defined in `windows-services.yml` so the proper Channel will not be used possibly causing false positives.