### PR TITLE
define security-mitigations service

### DIFF
--- a/rules/windows/builtin/security_mitigations/win_security_mitigations_defender_load_unsigned_dll.yml
+++ b/rules/windows/builtin/security_mitigations/win_security_mitigations_defender_load_unsigned_dll.yml
@@ -12,7 +12,7 @@ tags:
     - attack.t1574.002
 logsource:
     product: windows
-    category: security-mitigations
+    service: security-mitigations
 detection:
     selection:
         EventID:

--- a/rules/windows/builtin/security_mitigations/win_security_mitigations_defender_load_unsigned_dll.yml
+++ b/rules/windows/builtin/security_mitigations/win_security_mitigations_defender_load_unsigned_dll.yml
@@ -6,7 +6,7 @@ references:
     - https://www.sentinelone.com/blog/living-off-windows-defender-lockbit-ransomware-sideloads-cobalt-strike-through-microsoft-security-tool
 author: Bhabesh Raj
 date: 2022/08/02
-modified: 2022/08/05
+modified: 2022/09/28
 tags:
     - attack.defense_evasion
     - attack.t1574.002

--- a/rules/windows/builtin/security_mitigations/win_security_mitigations_unsigned_dll_from_susp_location.yml
+++ b/rules/windows/builtin/security_mitigations/win_security_mitigations_unsigned_dll_from_susp_location.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/nasbench/EVTX-ETW-Resources/blob/45fd5be71a51aa518b1b36d4e1f36af498084e27/ETWEventsList/CSV/Windows11/21H2/W11_21H2_Pro_20220719_22000.795/Providers/Microsoft-Windows-Security-Mitigations.csv
 author: Nasreddine Bencherchali
 date: 2022/08/03
-modified: 2022/08/05
+modified: 2022/09/28
 tags:
     - attack.defense_evasion
     - attack.t1574.002

--- a/rules/windows/builtin/security_mitigations/win_security_mitigations_unsigned_dll_from_susp_location.yml
+++ b/rules/windows/builtin/security_mitigations/win_security_mitigations_unsigned_dll_from_susp_location.yml
@@ -12,7 +12,7 @@ tags:
     - attack.t1574.002
 logsource:
     product: windows
-    category: security-mitigations
+    service: security-mitigations
 detection:
     selection:
         EventID:

--- a/tools/config/generic/windows-services.yml
+++ b/tools/config/generic/windows-services.yml
@@ -176,3 +176,8 @@ logsources:
         service: shell-core
         conditions:
             Channel: 'Microsoft-Windows-Shell-Core/Operational'
+    security-mitigations:
+        product: windows
+        service: security-mitigations
+        conditions:
+            Provider_Name: 'Microsoft-Windows-Security-Mitigations'


### PR DESCRIPTION
The category `security-mitigations` was not defined which could potentially cause false positives so I defined it.
I am not sure why it was a category instead of a service. It does not filter on any specific event ID like all of the other categories do so I changed the rule category to service and defined it there. The logs seem to be saved in both the `UserMode` and `KernelMode` channels so I defined the Provider Name instead of Channel in order to check both of these logs.