### PR TITLE
Aurora - Fix FP Found In Testing

### DIFF
--- a/rules/windows/builtin/code_integrity/win_codeintegrity_attempted_dll_load.yml
+++ b/rules/windows/builtin/code_integrity/win_codeintegrity_attempted_dll_load.yml
@@ -6,7 +6,7 @@ status: experimental
 references:
     - https://twitter.com/SBousseaden/status/1483810148602814466
 date: 2022/01/20
-modified: 2022/10/31
+modified: 2022/11/07
 tags:
     - attack.execution
 logsource:
@@ -79,7 +79,10 @@ detection:
             - 12
         ValidatedPolicy: 1
     filter_gac:
-        FileNameBuffer|endswith: '\stdole.dll'
+        # If other DLLs show up from this process. Filter the path containing this string `\Windows\assembly\GAC\`
+        FileNameBuffer|endswith:
+            - '\stdole.dll'
+            - '\msdatasrc.dll'
         ProcessNameBuffer|endswith: '\mscorsvw.exe'
         ProcessNameBuffer|contains: '\Windows\Microsoft.NET\'
         RequestedPolicy: 8

--- a/rules/windows/process_creation/proc_creation_win_cobaltstrike_process_patterns.yml
+++ b/rules/windows/process_creation/proc_creation_win_cobaltstrike_process_patterns.yml
@@ -7,7 +7,7 @@ references:
     - https://thedfirreport.com/2021/08/29/cobalt-strike-a-defenders-guide/
 author: Florian Roth
 date: 2021/07/27
-modified: 2022/09/20
+modified: 2022/11/07
 tags:
     - attack.execution
     - attack.t1059
@@ -15,31 +15,31 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection1:
+    selection_normal_1:
         CommandLine|contains: '\cmd.exe /C whoami'
         ParentImage|startswith: 'C:\Temp'
-    selection2:
+    selection_normal_2:
         CommandLine|contains:
             - 'cmd.exe /c echo'
             - '> \\\\.\\pipe'
             - '\whoami.exe'
         ParentImage|endswith: '\dllhost.exe'
-    selection3:
+    selection_normal_3:
         Image|endswith: '\cmd.exe'
         ParentImage|endswith: '\runonce.exe'
         ParentCommandLine|endswith: '\runonce.exe'
-    selection_special1:
+    selection_special_conhost:
         CommandLine|contains: 'conhost.exe 0xffffffff -ForceV1'
         ParentCommandLine|contains:
             - '/C whoami'
             - 'cmd.exe /C echo'
             - ' > \\\\.\\pipe'
-    filter_special1:
-        # Internet Download Manager - Chrome Extension
+    filter_internet_download_manager:
+        # Internet Download Manager - Chrome Extension (Remove this filter if you don't use this extension)
         ParentCommandLine|contains:
             - 'C:\Program Files (x86)\Internet Download Manager\IDMMsgHost.exe'
             - 'chrome-extension://'
-    condition: 1 of selection* and (selection_special1 and not filter_special1)
+    condition: 1 of selection_normal_* or (selection_special_conhost and not filter_internet_download_manager)
 falsepositives:
     - Other programs that cause these patterns (please report)
 level: high


### PR DESCRIPTION
This PR fixes

- FP found with the Code Integrity rule
- A logic error that was introduced in #3514 (by me 😅) with the use of an `and` instead of an `or` and mislabeled selections