### PR TITLE
fix: FP with dbgcore and dbghelp

### DIFF
--- a/rules/windows/image_load/image_load_side_load_dbgcore_dll.yml
+++ b/rules/windows/image_load/image_load_side_load_dbgcore_dll.yml
@@ -6,6 +6,7 @@ references:
     - https://hijacklibs.net/ # For list of DLLs that could be sideloaded (search for dlls mentioned here in there)
 author: Nasreddine Bencherchali, Wietze Beukema (project and research)
 date: 2022/10/25
+modified: 2022/10/28
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -25,24 +26,10 @@ detection:
             - 'C:\Windows\WinSxS\'
             - 'C:\Windows\SoftwareDistribution\'
             - 'C:\Windows\SystemTemp\'
-    filter_visual_studio:
-        ImageLoaded|startswith:
-            - 'C:\Program Files (x86)\Microsoft Visual Studio\'
-            - 'C:\Program Files\Microsoft Visual Studio\'
-    filter_windows_kits:
-        ImageLoaded|startswith: 'C:\Program Files (x86)\Windows Kits\10\Debuggers\'
-    filter_windbg:
-        ImageLoaded|startswith: 'C:\Program Files\WindowsApps\Microsoft.WinDbg_'
+            - 'C:\Program Files (x86)\'
+            - 'C:\Program Files\'
     filter_steam:
         ImageLoaded|endswith: '\Steam\bin\cef\cef.win7x64\dbgcore.dll'
-    filter_dell:
-        ImageLoaded: 'C:\Program Files\Dell\DTP\InstrumentationSubAgent\dbgcore.dll'
-    filter_office:
-        ImageLoaded|startswith:
-            - 'C:\Program Files\Microsoft Office\Office'
-            - 'C:\Program Files\Microsoft Office\Root\Office'
-            - 'C:\Program Files (x86)\Microsoft Office\Office'
-            - 'C:\Program Files (x86)\Microsoft Office\Root\Office'
     condition: selection and not 1 of filter_*
 falsepositives:
     - Legitimate applications loading their own versions of the DLL mentioned in this rule

--- a/rules/windows/image_load/image_load_side_load_dbghelp_dll.yml
+++ b/rules/windows/image_load/image_load_side_load_dbghelp_dll.yml
@@ -6,6 +6,7 @@ references:
     - https://hijacklibs.net/ # For list of DLLs that could be sideloaded (search for dlls mentioned here in there)
 author: Nasreddine Bencherchali, Wietze Beukema (project and research)
 date: 2022/10/25
+modified: 2022/10/28
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -19,25 +20,14 @@ detection:
     selection:
         ImageLoaded|endswith: '\dbghelp.dll'
     filter_generic:
-        - ImageLoaded:
-            - 'C:\Program Files (x86)\Microsoft Analysis Services\AS OLEDB\110\dbghelp.dll'
-            - 'C:\Program Files\Microsoft Analysis Services\AS OLEDB\110\dbghelp.dll'
-            - 'C:\Program Files\Common Files\microsoft shared\DW\DBGHELP.DLL'
-            - 'C:\Program Files\Dell\DTP\InstrumentationSubAgent\dbghelp.dll'
-            - 'C:\Program Files\DTrace\dbghelp.dll'
         - ImageLoaded|startswith:
             - 'C:\Windows\System32\'
             - 'C:\Windows\SysWOW64\'
             - 'C:\Windows\WinSxS\'
             - 'C:\Windows\SoftwareDistribution\'
             - 'C:\Windows\SystemTemp\'
-            - 'C:\Program Files (x86)\Microsoft Visual Studio\'
-            - 'C:\Program Files\Microsoft Visual Studio\'
-            - 'C:\Program Files (x86)\Windows Kits\10\'
-            - 'C:\Program Files\dotnet\sdk\'
-            - 'C:\Program Files\Microsoft Office\Office'
-            - 'C:\Program Files\Microsoft Office\Root\Office'
-            - 'C:\Program Files\WindowsApps\Microsoft.WinDbg_'
+            - 'C:\Program Files (x86)\'
+            - 'C:\Program Files\'
         - ImageLoaded|endswith:
             - '\Epic Games\Launcher\Engine\Binaries\ThirdParty\DbgHelp\dbghelp.dll'
             - '\Epic Games\MagicLegends\x86\dbghelp.dll'


### PR DESCRIPTION
This removes specific filters to the `dbghelp.dll` and `dbgcore.dll` Image Load rules. Since these 2 DLLs are used by a lot of processes living in the `C:\Program Files` and `C:\Program Files (x86)\` (Such as AV products and Dev Software which both often load their version of this DLL) it's better to add them to a generic filters