### PR TITLE
fix: update invoke-obfuscation rules

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_clip.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_clip.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 26)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
-modified: 2021/11/27
+modified: 2022/11/17
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -17,7 +17,17 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|re: '.*cmd.{0,5}(?:\/c|\/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\\"\{\d\}.+\-f.+\"'
+        # CommandLine|re: '.*cmd.{0,5}(?:\/c|\/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\\"\{\d\}.+\-f.+\"'
+        # Example 1: Cmd /c" echo/Invoke-Expression (New-Object Net.WebClient).DownloadString |cLiP&& POWerSheLl -Nolog -sT . (\"{1}{2}{0}\"-f'pe','Ad',(\"{1}{0}\" -f'Ty','d-' ) ) -Assemb ( \"{5}{1}{3}{0}{2}{4}\" -f'ows','y','.F',(\"{0}{1}{2}\" -f'stem.W','i','nd'),( \"{0}{1}\"-f 'o','rms' ),'S' ) ; ([SySTEM.wiNDows.FoRmS.CLiPbOArd]::( \"{1}{0}\" -f (\"{1}{0}\" -f'T','TTeX' ),'gE' ).\"invO`Ke\"( ) ) ^| ^&( \"{5}{1}{2}{4}{3}{0}\" -f 'n',( \"{1}{0}\"-f'KE-','o' ),(\"{2}{1}{0}\"-f 'pRESS','x','e' ),'o','i','iNV') ; [System.Windows.Forms.Clipboard]::(\"{0}{1}\" -f( \"{1}{0}\"-f'e','SetT' ),'xt').\"InV`oKe\"( ' ')"
+        # Example 2: CMD/c " ECho Invoke-Expression (New-Object Net.WebClient).DownloadString|c:\WiNDowS\SySteM32\cLip && powershElL -noPRO -sTa ^& (\"{2}{0}{1}\" -f 'dd',(\"{1}{0}\"-f 'ype','-T' ),'A' ) -AssemblyN (\"{0}{3}{2}{1}{4}\"-f'Pr','nCo',(\"{0}{1}\"-f'e','ntatio'),'es','re' ) ; ^& ( ( [StRinG]${ve`RB`OSE`pr`e`FeReNCE} )[1,3] + 'x'-JoiN'') ( ( [sySTem.WInDOWs.ClipbOaRD]::( \"{1}{0}\" -f(\"{0}{1}\" -f'tTe','xt' ),'ge' ).\"IN`Vo`Ke\"( ) ) ) ; [System.Windows.Clipboard]::( \"{2}{1}{0}\" -f't',( \"{0}{1}\" -f 'tT','ex' ),'Se' ).\"In`V`oKe\"( ' ' )"
+        CommandLine|contains|all:
+            - 'cmd'
+            - '&&'
+            - 'clipboard]::'
+            - '-f'
+        CommandLine|contains:
+            - '/c'
+            - '/r'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_stdin.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_stdin.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 25)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2021/11/27
+modified: 2022/11/17
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -16,9 +16,22 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        CommandLine|re: '.*cmd.{0,5}(?:\/c|\/r).+powershell.+(?:\$\{?input\}?|noexit).+\"'
-    condition: selection
+    selection_main:
+        # CommandLine|re: '.*cmd.{0,5}(?:\/c|\/r).+powershell.+(?:\$\{?input\}?|noexit).+\"'
+        # Example 1: c:\windows\sYstEm32\CmD.eXE /C"echO\Invoke-Expression (New-Object Net.WebClient).DownloadString | POwersHELl -NoEXiT -"
+        # Example 2: c:\WiNDOws\sysTEm32\cmd.EXe /C " ECHo Invoke-Expression (New-Object Net.WebClient).DownloadString | POwersHELl -nol ${EXEcUtIONCONTeXT}.INvOkEComMANd.InvOKEScRIPt( $InpUt )"
+        CommandLine|contains|all:
+            - 'cmd'
+            - 'powershell'
+        CommandLine|contains:
+            - '/c'
+            - '/r'
+    selection_other:
+        - CommandLine|contains: 'noexit'
+        - CommandLine|contains|all:
+            - 'input'
+            - '$'
+    condition: all of selection_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_var.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_var.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2021/11/27
+modified: 2022/11/17
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -17,7 +17,16 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
+        # CommandLine|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
+        # Example 1: C:\winDoWs\SySTeM32\cmd.Exe /C"SET NOtI=Invoke-Expression (New-Object Net.WebClient).DownloadString&& PowERshElL -NOl SET-iteM ( 'VAR' + 'i'+ 'A' + 'blE:Ao6' + 'I0') ( [TYpe](\"{2}{3}{0}{1}\"-F 'iRoN','mENT','e','nv') ) ; ${exECUtIONCOnTEXT}.\"IN`VO`KecOmMaND\".\"inVo`KES`crIPt\"( ( ( GEt-VAriAble ( 'a' + 'o6I0') -vaLU )::(\"{1}{4}{2}{3}{0}\" -f'e','gETenvIR','NtvaRIa','BL','ONme' ).Invoke(( \"{0}{1}\"-f'n','oti' ),( \"{0}{1}\" -f'pRoC','esS') )) )"
+        # Example 2: cMD.exe /C "seT SlDb=Invoke-Expression (New-Object Net.WebClient).DownloadString&& pOWErShell .(( ^&(\"{1}{0}{2}{3}\" -f 'eT-vaR','G','iab','lE' ) (\"{0}{1}\" -f '*m','DR*' ) ).\"na`ME\"[3,11,2]-JOIN'' ) ( ( ^&(\"{0}{1}\" -f'g','CI' ) (\"{0}{1}\" -f 'ENV',':SlDb' ) ).\"VA`luE\" ) "
+        CommandLine|contains|all:
+            - 'cmd'
+            - '"set'
+            - '-f'
+        CommandLine|contains:
+            - '/c'
+            - '/r'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_stdin.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_stdin.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task28)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/12
-modified: 2021/11/27
+modified: 2022/11/16
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -17,7 +17,16 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\${?input).*&&.*"'
+        # CommandLine|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\${?input).*&&.*"'
+        # Example 1: C:\wiNdOWs\SystEm32\cMD.EXe /c "sET XnK= Invoke-Expression (New-Object Net.WebClient).DownloadString && sET PZVh=ECho ${EXECutIoNcOnTExT}.inVokecommaNd.iNvoKeSCrIPt( ([eNvirOnMEnT]::GETenVIrOnmENtVARIABLe('XNk','pRoceSS'))) ^| poweRSHelL -NoE - && C:\wiNdOWs\SystEm32\cMD.EXe /c%PzVh%"
+        # Example 2: C:\winDowS\SysteM32\Cmd /C "set sHM=Invoke-Expression (New-Object Net.WebClient).DownloadString && SEt gBc=ECHO $eXECutionconTeXt.inVoKECOmmanD.InVoKESCripT( ([ENVirOnment]::geTenVIrONMEnTvaRIAble('shM','PRoCEss')) ) ^| C:\WiNDoWS\SYSwoW64\WindoWSpoWerSHelL\V1.0\pOwersheLl.EXe ^^^&( $PShOME[4]+$psHOMe[30]+'X') ( $InPUt) && C:\winDowS\SysteM32\Cmd /C %gbc%"
+        CommandLine|contains|all:
+            - 'set'
+            - '&&'
+        CommandLine|contains:
+            - 'environment'
+            - 'invoke'
+            - 'input'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_clip.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_clip.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task29)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
-modified: 2021/11/27
+modified: 2022/11/16
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -17,7 +17,20 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|re: '(?i).*?echo.*clip.*&&.*(Clipboard|i`?n`?v`?o`?k`?e`?).*'
+        # CommandLine|re: '(?i).*?echo.*clip.*&&.*(Clipboard|i`?n`?v`?o`?k`?e`?).*'
+        # Example 1: C:\WINdoWS\sySteM32\CMd /c " ECho\Invoke-Expression (New-Object Net.WebClient).DownloadString|Clip.Exe&&C:\WINdoWS\sySteM32\CMd /c pOWerSheLl -STa . ( \"{2}{0}{1}\"-f'dd-',(\"{0}{1}\" -f 'T','ype' ),'A' ) -Assembly ( \"{4}{1}{3}{0}{2}\"-f (\"{0}{1}\" -f 'nd','ow'),( \"{1}{0}\"-f'.W','stem' ),( \"{2}{1}{0}\" -f 'rms','Fo','s.'),'i','Sy') ; ${exeCUtIOnCONTeXT}.\"INV`oKECOM`m`ANd\".\"INV`ok`ESCriPT\"( ( [sYSteM.wiNDoWS.forMs.ClIPboaRD]::( \"{2}{0}{1}\" -f'Ex','t',(\"{0}{1}\" -f'Get','t' ) ).\"iNvo`Ke\"( )) ) ; [System.Windows.Forms.Clipboard]::(\"{1}{0}\" -f 'ar','Cle' ).\"in`V`oKE\"( )"
+        # Example 2: C:\WINDowS\sYsTEM32\CmD.eXE /C" echo\Invoke-Expression (New-Object Net.WebClient).DownloadString| C:\WIndOWs\SYSteM32\CLip &&C:\WINDowS\sYsTEM32\CmD.eXE /C POWERSHeLL -sT -noL [Void][System.Reflection.Assembly]::( \"{0}{3}{4}{1}{2}\" -f( \"{0}{1}\"-f'Lo','adW' ),( \"{0}{1}\"-f 'Par','t'),( \"{0}{1}{2}\"-f 'ial','N','ame'),'it','h' ).\"in`VO`KE\"( ( \"{3}{1}{4}{5}{2}{0}\"-f'rms','ystem.Windo','Fo','S','w','s.' )) ; ( [wIndows.fOrms.cLIPBOArD]::( \"{1}{0}\"-f'T',( \"{1}{0}\" -f'tEX','gET' )).\"i`Nvoke\"( ) ) ^^^| ^^^& ( ( ^^^& ( \"{2}{1}{0}\"-f 'e',( \"{2}{1}{0}\"-f'IABl','aR','v' ),( \"{0}{1}\"-f'Get','-' ) ) ( \"{1}{0}\"-f'*','*MDr' )).\"n`Ame\"[3,11,2]-jOin'') ; [Windows.Forms.Clipboard]::( \"{0}{1}\" -f (\"{1}{0}\"-f'tT','Se' ),'ext').\"in`VoKe\"(' ' )"
+        CommandLine|contains|all:
+            - 'echo'
+            - 'clip'
+            - '&&'
+        CommandLine|contains:
+            - 'clipboard'
+            - 'invoke'
+            - 'i`'
+            - 'n`'
+            - 'v`'
+            - 'o`'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_clip.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_clip.yml
@@ -31,6 +31,8 @@ detection:
             - 'n`'
             - 'v`'
             - 'o`'
