### PR TITLE
fix: FPs in testing environment

### DIFF
--- a/rules/windows/builtin/system/win_system_susp_service_installation.yml
+++ b/rules/windows/builtin/system/win_system_susp_service_installation.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects suspicious service installation commands
 author: pH-T
 date: 2022/03/18
-modified: 2022/11/10
+modified: 2022/11/14
 tags:
     - attack.persistence
     - attack.privilege_escalation
@@ -25,7 +25,7 @@ detection:
             - '\Users\Public\'
             - '\Windows\Temp\'
             - '\Perflogs\'
-            - 'C:\ProgramData\'
+            # - 'C:\ProgramData\'  # too many FPs (MySQL, McAfee, ...)
             - '\\\\.\\pipe'
             - '\ADMIN$\'
             - 'C:\Temp\'


### PR DESCRIPTION
I think we should not add ProgramData (was just added on Friday) as we already got 2 FPs in a testing environment which tells me we can suspect many more FPs in-the-wild.