### PR TITLE
Add OpenSSH Operational

### DIFF
--- a/rules/windows/builtin/openssh/win_sshd_openssh_server_listening_on_socket.yml
+++ b/rules/windows/builtin/openssh/win_sshd_openssh_server_listening_on_socket.yml
@@ -15,7 +15,7 @@ tags:
     - attack.t1021.004
 logsource:
     product: windows
-    service: sshd
+    service: openssh
 detection:
     selection:
         EventID: 4

--- a/rules/windows/builtin/sshd/win_sshd_openssh_server_listening_on_socket.yml
+++ b/rules/windows/builtin/sshd/win_sshd_openssh_server_listening_on_socket.yml
@@ -1,0 +1,27 @@
+title: OpenSSH Server Listening On Socket
+id: 3ce8e9a4-bc61-4c9b-8e69-d7e2492a8781
+status: experimental
+description: Detects scenarios where an attacker enables the OpenSSH server and server starts to listening on SSH socket.
+references:
+    - https://github.com/mdecrevoisier/EVTX-to-MITRE-Attack/tree/master/TA0008-Lateral%20Movement/T1021.004-Remote%20Service%20SSH
+    - https://winaero.com/enable-openssh-server-windows-10/
+    - https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse
+    - https://virtualizationreview.com/articles/2020/05/21/ssh-server-on-windows-10.aspx
+    - https://medium.com/threatpunter/detecting-adversary-tradecraft-with-image-load-event-logging-and-eql-8de93338c16
+author: mdecrevoisier
+date: 2022/10/25
+tags:
+    - attack.lateral_movement
+    - attack.t1021.004
+logsource:
+    product: windows
+    service: sshd
+detection:
+    selection:
+        EventID: 4
+        process: sshd
+        payload|startswith: 'Server listening on '
+    condition: selection
+falsepositives:
+    - Legitimate administrator activity
+level: medium

--- a/tools/config/elk-windows.yml
+++ b/tools/config/elk-windows.yml
@@ -99,4 +99,9 @@ logsources:
     service: shell-core
     conditions:
       EventLog: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      EventLog: 'OpenSSH/Operational'
 defaultindex: logstash-*

--- a/tools/config/elk-windows.yml
+++ b/tools/config/elk-windows.yml
@@ -101,7 +101,7 @@ logsources:
       EventLog: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       EventLog: 'OpenSSH/Operational'
 defaultindex: logstash-*

--- a/tools/config/elk-winlogbeat-sp.yml
+++ b/tools/config/elk-winlogbeat-sp.yml
@@ -99,6 +99,11 @@ logsources:
     service: shell-core
     conditions:
       log_name: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      log_name: 'OpenSSH/Operational'
 defaultindex: <winlogbeat-{now/d}>
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: event_data.\1/g'

--- a/tools/config/elk-winlogbeat-sp.yml
+++ b/tools/config/elk-winlogbeat-sp.yml
@@ -101,7 +101,7 @@ logsources:
       log_name: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       log_name: 'OpenSSH/Operational'
 defaultindex: <winlogbeat-{now/d}>

--- a/tools/config/elk-winlogbeat.yml
+++ b/tools/config/elk-winlogbeat.yml
@@ -101,7 +101,7 @@ logsources:
       logname: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       logname: 'OpenSSH/Operational'
 defaultindex: winlogbeat-*

--- a/tools/config/elk-winlogbeat.yml
+++ b/tools/config/elk-winlogbeat.yml
@@ -99,6 +99,11 @@ logsources:
     service: shell-core
     conditions:
       logname: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      logname: 'OpenSSH/Operational'
 defaultindex: winlogbeat-*
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: event_data.\1/g'

--- a/tools/config/fireeye-helix.yml
+++ b/tools/config/fireeye-helix.yml
@@ -129,7 +129,7 @@ logsources:
             channel: 'Microsoft-Windows-Shell-Core/Operational'
     windows-openssh:
         product: windows
-        service: sshd
+        service: openssh
         conditions:
             channel: 'OpenSSH/Operational'
     linux:

--- a/tools/config/fireeye-helix.yml
+++ b/tools/config/fireeye-helix.yml
@@ -127,6 +127,11 @@ logsources:
         service: shell-core
         conditions:
             channel: 'Microsoft-Windows-Shell-Core/Operational'
+    windows-openssh:
+        product: windows
+        service: sshd
+        conditions:
+            channel: 'OpenSSH/Operational'
     linux:
         product: linux
         index: posix

--- a/tools/config/generic/windows-services.yml
+++ b/tools/config/generic/windows-services.yml
@@ -185,6 +185,6 @@ logsources:
             Provider_Name: 'Microsoft-Windows-Security-Mitigations'
     windows-openssh:
         product: windows
-        service: sshd
+        service: openssh
         conditions:
             Provider_Name: 'OpenSSH/Operational'

--- a/tools/config/generic/windows-services.yml
+++ b/tools/config/generic/windows-services.yml
@@ -17,7 +17,7 @@ logsources:
         rewrite:
             product: windows
             service: powershell
-    # for the "classic" channel   
+    # for the "classic" channel
     ps_classic_start:
         category: ps_classic_start
         product: windows
@@ -178,8 +178,13 @@ logsources:
         service: shell-core
         conditions:
             Channel: 'Microsoft-Windows-Shell-Core/Operational'
