### PR TITLE
fix: fix issues and deprecate rule

### DIFF
--- a/rules-deprecated/windows/proc_access_win_in_memory_assembly_execution.yml
+++ b/rules-deprecated/windows/proc_access_win_in_memory_assembly_execution.yml
@@ -1,6 +1,6 @@
 title: Suspicious In-Memory Module Execution
 id: 5f113a8f-8b61-41ca-b90f-d374fa7e4a39
-status: experimental
+status: deprecated
 description: |
     Detects the access to processes by other suspicious processes which have reflectively loaded libraries in their memory space.
     An example is SilentTrinity C2 behaviour. Generally speaking, when Sysmon EventID 10 cannot reference a stack call to a dll loaded from disk (the standard way),

--- a/rules/application/rpc_firewall/rpc_firewall_sasec_recon.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_sasec_recon.yml
@@ -10,7 +10,7 @@ references:
     - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
-modified: 2022/01/01
+modified: 2022/11/17
 logsource:
     product: rpc_firewall
     category: application

--- a/rules/application/rpc_firewall/rpc_firewall_sasec_recon.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_sasec_recon.yml
@@ -1,4 +1,4 @@
-title: Remote Schedule Task Lateral Movement via SASec
+title: Recon Activity via SASec
 id: 0a3ff354-93fc-4273-8a03-1078782de5b7
 status: experimental
 description: Detects remote RPC calls to read information about scheduled tasks via SASec

--- a/rules/linux/auditd/lnx_auditd_web_rce.yml
+++ b/rules/linux/auditd/lnx_auditd_web_rce.yml
@@ -3,7 +3,7 @@ id: c0d3734d-330f-4a03-aae2-65dacc6a8222
 status: experimental
 description: Detects possible command execution by web application/web shell
 references:
-    - personal experience
+    - Personal Experience of the Author
 author: Ilyas Ochkov, Beyu Denis, oscd.community
 date: 2019/10/12
 modified: 2021/11/11
@@ -15,6 +15,10 @@ logsource:
     service: auditd
 detection:
     selection:
+        # You need to add to the following rules to your auditd.conf config:
+        #   -a always,exit -F arch=b32 -S execve -F euid=33 -k detect_execve_www
+        #   -a always,exit -F arch=b64 -S execve -F euid=33 -k detect_execve_www
+        # Change the number "33" to the ID of your WebServer user. Default: www-data:x:33:33
         type: 'SYSCALL'
         syscall: 'execve'
         key: 'detect_execve_www'

--- a/rules/linux/builtin/lnx_shell_susp_log_entries.yml
+++ b/rules/linux/builtin/lnx_shell_susp_log_entries.yml
@@ -11,7 +11,9 @@ logsource:
     product: linux
 detection:
     keywords:
+        # Generic suspicious log lines
         - entered promiscuous mode
+        # OSSEC https://github.com/ossec/ossec-hids/blob/master/etc/rules/syslog_rules.xml
         - Deactivating service
         - Oversized packet received from
         - imuxsock begins to drop messages

--- a/rules/windows/builtin/printservice/win_exploit_cve_2021_1675_printspooler.yml
+++ b/rules/windows/builtin/printservice/win_exploit_cve_2021_1675_printspooler.yml
@@ -8,7 +8,7 @@ references:
     - https://twitter.com/fuzzyf10w/status/1410202370835898371
 author: Florian Roth, KevTheHermit, fuzzyf10w, Tim Shelton
 date: 2021/06/30
-modified: 2022/06/22
+modified: 2022/11/15
 tags:
     - attack.execution
     - attack.t1569
@@ -18,9 +18,7 @@ logsource:
     service: printservice-admin
 detection:
     selection:
-        EventID:
-            - 808   # old id
-            - 4909  # new id
+        EventID: 808
         ErrorCode:
             - '0x45A'
             - '0x7e'


### PR DESCRIPTION
This PR covers the following:

- Renamed [0a3ff354-93fc-4273-8a03-1078782de5b7](https://github.com/SigmaHQ/sigma/blob/890c2496d1403df5e21782144e1582bcbab42fdb/rules/application/rpc_firewall/rpc_firewall_sasec_recon.yml) to Fix #3699 
- After I had a talk with [@M_haggis](https://twitter.com/M_haggis) we concluded that the EID `4909` doesn't exist in the referenced event log so it's been removed from the rule [4e64668a-4da1-49f5-a8df-9e2d5b866718](https://github.com/SigmaHQ/sigma/blob/890c2496d1403df5e21782144e1582bcbab42fdb/rules/windows/builtin/printservice/win_exploit_cve_2021_1675_printspooler.yml). This fixes #2744
- Deprecate [5f113a8f-8b61-41ca-b90f-d374fa7e4a39](https://github.com/SigmaHQ/sigma/blob/890c2496d1403df5e21782144e1582bcbab42fdb/rules/windows/process_access/proc_access_win_in_memory_assembly_execution.yml) as it generates too many FP with system processes and third part software
- Fix #1972 by adding the requested comments. Note that these comments were in the rule and got accidentally deleted in commit `0592cbb67af773bd58e2fc4678400aa4ddc36735`