### PR TITLE
Filter Dell Update Utility: proc_creation_win_susp_non_exe_image.yml

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_non_exe_image.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_non_exe_image.yml
@@ -86,7 +86,7 @@ detection:
     filter_windows_helper:
         ParentImage: C:\Windows\Temp\
         Image|startswith: 'C:\Windows\Temp\Helper\'
-    filer_dell_dock:
+    filter_dell_dock:
         ParentImage|startswith: 'C:\Windows\Temp\'
         ParentImage|endswith: '\TBT_Dock_Firmware\GetDockVer32W.exe'
     condition: not known_image_extension and not 1 of filter*

--- a/rules/windows/process_creation/proc_creation_win_susp_non_exe_image.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_non_exe_image.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Checks whether the image specified in a process creation event doesn't refer to an .exe file (caused by process ghosting or other unorthodox methods to start a process)
 author: Max Altgelt
 date: 2021/12/09
-modified: 2022/10/07
+modified: 2022/10/14
 references:
     - https://pentestlaboratories.com/2021/12/08/process-ghosting/
 tags:

--- a/rules/windows/process_creation/proc_creation_win_susp_non_exe_image.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_non_exe_image.yml
@@ -86,6 +86,9 @@ detection:
     filter_windows_helper:
         ParentImage: C:\Windows\Temp\
         Image|startswith: 'C:\Windows\Temp\Helper\'
+    filer_dell_dock:
+        ParentImage|startswith: 'C:\Windows\Temp\'
+        ParentImage|endswith: '\TBT_Dock_Firmware\GetDockVer32W.exe'
     condition: not known_image_extension and not 1 of filter*
 falsepositives:
     - Unknown


### PR DESCRIPTION
Added false positive filter for Dell Docking Station Update Utility.

The Image has a value similar to: C:\Windows\Temp\Helper\C9632CF058AE4321B6B0B5EA39B710FE

ParentImage will always be: C:\Windows\Temp\*\TBT_Dock_Firmware\GetDockVer32W.exe
SHA256: cd2688a74a151b03282388dadb8b6aaca309f2535c8b2b21d1243846d2b259dc