### PR TITLE
Update datadog sigmac

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -373,8 +373,8 @@ with the identifier `datadog-logs`. This query can be used in the Security Monit
 #### Config file
 The Datadog backend does not require a config file.
 If you choose to add one, you can specify tags in addition to the existing features.
-While attributes will be queried with `@my-attribute:attribute_value` specified tags will be queried with `my-tag:service_value`.
-For an example, see `tools/config/datadog.yml`.
+While attributes will be queried with `default_attribute: new_attribute` specified tags will be queried with `new_attribute`.
+For an example, see `tools/config/datadog.yml`, `DemoEventID` will be replaced by `@event.id`.
 
 #### Backend options
 The backend options allow you to override tags such as `index`, `service` and `source`. Note that `index` is not available in the Security Monitoring product.
@@ -382,6 +382,9 @@ The backend options allow you to override tags such as `index`, `service` and `s
 Example
 ```
 tools/sigmac -t datadog-logs ./rules/cloud/aws/aws_attached_malicious_lambda_layer.yml --backend-option index=index_value --backend-option service=service_value
+```
+```
+tools/sigmac -t datadog-logs ./rules/cloud/aws/aws_attached_malicious_lambda_layer.yml --config config/datadog.yml
 ```
 
 #### Tests

--- a/tools/config/datadog.yml
+++ b/tools/config/datadog.yml
@@ -2,4 +2,13 @@ title: Datadog Example Config
 order: 20
 backends:
   - datadog-logs
-tags: []
+index:
+service:
+source:
+host:
+device:
+env:
+version:
+tags:
+  DemoEventID: '@event.id'
+

--- a/tools/tests/test_backend_datadog.py
+++ b/tools/tests/test_backend_datadog.py
@@ -71,8 +71,8 @@ class TestDatadogLogsBackend(unittest.TestCase):
                 "condition": "selection",
             }
         }
-        query = self.generate_query(rule, config={"tags": ["test-tag"]})
-        expected_query = "@attribute:test AND test-tag:mytag"
+        query = self.generate_query(rule, config={"tags": {"test-tag":"test-tag2"}})
+        expected_query = "@attribute:test AND test-tag2:mytag"
         self.assertEqual(query, expected_query)
 
     def test_special_characters_escape(self):


### PR DESCRIPTION
This PR update to datagdog converter, I've added the possibiility to have differents 'attributes' than the default one from the rules. Example: `EventID` is translated to `@evt.id` to match our datadog indexation.

![2022-09-28_08-33](https://user-images.githubusercontent.com/5891788/192779587-f359a585-9d3a-4b58-b63c-d78c888dcfed.png)

I also rewrite the datadog test so match the new update.

![2022-09-28_08-34](https://user-images.githubusercontent.com/5891788/192779594-19594fb1-7d77-4284-958f-b007e13935dd.png)
