### PR TITLE
feat: add missing `Microsoft-Windows-LDAP-Client/Debug` ETW provider

### DIFF
--- a/tools/config/elk-windows.yml
+++ b/tools/config/elk-windows.yml
@@ -104,4 +104,9 @@ logsources:
     service: openssh
     conditions:
       EventLog: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      EventLog: 'Microsoft-Windows-LDAP-Client/Debug'
 defaultindex: logstash-*

--- a/tools/config/elk-winlogbeat-sp.yml
+++ b/tools/config/elk-winlogbeat-sp.yml
@@ -104,6 +104,11 @@ logsources:
     service: openssh
     conditions:
       log_name: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      log_name: 'Microsoft-Windows-LDAP-Client/Debug'
 defaultindex: <winlogbeat-{now/d}>
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: event_data.\1/g'

--- a/tools/config/elk-winlogbeat.yml
+++ b/tools/config/elk-winlogbeat.yml
@@ -104,6 +104,11 @@ logsources:
     service: openssh
     conditions:
       logname: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      logname: 'Microsoft-Windows-LDAP-Client/Debug'
 defaultindex: winlogbeat-*
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: event_data.\1/g'

--- a/tools/config/fireeye-helix.yml
+++ b/tools/config/fireeye-helix.yml
@@ -132,6 +132,11 @@ logsources:
         service: openssh
         conditions:
             channel: 'OpenSSH/Operational'
+    windows-ldap-debug:
+        product: windows
+        service: ldap_debug
+        conditions:
+            channel: 'Microsoft-Windows-LDAP-Client/Debug'
     linux:
         product: linux
         index: posix

--- a/tools/config/generic/windows-services.yml
+++ b/tools/config/generic/windows-services.yml
@@ -188,3 +188,8 @@ logsources:
         service: openssh
         conditions:
             Provider_Name: 'OpenSSH/Operational'
+    windows-ldap-debug:
+        product: windows
+        service: ldap_debug
+        conditions:
+            Provider_Name: 'Microsoft-Windows-LDAP-Client/Debug'

--- a/tools/config/hawk.yml
+++ b/tools/config/hawk.yml
@@ -205,16 +205,11 @@ logsources:
        - 19
        - 20
        - 21
- windows-ldap-query:
-   product: windows
-   category: ldap_query
-   conditions:
-     event_channel: "Microsoft-Windows-LDAP-Client/Debug ETW"
  windows-ldap-debug:
    product: windows
    category: ldap_debug
    conditions:
-     event_channel: "Microsoft-Windows-LDAP-Client/Debug ETW"
+     event_channel: "Microsoft-Windows-LDAP-Client/Debug"
  windows-driver-load:
    product: windows
    category: driver_load

--- a/tools/config/logpoint-windows.yml
+++ b/tools/config/logpoint-windows.yml
@@ -104,6 +104,11 @@ logsources:
     service: openssh
     conditions:
       event_source: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      event_source: 'Microsoft-Windows-LDAP-Client/Debug'
 fieldmappings:
     EventID: event_id
     FailureCode: result_code

--- a/tools/config/logstash-windows.yml
+++ b/tools/config/logstash-windows.yml
@@ -125,4 +125,9 @@ logsources:
     service: openssh
     conditions:
       Channel: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      Channel: 'Microsoft-Windows-LDAP-Client/Debug'
 defaultindex: logstash-*

--- a/tools/config/powershell.yml
+++ b/tools/config/powershell.yml
@@ -146,3 +146,8 @@ logsources:
     service: openssh
     conditions:
       LogName: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      LogName: 'Microsoft-Windows-LDAP-Client/Debug'

--- a/tools/config/splunk-windows.yml
+++ b/tools/config/splunk-windows.yml
@@ -161,6 +161,11 @@ logsources:
     service: openssh
     conditions:
       source: 'WinEventLog:OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      source: 'WinEventLog:Microsoft-Windows-LDAP-Client/Debug'
   windows-defender:
     product: windows
     service: windefend

--- a/tools/config/sumologic.yml
+++ b/tools/config/sumologic.yml
@@ -135,6 +135,11 @@ logsources:
     service: openssh
     conditions:
       EventChannel: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      source: 'Microsoft-Windows-LDAP-Client/Debug'
   apache:
     service: apache
     index: WEBSERVER

--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -409,6 +409,11 @@ logsources:
     service: openssh
     sources:
       - 'WinEventLog:OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    sources:
+      - 'WinEventLog:Microsoft-Windows-LDAP-Client/Debug'
   apache:
     category: webserver
     sources:

--- a/tools/config/winlogbeat-modules-enabled.yml
+++ b/tools/config/winlogbeat-modules-enabled.yml
@@ -149,6 +149,11 @@ logsources:
     service: openssh
     conditions:
       winlog.channel: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      winlog.channel: 'Microsoft-Windows-LDAP-Client/Debug'
 defaultindex: winlogbeat-*
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: winlog.event_data.\1/g'

--- a/tools/config/winlogbeat-old.yml
+++ b/tools/config/winlogbeat-old.yml
@@ -112,6 +112,11 @@ logsources:
     service: openssh
     conditions:
       log_name: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      log_name: 'Microsoft-Windows-LDAP-Client/Debug'
 defaultindex: winlogbeat-*
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: event_data.\1/g'

--- a/tools/config/winlogbeat.yml
+++ b/tools/config/winlogbeat.yml
@@ -138,6 +138,11 @@ logsources:
     service: openssh
     conditions:
       winlog.channel: 'OpenSSH/Operational'
+  windows-ldap-debug:
+    product: windows
+    service: ldap_debug
+    conditions:
+      winlog.channel: 'Microsoft-Windows-LDAP-Client/Debug'
 defaultindex: winlogbeat-*
 # Extract all field names with yq:
 # yq -r '.detection | del(.condition) | map(keys) | .[][]' $(find sigma/rules/windows -name '*.yml') | sort -u | grep -v ^EventID$ | sed 's/^\(.*\)/    \1: winlog.event_data.\1/g'


### PR DESCRIPTION
This PR covers the following:

- Fixes a broken provider name in the `hawk.yml` config (I don't think the ETW word is part of the provider name?)
- Add the missing provider to other configs 