### PR TITLE
fix: explicitly escape `{` to make it clear that it is a literal

### DIFF
--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_stdin.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_stdin.yml
@@ -21,7 +21,7 @@ logsource:
     definition: PowerShell Module Logging must be enabled
 detection:
     selection_4103:
-        Payload|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\${?input).*&&.*"'
+        Payload|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\$\{?input).*&&.*"'
     condition: selection_4103
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_stdin.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_stdin.yml
@@ -21,7 +21,7 @@ logsource:
     definition: PowerShell Module Logging must be enabled
 detection:
     selection_4103:
-        Payload|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\$\{?input).*&&.*"'
+        Payload|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\$?\{?input).*&&.*"'
     condition: selection_4103
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_stdin.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_stdin.yml
@@ -18,7 +18,7 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection_4104:
-        ScriptBlockText|re: '.*cmd.{0,5}(?:\/c|\/r).+powershell.+(?:\$\{?input\}?|noexit).+\"'
+        ScriptBlockText|re: '.*cmd.{0,5}(?:\/c|\/r).+powershell.+(?:\$?\{?input\}?|noexit).+\"'
     condition: selection_4104
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_stdin.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_stdin.yml
@@ -18,7 +18,7 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection_4104:
-        ScriptBlockText|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\${?input).*&&.*"'
+        ScriptBlockText|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\$\{?input).*&&.*"'
     condition: selection_4104
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_lolbin_class_exec_xwizard.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_class_exec_xwizard.yml
@@ -16,7 +16,7 @@ logsource:
 detection:
     selection:
         Image|endswith: '\xwizard.exe'
-        CommandLine|re: '{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}}'
+        CommandLine|re: '\{[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}\}'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_powershell_cmdline_special_characters.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_cmdline_special_characters.yml
@@ -30,7 +30,7 @@ detection:
         Image|endswith:
             - '\powershell.exe'
             - '\pwsh.exe'
-        CommandLine|re: '.*{.*{.*{.*{.*{.*'
+        CommandLine|re: '.*\{.*\{.*\{.*\{.*\{.*'
     selection4:
         Image|endswith:
             - '\powershell.exe'


### PR DESCRIPTION
Thank you for maintaining Sigma :)

I noticed that  `{` was not escaped in some yml `|re` block.
This will cause regex compilation errors in programming languages ​​such as Rust, Java and .NET, So I escaped `{` explicitly.

ref: [Character Escapes in .NET](https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-escapes-in-regular-expressions#character-escapes-in-net)

I would appreciate it if you could review🙏