### PR TITLE
Create net_dns_cdn_cobaltstrike.yml

### DIFF
--- a/rules/network/dns/net_dns_cdn_cobaltstrike.yml
+++ b/rules/network/dns/net_dns_cdn_cobaltstrike.yml
@@ -1,4 +1,4 @@
-title: Cobalt Strike abusing fastly.net CDN
+title: Cobalt Strike Abusing Fastly Cdn
 id: 8ce3f9d5-e4d4-4b8f-8d08-26a1f53837d3
 status: test
 description: Detects suspicious DNS queries known from Cobalt Strike abusing fastly CDN

--- a/rules/network/dns/net_dns_cdn_cobaltstrike.yml
+++ b/rules/network/dns/net_dns_cdn_cobaltstrike.yml
@@ -18,5 +18,5 @@ detection:
         query|re: (.*\.){6}
     condition: selection
 falsepositives:
-    - Unknown
+    - Unknown, might need to exclude internet browsers initiating these DNS requests
 level: critical

--- a/rules/network/dns/net_dns_cdn_cobaltstrike.yml
+++ b/rules/network/dns/net_dns_cdn_cobaltstrike.yml
@@ -12,11 +12,11 @@ tags:
 logsource:
     category: dns
 detection:
-    selection:
-        query|endswith:
-            - 'fastly.net'
+    selection1:
+        query|endswith: 'fastly.net'
+    selection2:
         query|re: (.*\.){6}
-    condition: selection
+    condition: selection1 and selection2
 falsepositives:
     - Unknown, might need to exclude internet browsers initiating these DNS requests
 level: critical

--- a/rules/network/dns/net_dns_cdn_cobaltstrike.yml
+++ b/rules/network/dns/net_dns_cdn_cobaltstrike.yml
@@ -1,0 +1,22 @@
+title: Cobalt Strike abusing fastly.net CDN
+id: 8ce3f9d5-e4d4-4b8f-8d08-26a1f53837d3
+status: test
+description: Detects suspicious DNS queries known from Cobalt Strike abusing fastly CDN
+references:
+    - https://thedfirreport.com/2022/01/24/cobalt-strike-a-defenders-guide-part-2/
+author: Sorina Ionescu
+date: 2022/10/18
+tags:
+    - attack.command_and_control
+    - attack.t1071.004
+logsource:
+    category: dns
+detection:
+    selection:
+        query|endswith:
+            - 'fastly.net'
+        query|re: (.*\.){6}
+    condition: selection
+falsepositives:
+    - Unknown
+level: critical


### PR DESCRIPTION
Cobalt Strike is abusing Fastly CDN by using quite unique patterns of using 6 subdomains, seen on one than more sources. However this detection might still be the case of false negatives