### PR TITLE
Rule Dev

### DIFF
--- a/rules/windows/driver_load/driver_load_vuln_drivers.yml
+++ b/rules/windows/driver_load/driver_load_vuln_drivers.yml
@@ -19,8 +19,9 @@ references:
     - https://www.unknowncheats.me/forum/downloads.php?do=file&id=21780
     - https://www.rapid7.com/db/modules/exploit/windows/local/razer_zwopenprocess/
     - https://www.unknowncheats.me/forum/downloads.php?do=file&id=25444
+    - https://www.zscaler.com/blogs/security-research/technical-analysis-windows-clfs-zero-day-vulnerability-cve-2022-37969-part
 date: 2022/08/18
-modified: 2022/10/10
+modified: 2022/10/19
 logsource:
     product: windows
     category: driver_load
@@ -280,6 +281,9 @@ detection:
             - 'SHA1=d0a228ed8af190dec0c1a812e212f5e68ee3b43e'
             - 'SHA1=7d2fc1a6729521e5c76f659e4c398e2061f7ed5e'
             - 'SHA1=f999709e5b00a68a0f4fa912619fe6548ad0c42d'
+            # Vuln driver version obtained from: https://www.zscaler.com/blogs/security-research/technical-analysis-windows-clfs-zero-day-vulnerability-cve-2022-37969-part
+            # Version hash obtained from: https://winbindex.m417z.com/?arch=&file=clfs.sys
+            - 'SHA1=06232f7ea7ea24102d452427aedbbc8b8e188a0c'
             # The list below is from https://github.com/namazso/physmem_drivers
             - 'SHA256=05F052C64D192CF69A462A5EC16DDA0D43CA5D0245900C9FCB9201685A2E7748'
             - 'SHA256=4045AE77859B1DBF13972451972EAAF6F3C97BEA423E9E78F1C2F14330CD47CA'
@@ -530,6 +534,9 @@ detection:
             - 'SHA256=1d053020079124ac526d84affb17bf4a1563ecd872c83b4b6299c9aa6a732557'
             - 'SHA256=c059f1b2b73ecab48d62f469d48dbde74a80c4ada07f0bd3b417ec4e044fb522'
             - 'SHA256=a66d2fb7ef7350ea74d4290c57fb62bc59c6ea93f759d4ca93c3febca7aeb512'
+            # Vuln driver version obtained from: https://www.zscaler.com/blogs/security-research/technical-analysis-windows-clfs-zero-day-vulnerability-cve-2022-37969-part
+            # Version hash obtained from: https://winbindex.m417z.com/?arch=&file=clfs.sys
+            - 'SHA256=5d712d3fad791bdc67502ed7c6586ca39d12ae26c7b245c36effec92e3cda08e'
     selection_other:
         - SHA1:
             # The list below is from https://github.com/namazso/physmem_drivers and the SHA1 are from VT
@@ -785,6 +792,9 @@ detection:
             - 'd0a228ed8af190dec0c1a812e212f5e68ee3b43e'
             - '7d2fc1a6729521e5c76f659e4c398e2061f7ed5e'
             - 'f999709e5b00a68a0f4fa912619fe6548ad0c42d'
+            # Vuln driver version obtained from: https://www.zscaler.com/blogs/security-research/technical-analysis-windows-clfs-zero-day-vulnerability-cve-2022-37969-part
+            # Version hash obtained from: https://winbindex.m417z.com/?arch=&file=clfs.sys
+            - '06232f7ea7ea24102d452427aedbbc8b8e188a0c'
         - SHA256:
             # The list below is from https://github.com/namazso/physmem_drivers
             - '04A85E359525D662338CAE86C1E59B1D7AA9BD12B920E8067503723DC1E03162'
@@ -1045,6 +1055,9 @@ detection:
             - '1d053020079124ac526d84affb17bf4a1563ecd872c83b4b6299c9aa6a732557'
             - 'c059f1b2b73ecab48d62f469d48dbde74a80c4ada07f0bd3b417ec4e044fb522'
             - 'a66d2fb7ef7350ea74d4290c57fb62bc59c6ea93f759d4ca93c3febca7aeb512'
+            # Vuln driver version obtained from: https://www.zscaler.com/blogs/security-research/technical-analysis-windows-clfs-zero-day-vulnerability-cve-2022-37969-part
+            # Version hash obtained from: https://winbindex.m417z.com/?arch=&file=clfs.sys
+            - '5d712d3fad791bdc67502ed7c6586ca39d12ae26c7b245c36effec92e3cda08e'
     condition: 1 of selection*
 falsepositives:
     - Unknown

