### PR TITLE
Update microsoft365_pst_export_alert.yml

### DIFF
--- a/rules/cloud/m365/microsoft365_pst_export_alert.yml
+++ b/rules/cloud/m365/microsoft365_pst_export_alert.yml
@@ -1,11 +1,13 @@
 title: PST Export Alert
 id: 18b88d08-d73e-4f21-bc25-4b9892a4fdd0
 status: experimental
-description: Alert on when a user has performed an eDiscovery search or exported a PST file from the search. This PST file usually has sensitive information including email body content
+description: Alert when a user has performed an export to a search using 'New-ComplianceSearchAction' with the '-Export' flag. This detection will detect PST export even if the 'eDiscovery search or exported' alert is disabled in the O365.
+This rule will apply to ExchangePowerShell usage and from the cloud.
 references:
     - https://attack.mitre.org/techniques/T1114/
-author: 'Sorina Ionescu'
-date: 2022/02/08
+    - https://learn.microsoft.com/en-us/powershell/module/exchange/new-compliancesearchaction?view=exchange-ps
+author: 'Nikita Khalimonenkov'
+date: 2022/11/17
 tags:
     - attack.collection
     - attack.t1114
@@ -15,8 +17,10 @@ logsource:
 detection:
     selection:
         eventSource: SecurityComplianceCenter
-        eventName: 'eDiscovery search started or exported'
-        status: success
+        Payload|contains|all:
+            - 'New-ComplianceSearchAction'
+            - 'Export'
+            - 'pst'
     condition: selection
 falsepositives:
     - PST export can be done for legitimate purposes but due to the sensitive nature of its content it must be monitored.

--- a/rules/cloud/m365/microsoft365_pst_export_alert.yml
+++ b/rules/cloud/m365/microsoft365_pst_export_alert.yml
@@ -1,13 +1,11 @@
 title: PST Export Alert
 id: 18b88d08-d73e-4f21-bc25-4b9892a4fdd0
 status: experimental
-description: Alert when a user has performed an export to a search using 'New-ComplianceSearchAction' with the '-Export' flag. This detection will detect PST export even if the 'eDiscovery search or exported' alert is disabled in the O365.
-This rule will apply to ExchangePowerShell usage and from the cloud.
+description: Alert on when a user has performed an eDiscovery search or exported a PST file from the search. This PST file usually has sensitive information including email body content
 references:
     - https://attack.mitre.org/techniques/T1114/
-    - https://learn.microsoft.com/en-us/powershell/module/exchange/new-compliancesearchaction?view=exchange-ps
-author: 'Nikita Khalimonenkov'
-date: 2022/11/17
+author: 'Sorina Ionescu'
+date: 2022/02/08
 tags:
     - attack.collection
     - attack.t1114
@@ -17,10 +15,8 @@ logsource:
 detection:
     selection:
         eventSource: SecurityComplianceCenter
-        Payload|contains|all:
-            - 'New-ComplianceSearchAction'
-            - 'Export'
-            - 'pst'
+        eventName: 'eDiscovery search started or exported'
+        status: success
     condition: selection
 falsepositives:
     - PST export can be done for legitimate purposes but due to the sensitive nature of its content it must be monitored.

--- a/rules/cloud/m365/microsoft365_pst_export_alert_when_policy_is_disabled.yml
+++ b/rules/cloud/m365/microsoft365_pst_export_alert_when_policy_is_disabled.yml
@@ -1,0 +1,27 @@
+title: PST Export Alert Even When 'eDiscovery search or exported' Alert Policy is Disabled
+id: 6897cd82-6664-11ed-9022-0242ac120002
+status: experimental
+description: Alert when a user has performed an export to a search using 'New-ComplianceSearchAction' with the '-Export' flag. This detection will detect PST export even if the 'eDiscovery search or exported' alert is disabled in the O365.
+This rule will apply to ExchangePowerShell usage and from the cloud.
+references:
+    - https://attack.mitre.org/techniques/T1114/
+    - https://learn.microsoft.com/en-us/powershell/module/exchange/new-compliancesearchaction?view=exchange-ps
+author: 'Nikita Khalimonenkov'
+date: 2022/11/17
+tags:
+    - attack.collection
+    - attack.t1114
+logsource:
+    service: threat_management
+    product: m365
+detection:
+    selection:
+        eventSource: SecurityComplianceCenter
+        Payload|contains|all:
+            - 'New-ComplianceSearchAction'
+            - 'Export'
+            - 'pst'
+    condition: selection
+falsepositives:
+    - Exporting a PST can be done for legitimate purposes by legitimate sources, but due to the sensitive nature of PST content, it must be monitored.
+level: medium


### PR DESCRIPTION
The previous detection will detect only when the "eDiscovery search or exported" alert policy is enabled.
An attacker can easily disable the alert policy, and you will not see it.
During my research, I found that when a user performs an export to a PST file using ExchangePowerShell or the  Security & Compliance center, there is a log that can indicate an event when the alert policy is being disabled.
Hunting for "New-ComplianceSearchAction" and payload containing '-Export' and 'pst,' you will have 100% detection.