### PR TITLE
refactor: remove unneeded escapes(in `|re` block)

### DIFF
--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_clip.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_clip.yml
@@ -21,7 +21,7 @@ logsource:
     definition: PowerShell Module Logging must be enabled
 detection:
     selection_4103:
-        Payload|re: '.*cmd.{0,5}(?:/c|/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\"\{\d\}.+\-f.+"'
+        Payload|re: '.*cmd.{0,5}(?:/c|/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\"\{\d\}.+-f.+"'
     condition: selection_4103
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_clip.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_clip.yml
@@ -21,7 +21,7 @@ logsource:
     definition: PowerShell Module Logging must be enabled
 detection:
     selection_4103:
-        Payload|re: '.*cmd.{0,5}(?:\/c|\/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\\"\{\d\}.+\-f.+\"'
+        Payload|re: '.*cmd.{0,5}(?:/c|/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\"\{\d\}.+\-f.+"'
     condition: selection_4103
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_clip.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_clip.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 26)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
-modified: 2022/11/27
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_stdin.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_stdin.yml
@@ -21,7 +21,7 @@ logsource:
     definition: PowerShell Module Logging must be enabled
 detection:
     selection_4103:
-        Payload|re: '.*cmd.{0,5}(?:\/c|\/r).+powershell.+(?:\$\{?input\}?|noexit).+\"'
+        Payload|re: '.*cmd.{0,5}(?:/c|/r).+powershell.+(?:\$\{?input\}?|noexit).+"'
     condition: selection_4103
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_stdin.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_stdin.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 25)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2022/11/29
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_var.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_var.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2022/11/29
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_var.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_var.yml
@@ -21,7 +21,7 @@ logsource:
     definition: PowerShell Module Logging must be enabled
 detection:
     selection_4103:
-        Payload|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
+        Payload|re: '.*cmd.{0,5}(?:/c|/r)(?:\s|)"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\"\s+?-f(?:.*\)){1,}.*"'
     condition: selection_4103
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_var.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_var.yml
@@ -21,7 +21,7 @@ logsource:
     definition: PowerShell Module Logging must be enabled
 detection:
     selection_4103:
-        Payload|re: '(?i).*&&set.*(\{\d\}){2,}\\\"\s+?\-f.*&&.*cmd.*\/c' # FPs with |\/r
+        Payload|re: '(?i).*&&set.*(\{\d\}){2,}\\"\s+?\-f.*&&.*cmd.*/c' # FPs with |\/r
     condition: selection_4103
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_var.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_var.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
-modified: 2022/11/29
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_var.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_var.yml
@@ -21,7 +21,7 @@ logsource:
     definition: PowerShell Module Logging must be enabled
 detection:
     selection_4103:
-        Payload|re: '(?i).*&&set.*(\{\d\}){2,}\\"\s+?\-f.*&&.*cmd.*/c' # FPs with |\/r
+        Payload|re: '(?i).*&&set.*(\{\d\}){2,}\\"\s+?-f.*&&.*cmd.*/c' # FPs with |\/r
     condition: selection_4103
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_clip.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_clip.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 26)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
-modified: 2022/11/27
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_clip.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_clip.yml
@@ -18,7 +18,7 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection_4104:
-        ScriptBlockText|re: '.*cmd.{0,5}(?:/c|/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\"\{\d\}.+\-f.+"'
+        ScriptBlockText|re: '.*cmd.{0,5}(?:/c|/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\"\{\d\}.+-f.+"'
     condition: selection_4104
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_clip.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_clip.yml
@@ -18,7 +18,7 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection_4104:
-        ScriptBlockText|re: '.*cmd.{0,5}(?:\/c|\/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\\"\{\d\}.+\-f.+\"'
+        ScriptBlockText|re: '.*cmd.{0,5}(?:/c|/r).+clip(?:\.exe)?.{0,4}&&.+clipboard]::\(\s\\"\{\d\}.+\-f.+"'
     condition: selection_4104
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_var.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_var.yml
@@ -18,7 +18,7 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection_4104:
-        ScriptBlockText|re: '.*cmd.{0,5}(?:/c|/r)(?:\s|)"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\"\s+?\-f(?:.*\)){1,}.*"'
+        ScriptBlockText|re: '.*cmd.{0,5}(?:/c|/r)(?:\s|)"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\"\s+?-f(?:.*\)){1,}.*"'
     condition: selection_4104
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_var.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_var.yml
@@ -18,7 +18,7 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection_4104:
-        ScriptBlockText|re: '.*cmd.{0,5}(?:\/c|\/r)(?:\s|)\"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\\"\s+?\-f(?:.*\)){1,}.*\"'
+        ScriptBlockText|re: '.*cmd.{0,5}(?:/c|/r)(?:\s|)"set\s[a-zA-Z]{3,6}.*(?:\{\d\}){1,}\\"\s+?\-f(?:.*\)){1,}.*"'
     condition: selection_4104
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_var.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_var.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2022/11/29
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_var.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_var.yml
@@ -18,7 +18,7 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection_4104:
-        ScriptBlockText|re: '(?i).*&&set.*(\{\d\}){2,}\\\"\s+?\-f.*&&.*cmd.*\/c' # FPs with |\/r
+        ScriptBlockText|re: '(?i).*&&set.*(\{\d\}){2,}\\"\s+?-f.*&&.*cmd.*/c' # FPs with |\/r
     condition: selection_4104
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_var.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_var.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
-modified: 2022/11/29
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.t1027


### PR DESCRIPTION
Thank you for maintaining Sigma :)
I noticed some yml `|re` blocks have unneeded escapes like bellow. So I removed unneeded escapes in this PR.
- `\/c`
- `\/r`
- `\"`
- `\-`

Besides in rare cases,  `/`, `-` and `"` should not be escaped and will actually cause parsing errors on some regex libraries when there are unneeded escapes(ref: https://github.com/rust-lang/regex/issues/501#issuecomment-1333797955).

I have also confirmed that the regex which removed unneeded escapes didn't cause compilation errors in the following programming languages.

- Java (v17.0.4.1)
- Node.js (v18.12.1)
- Golang (v1.19)
- PHP (v8.1.111)
- .NET (v7.0.100) 
- Rust (v1.65.0)
- Perl (v5.30.3)
- Python (v3.11)

I would appreciate it if you could review🙏