### PR TITLE
feat: add more clarification to the test

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -871,7 +871,9 @@ class TestRules(unittest.TestCase):
     def test_field_name_typo(self):
         # add "OriginalFilename" after Aurora switched to SourceFilename
         # add "ProviderName" after special case powershell classic is resolved
-        typos = ["ServiceFilename", "TargetFileName", "SourceFileName", "Commandline", "Targetobject"]
+        
+        # typos is a list of tuples where each tuple contains ("The typo", "The correct version")
+        typos = [("ServiceFilename", "ServiceFileName"), ("TargetFileName", "TargetFilename"), ("SourceFileName", "OriginalFileName"), ("Commandline", "CommandLine"), ("Targetobject", "TargetObject"), ("OriginalName", "OriginalFileName")]
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             detection = self.get_rule_part(file_path=file, part_name="detection")
@@ -880,8 +882,8 @@ class TestRules(unittest.TestCase):
                     if isinstance(detection[search_identifier], dict):
                         for field in detection[search_identifier]:
                             for typo in typos:
-                                if typo in field:
-                                    print(Fore.RED + "Rule {} has a common typo ({}) in selection ({}/{})".format(file, typo, search_identifier, field))
+                                if typo[0] in field:
+                                    print(Fore.RED + "Rule {} has a common typo ({}) which should be ({}) in selection ({}/{})".format(file, typo[0], typo[1], search_identifier, field))
                                     faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED + "There are rules with common typos in field names.")


### PR DESCRIPTION
This PR covers the following:

- Added `OriginalName` as a typo to `OriginalFileName`
- Changed the typo list to a tuple list where each tuple has the `("typo version", "correct version")` to be able to show the correct version in the test results