--- a/rules/windows/file/file_event/file_event_win_ghostpack_safetykatz.yml
+++ b/rules/windows/file/file_event/file_event_win_ghostpack_safetykatz.yml
@@ -1,22 +1,23 @@
-title: Detection of SafetyKatz
+title: SafetyKatz Default Dump Filename
 id: e074832a-eada-4fd7-94a1-10642b130e16
 status: test
-description: Detects possible SafetyKatz Behaviour
+description: Detects default lsass dump filename from SafetyKatz
 author: Markus Neis
 references:
-  - https://github.com/GhostPack/SafetyKatz
+    - https://github.com/GhostPack/SafetyKatz
+    - https://github.com/GhostPack/SafetyKatz/blob/715b311f76eb3a4c8d00a1bd29c6cd1899e450b7/SafetyKatz/Program.cs#L63
 date: 2018/07/24
 modified: 2021/11/27
-logsource:
-  category: file_event
-  product: windows
-detection:
-  selection:
-    TargetFilename|endswith: '\Temp\debug.bin'
-  condition: selection
-falsepositives:
-  - Unknown
-level: high
 tags:
-  - attack.credential_access
-  - attack.t1003.001
+    - attack.credential_access
+    - attack.t1003.001
+logsource:
+    category: file_event
+    product: windows
+detection:
+    selection:
+        TargetFilename|endswith: '\Temp\debug.bin'
+    condition: selection
+falsepositives:
+    - Rare legitimate files with similar filename structure
+level: high

--- a/rules/windows/process_creation/proc_creation_win_accesschk_usage_after_priv_escalation.yml
+++ b/rules/windows/process_creation/proc_creation_win_accesschk_usage_after_priv_escalation.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/carlospolop/PEASS-ng/blob/fa0f2e17fbc1d86f1fd66338a40e665e7182501d/winPEAS/winPEASbat/winPEAS.bat
     - https://github.com/gladiatx0r/Powerless/blob/04f553bbc0c65baf4e57344deff84e3f016e6b51/Powerless.bat
 date: 2020/10/13
-modified: 2022/06/20
+modified: 2022/10/20
 logsource:
     product: windows
     category: process_creation
@@ -17,7 +17,10 @@ detection:
     selection_img:
         - Product|endswith: 'AccessChk'
         - Description|contains: 'Reports effective permissions'
-        - Image|endswith: '\accesschk.exe'
+        - Image|endswith:
+            - '\accesschk.exe'
+            - '\accesschk64.exe'
+        - OriginalFileName: 'accesschk.exe'
     selection_cli:
         CommandLine|contains: # These are the most common flags used with this tool. You could add other combinations if needed
             - 'uwcqv '

--- a/rules/windows/process_creation/proc_creation_win_always_install_elevated_msi_spawned_cmd_powershell.yml
+++ b/rules/windows/process_creation/proc_creation_win_always_install_elevated_msi_spawned_cmd_powershell.yml
@@ -6,22 +6,26 @@ author: Teymur Kheirkhabarov (idea), Mangatas Tondang (rule), oscd.community
 references:
     - https://image.slidesharecdn.com/kheirkhabarovoffzonefinal-181117201458/95/hunting-for-privilege-escalation-in-windows-environment-50-638.jpg
 date: 2020/10/13
-modified: 2022/07/14
+modified: 2022/10/20
 logsource:
     product: windows
     category: process_creation
 detection:
-    image:
-        Image|endswith:
+    selection_img:
+        - Image|endswith:
             - '\cmd.exe'
             - '\powershell.exe'
             - '\pwsh.exe'
-    parent_image:
+        - OriginalFileName:
+            - 'Cmd.Exe'
+            - 'PowerShell.EXE'
+            - 'pwsh.dll'
+    selection_parent:
         ParentImage|contains|all:
             - '\Windows\Installer\'
             - 'msi'
         ParentImage|endswith: 'tmp'
-    condition: image and parent_image
+    condition: all of selection_*
 fields:
     - Image
     - ParentImage