-    security-mitigations:
+    windows-security-mitigations:
         product: windows
         service: security-mitigations
         conditions:
             Provider_Name: 'Microsoft-Windows-Security-Mitigations'
+    windows-openssh:
+        product: windows
+        service: sshd
+        conditions:
+            Provider_Name: 'OpenSSH/Operational'

--- a/tools/config/logpoint-windows.yml
+++ b/tools/config/logpoint-windows.yml
@@ -101,7 +101,7 @@ logsources:
       event_source: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       event_source: 'OpenSSH/Operational'
 fieldmappings:

--- a/tools/config/logpoint-windows.yml
+++ b/tools/config/logpoint-windows.yml
@@ -99,6 +99,11 @@ logsources:
     service: shell-core
     conditions:
       event_source: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      event_source: 'OpenSSH/Operational'
 fieldmappings:
     EventID: event_id
     FailureCode: result_code

--- a/tools/config/logstash-windows.yml
+++ b/tools/config/logstash-windows.yml
@@ -120,4 +120,9 @@ logsources:
     service: shell-core
     conditions:
       Channel: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      Channel: 'OpenSSH/Operational'
 defaultindex: logstash-*

--- a/tools/config/logstash-windows.yml
+++ b/tools/config/logstash-windows.yml
@@ -122,7 +122,7 @@ logsources:
       Channel: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       Channel: 'OpenSSH/Operational'
 defaultindex: logstash-*

--- a/tools/config/powershell.yml
+++ b/tools/config/powershell.yml
@@ -141,3 +141,8 @@ logsources:
     service: shell-core
     conditions:
       LogName: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      LogName: 'OpenSSH/Operational'

--- a/tools/config/powershell.yml
+++ b/tools/config/powershell.yml
@@ -143,6 +143,6 @@ logsources:
       LogName: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       LogName: 'OpenSSH/Operational'

--- a/tools/config/splunk-windows.yml
+++ b/tools/config/splunk-windows.yml
@@ -156,6 +156,11 @@ logsources:
     service: shell-core
     conditions:
       source: 'WinEventLog:Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      source: 'WinEventLog:OpenSSH/Operational'
   windows-defender:
     product: windows
     service: windefend

--- a/tools/config/splunk-windows.yml
+++ b/tools/config/splunk-windows.yml
@@ -158,7 +158,7 @@ logsources:
       source: 'WinEventLog:Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       source: 'WinEventLog:OpenSSH/Operational'
   windows-defender:

--- a/tools/config/sumologic.yml
+++ b/tools/config/sumologic.yml
@@ -130,6 +130,11 @@ logsources:
     service: shell-core
     conditions:
       EventChannel: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      EventChannel: 'OpenSSH/Operational'
   apache:
     service: apache
     index: WEBSERVER

--- a/tools/config/sumologic.yml
+++ b/tools/config/sumologic.yml
@@ -132,7 +132,7 @@ logsources:
       EventChannel: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       EventChannel: 'OpenSSH/Operational'
   apache:

--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -406,7 +406,7 @@ logsources:
       - 'WinEventLog:Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     sources:
       - 'WinEventLog:OpenSSH/Operational'
   apache:

--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -404,6 +404,11 @@ logsources:
     service: shell-core
     sources:
       - 'WinEventLog:Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    sources:
+      - 'WinEventLog:OpenSSH/Operational'
   apache:
     category: webserver
     sources:

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -146,7 +146,7 @@ logsources:
       winlog.channel: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       winlog.channel: 'OpenSSH/Operational'
 defaultindex: winlogbeat-*

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -144,6 +144,11 @@ logsources:
     service: shell-core
     conditions:
       winlog.channel: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      winlog.channel: 'OpenSSH/Operational'
 defaultindex: winlogbeat-*
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: winlog.event_data.\1/g'

--- a/tools/config/winlogbeat-old.yml
+++ b/tools/config/winlogbeat-old.yml
@@ -107,6 +107,11 @@ logsources:
     service: shell-core
     conditions:
       log_name: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      log_name: 'OpenSSH/Operational'
 defaultindex: winlogbeat-*
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: event_data.\1/g'

--- a/tools/config/winlogbeat-old.yml
+++ b/tools/config/winlogbeat-old.yml
@@ -109,7 +109,7 @@ logsources:
       log_name: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       log_name: 'OpenSSH/Operational'
 defaultindex: winlogbeat-*

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -133,6 +133,11 @@ logsources:
     service: shell-core
     conditions:
       winlog.channel: 'Microsoft-Windows-Shell-Core/Operational'
+  windows-openssh:
+    product: windows
+    service: sshd
+    conditions:
+      winlog.channel: 'OpenSSH/Operational'
 defaultindex: winlogbeat-*
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: winlog.event_data.\1/g'

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -135,7 +135,7 @@ logsources:
       winlog.channel: 'Microsoft-Windows-Shell-Core/Operational'
   windows-openssh:
     product: windows
-    service: sshd
+    service: openssh
     conditions:
       winlog.channel: 'OpenSSH/Operational'
 defaultindex: winlogbeat-*


### PR DESCRIPTION
This PR covers the following:

- Add "OpenSSH/Operational" log source to solve this [Issue #13](https://github.com/SigmaHQ/sigma-specification/issues/13)
- Add the first `sshd` rule, based on this [OpenSSH Server Listening On Socket](https://github.com/mdecrevoisier/SIGMA-detection-rules/blob/main/windows-openssh/win-os-OpenSSH%20server%20listening.yaml)