### PR TITLE
Fix False Positives

### DIFF
--- a/rules/windows/image_load/image_load_scrcons_imageload_wmi_scripteventconsumer.yml
+++ b/rules/windows/image_load/image_load_scrcons_imageload_wmi_scripteventconsumer.yml
@@ -4,28 +4,29 @@ status: test
 description: Detects signs of the WMI script host process %SystemRoot%\system32\wbem\scrcons.exe functionality being used via images being loaded by a process.
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 references:
-  - https://twitter.com/HunterPlaybook/status/1301207718355759107
-  - https://www.mdsec.co.uk/2020/09/i-like-to-move-it-windows-lateral-movement-part-1-wmi-event-subscription/
-  - https://threathunterplaybook.com/notebooks/windows/08_lateral_movement/WIN-200902020333.html
+    - https://twitter.com/HunterPlaybook/status/1301207718355759107
+    - https://www.mdsec.co.uk/2020/09/i-like-to-move-it-windows-lateral-movement-part-1-wmi-event-subscription/
+    - https://threathunterplaybook.com/notebooks/windows/08_lateral_movement/WIN-200902020333.html
 date: 2020/09/02
-modified: 2021/11/27
+modified: 2022/10/11
 logsource:
-  category: image_load
-  product: windows
+    category: image_load
+    product: windows
 detection:
-  selection:
-    Image|endswith: '\scrcons.exe'
-    ImageLoaded|endswith:
-      - '\vbscript.dll'
-      - '\wbemdisp.dll'
-      - '\wshom.ocx'
-      - '\scrrun.dll'
-  condition: selection
+    selection:
+        Image|endswith: '\scrcons.exe'
+        ImageLoaded|endswith:
+            - '\vbscript.dll'
+            - '\wbemdisp.dll'
+            - '\wshom.ocx'
+            - '\scrrun.dll'
+    condition: selection
 falsepositives:
-  - Unknown
-level: high
+    - Legitimate event consumers
+    - Dell computers on some versions register an event consumer that is known to cause false positives when brightness is changed by the corresponding keyboard button
+level: medium
 tags:
-  - attack.lateral_movement
-  - attack.privilege_escalation
-  - attack.persistence
-  - attack.t1546.003
+    - attack.lateral_movement
+    - attack.privilege_escalation
+    - attack.persistence
+    - attack.t1546.003

--- a/rules/windows/image_load/image_load_side_load_antivirus.yml
+++ b/rules/windows/image_load/image_load_side_load_antivirus.yml
@@ -6,7 +6,7 @@ references:
     - https://hijacklibs.net/ # For list of DLLs that could be sideloaded (search for dlls mentioned here in there)
 author: Nasreddine Bencherchali, Wietze Beukema (project and research)
 date: 2022/08/17
-modified: 2022/09/21
+modified: 2022/10/13
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -24,9 +24,13 @@ detection:
         ImageLoaded|startswith:
             - 'C:\Program Files\Bitdefender Antivirus Free\'
             - 'C:\Program Files (x86)\Bitdefender Antivirus Free\'
-    filter_log_dll_other:
-        - ImageLoaded: 'C:\Program Files\Dell\SARemediation\plugin\log.dll'
-        - ImageLoaded|startswith: 'C:\Program Files\Canon\MyPrinter\'
+    filter_log_dll_dell_sar:
+        Image: 'C:\Program Files\Dell\SARemediation\audit\TelemetryUtility.exe'
+        ImageLoaded:
+            - 'C:\Program Files\Dell\SARemediation\plugin\log.dll'
+            - 'C:\Program Files\Dell\SARemediation\audit\log.dll'
+    filter_log_dll_canon:
+        ImageLoaded|startswith: 'C:\Program Files\Canon\MyPrinter\'
     # F-Secure
     selection_fsecure:
         ImageLoaded|endswith: '\qrt.dll'