--- a/rules/windows/process_creation/proc_creation_win_always_install_elevated_windows_installer.yml
+++ b/rules/windows/process_creation/proc_creation_win_always_install_elevated_windows_installer.yml
@@ -4,7 +4,7 @@ description: This rule looks for Windows Installer service (msiexec.exe) trying 
 status: experimental
 author: Teymur Kheirkhabarov (idea), Mangatas Tondang (rule), oscd.community
 date: 2020/10/13
-modified: 2022/08/25
+modified: 2022/10/20
 references:
     - https://image.slidesharecdn.com/kheirkhabarovoffzonefinal-181117201458/95/hunting-for-privilege-escalation-in-windows-environment-48-638.jpg
 tags:
@@ -14,19 +14,18 @@ logsource:
     product: windows
     category: process_creation
 detection:
-    integrity_level:
-        IntegrityLevel: 'System'
-    user:
+    selection_user:
         User|contains: # covers many language settings
             - 'AUTHORI'
             - 'AUTORI'
-    image_1:
+    selection_image_1:
         Image|contains|all:
             - '\Windows\Installer\'
             - 'msi'
         Image|endswith: 'tmp'
-    image_2:
+    selection_image_2:
         Image|endswith: '\msiexec.exe'
+        IntegrityLevel: 'System'
     filter_installer:
         ParentImage: 'C:\Windows\System32\services.exe'
     filter_repair:
@@ -40,7 +39,7 @@ detection:
             - 'C:\Program Files (x86)\Avast Software\'
             - 'C:\Program Files\Google\Update\'
             - 'C:\Program Files (x86)\Google\Update\'
-    condition: ( (image_1 and user) or (image_2 and user and integrity_level) ) and not 1 of filter*
+    condition: 1 of selection_image_* and selection_user and not 1 of filter*
 fields:
     - IntegrityLevel
     - User

--- a/rules/windows/process_creation/proc_creation_win_hack_rubeus.yml
+++ b/rules/windows/process_creation/proc_creation_win_hack_rubeus.yml
@@ -4,38 +4,43 @@ status: stable
 description: Detects the execution of the hacktool Rubeus via PE information of command line parameters
 author: Florian Roth
 references:
-  - https://www.harmj0y.net/blog/redteaming/from-kekeo-to-rubeus/
-  - https://m0chan.github.io/2019/07/31/How-To-Attack-Kerberos-101.html
+    - https://www.harmj0y.net/blog/redteaming/from-kekeo-to-rubeus/
+    - https://m0chan.github.io/2019/07/31/How-To-Attack-Kerberos-101.html
+    - https://github.com/GhostPack/Rubeus
 date: 2018/12/19
 modified: 2022/10/11
 logsource:
-  category: process_creation
-  product: windows
+    category: process_creation
+    product: windows
 detection:
-  selection:
-    - Image|endswith: '\Rubeus.exe'
-    - OriginalFileName: 'Rubeus.exe'
-    - Description: 'Rubeus'
-    - CommandLine|contains:
-      - ' asreproast '
-      - ' dump /service:krbtgt '
-      - ' kerberoast '
-      - ' createnetonly /program:'
-      - ' ptt /ticket:'
-      - ' /impersonateuser:'
-      - ' renew /ticket:'
-      - ' asktgt /user:'
-      - ' harvest /interval:'
-      - ' s4u /user:'
-      - ' s4u /ticket:'
-      - ' hash /password:'
-  condition: selection
+    selection:
+        - Image|endswith: '\Rubeus.exe'
+        - OriginalFileName: 'Rubeus.exe'
+        - Description: 'Rubeus'
+        - CommandLine|contains:
+            - ' asreproast '
+            - ' dump /service:krbtgt '
+            - ' dump /luid:0x'
+            - ' kerberoast '
+            - ' createnetonly /program:'
+            - ' ptt /ticket:'
+            - ' /impersonateuser:'
+            - ' renew /ticket:'
+            - ' asktgt /user:'
+            - ' harvest /interval:'
+            - ' s4u /user:'
+            - ' s4u /ticket:'
+            - ' hash /password:'
+            - ' golden /aes256:'
+            - ' silver /user:'
+            - ' silver /user:'
+    condition: selection
 falsepositives:
-  - Unlikely
+    - Unlikely
 level: critical
 tags:
-  - attack.credential_access
-  - attack.t1003
-  - attack.t1558.003
-  - attack.lateral_movement
-  - attack.t1550.003
+    - attack.credential_access
+    - attack.t1003
+    - attack.t1558.003
+    - attack.lateral_movement
+    - attack.t1550.003

