### PR TITLE
Create file_event_win_remote_cred_dump.yml

### DIFF
--- a/rules/windows/file/file_event/file_event_win_remote_cred_dump.yml
+++ b/rules/windows/file/file_event/file_event_win_remote_cred_dump.yml
@@ -1,0 +1,28 @@
+title: Remote Credential Dump
+id: 02773bed-83bf-469f-b7ff-e676e7d78bab
+status: experimental
+description: Detects default filenames outputted by execution of CrackMapExec and Impacket-secretsdump against an endpoint.
+references:
+    - https://github.com/Porchetta-Industries/CrackMapExec
+    - https://github.com/SecureAuthCorp/impacket/blob/master/examples/secretsdump.py
+author: SecurityAura
+date: 2022/11/16
+modified: 2022/11/16
+tags:
+    - attack.credential
+    - attack.t1003
+logsource:
+    product: windows
+    category: file_event
+detection:
+    selection:
+        Image|endswith:
+            - 'svchost.exe'
+        CommandLine|contains:
+            - 'RemoteRegistry'
+        TargetFilename|endswith:
+            - '\Windows\System32\????????.tmp'
+    condition: selection
+falsepositives:
+    - Unknown
+level: experimental

--- a/rules/windows/file/file_event/file_event_win_remote_cred_dump.yml
+++ b/rules/windows/file/file_event/file_event_win_remote_cred_dump.yml
@@ -1,5 +1,5 @@
 title: Remote Credential Dump
-id: 02773bed-83bf-469f-b7ff-e676e7d78bab
+id: 6e2a900a-ced9-4e4a-a9c2-13e706f9518a
 status: experimental
 description: Detects default filenames output from the execution of CrackMapExec and Impacket-secretsdump against an endpoint.
 references:

--- a/rules/windows/file/file_event/file_event_win_remote_cred_dump.yml
+++ b/rules/windows/file/file_event/file_event_win_remote_cred_dump.yml
@@ -15,7 +15,7 @@ logsource:
     category: file_event
 detection:
     selection:
-        Image|endswith: 'svchost.exe'
+        Image|endswith: '\svchost.exe'
         # CommandLine|contains: 'RemoteRegistry' # Uncomment this line if you collect CommandLine data for files events from more accuracy
         TargetFilename|endswith: '\Windows\System32\????????.tmp'
     condition: selection

--- a/rules/windows/file/file_event/file_event_win_remote_cred_dump.yml
+++ b/rules/windows/file/file_event/file_event_win_remote_cred_dump.yml
@@ -1,28 +1,24 @@
 title: Remote Credential Dump
 id: 02773bed-83bf-469f-b7ff-e676e7d78bab
 status: experimental
-description: Detects default filenames outputted by execution of CrackMapExec and Impacket-secretsdump against an endpoint.
+description: Detects default filenames output from the execution of CrackMapExec and Impacket-secretsdump against an endpoint.
 references:
     - https://github.com/Porchetta-Industries/CrackMapExec
     - https://github.com/SecureAuthCorp/impacket/blob/master/examples/secretsdump.py
 author: SecurityAura
 date: 2022/11/16
-modified: 2022/11/16
 tags:
-    - attack.credential
+    - attack.credential_access
     - attack.t1003
 logsource:
     product: windows
     category: file_event
 detection:
     selection:
-        Image|endswith:
-            - 'svchost.exe'
-        CommandLine|contains:
-            - 'RemoteRegistry'
-        TargetFilename|endswith:
-            - '\Windows\System32\????????.tmp'
+        Image|endswith: 'svchost.exe'
+        # CommandLine|contains: 'RemoteRegistry' # Uncomment this line if you collect CommandLine data for files events from more accuracy
+        TargetFilename|endswith: '\Windows\System32\????????.tmp'
     condition: selection
 falsepositives:
     - Unknown
-level: experimental
+level: high


### PR DESCRIPTION
After some testing, @ecote7 and I found out that when you use CrackMapExec or Impacket-secretsdump to dump LSA secrets against a remote endpoint, they'll be temporarily stored in a randomly named 8 characters .tmp file in the C:\Windows\System32 directory. Seems to be the case for other creds that gets dumped through this tool, even SAM.

Run the query against a few EDR endpoints and it seems to be high fidelity as a svchost.exe RemoteRegistry process will rarely create files there, if ever.

This is my 1st git push request ever, and my 1st time writing a Sigma rule. So if it can be adjusted, tweaked, fixed, etc. feel entirely free to do so and I'll appreciate any pointers you may have!