### PR TITLE
Rule Dev

### DIFF
--- a/rules/windows/builtin/application/win_msi_install_from_susp_locations.yml
+++ b/rules/windows/builtin/application/win_msi_install_from_susp_locations.yml
@@ -33,6 +33,6 @@ detection:
     condition: selection and not 1 of filter_*
 falsepositives:
     - Some false positives may occur depending on the environnement
-level: high
+level: medium
 tags:
     - attack.execution

--- a/rules/windows/builtin/security/win_security_account_backdoor_dcsync_rights.yml
+++ b/rules/windows/builtin/security/win_security_account_backdoor_dcsync_rights.yml
@@ -15,7 +15,7 @@ tags:
 logsource:
     product: windows
     service: security
-    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141. Note that the default policy does not cover User objects. For that a custom AuditRule need to be setup (See https://github.com/OTRF/Set-AuditRule)
 detection:
     selection:
         EventID: 5136

--- a/rules/windows/builtin/security/win_security_account_backdoor_dcsync_rights.yml
+++ b/rules/windows/builtin/security/win_security_account_backdoor_dcsync_rights.yml
@@ -15,6 +15,7 @@ tags:
 logsource:
     product: windows
     service: security
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to recieve events. Audit events are generated only for objects with configured system access control lists (SACLs), and only when they are accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
 detection:
     selection:
         EventID: 5136

--- a/rules/windows/builtin/security/win_security_account_backdoor_dcsync_rights.yml
+++ b/rules/windows/builtin/security/win_security_account_backdoor_dcsync_rights.yml
@@ -15,12 +15,12 @@ tags:
 logsource:
     product: windows
     service: security
-    definition: The "Audit Directory Service Changes" logging policy must be configured in order to recieve events. Audit events are generated only for objects with configured system access control lists (SACLs), and only when they are accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
 detection:
     selection:
         EventID: 5136
         AttributeLDAPDisplayName: 'ntSecurityDescriptor'
-        AttributeValue|contains: 
+        AttributeValue|contains:
             - '1131f6ad-9c07-11d1-f79f-00c04fc2dcd2'
             - '1131f6aa-9c07-11d1-f79f-00c04fc2dcd2'
             - '89e95b76-444d-4c62-991a-0facbeda640c'

--- a/rules/windows/builtin/security/win_security_alert_ad_user_backdoors.yml
+++ b/rules/windows/builtin/security/win_security_alert_ad_user_backdoors.yml
@@ -4,35 +4,35 @@ status: test
 description: Detects scenarios where one can control another users or computers account without having to use their credentials.
 author: '@neu5ron'
 references:
-  - https://msdn.microsoft.com/en-us/library/cc220234.aspx
-  - https://adsecurity.org/?p=3466
-  - https://www.harmj0y.net/blog/redteaming/another-word-on-delegation/
+    - https://msdn.microsoft.com/en-us/library/cc220234.aspx
+    - https://adsecurity.org/?p=3466
+    - https://www.harmj0y.net/blog/redteaming/another-word-on-delegation/
 date: 2017/04/13
 modified: 2021/11/27
 logsource:
-  product: windows
-  service: security
-  definition: 'Requirements: Audit Policy : Account Management > Audit User Account Management, Group Policy : Computer Configuration\Windows Settings\Security Settings\Advanced Audit Policy Configuration\Audit Policies\Account Management\Audit User Account Management, DS Access > Audit Directory Service Changes, Group Policy : Computer Configuration\Windows Settings\Security Settings\Advanced Audit Policy Configuration\Audit Policies\DS Access\Audit Directory Service Changes'
+    product: windows
+    service: security
+    definition: 'Requirements: Audit Policy : Account Management > Audit User Account Management, Group Policy : Computer Configuration\Windows Settings\Security Settings\Advanced Audit Policy Configuration\Audit Policies\Account Management\Audit User Account Management, DS Access > Audit Directory Service Changes, Group Policy : Computer Configuration\Windows Settings\Security Settings\Advanced Audit Policy Configuration\Audit Policies\DS Access\Audit Directory Service Changes'
 detection:
-  selection1:
-    EventID: 4738
-  filter_null:
-    - AllowedToDelegateTo: '-'
-    - AllowedToDelegateTo: 
-  selection_5136_1:
-    EventID: 5136
-    AttributeLDAPDisplayName: 'msDS-AllowedToDelegateTo'
-  selection_5136_2:
-    EventID: 5136
-    ObjectClass: 'user'
-    AttributeLDAPDisplayName: 'servicePrincipalName'
-  selection_5136_3:
-    EventID: 5136
-    AttributeLDAPDisplayName: 'msDS-AllowedToActOnBehalfOfOtherIdentity'
-  condition: (selection1 and not filter_null) or 1 of selection_5136_*
+    selection1:
+        EventID: 4738
+    filter_null:
+        - AllowedToDelegateTo: '-'
+        - AllowedToDelegateTo:
+    selection_5136_1:
+        EventID: 5136
+        AttributeLDAPDisplayName: 'msDS-AllowedToDelegateTo'
+    selection_5136_2:
+        EventID: 5136
+        ObjectClass: 'user'
+        AttributeLDAPDisplayName: 'servicePrincipalName'
+    selection_5136_3:
+        EventID: 5136
+        AttributeLDAPDisplayName: 'msDS-AllowedToActOnBehalfOfOtherIdentity'
+    condition: (selection1 and not filter_null) or 1 of selection_5136_*
 falsepositives:
-  - Unknown
+    - Unknown
 level: high
 tags:
-  - attack.t1098
-  - attack.persistence
+    - attack.t1098
+    - attack.persistence

--- a/rules/windows/builtin/security/win_security_possible_dc_shadow.yml
+++ b/rules/windows/builtin/security/win_security_possible_dc_shadow.yml
@@ -4,7 +4,7 @@ description: Detects DCShadow via create new SPN
 status: experimental
 author: Ilyas Ochkov, oscd.community, Chakib Gzenayi (@Chak092), Hosni Mribah
 date: 2019/10/25
-modified: 2022/09/29
+modified: 2022/10/17
 references:
     - https://github.com/Neo23x0/sigma/blob/ec5bb710499caae6667c7f7311ca9e92c03b9039/rules/windows/builtin/win_dcsync.yml
     - https://twitter.com/gentilkiwi/status/1003236624925413376
@@ -16,6 +16,7 @@ tags:
 logsource:
     product: windows
     service: security
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to recieve events. Audit events are generated only for objects with configured system access control lists (SACLs), and only when they are accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
 detection:
     selection1:
         EventID: 4742
@@ -24,7 +25,7 @@ detection:
         EventID: 5136
         AttributeLDAPDisplayName: servicePrincipalName
         AttributeValue|startswith: 'GC/'
-    condition: selection1 or selection2
+    condition: 1 of selection*
 falsepositives:
     - Valid on domain controllers; exclude known DCs
 level: medium

--- a/rules/windows/builtin/security/win_security_possible_dc_shadow.yml
+++ b/rules/windows/builtin/security/win_security_possible_dc_shadow.yml
@@ -16,7 +16,7 @@ tags:
 logsource:
     product: windows
     service: security
-    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141. Note that the default policy does not cover User objects. For that a custom AuditRule need to be setup (See https://github.com/OTRF/Set-AuditRule)
 detection:
     selection1:
         EventID: 4742

--- a/rules/windows/builtin/security/win_security_possible_dc_shadow.yml
+++ b/rules/windows/builtin/security/win_security_possible_dc_shadow.yml
@@ -16,7 +16,7 @@ tags:
 logsource:
     product: windows
     service: security
-    definition: The "Audit Directory Service Changes" logging policy must be configured in order to recieve events. Audit events are generated only for objects with configured system access control lists (SACLs), and only when they are accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
 detection:
     selection1:
         EventID: 4742

--- a/rules/windows/builtin/security/win_security_susp_ldap_dataexchange.yml
+++ b/rules/windows/builtin/security/win_security_susp_ldap_dataexchange.yml
@@ -12,7 +12,7 @@ modified: 2022/10/05
 logsource:
     product: windows
     service: security
-    definition: The "Audit Directory Service Changes" logging policy must be configured in order to recieve events. Audit events are generated only for objects with configured system access control lists (SACLs), and only when they are accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
 detection:
     selection:
         EventID: 5136

--- a/rules/windows/builtin/security/win_security_susp_ldap_dataexchange.yml
+++ b/rules/windows/builtin/security/win_security_susp_ldap_dataexchange.yml
@@ -12,7 +12,7 @@ modified: 2022/10/05
 logsource:
     product: windows
     service: security
-    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141. Note that the default policy does not cover User objects. For that a custom AuditRule need to be setup (See https://github.com/OTRF/Set-AuditRule)
 detection:
     selection:
         EventID: 5136

--- a/rules/windows/builtin/security/win_security_susp_ldap_dataexchange.yml
+++ b/rules/windows/builtin/security/win_security_susp_ldap_dataexchange.yml
@@ -12,6 +12,7 @@ modified: 2022/10/05
 logsource:
     product: windows
     service: security
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to recieve events. Audit events are generated only for objects with configured system access control lists (SACLs), and only when they are accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
 detection:
     selection:
         EventID: 5136

--- a/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
+++ b/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects possible addition of shadow credentials to an active directory object.
 author: Nasreddine Bencherchali (rule), Elastic (idea)
 references:
-    - https://www.elastic.co/guide/en/security/7.17/prebuilt-rule-0-16-1-potential-shadow-credentials-added-to-ad-object.html
+    - https://www.elastic.co/guide/en/security/8.4/potential-shadow-credentials-added-to-ad-object.html
     - https://cyberstoph.org/posts/2022/03/detecting-shadow-credentials/
     - https://twitter.com/SBousseaden/status/1581300963650187264?
 date: 2022/10/17
@@ -16,6 +16,10 @@ detection:
     selection:
         EventID: 5136
         AttributeLDAPDisplayName: 'msDS-KeyCredentialLink'
+        # If you experience a lot of FP you could uncomment the selection below
+        # There could be other cases for other tooling add them accordingly
+        #AttributeValue|contains: 'B:828'
+        #OperationType: '%%14674' # Value Added
     condition: selection
 falsepositives:
     - Modifications in the msDS-KeyCredentialLink attribute can be done legitimately by the Azure AD Connect synchronization account or the ADFS service account. These accounts can be added as Exceptions. (From elastic FP section)

--- a/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
+++ b/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
@@ -11,14 +11,14 @@ date: 2022/10/17
 logsource:
     product: windows
     service: security
-    definition: The "Audit Directory Service Changes" logging policy must be configured in order to recieve events. Audit events are generated only for objects with configured system access control lists (SACLs), and only when they are accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
 detection:
     selection:
         EventID: 5136
         AttributeLDAPDisplayName: 'msDS-KeyCredentialLink'
     condition: selection
 falsepositives:
-    - Unknown
+    - Modifications in the msDS-KeyCredentialLink attribute can be done legitimately by the Azure AD Connect synchronization account or the ADFS service account. These accounts can be added as Exceptions. (From elastic FP section)
 level: high
 tags:
     - attack.credential_access

--- a/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
+++ b/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
@@ -1,0 +1,25 @@
+title: Possible Shadow Credentials Added
+id: f598ea0c-c25a-4f72-a219-50c44411c791
+status: experimental
+description: Detects possible addition of shadow credentials to an active directory object.
+author: Nasreddine Bencherchali (rule), Elastic (idea)
+references:
+    - https://www.elastic.co/guide/en/security/7.17/prebuilt-rule-0-16-1-potential-shadow-credentials-added-to-ad-object.html
+    - https://cyberstoph.org/posts/2022/03/detecting-shadow-credentials/
+    - https://twitter.com/SBousseaden/status/1581300963650187264?
+date: 2022/10/17
+logsource:
+    product: windows
+    service: security
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to recieve events. Audit events are generated only for objects with configured system access control lists (SACLs), and only when they are accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
+detection:
+    selection:
+        EventID: 5136
+        AttributeLDAPDisplayName: 'msDS-KeyCredentialLink'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high
+tags:
+    - attack.credential_access
+    - attack.t1556

--- a/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
+++ b/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
@@ -8,6 +8,9 @@ references:
     - https://cyberstoph.org/posts/2022/03/detecting-shadow-credentials/
     - https://twitter.com/SBousseaden/status/1581300963650187264?
 date: 2022/10/17
+tags:
+    - attack.credential_access
+    - attack.t1556
 logsource:
     product: windows
     service: security
@@ -24,6 +27,3 @@ detection:
 falsepositives:
     - Modifications in the msDS-KeyCredentialLink attribute can be done legitimately by the Azure AD Connect synchronization account or the ADFS service account. These accounts can be added as Exceptions. (From elastic FP section)
 level: high
-tags:
-    - attack.credential_access
-    - attack.t1556

--- a/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
+++ b/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
@@ -14,7 +14,7 @@ tags:
 logsource:
     product: windows
     service: security
-    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141
+    definition: The "Audit Directory Service Changes" logging policy must be configured in order to receive events. Audit events are generated only for objects with configured system access control lists (SACLs). Audit events are generated only for objects with configured system access control lists (SACLs) and only when accessed in a manner that matches their SACL settings. This policy covers the following events ids - 5136, 5137, 5138, 5139, 5141. Note that the default policy does not cover User objects. For that a custom AuditRule need to be setup (See https://github.com/OTRF/Set-AuditRule)
 detection:
     selection:
         EventID: 5136

--- a/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
+++ b/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
@@ -25,6 +25,7 @@ detection:
         #OperationType: '%%14674' # Value Added
     # As stated in the FP sections it's better to filter out the expected accounts that perform this operation to tighten the logic
     # Uncomment the filter below and add the account name (or any other specific field) accordingly
+    # Don't forget to add it to the condition section below
     #filter:
         #SubjectUserName: "%name%"
     condition: selection

--- a/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
+++ b/rules/windows/builtin/security/win_security_susp_possible_shadow_credentials_added.yml
@@ -23,6 +23,10 @@ detection:
         # There could be other cases for other tooling add them accordingly
         #AttributeValue|contains: 'B:828'
         #OperationType: '%%14674' # Value Added
+    # As stated in the FP sections it's better to filter out the expected accounts that perform this operation to tighten the logic
+    # Uncomment the filter below and add the account name (or any other specific field) accordingly
+    #filter:
+        #SubjectUserName: "%name%"
     condition: selection
 falsepositives:
     - Modifications in the msDS-KeyCredentialLink attribute can be done legitimately by the Azure AD Connect synchronization account or the ADFS service account. These accounts can be added as Exceptions. (From elastic FP section)

--- a/rules/windows/file/file_access/file_access_win_credential_manager_stealing.yml
+++ b/rules/windows/file/file_access/file_access_win_credential_manager_stealing.yml
@@ -29,4 +29,5 @@ detection:
     condition: selection and not 1 of filter_*
 falsepositives:
     - Legitimate software installed by the users for example in the "AppData" directory may access these files (for any reason).
+# Increase level after false positives filters are good enough
 level: medium

--- a/rules/windows/file/file_access/file_access_win_dpapi_master_key_access.yml
+++ b/rules/windows/file/file_access/file_access_win_dpapi_master_key_access.yml
@@ -1,0 +1,31 @@
+title: Suspicious Access To Windows DPAPI Master Keys
+id: 46612ae6-86be-4802-bc07-39b59feb1309
+status: experimental
+description: Detects suspicious processes based on name and location that access the Windows Data Protection API Master keys. Which can be a sign of credential stealing. Example case would be usage of mimikatz "dpapi::masterkey" function
+references:
+    - https://web.archive.org/web/20181130065817/http://www.harmj0y.net/blog/redteaming/operational-guidance-for-offensive-user-dpapi-abuse/
+    - https://book.hacktricks.xyz/windows-hardening/windows-local-privilege-escalation/dpapi-extracting-passwords
+author: Nasreddine Bencherchali
+date: 2022/10/17
+tags:
+    - attack.credential_access
+    - attack.t1555.004
+logsource:
+    category: file_access
+    product: windows
+detection:
+    selection:
+        FileName|contains:
+            - '\Microsoft\Protect\S-1-5-18\' # For System32
+            - '\Microsoft\Protect\S-1-5-21-' # For Users
+    filter_system_folders:
+        Image|startswith:
+            - 'C:\Program Files\'
+            - 'C:\Program Files (x86)\'
+            - 'C:\Windows\system32\'
+            - 'C:\Windows\SysWOW64\'
+    condition: selection and not 1 of filter_*
+falsepositives:
+    - Unknown
+# Increase level after false positives filters are good enough
+level: medium

--- a/rules/windows/file/file_access/file_access_win_susp_cred_hist_access.yml
+++ b/rules/windows/file/file_access/file_access_win_susp_cred_hist_access.yml
@@ -1,0 +1,31 @@
+title: Suspicious Access To Windows Credential History File
+id: 7a2a22ea-a203-4cd3-9abf-20eb1c5c6cd2
+status: experimental
+description: Detects suspicious processes based on name and location that access the Windows Credential History File. Which can be a sign of credential stealing. Example case would be usage of mimikatz "dpapi::credhist" function
+references:
+    - https://tools.thehacker.recipes/mimikatz/modules/dpapi/credhist
+    - https://www.passcape.com/windows_password_recovery_dpapi_credhist
+author: Nasreddine Bencherchali
+date: 2022/10/17
+tags:
+    - attack.credential_access
+    - attack.t1555.004
+logsource:
+    category: file_access
+    product: windows
+detection:
+    selection:
+        FileName|endswith: '\Microsoft\Protect\CREDHIST'
+    filter_system_folders:
+        Image|startswith:
+            - 'C:\Program Files\'
+            - 'C:\Program Files (x86)\'
+            - 'C:\Windows\system32\'
+            - 'C:\Windows\SysWOW64\'
+    filter_processes:
+        Image: 'C:\Windows\explorer.exe'
+    condition: selection and not 1 of filter_*
+falsepositives:
+    - Unknown
+# Increase level after false positives filters are good enough
+level: medium

--- a/rules/windows/powershell/powershell_script/posh_ps_using_set_service_to_hide_services.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_using_set_service_to_hide_services.yml
@@ -1,4 +1,4 @@
-title: Windows PowerShell Web Request
+title: Abuse of Service Permissions to Hide Services Via Set-Service - PS
 id: 953945c5-22fe-4a92-9f8a-a9edc1e522da
 related:
     - id: 514e4c3a-c77d-4cde-a00f-046425e2301e

--- a/rules/windows/powershell/powershell_script/posh_ps_using_set_service_to_hide_services.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_using_set_service_to_hide_services.yml
@@ -1,9 +1,7 @@
-title: Abuse of Service Permissions to Hide Services Via Set-Service
-id: 514e4c3a-c77d-4cde-a00f-046425e2301e
+title: Windows PowerShell Web Request
+id: 953945c5-22fe-4a92-9f8a-a9edc1e522da
 related:
-    - id: a537cfc3-4297-4789-92b5-345bfd845ad0
-      type: derived
-    - id: 953945c5-22fe-4a92-9f8a-a9edc1e522da
+    - id: 514e4c3a-c77d-4cde-a00f-046425e2301e
       type: similar
 status: experimental
 description: Detects usage of the "Set-Service" powershell cmdlet to configure a new SecurityDescriptor that allows a service to be hidden from other utilities such as "sc.exe", "Get-Service"...etc. (Works only in powershell 7)
@@ -18,22 +16,19 @@ tags:
     - attack.privilege_escalation
     - attack.t1574.011
 logsource:
-    category: process_creation
     product: windows
+    category: ps_script
+    definition: Script block logging must be enabled
 detection:
-    selection_img:
-        - Image|endswith: '\pwsh.exe'
-        - OriginalFileName: 'pwsh.dll'
-    selection_sddl:
-        # Example would be: "D:(D;;DCLCWPDTSD;;;IU)(D;;DCLCWPDTSD;;;SU)(D;;DCLCWPDTSD;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
-        CommandLine|contains|all:
+    selection:
+        ScriptBlockText|contains|all:
             - 'Set-Service '
             - 'DCLCWPDTSD'
-    selection_cmdlet:
-        CommandLine|contains:
+        ScriptBlockText|contains:
             - '-SecurityDescriptorSddl '
             - '-sd '
-    condition: all of selection_*
+    condition: selection
 falsepositives:
     - Rare intended use of hidden services
+    - Rare FP could occure due to the non linearity of the ScriptBlockText log
 level: high

--- a/rules/windows/process_creation/proc_creation_win_enumeration_for_credentials_cli.yml
+++ b/rules/windows/process_creation/proc_creation_win_enumeration_for_credentials_cli.yml
@@ -37,7 +37,7 @@ detection:
             - '\Software\RealVNC\WinVNC4'
     condition: selection
 falsepositives:
-    - Unlikely
+    - Unknown
 level: medium
 tags:
     - attack.credential_access

--- a/rules/windows/process_creation/proc_creation_win_etw_modification_cmdline.yml
+++ b/rules/windows/process_creation/proc_creation_win_etw_modification_cmdline.yml
@@ -4,27 +4,27 @@ status: test
 description: Potential adversaries stopping ETW providers recording loaded .NET assemblies.
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 references:
-  - https://twitter.com/_xpn_/status/1268712093928378368
-  - https://social.msdn.microsoft.com/Forums/vstudio/en-US/0878832e-39d7-4eaf-8e16-a729c4c40975/what-can-i-use-e13c0d23ccbc4e12931bd9cc2eee27e4-for?forum=clr
-  - https://github.com/dotnet/runtime/blob/ee2355c801d892f2894b0f7b14a20e6cc50e0e54/docs/design/coreclr/jit/viewing-jit-dumps.md#setting-configuration-variables
-  - https://github.com/dotnet/runtime/blob/f62e93416a1799aecc6b0947adad55a0d9870732/src/coreclr/src/inc/clrconfigvalues.h#L35-L38
-  - https://github.com/dotnet/runtime/blob/7abe42dc1123722ed385218268bb9fe04556e3d3/src/coreclr/src/inc/clrconfig.h#L33-L39
-  - https://github.com/dotnet/runtime/search?p=1&q=COMPlus_&unscoped_q=COMPlus_
-  - https://bunnyinside.com/?term=f71e8cb9c76a
-  - http://managed670.rssing.com/chan-5590147/all_p1.html
-  - https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/docs/coding-guidelines/clr-jit-coding-conventions.md#1412-disabling-code
+    - https://twitter.com/_xpn_/status/1268712093928378368
+    - https://social.msdn.microsoft.com/Forums/vstudio/en-US/0878832e-39d7-4eaf-8e16-a729c4c40975/what-can-i-use-e13c0d23ccbc4e12931bd9cc2eee27e4-for?forum=clr
+    - https://github.com/dotnet/runtime/blob/ee2355c801d892f2894b0f7b14a20e6cc50e0e54/docs/design/coreclr/jit/viewing-jit-dumps.md#setting-configuration-variables
+    - https://github.com/dotnet/runtime/blob/f62e93416a1799aecc6b0947adad55a0d9870732/src/coreclr/src/inc/clrconfigvalues.h#L35-L38
+    - https://github.com/dotnet/runtime/blob/7abe42dc1123722ed385218268bb9fe04556e3d3/src/coreclr/src/inc/clrconfig.h#L33-L39
+    - https://github.com/dotnet/runtime/search?p=1&q=COMPlus_&unscoped_q=COMPlus_
+    - https://bunnyinside.com/?term=f71e8cb9c76a
+    - http://managed670.rssing.com/chan-5590147/all_p1.html
+    - https://github.com/dotnet/runtime/blob/4f9ae42d861fcb4be2fcd5d3d55d5f227d30e723/docs/coding-guidelines/clr-jit-coding-conventions.md#1412-disabling-code
 date: 2020/05/02
 modified: 2021/11/27
 logsource:
-  category: process_creation
-  product: windows
+    category: process_creation
+    product: windows
 detection:
-  selection:
-    CommandLine|contains: 'COMPlus_ETWEnabled=0'
-  condition: selection
+    selection:
+        CommandLine|contains: 'COMPlus_ETWEnabled=0'
+    condition: selection
 falsepositives:
-  - Unknown
+    - Unlikely
 level: high
 tags:
-  - attack.defense_evasion
-  - attack.t1562
+    - attack.defense_evasion
+    - attack.t1562

--- a/rules/windows/process_creation/proc_creation_win_lolbin_susp_wsl.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_susp_wsl.yml
@@ -24,6 +24,7 @@ detection:
     condition: all of selection*
 falsepositives:
     - Automation and orchestration scripts may use this method execute scripts etc
+    - Legitimate use by Windows
 level: medium
 tags:
     - attack.execution

--- a/rules/windows/process_creation/proc_creation_win_using_sc_to_hide_sevices.yml
+++ b/rules/windows/process_creation/proc_creation_win_using_sc_to_hide_sevices.yml
@@ -6,6 +6,7 @@ author: Andreas Hunkeler (@Karneades)
 references:
     - https://blog.talosintelligence.com/2021/10/threat-hunting-in-large-datasets-by.html
     - https://www.sans.org/blog/red-team-tactics-hiding-windows-services/
+    - https://twitter.com/Alh4zr3d/status/1580925761996828672
 date: 2021/12/20
 modified: 2022/08/08
 logsource:

--- a/rules/windows/process_creation/proc_creation_win_using_set_service_to_hide_services.yml
+++ b/rules/windows/process_creation/proc_creation_win_using_set_service_to_hide_services.yml
@@ -1,0 +1,35 @@
+title: Abuse of Service Permissions to Hide Services Via Set-Service
+id: 514e4c3a-c77d-4cde-a00f-046425e2301e
+related:
+    - id: a537cfc3-4297-4789-92b5-345bfd845ad0
+      type: derived
+status: experimental
+description: Detects usage of the "Set-Service" powershell cmdlet to configure a new SecurityDescriptor that allows a service to be hidden from other utilities such as "sc.exe", "Get-Service"...etc. (Works only in powershell 7)
+author: Nasreddine Bencherchali
+references:
+    - https://twitter.com/Alh4zr3d/status/1580925761996828672
+    - https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-service?view=powershell-7.2
+date: 2022/10/17
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\pwsh.exe'
+        - OriginalFileName: 'pwsh.dll'
+    selection_sddl:
+        # Example would be: "D:(D;;DCLCWPDTSD;;;IU)(D;;DCLCWPDTSD;;;SU)(D;;DCLCWPDTSD;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)"
+        CommandLine|contains: 'DCLCWPDTSD'
+    selection_cmdlet:
+        CommandLine|contains:
+            - '-SecurityDescriptorSddl '
+            - '-sd '
+    condition: all of selection_*
+falsepositives:
+    - Rare intended use of hidden services
+level: high
+tags:
+    - attack.persistence
+    - attack.defense_evasion
+    - attack.privilege_escalation
+    - attack.t1574.011


### PR DESCRIPTION
This PR covers the following

- Add missing definitions for Audit Directory Services Changes events
- Added new rule for hiding services by changing the SDDL (ProcCreation+PowerShell ScriptBlock) (Ref: https://twitter.com/Alh4zr3d/status/1580925761996828672) - Powershell 7 variant
- Added 3 new `file_access` rules for DPAPI keys/files (Will definitely require some more future FP tuning as they are other third-party software installed in AppData that could access this)
- Small additions to FP sections for some rules
- Reduce the level of [c7c8aa1c-5aff-408e-828b-998e3620b341](https://github.com/SigmaHQ/sigma/blob/88f6f1767fb5b921230abab2a206e7e37ed8564b/rules/windows/builtin/application/win_msi_install_from_susp_locations.yml) to medium