--- a/rules/windows/process_creation/proc_creation_win_hack_rubeus.yml
+++ b/rules/windows/process_creation/proc_creation_win_hack_rubeus.yml
@@ -33,7 +33,6 @@ detection:
             - ' hash /password:'
             - ' golden /aes256:'
             - ' silver /user:'
-            - ' silver /user:'
     condition: selection
 falsepositives:
     - Unlikely

--- a/rules/windows/process_creation/proc_creation_win_hack_safetykatz.yml
+++ b/rules/windows/process_creation/proc_creation_win_hack_safetykatz.yml
@@ -1,0 +1,23 @@
+title: SafetyKatz Hack Tool
+id: b1876533-4ed5-4a83-90f3-b8645840a413
+status: experimental
+description: Detects the execution of the hacktool SafetyKatz via PE information and default Image name
+author: Nasreddine Bencherchali
+references:
+    - https://github.com/GhostPack/SafetyKatz
+date: 2022/10/20
+tags:
+    - attack.credential_access
+    - attack.t1003.001
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        - Image|endswith: '\SafetyKatz.exe'
+        - OriginalFileName: 'SafetyKatz.exe'
+        - Description: 'SafetyKatz'
+    condition: selection
+falsepositives:
+    - Unlikely
+level: critical

--- a/rules/windows/process_creation/proc_creation_win_pua_seatbelt.yml
+++ b/rules/windows/process_creation/proc_creation_win_pua_seatbelt.yml
@@ -1,0 +1,55 @@
+title: Seatbelt PUA Tool
+id: 38646daa-e78f-4ace-9de0-55547b2d30da
+status: experimental
+description: Detects the execution of the PUA/Recon tool Seatbelt via PE information of command line parameters
+author: Nasreddine Bencherchali
+references:
+    - https://github.com/GhostPack/Seatbelt
+    - https://www.bluetangle.dev/2022/08/fastening-seatbelt-on-threat-hunting.html
+date: 2022/10/18
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        - Image|endswith: '\Seatbelt.exe'
+        - OriginalFileName: 'Seatbelt.exe'
+        - Description: 'Seatbelt'
+        - CommandLine|contains:
+            # This just a list of the commands that will produce the least amount of FP in "theory"
+            # Comment out/in as needed in your environment
+            # To get the full list of commands see reference section
+            - ' DpapiMasterKeys'
+            - ' InterestingProcesses'
+            - ' InterestingFiles'
+            - ' CertificateThumbprints'
+            - ' ChromiumBookmarks'
+            - ' ChromiumHistory'
+            - ' ChromiumPresence'
+            - ' CloudCredentials'
+            - ' CredEnum'
+            - ' CredGuard'
+            - ' FirefoxHistory'
+            - ' ProcessCreationEvents'
+            #- ' RDPSessions'
+            #- ' PowerShellHistory'
+    group_list:
+        CommandLine|contains:
+            - ' -group=misc'
+            - ' -group=remote'
+            - ' -group=chromium'
+            - ' -group=slack'
+            - ' -group=system'
+            - ' -group=user'
+            - ' -group=all'
+    group_output:
+        CommandLine|contains: ' -outputfile='
+    condition: selection or all of group_*
+falsepositives:
+    - Unlikely
+level: high
+tags:
+    - attack.discovery
+    - attack.t1526
+    - attack.t1087
+    - attack.t1083

--- a/rules/windows/process_creation/proc_creation_win_sharpup.yml
+++ b/rules/windows/process_creation/proc_creation_win_sharpup.yml
@@ -11,23 +11,23 @@ tags:
     - attack.t1574.005
 author: Florian Roth
 date: 2022/08/20
+modified: 2022/10/18
 logsource:
     category: process_creation
     product: windows
 detection:
     selection:
-        Image|endswith: '\SharpUp.exe'
-    selection_pe:
-        Description: 'SharpUp'
-    selection_commandline:
-        CommandLine|contains: 
+        - Image|endswith: '\SharpUp.exe'
+        - Description: 'SharpUp'
+        - CommandLine|contains:
             - 'HijackablePaths'
             - 'UnquotedServicePath'
             - 'ProcessDLLHijack'
             - 'ModifiableServiceBinaries'
             - 'ModifiableScheduledTask'
             - 'DomainGPPPassword'
-    condition: 1 of selection*
+            - 'CachedGPPPassword'
+    condition: selection
 falsepositives:
     - Unknown
 level: critical