--- a/rules/windows/image_load/image_load_wmic_remote_xsl_scripting_dlls.yml
+++ b/rules/windows/image_load/image_load_wmic_remote_xsl_scripting_dlls.yml
@@ -4,24 +4,26 @@ status: test
 description: Detects threat actors proxy executing code and bypassing application controls by leveraging wmic and the `/FORMAT` argument switch to download and execute an XSL file (i.e js, vbs, etc).
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 references:
-  - https://securitydatasets.com/notebooks/small/windows/05_defense_evasion/SDWIN-201017061100.html
-  - https://twitter.com/dez_/status/986614411711442944
-  - https://lolbas-project.github.io/lolbas/Binaries/Wmic/
+    - https://securitydatasets.com/notebooks/small/windows/05_defense_evasion/SDWIN-201017061100.html
+    - https://twitter.com/dez_/status/986614411711442944
+    - https://lolbas-project.github.io/lolbas/Binaries/Wmic/
 date: 2020/10/17
-modified: 2021/11/27
+modified: 2022/10/13
 logsource:
-  category: image_load
-  product: windows
+    category: image_load
+    product: windows
 detection:
-  selection:
-    Image|endswith: '\wmic.exe'
-    ImageLoaded|endswith:
-      - '\jscript.dll'
-      - '\vbscript.dll'
-  condition: selection
+    selection:
+        Image|endswith: '\wmic.exe'
+        ImageLoaded|endswith:
+            - '\jscript.dll'
+            - '\vbscript.dll'
+    condition: selection
 falsepositives:
-  - Apparently, wmic os get lastboottuptime loads vbscript.dll
-level: high
+    - The command wmic os get lastboottuptime loads vbscript.dll
+    - The command wmic os get locale loads vbscript.dll
+    - Since the ImageLoad event doesn't have enough information in this case. It's better to look at the recent process creation events that spawned the WMIC process and investigate the command line and parent/child processes to get more insights
+level: medium
 tags:
-  - attack.defense_evasion
-  - attack.t1220
+    - attack.defense_evasion
+    - attack.t1220

--- a/rules/windows/powershell/powershell_module/posh_pm_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_alternate_powershell_hosts.yml
@@ -25,6 +25,9 @@ detection:
             - '= powershell' # Host Application=...powershell.exe or Application hote=...powershell.exe in French Win10 event
             - '= C:\Windows\System32\WindowsPowerShell\v1.0\powershell'
             - '= C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell'
+            # In some cases powershell was invoked with inverted slashes
+            - '= C:/Windows/System32/WindowsPowerShell/v1.0/powershell'
+            - '= C:/Windows/SysWOW64/WindowsPowerShell/v1.0/powershell'
     filter_citrix:
         ContextInfo|contains: 'ConfigSyncRun.exe'
     filter_adace:  # Active Directory Administrative Center Enhancements

--- a/rules/windows/process_creation/proc_creation_win_lolbin_findstr.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_findstr.yml
@@ -8,7 +8,7 @@ references:
     - https://oddvar.moe/2018/04/11/putting-data-in-alternate-data-streams-and-how-to-execute-it-part-2/
     - https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 date: 2020/10/05
-modified: 2022/06/20
+modified: 2022/10/11
 logsource:
     category: process_creation
     product: windows
@@ -19,20 +19,20 @@ detection:
         - OriginalFileName: 'FINDSTR.EXE'
     selection_cli_download_1:
         CommandLine|contains:
-            - /v
-            - -v
+            - ' /v '
+            - ' -v '
     selection_cli_download_2:
         CommandLine|contains:
-            - /l
-            - -l
+            - ' /l '
+            - ' -l '
     selection_cli_creds_1:
         CommandLine|contains:
-            - /s
-            - -s
+            - ' /s '
+            - ' -s '
     selection_cli_creds_2:
         CommandLine|contains:
-            - /i
-            - -i
+            - ' /i '
+            - ' -i '
     condition: selection_findstr and (all of selection_cli_download* or all of selection_cli_creds*)
 falsepositives:
     - Administrative findstr usage

