### PR TITLE
.NET CLR Usage Log

### DIFF
--- a/rules/windows/file/file_event/file_event_win_net_cli_artefact.yml
+++ b/rules/windows/file/file_event/file_event_win_net_cli_artefact.yml
@@ -1,10 +1,10 @@
 title: NET CLR Binary Execution Usage Log Artifact
 id: e0b06658-7d1d-4cd3-bf15-03467507ff7c
 status: experimental
-description: The CLR (crl.dll) create a Usage Log file named after the executing process once the assembly is finished executing for the first time in the (user) session context
+description: Detects the creation of Usage Log files by the CLR (clr.dll). These files are named after the executing process once the assembly is finished executing for the first time in the (user) session context
 references:
     - https://bohops.com/2021/03/16/investigating-net-clr-usage-log-tampering-techniques-for-edr-evasion/
-    - https://github.com/olafhartong/sysmon-modular/blob/master/11_file_create/include_dotnet.xml
+    - https://github.com/olafhartong/sysmon-modular/blob/fa1ae53132403d262be2bbd7f17ceea7e15e8c78/11_file_create/include_dotnet.xml
 author: frack113
 date: 2022/11/18
 tags:

--- a/rules/windows/file/file_event/file_event_win_net_cli_artefact.yml
+++ b/rules/windows/file/file_event/file_event_win_net_cli_artefact.yml
@@ -1,0 +1,29 @@
+title: NET CLR Binary Execution Log Artefact
+id: e0b06658-7d1d-4cd3-bf15-03467507ff7c
+status: experimental
+description: The CLR (crl.dll) create a Usage Log file named after the executing process once the assembly is finished executing for the first time in the (user) session context
+references:
+    - https://bohops.com/2021/03/16/investigating-net-clr-usage-log-tampering-techniques-for-edr-evasion/
+    - https://github.com/olafhartong/sysmon-modular/blob/master/11_file_create/include_dotnet.xml
+author: frack113
+date: 2022/11/18
+tags:
+    - attack.defense_evasion
+    - attack.t1218
+logsource:
+    category: file_event
+    product: windows
+detection:
+    selection:
+        TargetFilename|endswith:
+            - '\UsageLogs\cscript.exe.log'
+            - '\UsageLogs\wscript.exe.log'
+            - '\UsageLogs\wmic.exe.log'
+            - '\UsageLogs\mshta.exe.log'
+            - '\UsageLogs\svchost.exe.log'
+            - '\UsageLogs\regsvr32.exe.log'
+            - '\UsageLogs\rundll32.exe.log'
+    condition: selection
+falsepositives:
+    - Legitimate use
+level: medium

--- a/rules/windows/file/file_event/file_event_win_net_cli_artefact.yml
+++ b/rules/windows/file/file_event/file_event_win_net_cli_artefact.yml
@@ -1,4 +1,4 @@
-title: NET CLR Binary Execution Log Artefact
+title: NET CLR Binary Execution Usage Log Artifact
 id: e0b06658-7d1d-4cd3-bf15-03467507ff7c
 status: experimental
 description: The CLR (crl.dll) create a Usage Log file named after the executing process once the assembly is finished executing for the first time in the (user) session context

--- a/rules/windows/registry/registry_set/registry_set_net_cli_ngenassemblyusagelog.yml
+++ b/rules/windows/registry/registry_set/registry_set_net_cli_ngenassemblyusagelog.yml
@@ -1,7 +1,8 @@
-title: NET NGenAssemblyUsageLog Log Key
+title: NET NGenAssemblyUsageLog Registry Key Tamper
 id: 28036918-04d3-423d-91c0-55ecf99fb892
 status: experimental
 description: |
+  Detects changes to the NGenAssemblyUsageLog registry key.
   .NET Usage Log output location can be controlled by setting the NGenAssemblyUsageLog CLR configuration knob in the Registry or by configuring an environment variable (as described in the next section).
   By simplify specifying an arbitrary value (e.g. fake output location or junk data) for the expected value, a Usage Log file for the .NET execution context will not be created.
 references:

--- a/rules/windows/registry/registry_set/registry_set_net_cli_ngenassemblyusagelog.yml
+++ b/rules/windows/registry/registry_set/registry_set_net_cli_ngenassemblyusagelog.yml
@@ -1,0 +1,24 @@
+title: NET NGenAssemblyUsageLog Log Key
+id: 28036918-04d3-423d-91c0-55ecf99fb892
+status: experimental
+description: |
+  .NET Usage Log output location can be controlled by setting the NGenAssemblyUsageLog CLR configuration knob in the Registry or by configuring an environment variable (as described in the next section).
+  By simplify specifying an arbitrary value (e.g. fake output location or junk data) for the expected value, a Usage Log file for the .NET execution context will not be created.
+references:
+    - https://bohops.com/2021/03/16/investigating-net-clr-usage-log-tampering-techniques-for-edr-evasion/
+author: frack113
+date: 2022/11/18
+tags:
+    - attack.defense_evasion
+    - attack.t1112
+logsource:
+    product: windows
+    category: registry_set
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject|endswith: 'SOFTWARE\Microsoft\.NETFramework\NGenAssemblyUsageLog'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
https://bohops.com/2021/03/16/investigating-net-clr-usage-log-tampering-techniques-for-edr-evasion/

e0b06658-7d1d-4cd3-bf15-03467507ff7c : 
    check creation of the log file

28036918-04d3-423d-91c0-55ecf99fb892:
    The key do not exist on Windows 10 and 11.
    But can not generate a CreateKey event with sysmon or aurora so use the SetValue to trigger an alert