### PR TITLE
Fix small typos

### DIFF
--- a/rules/windows/file_event/file_event_win_ripzip_attack.yml
+++ b/rules/windows/file_event/file_event_win_ripzip_attack.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/jonasLyk/status/1549338335243534336?t=CrmPocBGLbDyE4p6zTX1cg&s=19
 author: Greg (rule)
 date: 2022/07/21
-modified: 2022/07/25
+modified: 2022/09/27
 tags:
     - attack.t1547
     - attack.persistence
@@ -15,7 +15,7 @@ logsource:
     product: windows
 detection:
     selection: # %APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\target.lnk.{0AFACED1-E828-11D1-9187-B532F1E9575D}\target.lnk
-        TargetFileName|contains|all:
+        TargetFilename|contains|all:
             - '\Microsoft\Windows\Start Menu\Programs\Startup'
             - '.lnk.{0AFACED1-E828-11D1-9187-B532F1E9575D}'
         Image|endswith: '\explorer.exe'

--- a/rules/windows/process_creation/proc_creation_win_process_dump_rundll32_comsvcs.yml
+++ b/rules/windows/process_creation/proc_creation_win_process_dump_rundll32_comsvcs.yml
@@ -14,7 +14,7 @@ references:
     - https://twitter.com/Wietze/status/1542107456507203586
 author: Florian Roth, Modexp, Nasreddine Bencherchali (update)
 date: 2020/02/18
-modified: 2022/08/04
+modified: 2022/09/27
 tags:
     - attack.defense_evasion
     - attack.credential_access
@@ -33,7 +33,7 @@ detection:
         CommandLine|contains|all:
             - 'comsvcs'
             - 'full'
-        Commandline|contains:
+        CommandLine|contains:
             - '24 '
             - '#24'
             - '#+24'

--- a/rules/windows/process_creation/proc_creation_win_susp_sharpview.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_sharpview.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/PowerShellMafia/PowerSploit/blob/dev/Recon/PowerView.ps1
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1049/T1049.md#atomic-test-4---system-discovery-using-sharpview
 date: 2021/12/10
-modified: 2022/09/13
+modified: 2022/09/27
 logsource:
     category: process_creation
     product: windows
@@ -16,7 +16,7 @@ detection:
     selection:
         - OriginalFileName: SharpView.exe
         - Image|endswith: '\SharpView.exe'
-        - Commandline|contains:
+        - CommandLine|contains:
             - Get-DomainGPOUserLocalGroupMapping
             - Find-GPOLocation
             - Get-DomainGPOComputerLocalGroupMapping


### PR DESCRIPTION
Fixed small typo in event field name.

EID 1: https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=90001
EID 11: https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=90011