### PR TITLE
Fix FP In Testing

### DIFF
--- a/rules/windows/process_access/process_access_win_shellcode_inject_msf_empire.yml
+++ b/rules/windows/process_access/process_access_win_shellcode_inject_msf_empire.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects shellcode injection by Metasploit's migrate and Empire's psinject
 author: Bhabesh Raj
 date: 2022/03/11
-modified: 2022/09/21
+modified: 2022/10/20
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
@@ -41,9 +41,17 @@ detection:
         GrantedAccess: 0x1F3FFF
         CallTrace|startswith: 'C:\Windows\System32\ntdll.dll'
     filter_dell_specifc:
-        SourceImage: C:\Program Files (x86)\Dell\UpdateService\ServiceShell.exe
-        TargetImage: C:\Windows\Explorer.EXE
+        SourceImage: 'C:\Program Files (x86)\Dell\UpdateService\ServiceShell.exe'
+        TargetImage: 'C:\Windows\Explorer.EXE'
         GrantedAccess: 0x1F3FFF
+        CallTrace|startswith: 'C:\Windows\System32\ntdll.dll'
+    filter_visual_studio:
+        SourceImage:
+            - 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\PerfWatson2.exe'
+            - 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\PerfWatson2.exe'
+        TargetImage:
+            - 'C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\devenv.exe'
+            - 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\devenv.exe'
         CallTrace|startswith: 'C:\Windows\System32\ntdll.dll'
     condition: selection and not 1 of filter_*
 falsepositives:

--- a/rules/windows/process_creation/proc_creation_win_lolbin_susp_wsl.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_susp_wsl.yml
@@ -21,10 +21,20 @@ detection:
             - ' --exec '
             - ' --system '
             - ' /mnt/c' # Path to mounted "C:\" partition (Indication of running Windows binaries via WSL)
-    condition: all of selection*
+    filter_kill:
+        # This filter is to handle a FP that occures when a process is spawned from WSL and then closed by the user
+        # Example would be to open VsCode through it's server extension from WSL
+            # GrandparentCommandLine: "C:\Users\XXX\AppData\Local\Programs\Microsoft VS Code\Code.exe" --ms-enable-electron-run-as-node c:\Users\XXX\.vscode\extensions\ms-vscode-remote.remote-wsl-0.72.0\dist\wslDaemon.js
+            # ParentCommandLine: C:\WINDOWS\system32\cmd.exe /d /s /c "C:\WINDOWS\System32\wsl.exe -d Ubuntu-20.04 -e kill 1366"
+            # CommandLine: C:\WINDOWS\System32\wsl.exe -d Ubuntu-20.04 -e kill 1366
+        ParentImage|endswith: '\cmd.exe'
+        CommandLine|contains|all:
+            - ' -d '
+            - ' -e kill '
+    condition: all of selection* and not 1 of filter_*
 falsepositives:
     - Automation and orchestration scripts may use this method execute scripts etc
-    - Legitimate use by Windows
+    - Legitimate use by Windows to kill processes opened via WSL (example VsCode WSL server)
 level: medium
 tags:
     - attack.execution

--- a/rules/windows/process_creation/proc_creation_win_lolbin_susp_wsl.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_susp_wsl.yml
@@ -8,6 +8,11 @@ references:
     - https://twitter.com/nas_bench/status/1535431474429808642
 date: 2020/10/05
 modified: 2022/06/11
+tags:
+    - attack.execution
+    - attack.defense_evasion
+    - attack.t1218
+    - attack.t1202
 logsource:
     category: process_creation
     product: windows
@@ -36,8 +41,4 @@ falsepositives:
     - Automation and orchestration scripts may use this method execute scripts etc
     - Legitimate use by Windows to kill processes opened via WSL (example VsCode WSL server)
 level: medium
-tags:
-    - attack.execution
-    - attack.defense_evasion
-    - attack.t1218
-    - attack.t1202
+

--- a/rules/windows/registry/registry_delete/registry_delete_removal_com_hijacking_registry_key.yml
+++ b/rules/windows/registry/registry_delete/registry_delete_removal_com_hijacking_registry_key.yml
@@ -11,6 +11,9 @@ references:
     - https://docs.microsoft.com/en-us/windows/win32/shell/shell-and-managed-code
 date: 2020/05/02
 modified: 2022/10/20
+tags:
+    - attack.defense_evasion
+    - attack.t1112
 logsource:
     product: windows
     category: registry_delete
@@ -52,6 +55,4 @@ detection:
 falsepositives:
     - Legitimate software (un)installations are known to cause some false positives. Please add them as a filter when encountered
 level: medium
-tags:
-    - attack.defense_evasion
-    - attack.t1112
+

--- a/rules/windows/registry/registry_delete/registry_delete_removal_com_hijacking_registry_key.yml
+++ b/rules/windows/registry/registry_delete/registry_delete_removal_com_hijacking_registry_key.yml
@@ -10,7 +10,7 @@ references:
     - https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-iexecutecommand
     - https://docs.microsoft.com/en-us/windows/win32/shell/shell-and-managed-code
 date: 2020/05/02
-modified: 2022/09/21
+modified: 2022/10/20
 logsource:
     product: windows
     category: registry_delete