--- a/rules/windows/process_creation/proc_creation_win_susp_service_dacl_modification.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_service_dacl_modification.yml
@@ -4,30 +4,31 @@ status: test
 description: Detects suspicious DACL modifications that can  be used to hide services or make them unstopable
 author: Jonhnathan Ribeiro, oscd.community
 references:
-  - https://www.sans.org/blog/red-team-tactics-hiding-windows-services/
-  - https://docs.microsoft.com/pt-br/windows/win32/secauthz/sid-strings
+    - https://www.sans.org/blog/red-team-tactics-hiding-windows-services/
+    - https://docs.microsoft.com/pt-br/windows/win32/secauthz/sid-strings
 date: 2020/10/16
-modified: 2021/11/27
+modified: 2022/10/18
 logsource:
-  category: process_creation
-  product: windows
+    category: process_creation
+    product: windows
 detection:
-  selection:
-    Image|endswith: '\sc.exe'
-    CommandLine|contains|all:
-      - 'sdset'
-      - 'D;;'
-  sids:
-    CommandLine|contains:
-      - ';;;IU'
-      - ';;;SU'
-      - ';;;BA'
-      - ';;;SY'
-      - ';;;WD'
-  condition: selection and sids
+    selection_sc:
+        - Image|endswith: '\sc.exe'
+        - OriginalFileName: 'sc.exe'
+    selection_sdset:
+        CommandLine|contains|all:
+            - 'sdset'
+            - 'D;;'
+        CommandLine|contains:
+            - ';;;IU'
+            - ';;;SU'
+            - ';;;BA'
+            - ';;;SY'
+            - ';;;WD'
+    condition: all of selection_*
 falsepositives:
-  - Unknown
+    - Unknown
 level: high
 tags:
-  - attack.persistence
-  - attack.t1543.003
+    - attack.persistence
+    - attack.t1543.003

--- a/rules/windows/process_creation/proc_creation_win_susp_service_dacl_modification_set_service.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_service_dacl_modification_set_service.yml
@@ -1,0 +1,40 @@
+title: Suspicious Service DACL Modification Via Set-Service Cmdlet
+id: a95b9b42-1308-4735-a1af-abb1c5e6f5ac
+related:
+    - id: 99cf1e02-00fb-4c0d-8375-563f978dfd37
+      type: derived
+status: experimental
+description: Detects suspicious DACL modifications via the "Set-Service" cmdlet using the "SecurityDescriptorSddl" flag (Only available with PowerShell 7) that can be used to hide services or make them unstopable
+author: Nasreddine Bencherchali
+references:
+    - https://www.sans.org/blog/red-team-tactics-hiding-windows-services/
+    - https://docs.microsoft.com/pt-br/windows/win32/secauthz/sid-strings
+date: 2022/10/18
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\pwsh.exe'
+        - OriginalFileName: 'pwsh.dll'
+    selection_sddl_flag:
+        CommandLine|contains:
+            - '-SecurityDescriptorSddl '
+            - '-sd '
+    selection_set_service:
+        CommandLine|contains|all:
+            - 'Set-Service '
+            - 'D;;'
+        CommandLine|contains:
+            - ';;;IU'
+            - ';;;SU'
+            - ';;;BA'
+            - ';;;SY'
+            - ';;;WD'
+    condition: all of selection_*
+falsepositives:
+    - Unknown
+level: high
+tags:
+    - attack.persistence
+    - attack.t1543.003


### PR DESCRIPTION
This PR covers the following:

- Add new vuln driver hash related CVE-2022-37696
- Updated some hack tool rules (SafetyKatz, Rubeus, SharpUp) with some more CLI options and more
- Added new rules for default SafetyKatz and Seatbelt execution w/ CLI options
- Add variation of the technique described in the rule [99cf1e02-00fb-4c0d-8375-563f978dfd37](https://github.com/SigmaHQ/sigma/blob/58f1d6fa2c679198f2932e3c361d5fa827effa95/rules/windows/process_creation/proc_creation_win_susp_service_dacl_modification.yml) using the "set-service" cmdlet
- Updated some rules that were missing the `OriginalFileName` field
- Reworked the condition and selections for the rule [cd951fdc-4b2f-47f5-ba99-a33bf61e3770](https://github.com/SigmaHQ/sigma/blob/48fb89cbfba5a981855a63db2762882c801410c7/rules/windows/process_creation/proc_creation_win_always_install_elevated_windows_installer.yml) 