### PR TITLE
feat: new test for special references case

### DIFF
--- a/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
+++ b/rules/proxy/proxy_ua_bitsadmin_susp_tld.yml
@@ -1,7 +1,10 @@
 title: Bitsadmin to Uncommon TLD
 id: 9eb68894-7476-4cd6-8752-23b51f5883a7
 status: experimental
-description: Detects Bitsadmin connections to domains with uncommon TLDs - https://twitter.com/jhencinski/status/1102695118455349248 - https://isc.sans.edu/forums/diary/Investigating+Microsoft+BITS+Activity/23281/
+description: Detects Bitsadmin connections to domains with uncommon TLDs
+references:
+    - https://twitter.com/jhencinski/status/1102695118455349248
+    - https://isc.sans.edu/forums/diary/Investigating+Microsoft+BITS+Activity/23281/
 author: Florian Roth, Tim Shelton
 date: 2019/03/07
 modified: 2022/08/16

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -672,6 +672,25 @@ class TestRules(unittest.TestCase):
         self.assertEqual(faulty_rules, [], Fore.RED +
                          "There are rules with malformed 'references' fields. (has to be a list of values even if it contains only a single value)")
 
+    def test_references_in_description(self):
+        # This test checks for the presence of a links and special keywords in the "description" field while there is no "references" field.
+        faulty_rules = []
+        for file in self.yield_next_rule_file_path(self.path_to_rules):
+            references = self.get_rule_part(
+                file_path=file, part_name="references")
+            # Reference field doesn't exist
+            if not references:
+                descriptionfield = self.get_rule_part(
+                    file_path=file, part_name="description")
+                if descriptionfield:
+                    for i in ["http://", "https://", "Internal Research"]: # Extends the list with other common references starters
+                        if i in descriptionfield:
+                            print(Fore.RED + "Rule {} has malformed description field that contain references to external links.".format(file))
+                            faulty_rules.append(file)
+
+        self.assertEqual(faulty_rules, [], Fore.RED +
+                         "There are rules with malformed 'description' fields. (links and external references have to be in a seperate field named 'references'. see specification https://github.com/SigmaHQ/sigma-specification)")
+
     def test_references_plural(self):
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -685,7 +685,7 @@ class TestRules(unittest.TestCase):
                 if descriptionfield:
                     for i in ["http://", "https://", "internal research"]: # Extends the list with other common references starters
                         if i in descriptionfield.lower():
-                            print(Fore.RED + "Rule {} has malformed description field that contain references to external links.".format(file))
+                            print(Fore.RED + "Rule {} has a field that contains references to external links but no references set. Add a 'references' key and add URLs as list items.".format(file))
                             faulty_rules.append(file)
 
         self.assertEqual(faulty_rules, [], Fore.RED +

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -683,8 +683,8 @@ class TestRules(unittest.TestCase):
                 descriptionfield = self.get_rule_part(
                     file_path=file, part_name="description")
                 if descriptionfield:
-                    for i in ["http://", "https://", "Internal Research"]: # Extends the list with other common references starters
-                        if i in descriptionfield:
+                    for i in ["http://", "https://", "internal research"]: # Extends the list with other common references starters
+                        if i in descriptionfield.lower():
                             print(Fore.RED + "Rule {} has malformed description field that contain references to external links.".format(file))
                             faulty_rules.append(file)
 


### PR DESCRIPTION
This PR adds a new test for a rare case that occurred in internal testing. Where someone adds a link to a rule but misses adding the reference field (See internal discussion for details).

Basically, it makes sure that if a rule doesn't have a `references` field then the description field doesn't contain special keywords used in the references. (Currently the supported keywords are `http://`, `https://` and `Internal Research`)