@@ -44,9 +44,13 @@ detection:
         Image|contains: 'peazip'
         # We don't use the HKCR anchor as it could be logged as a different variation (HKEY_CLASSES_ROOT)
         TargetObject|contains: '\PeaZip.'
+    filter_everything:
+        Image|endswith: '\Everything.exe'
+        # We don't use the HKCR anchor as it could be logged as a different variation (HKEY_CLASSES_ROOT)
+        TargetObject|contains: '\Everything.'
     condition: selection and not 1 of filter_*
 falsepositives:
-    - Unknown
+    - Legitimate software (un)installations are known to cause some false positives. Please add them as a filter when encountered
 level: medium
 tags:
     - attack.defense_evasion

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
@@ -5,14 +5,17 @@ related:
       type: derived
 status: experimental
 description: Detects modification of autostart extensibility point (ASEP) in registry.
-author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1547.001/T1547.001.md
     - https://docs.microsoft.com/en-us/sysinternals/downloads/autoruns
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
     - https://oddvar.moe/2018/03/21/persistence-using-runonceex-hidden-from-autoruns-exe/
+author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
 modified: 2022/10/20
+tags:
+    - attack.persistence
+    - attack.t1547.001
 logsource:
     category: registry_set
     product: windows
@@ -137,15 +140,12 @@ detection:
         TargetObject|endswith: '\Microsoft\Windows\CurrentVersion\Run\Everything'
         Details|endswith: '\Everything\Everything.exe" -startup' # We remove the starting part as it could be installed in different locations
     condition: all of current_version_* and not 1 of filter_*
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium
 fields:
     - SecurityID
     - ObjectName
     - OldValueType
     - NewValueType
-falsepositives:
-    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
-    - Legitimate administrator sets up autorun keys for legitimate reason
-level: medium
-tags:
-    - attack.persistence
-    - attack.t1547.001

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
@@ -127,7 +127,7 @@ detection:
             - '"C:\Program Files\AVG\Antivirus\AvLaunch.exe" /gui'
             - '"C:\Program Files (x86)\AVG\Antivirus\AvLaunch.exe" /gui'
             - '{472083B0-C522-11CF-8763-00608CC02F24}'
-    filter_aurora_dashbaord:
+    filter_aurora_dashboard:
         Image|endswith:
             - '\aurora-agent-64.exe'
             - '\aurora-agent.exe'

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
@@ -12,7 +12,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
     - https://oddvar.moe/2018/03/21/persistence-using-runonceex-hidden-from-autoruns-exe/
 date: 2019/10/25
-modified: 2022/10/18
+modified: 2022/10/20
 logsource:
     category: registry_set
     product: windows
@@ -135,7 +135,7 @@ detection:
         Details: 'C:\Program Files\Aurora-Agent\tools\aurora-dashboard.exe'
     filter_everything:
         TargetObject|endswith: '\Microsoft\Windows\CurrentVersion\Run\Everything'
-        Details: '"C:\Program Files\Everything\Everything.exe" -startup'
+        Details|endswith: '\Everything\Everything.exe" -startup' # We remove the starting part as it could be installed in different locations
     condition: all of current_version_* and not 1 of filter_*
 fields:
     - SecurityID

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
@@ -140,12 +140,12 @@ detection:
         TargetObject|endswith: '\Microsoft\Windows\CurrentVersion\Run\Everything'
         Details|endswith: '\Everything\Everything.exe" -startup' # We remove the starting part as it could be installed in different locations
     condition: all of current_version_* and not 1 of filter_*
-falsepositives:
-    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
-    - Legitimate administrator sets up autorun keys for legitimate reason
-level: medium
 fields:
     - SecurityID
     - ObjectName
     - OldValueType
     - NewValueType
+falsepositives:
+    - Legitimate software automatically (mostly, during installation) sets up autorun keys for legitimate reason
+    - Legitimate administrator sets up autorun keys for legitimate reason
+level: medium


### PR DESCRIPTION
This PR covers the following:

- Adds a filter to the rule [dec44ca7-61ad-493c-bfd7-8819c5faa09b](https://github.com/SigmaHQ/sigma/blob/f976ad48c1dcd63b1e1e888ff662adf625b7021b/rules/windows/process_creation/proc_creation_win_lolbin_susp_wsl.yml) to fix a false positives that occurs via VsCode Server extension 
- Filter Visual Studio in the [250ae82f-736e-4844-a68b-0b5e8cc887da](https://github.com/SigmaHQ/sigma/blob/ee850aaf2cdc23d503e43593d9a1c20a5123c89c/rules/windows/process_access/process_access_win_shellcode_inject_msf_empire.yml) as it's causing FP just by starting it.
- Tighten the filters for the `everything.exe` process for the rules [20f0ee37-5942-4e45-b7d5-c5b5db9df5cd](https://github.com/SigmaHQ/sigma/blob/e93b7bf5711cd0f45decb6fe06ded830c77ecd57/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml) and [96f697b0-b499-4e5d-9908-a67bec11cdb6](https://github.com/SigmaHQ/sigma/blob/16990093933fe8c82c3ad879d306d706b350162a/rules/windows/registry/registry_delete/registry_delete_removal_com_hijacking_registry_key.yml)