--- a/rules/windows/process_creation/proc_creation_win_wmi_persistence_script_event_consumer.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmi_persistence_script_event_consumer.yml
@@ -4,21 +4,22 @@ status: test
 description: Detects WMI script event consumers
 author: Thomas Patzke
 references:
-  - https://www.eideon.com/2018-03-02-THL03-WMIBackdoors/
+    - https://www.eideon.com/2018-03-02-THL03-WMIBackdoors/
 date: 2018/03/07
-modified: 2021/11/27
+modified: 2022/10/11
 logsource:
-  category: process_creation
-  product: windows
+    category: process_creation
+    product: windows
 detection:
-  selection:
-    Image: C:\WINDOWS\system32\wbem\scrcons.exe
-    ParentImage: C:\Windows\System32\svchost.exe
-  condition: selection
+    selection:
+        Image: C:\WINDOWS\system32\wbem\scrcons.exe
+        ParentImage: C:\Windows\System32\svchost.exe
+    condition: selection
 falsepositives:
-  - Legitimate event consumers
-level: high
+    - Legitimate event consumers
+    - Dell computers on some versions register an event consumer that is known to cause false positives when brightness is changed by the corresponding keyboard button
+level: medium
 tags:
-  - attack.persistence
-  - attack.privilege_escalation
-  - attack.t1546.003
+    - attack.persistence
+    - attack.privilege_escalation
+    - attack.t1546.003

--- a/rules/windows/registry/registry_set/registry_set_disable_winevt_logging.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_winevt_logging.yml
@@ -1,9 +1,9 @@
 title: Disable Winevt Event Logging Via Registry
 id: 2f78da12-f7c7-430b-8b19-a28f269b77a3
-description: Detects tempering with the "Enabled" registry key in order to disable windows logging of a windows event channel
+description: Detects tampering with the "Enabled" registry key in order to disable windows logging of a windows event channel
 author: frack113, Nasreddine Bencherchali
 date: 2022/07/04
-modified: 2022/09/20
+modified: 2022/10/11
 status: experimental
 references:
     - https://twitter.com/WhichbufferArda/status/1543900539280293889
@@ -29,6 +29,9 @@ detection:
             - '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-ASN1\'
             - '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-Kernel-AppCompat\'
             - '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-Runtime\Error\'
+    filter_trusted_installer:
+        Image: C:\Windows\servicing\TrustedInstaller.exe
+        TargetObject|contains: '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-Compat-Appraiser'
     filter_empty: # This filter is related to aurora. Should be removed when fix is deployed. # TODO: Remove later
         Image:
             - ''


### PR DESCRIPTION
This PR fixes some false positives found in testing

- Reduced the level of the following three rules due to untunable FP. By that, I mean that when the rules trigger the event doesn't contain enough information on its own to let the analysts know whether the action was malicious or not. It needs to be correlated with other events such as process creation for example in order to obtain useful information. Since I was able to trigger these rules in a benign way. I think it's better to reduce the level to medium. At least until correlation is introduced to SIGMA. (Example of FP was discussed in keybase)
  - [b439f47d-ef52-4b29-9a2f-57d8a96cb6b8](https://github.com/SigmaHQ/sigma/blob/7fb8272f948cc0b528fe7bd36df36449f74b2266/rules/windows/image_load/image_load_scrcons_imageload_wmi_scripteventconsumer.yml)
  - [06ce37c2-61ab-4f05-9ff5-b1a96d18ae32](https://github.com/SigmaHQ/sigma/blob/7fb8272f948cc0b528fe7bd36df36449f74b2266/rules/windows/image_load/image_load_wmic_remote_xsl_scripting_dlls.yml)
  - [ec1d5e28-8f3b-4188-a6f8-6e8df81dc28e](https://github.com/SigmaHQ/sigma/search?q=ec1d5e28-8f3b-4188-a6f8-6e8df81dc28e)
 - Added FP to AV DLL Sideloading Rule based on DELL SAR processes
 - Other FP found during testing which are staright forward to understand from the change itself.