### PR TITLE
Add rule for suspicious lolbin executing in non-c drive

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
@@ -3,7 +3,7 @@ id: 5b80cf53-3a46-4adc-960b-05ec19348d74
 status: experimental
 description: Detects Wscript, Cscript or Regsvr executing from a drive other than C
 author: Aaron Herman
-date: 2022/08/31
+date: 2022/10/01
 references:
     - https://github.com/pr0xylife/Qakbot/blob/main/Qakbot_BB_30.09.2022.txt
 tags:

--- a/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
@@ -1,4 +1,4 @@
-title: Wscript execution from Non-C Drive
+title: Wscript Execution from Non C Drive
 id: 5b80cf53-3a46-4adc-960b-05ec19348d74
 status: experimental
 description: Detects Wscript or Cscript executing from a drive other than C. This has been observed with Qakbot executing from within a mounted ISO file.

--- a/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
@@ -27,9 +27,9 @@ detection:
         CommandLine|contains: ':\'
     filter_drive_path:
         CommandLine|contains: 
-            - ' C:\'
-            - " 'C:\"
-            - ' "C:\'
+            - ' C:\\'
+            - " 'C:\\"
+            - ' "C:\\'
     filter_env_vars:
         CommandLine|contains: '%'
     filter_unc_paths:

--- a/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
@@ -15,7 +15,7 @@ logsource:
     product: windows
 detection:
     selection_lolbin:
-        CommandLine|contains:
+        Image|endswith:
             - '\wscript.exe'
             - '\cscript.exe'
     selection_exetensions:

--- a/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
@@ -26,9 +26,14 @@ detection:
     selection_drive_path:
         CommandLine|contains: ':\'
     filter_drive_path:
-        CommandLine|contains: 'C:\'
+        CommandLine|contains: 
+            - ' C:\'
+            - " 'C:\"
+            - ' "C:\'
     filter_env_vars:
         CommandLine|contains: '%'
+    filter_unc_paths:
+        CommandLine|contains: ' \\\\'
     condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Legitimate applications installed on other partitions such as "D:"

--- a/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
@@ -6,6 +6,7 @@ author: Aaron Herman
 date: 2022/10/01
 references:
     - https://github.com/pr0xylife/Qakbot/blob/main/Qakbot_BB_30.09.2022.txt
+    - https://app.any.run/tasks/4985c746-601e-401a-9ccf-ae350ac2e887/
 tags:
     - attack.execution
     - attack.t1059
@@ -15,14 +16,16 @@ logsource:
 detection:
     selection_lolbin:
         CommandLine|contains:
-            - 'wscript.exe'
-            - 'cscript.exe'
+            - '\wscript.exe'
+            - '\cscript.exe'
     selection_exetensions:
         CommandLine|contains: '.js'
     selection_drive_path:
         CommandLine|contains: ':\'
     filter_drive_path:
         CommandLine|contains: 'C:\'
+    filter_env_vars:
+        CommandLine|contains: '%'
     condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Rare legitimate execution from a mounted drive by an administrator

--- a/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
@@ -1,0 +1,32 @@
+title: Wscript execution from Non-C Drive
+id: 5b80cf53-3a46-4adc-960b-05ec19348d74
+status: experimental
+description: Detects Wscript, Cscript or Regsvr executing from a drive other than C
+author: Aaron Herman
+date: 2022/08/31
+references:
+    - https://github.com/pr0xylife/Qakbot/blob/main/Qakbot_BB_30.09.2022.txt
+tags:
+    - attack.execution
+    - attack.t1059
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_lolbin:
+        CommandLine|contains:
+            - 'wscript.exe'
+            - 'cscript.exe'
+            - 'regsvr32'
+    selection_exetensions:
+        CommandLine|contains:
+            - '.js'
+            - '.dll'
+    selection_drive_path:
+        CommandLine|contains: ':\'
+    filter_drive_path:
+        CommandLine|contains: 'C:\'
+    condition: all of selection_* and not 1 of filter_*
+falsepositives:
+    - Rare legitimate execution from a mounted drive by an administrator
+level: high

--- a/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
@@ -1,7 +1,7 @@
 title: Wscript execution from Non-C Drive
 id: 5b80cf53-3a46-4adc-960b-05ec19348d74
 status: experimental
-description: Detects Wscript, Cscript or Regsvr executing from a drive other than C
+description: Detects Wscript or Cscript executing from a drive other than C. This has been observed with Qakbot executing from within a mounted ISO file.
 author: Aaron Herman
 date: 2022/10/01
 references:
@@ -17,11 +17,8 @@ detection:
         CommandLine|contains:
             - 'wscript.exe'
             - 'cscript.exe'
-            - 'regsvr32'
     selection_exetensions:
-        CommandLine|contains:
-            - '.js'
-            - '.dll'
+        CommandLine|contains: '.js'
     selection_drive_path:
         CommandLine|contains: ':\'
     filter_drive_path:

--- a/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_lolbin_non_c_drive.yml
@@ -19,7 +19,10 @@ detection:
             - '\wscript.exe'
             - '\cscript.exe'
     selection_exetensions:
-        CommandLine|contains: '.js'
+        CommandLine|contains:
+            - '.js'
+            - '.vbs'
+            - '.vbe'
     selection_drive_path:
         CommandLine|contains: ':\'
     filter_drive_path:
@@ -28,5 +31,5 @@ detection:
         CommandLine|contains: '%'
     condition: all of selection_* and not 1 of filter_*
 falsepositives:
-    - Rare legitimate execution from a mounted drive by an administrator
+    - Legitimate applications installed on other partitions such as "D:"
 level: high


### PR DESCRIPTION
[Any.run example](https://app.any.run/tasks/dba6aa0f-f981-4730-b274-e157ff61e685/) - if it used Win 10 and user doesn't have WinRAR, it'll mount and execute the same except not using Desktop folder in C drive.