+            - 'k`'
+            - 'e`'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_var.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_var.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
-modified: 2021/11/27
+modified: 2022/11/16
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -17,7 +17,21 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|re: '(?i).*&&set.*(\{\d\}){2,}\\\"\s+?\-f.*&&.*cmd.*\/c' # FPs with |\/r
+        # CommandLine|re: '(?i).*&&set.*(\{\d\}){2,}\\\"\s+?\-f.*&&.*cmd.*\/c' # FPs with |\/r
+        # Example 1: CMD /C"sET KUR=Invoke-Expression (New-Object Net.WebClient).DownloadString&&Set MxI=C:\wINDowS\sYsWow64\winDOWspoWERSheLl\V1.0\PowerShelL.EXe ${ExEcut`IoN`cON`TExT}.\"invo`kEcoMm`A`ND\".( \"{2}{1}{0}\" -f 'pt','EscRi','INvOk' ).Invoke( ( .( \"{0}{1}\" -f'D','IR' ) ( \"{0}{1}\"-f'ENV:kU','R')).\"vAl`Ue\" )&& CMD /C%mXI%"
+        # Example 2: c:\WiNDOWS\sYSTEm32\CmD.exE /C "sEt DeJLz=Invoke-Expression (New-Object Net.WebClient).DownloadString&&set yBKM=PoWERShelL -noeX ^^^&(\"{2}{0}{1}\"-f '-ItE','m','seT') ( 'V' + 'a'+ 'RiAblE:z8J' +'U2' + 'l' ) ([TYpE]( \"{2}{3}{0}{1}\"-f 'e','NT','e','NViRONM' ) ) ; ^^^& ( ( [sTrIng]${VE`Rbo`SepReFER`Ence})[1,3] + 'X'-joIN'')( ( (.('gI') ('V' + 'a' + 'RIAbLe:z8j' + 'u2' +'l' ) ).vALUe::( \"{2}{5}{0}{1}{6}{4}{3}\" -f 'IRo','Nm','GETE','ABlE','I','nv','enTVAr').Invoke(( \"{0}{1}\"-f'd','ejLz' ),( \"{1}{2}{0}\"-f'cEss','P','RO') )) )&& c:\WiNDOWS\sYSTEm32\CmD.exE /C %ybkm%"
+        CommandLine|contains|all:
+            - '&&set'
+            - 'cmd'
+            - '/c'
+            - '-f'
+        CommandLine|contains:
+            - '{0}'
+            - '{1}'
+            - '{2}'
+            - '{3}'
+            - '{4}'
+            - '{5}'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
This PR aims to update the `Invoke-Obfuscation` rule that used regular expressions into rules that use simple concatenation. Basically, the regex allows for more specificity. The one used in the rule used a lot of greedy modifiers such as the `.*` and only a couple of markers. I would argue that the following update will give the same results in 90% of the case.

Note: Since the same regular expressions were used in the `System`, `Security`, and `PowerShell` variation of the rules. If this PR gets accepted, I would update the rest.