### PR TITLE
Add PowerShellCore Eventlog

### DIFF
--- a/tools/config/fireeye-helix.yml
+++ b/tools/config/fireeye-helix.yml
@@ -102,7 +102,9 @@ logsources:
         index: windows
         service: powershell
         conditions:
-            channel: 'Microsoft-Windows-Powershell'
+            channel:
+            - 'Microsoft-Windows-Powershell'
+            - 'PowerShellCore'
     windows-bits-client:
         product: windows
         service: bits-client

--- a/tools/config/generic/windows-services.yml
+++ b/tools/config/generic/windows-services.yml
@@ -66,7 +66,9 @@ logsources:
         product: windows
         service: powershell
         conditions:
-            Channel: 'Microsoft-Windows-PowerShell/Operational'
+            Channel:
+                - 'Microsoft-Windows-PowerShell/Operational'
+                - 'PowerShellCore/Operational'
     windows-classicpowershell:
         product: windows
         service: powershell-classic

--- a/tools/config/powershell.yml
+++ b/tools/config/powershell.yml
@@ -27,7 +27,9 @@ logsources:
     product: windows
     service: powershell
     conditions:
-      LogName: 'Microsoft-Windows-PowerShell/Operational'
+      LogName:
+        - 'Microsoft-Windows-PowerShell/Operational'
+        - 'PowerShellCore/Operational'
   windows-classicpowershell:
     product: windows
     service: powershell-classic

--- a/tools/config/splunk-windows.yml
+++ b/tools/config/splunk-windows.yml
@@ -41,7 +41,9 @@ logsources:
     product: windows
     service: powershell
     conditions:
-      source: 'WinEventLog:Microsoft-Windows-PowerShell/Operational'
+      source:
+        - 'WinEventLog:Microsoft-Windows-PowerShell/Operational'
+        - 'WinEventLog:PowerShellCore/Operational'
   windows-classicpowershell:
     product: windows
     service: powershell-classic

--- a/tools/config/sumologic.yml
+++ b/tools/config/sumologic.yml
@@ -52,7 +52,9 @@ logsources:
     product: windows
     service: powershell
     conditions:
-      EventChannel: Microsoft-Windows-Powershell
+      EventChannel:
+        - Microsoft-Windows-Powershell
+        - PowerShellCore
     index: WINDOWS
   windows-system:
     product: windows

--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -314,6 +314,7 @@ logsources:
     service: powershell
     sources:
       - "WinEventLog:Microsoft-Windows-PowerShell/Operational"
+      - "WinEventLog:PowerShellCore/Operational"
   windows-classicpowershell:
     product: windows
     service: powershell-classic

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -40,7 +40,9 @@ logsources:
     product: windows
     service: powershell
     conditions:
-      winlog.channel: 'Microsoft-Windows-PowerShell/Operational'
+      winlog.channel:
+        - 'Microsoft-Windows-PowerShell/Operational'
+        - 'PowerShellCore/Operational'
   windows-classicpowershell:
     product: windows
     service: powershell-classic

--- a/tools/config/winlogbeat-old.yml
+++ b/tools/config/winlogbeat-old.yml
@@ -38,7 +38,9 @@ logsources:
     product: windows
     service: powershell
     conditions:
-      winlog.channel: 'Microsoft-Windows-PowerShell/Operational'
+      winlog.channel:
+        - 'Microsoft-Windows-PowerShell/Operational'
+        - 'PowerShellCore/Operational'
   windows-classicpowershell:
     product: windows
     service: powershell-classic

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -39,7 +39,9 @@ logsources:
     product: windows
     service: powershell
     conditions:
-      winlog.channel: 'Microsoft-Windows-PowerShell/Operational'
+      winlog.channel:
+        - 'Microsoft-Windows-PowerShell/Operational'
+        - 'PowerShellCore/Operational'
   windows-classicpowershell:
     product: windows
     service: powershell-classic

--- a/tools/config/zircolite.yml
+++ b/tools/config/zircolite.yml
@@ -27,7 +27,9 @@ logsources:
     product: windows
     service: powershell
     conditions:
-      Channel: 'Microsoft-Windows-PowerShell/Operational'
+      Channel:
+        - 'Microsoft-Windows-PowerShell/Operational'
+        - 'PowerShellCore/Operational'
   windows-classicpowershell:
     product: windows
     service: powershell-classic


### PR DESCRIPTION
This PR aims to add mapping to the `PowerShellCore/Operational` which is the event log used in PowerShell 7 instead of the usual PowerShell 5 `Microsoft-Windows-PowerShell/Operational`.

Note that I added it to the same category/service to avoid rule duplication in the future. As the EIDs are the same in both versions of PowerShell

---

Just for reference, if you want to set up PowerShell 7 logging use the following steps
- Execute `C:\Program Files\PowerShell\7\InstallPSCorePolicyDefinitions.ps1`
- Open `gpedit.msc` and navigate to `Administrative Templates`
- There you'll find a new folder called `PowerShell Core`. Which has a similar structure to the PowerShell 5 logging.