### PR TITLE
fix: update invoke-obfsucation ules to not use regex

### DIFF
--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_var_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_var_services_security.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2021/12/02
+modified: 2022/11/17
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -22,7 +22,16 @@ logsource:
 detection:
     selection:
         EventID: 4697
-        ServiceFileName|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
+        # ServiceFileName|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
+        # Example 1: C:\winDoWs\SySTeM32\cmd.Exe /C"SET NOtI=Invoke-Expression (New-Object Net.WebClient).DownloadString&& PowERshElL -NOl SET-iteM ( 'VAR' + 'i'+ 'A' + 'blE:Ao6' + 'I0') ( [TYpe](\"{2}{3}{0}{1}\"-F 'iRoN','mENT','e','nv') ) ; ${exECUtIONCOnTEXT}.\"IN`VO`KecOmMaND\".\"inVo`KES`crIPt\"( ( ( GEt-VAriAble ( 'a' + 'o6I0') -vaLU )::(\"{1}{4}{2}{3}{0}\" -f'e','gETenvIR','NtvaRIa','BL','ONme' ).Invoke(( \"{0}{1}\"-f'n','oti' ),( \"{0}{1}\" -f'pRoC','esS') )) )"
+        # Example 2: cMD.exe /C "seT SlDb=Invoke-Expression (New-Object Net.WebClient).DownloadString&& pOWErShell .(( ^&(\"{1}{0}{2}{3}\" -f 'eT-vaR','G','iab','lE' ) (\"{0}{1}\" -f '*m','DR*' ) ).\"na`ME\"[3,11,2]-JOIN'' ) ( ( ^&(\"{0}{1}\" -f'g','CI' ) (\"{0}{1}\" -f 'ENV',':SlDb' ) ).\"VA`luE\" ) "
+        ServiceFileName|contains|all:
+            - 'cmd'
+            - '"set'
+            - '-f'
+        ServiceFileName|contains:
+            - '/c'
+            - '/r'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_via_var_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_via_var_services_security.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
-modified: 2022/10/09
+modified: 2022/11/17
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -22,7 +22,21 @@ logsource:
 detection:
     selection:
         EventID: 4697
-        ServiceFileName|re: '(?i).*&&set.*(\{\d\}){2,}\\\"\s+?\-f.*&&.*cmd.*\/c' # FPs with |\/r
+        # ServiceFileName|re: '(?i).*&&set.*(\{\d\}){2,}\\\"\s+?\-f.*&&.*cmd.*\/c' # FPs with |\/r
+        # Example 1: CMD /C"sET KUR=Invoke-Expression (New-Object Net.WebClient).DownloadString&&Set MxI=C:\wINDowS\sYsWow64\winDOWspoWERSheLl\V1.0\PowerShelL.EXe ${ExEcut`IoN`cON`TExT}.\"invo`kEcoMm`A`ND\".( \"{2}{1}{0}\" -f 'pt','EscRi','INvOk' ).Invoke( ( .( \"{0}{1}\" -f'D','IR' ) ( \"{0}{1}\"-f'ENV:kU','R')).\"vAl`Ue\" )&& CMD /C%mXI%"
+        # Example 2: c:\WiNDOWS\sYSTEm32\CmD.exE /C "sEt DeJLz=Invoke-Expression (New-Object Net.WebClient).DownloadString&&set yBKM=PoWERShelL -noeX ^^^&(\"{2}{0}{1}\"-f '-ItE','m','seT') ( 'V' + 'a'+ 'RiAblE:z8J' +'U2' + 'l' ) ([TYpE]( \"{2}{3}{0}{1}\"-f 'e','NT','e','NViRONM' ) ) ; ^^^& ( ( [sTrIng]${VE`Rbo`SepReFER`Ence})[1,3] + 'X'-joIN'')( ( (.('gI') ('V' + 'a' + 'RIAbLe:z8j' + 'u2' +'l' ) ).vALUe::( \"{2}{5}{0}{1}{6}{4}{3}\" -f 'IRo','Nm','GETE','ABlE','I','nv','enTVAr').Invoke(( \"{0}{1}\"-f'd','ejLz' ),( \"{1}{2}{0}\"-f'cEss','P','RO') )) )&& c:\WiNDOWS\sYSTEm32\CmD.exE /C %ybkm%"
+        ServiceFileName|contains|all:
+            - '&&set'
+            - 'cmd'
+            - '/c'
+            - '-f'
+        ServiceFileName|contains:
+            - '{0}'
+            - '{1}'
+            - '{2}'
+            - '{3}'
+            - '{4}'
+            - '{5}'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_stdin_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_stdin_services.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 25)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2021/11/30
+modified: 2022/11/17
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -16,11 +16,24 @@ logsource:
     product: windows
     service: system
 detection:
-    selection:
+    selection_main:
         Provider_Name: 'Service Control Manager'
         EventID: 7045
-        ImagePath|re: '.*cmd.{0,5}(?:\/c|\/r).+powershell.+(?:\$\{?input\}?|noexit).+\"'
-    condition: selection
+        # ImagePath|re: '.*cmd.{0,5}(?:\/c|\/r).+powershell.+(?:\$\{?input\}?|noexit).+\"'
+        # Example 1: c:\windows\sYstEm32\CmD.eXE /C"echO\Invoke-Expression (New-Object Net.WebClient).DownloadString | POwersHELl -NoEXiT -"
+        # Example 2: c:\WiNDOws\sysTEm32\cmd.EXe /C " ECHo Invoke-Expression (New-Object Net.WebClient).DownloadString | POwersHELl -nol ${EXEcUtIONCONTeXT}.INvOkEComMANd.InvOKEScRIPt( $InpUt )"
+        ImagePath|contains|all:
+            - 'cmd'
+            - 'powershell'
+        ImagePath|contains:
+            - '/c'
+            - '/r'
+    selection_other:
+        - ImagePath|contains: 'noexit'
+        - ImagePath|contains|all:
+            - 'input'
+            - '$'
+    condition: all of selection_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_var_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_var_services.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2021/11/30
+modified: 2022/11/17
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -19,7 +19,16 @@ detection:
     selection:
         Provider_Name: 'Service Control Manager'
         EventID: 7045
-        ImagePath|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
+        # ImagePath|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
+        # Example 1: C:\winDoWs\SySTeM32\cmd.Exe /C"SET NOtI=Invoke-Expression (New-Object Net.WebClient).DownloadString&& PowERshElL -NOl SET-iteM ( 'VAR' + 'i'+ 'A' + 'blE:Ao6' + 'I0') ( [TYpe](\"{2}{3}{0}{1}\"-F 'iRoN','mENT','e','nv') ) ; ${exECUtIONCOnTEXT}.\"IN`VO`KecOmMaND\".\"inVo`KES`crIPt\"( ( ( GEt-VAriAble ( 'a' + 'o6I0') -vaLU )::(\"{1}{4}{2}{3}{0}\" -f'e','gETenvIR','NtvaRIa','BL','ONme' ).Invoke(( \"{0}{1}\"-f'n','oti' ),( \"{0}{1}\" -f'pRoC','esS') )) )"
+        # Example 2: cMD.exe /C "seT SlDb=Invoke-Expression (New-Object Net.WebClient).DownloadString&& pOWErShell .(( ^&(\"{1}{0}{2}{3}\" -f 'eT-vaR','G','iab','lE' ) (\"{0}{1}\" -f '*m','DR*' ) ).\"na`ME\"[3,11,2]-JOIN'' ) ( ( ^&(\"{0}{1}\" -f'g','CI' ) (\"{0}{1}\" -f 'ENV',':SlDb' ) ).\"VA`luE\" ) "
+        ImagePath|contains|all:
+            - 'cmd'
+            - '"set'
+            - '-f'
+        ImagePath|contains:
+            - '/c'
+            - '/r'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_via_stdin_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_via_stdin_services.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task28)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/12
-modified: 2021/11/30
+modified: 2022/11/17
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -19,7 +19,16 @@ detection:
     selection:
         Provider_Name: 'Service Control Manager'
         EventID: 7045
-        ImagePath|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\${?input).*&&.*"'
+        # ImagePath|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\${?input).*&&.*"'
+        # Example 1: C:\wiNdOWs\SystEm32\cMD.EXe /c "sET XnK= Invoke-Expression (New-Object Net.WebClient).DownloadString && sET PZVh=ECho ${EXECutIoNcOnTExT}.inVokecommaNd.iNvoKeSCrIPt( ([eNvirOnMEnT]::GETenVIrOnmENtVARIABLe('XNk','pRoceSS'))) ^| poweRSHelL -NoE - && C:\wiNdOWs\SystEm32\cMD.EXe /c%PzVh%"
+        # Example 2: C:\winDowS\SysteM32\Cmd /C "set sHM=Invoke-Expression (New-Object Net.WebClient).DownloadString && SEt gBc=ECHO $eXECutionconTeXt.inVoKECOmmanD.InVoKESCripT( ([ENVirOnment]::geTenVIrONMEnTvaRIAble('shM','PRoCEss')) ) ^| C:\WiNDoWS\SYSwoW64\WindoWSpoWerSHelL\V1.0\pOwersheLl.EXe ^^^&( $PShOME[4]+$psHOMe[30]+'X') ( $InPUt) && C:\winDowS\SysteM32\Cmd /C %gbc%"
+        ImagePath|contains|all:
+            - 'set'
+            - '&&'
+        ImagePath|contains:
+            - 'environment'
+            - 'invoke'
+            - 'input'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_via_var_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_via_var_services.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
-modified: 2021/11/30
+modified: 2022/11/17
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -19,7 +19,21 @@ detection:
     selection:
         Provider_Name: 'Service Control Manager'
         EventID: 7045
-        ImagePath|re: '(?i).*&&set.*(\{\d\}){2,}\\\"\s+?\-f.*&&.*cmd.*\/c' # FPs with |\/r
+        # ImagePath|re: '(?i).*&&set.*(\{\d\}){2,}\\\"\s+?\-f.*&&.*cmd.*\/c' # FPs with |\/r
+        # Example 1: CMD /C"sET KUR=Invoke-Expression (New-Object Net.WebClient).DownloadString&&Set MxI=C:\wINDowS\sYsWow64\winDOWspoWERSheLl\V1.0\PowerShelL.EXe ${ExEcut`IoN`cON`TExT}.\"invo`kEcoMm`A`ND\".( \"{2}{1}{0}\" -f 'pt','EscRi','INvOk' ).Invoke( ( .( \"{0}{1}\" -f'D','IR' ) ( \"{0}{1}\"-f'ENV:kU','R')).\"vAl`Ue\" )&& CMD /C%mXI%"
+        # Example 2: c:\WiNDOWS\sYSTEm32\CmD.exE /C "sEt DeJLz=Invoke-Expression (New-Object Net.WebClient).DownloadString&&set yBKM=PoWERShelL -noeX ^^^&(\"{2}{0}{1}\"-f '-ItE','m','seT') ( 'V' + 'a'+ 'RiAblE:z8J' +'U2' + 'l' ) ([TYpE]( \"{2}{3}{0}{1}\"-f 'e','NT','e','NViRONM' ) ) ; ^^^& ( ( [sTrIng]${VE`Rbo`SepReFER`Ence})[1,3] + 'X'-joIN'')( ( (.('gI') ('V' + 'a' + 'RIAbLe:z8j' + 'u2' +'l' ) ).vALUe::( \"{2}{5}{0}{1}{6}{4}{3}\" -f 'IRo','Nm','GETE','ABlE','I','nv','enTVAr').Invoke(( \"{0}{1}\"-f'd','ejLz' ),( \"{1}{2}{0}\"-f'cEss','P','RO') )) )&& c:\WiNDOWS\sYSTEm32\CmD.exE /C %ybkm%"
+        ImagePath|contains|all:
+            - '&&set'
+            - 'cmd'
+            - '/c'
+            - '-f'
+        ImagePath|contains:
+            - '{0}'
+            - '{1}'
+            - '{2}'
+            - '{3}'
+            - '{4}'
+            - '{5}'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_dnsexfiltration.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_dnsexfiltration.yml
@@ -16,7 +16,7 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection_cmdlet:
-        - ScriptBlockText|contains: Invoke-DNSExfiltrator
+        - ScriptBlockText|contains: 'Invoke-DNSExfiltrator'
         - ScriptBlockText|contains|all:
             - ' -i '
             - ' -d '

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_nightmare.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_nightmare.yml
@@ -16,7 +16,7 @@ logsource:
     definition: Script Block Logging must be enabled
 detection:
     selection:
-        ScriptBlockText|contains: Invoke-Nightmare
+        ScriptBlockText|contains: 'Invoke-Nightmare'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
This PR is a continuation of #3703

Note that I didn't update the PowerShell version of these rules due to the nonlinearity of the `ScriptBlockText` it could generate more FP than we wanted. So I kept it as regex for now.