### PR TITLE
feat: general updates and fixes

### DIFF
--- a/rules-deprecated/windows/proc_creation_win_office_from_proxy_executing_regsvr32_payload.yml
+++ b/rules-deprecated/windows/proc_creation_win_office_from_proxy_executing_regsvr32_payload.yml
@@ -1,6 +1,6 @@
 title: Excel Proxy Executing Regsvr32 With Payload
 id: 9d1c72f5-43f0-4da5-9320-648cf2099dd0
-status: experimental
+status: deprecated
 description: |
   Excel called wmic to finally proxy execute regsvr32 with the payload.
   An attacker wanted to break suspicious parent-child chain (Office app spawns LOLBin).

--- a/rules-deprecated/windows/proc_creation_win_office_from_proxy_executing_regsvr32_payload2.yml
+++ b/rules-deprecated/windows/proc_creation_win_office_from_proxy_executing_regsvr32_payload2.yml
@@ -1,0 +1,49 @@
+title: Excel Proxy Executing Regsvr32 With Payload Alternate
+id: c0e1c3d5-4381-4f18-8145-2583f06a1fe5
+status: deprecated
+description: |
+  Excel called wmic to finally proxy execute regsvr32 with the payload.
+  An attacker wanted to break suspicious parent-child chain (Office app spawns LOLBin).
+  But we have command-line in the event which allow us to "restore" this suspicious parent-child chain and detect it.
+  Monitor process creation with "wmic process call create" and LOLBins in command-line with parent Office application processes.
+references:
+    - https://thedfirreport.com/2021/03/29/sodinokibi-aka-revil-ransomware/
+    - https://github.com/vadim-hunter/Detection-Ideas-Rules/blob/02bcbfc2bfb8b4da601bb30de0344ae453aa1afe/Threat%20Intelligence/The%20DFIR%20Report/20210329_Sodinokibi_(aka_REvil)_Ransomware.yaml
+author: 'Vadim Khrykov (ThreatIntel), Cyb3rEng (Rule)'
+date: 2021/08/23
+modified: 2022/12/02
+tags:
+    - attack.t1204.002
+    - attack.t1047
+    - attack.t1218.010
+    - attack.execution
+    - attack.defense_evasion
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    #useful_information: add more LOLBins to the rules logic of your choice.
+    selection1:
+        CommandLine|contains:
+            - 'regsvr32'
+            - 'rundll32'
+            - 'msiexec'
+            - 'mshta'
+            - 'verclsid'
+    selection2:
+        - Image|endswith: '\wbem\WMIC.exe'
+        - CommandLine|contains: 'wmic '
+    selection3:
+        ParentImage|endswith:
+            - '\winword.exe'
+            - '\excel.exe'
+            - '\powerpnt.exe'
+    selection4:
+        CommandLine|contains|all:
+            - 'process'
+            - 'create'
+            - 'call'
+    condition: all of selection*
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/builtin/bits_client/win_bits_client_susp_domain.yml
+++ b/rules/windows/builtin/bits_client/win_bits_client_susp_domain.yml
@@ -8,7 +8,7 @@ references:
     - https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/ransomware-hive-conti-avoslocker
 author: Florian Roth
 date: 2022/06/28
-modified: 2022/08/09
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -35,6 +35,9 @@ detection:
             - 'anonfiles.com'
             - 'send.exploit.in'
             - 'transfer.sh'
+            - 'privatlab.net'
+            - 'privatlab.com'
+            - 'sendspace.com'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/create_stream_hash/create_stream_hash_susp_domain_ext_combo.yml
+++ b/rules/windows/create_stream_hash/create_stream_hash_susp_domain_ext_combo.yml
@@ -4,8 +4,10 @@ status: experimental
 description: Detects the download of suspicious file type from a well-known file and paste sharing domain
 references:
     - https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=90015
+    - https://www.cisa.gov/uscert/ncas/alerts/aa22-321a
 author: Florian Roth
 date: 2022/08/24
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.s0139
@@ -32,6 +34,9 @@ detection:
             - 'storage.googleapis.com'
             - 'anonfiles.com'
             - 'send.exploit.in'
+            - 'privatlab.net'
+            - 'privatlab.com'
+            - 'sendspace.com'
     selection_extension:
         TargetFilename|contains:
             - '.exe:Zone'

--- a/rules/windows/create_stream_hash/create_stream_hash_susp_domain_ext_combo_med.yml
+++ b/rules/windows/create_stream_hash/create_stream_hash_susp_domain_ext_combo_med.yml
@@ -4,8 +4,10 @@ status: experimental
 description: Detects the download of suspicious file type from a well-known file and paste sharing domain
 references:
     - https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=90015
+    - https://www.cisa.gov/uscert/ncas/alerts/aa22-321a
 author: Florian Roth
 date: 2022/08/24
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.s0139
@@ -32,6 +34,9 @@ detection:
             - 'storage.googleapis.com'
             - 'anonfiles.com'
             - 'send.exploit.in'
+            - 'privatlab.net'
+            - 'privatlab.com'
+            - 'sendspace.com'
     selection_extension:
         TargetFilename|contains:
             - '.ps1:Zone'

--- a/rules/windows/file/file_event/file_event_win_create_non_existent_dlls.yml
+++ b/rules/windows/file/file_event/file_event_win_create_non_existent_dlls.yml
@@ -1,0 +1,30 @@
+title: Creation Of Non-Existent DLLs In System Folders
+id: df6ecb8b-7822-4f4b-b412-08f524b4576c
+status: experimental
+description: Detects the creation of system dlls that are not present on the system. Usualy to achieve dll hijacking
+references:
+    - https://decoded.avast.io/martinchlumecky/png-steganography/
+    - https://posts.specterops.io/lateral-movement-scm-and-dll-hijacking-primer-d2f61e8ab992
+author: Nasreddine Bencherchali
+date: 2022/12/01
+tags:
+    - attack.defense_evasion
+    - attack.persistence
+    - attack.privilege_escalation
+    - attack.t1574.001
+    - attack.t1574.002
+logsource:
+    product: windows
+    category: file_event
+detection:
+    selection:
+        TargetFilename:
+            - 'C:\Windows\System32\WLBSCTRL.dll'
+            - 'C:\Windows\System32\TSMSISrv.dll'
+            - 'C:\Windows\System32\TSVIPSrv.dll'
+    filter:
+        Image|startswith: 'C:\Windows\System32\'
+    condition: selection and not filter
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/image_load/image_load_side_load_scm.yml
+++ b/rules/windows/image_load/image_load_side_load_scm.yml
@@ -1,0 +1,29 @@
+title: SCM DLL Sideload
+id: bc3cc333-48b9-467a-9d1f-d44ee594ef48
+status: experimental
+description: Detects DLL sideloading of DLLs that are loaded by the SCM for some services (IKE, IKEEXT, SessionEnv) which do not exists on a typical modern system
+references:
+    - https://decoded.avast.io/martinchlumecky/png-steganography/
+    - https://posts.specterops.io/lateral-movement-scm-and-dll-hijacking-primer-d2f61e8ab992
+author: Nasreddine Bencherchali
+date: 2022/12/01
+tags:
+    - attack.defense_evasion
+    - attack.persistence
+    - attack.privilege_escalation
+    - attack.t1574.001
+    - attack.t1574.002
+logsource:
+    category: image_load
+    product: windows
+detection:
+    selection:
+        ImageLoaded:
+            - 'C:\Windows\System32\WLBSCTRL.dll'
+            - 'C:\Windows\System32\TSMSISrv.dll'
+            - 'C:\Windows\System32\TSVIPSrv.dll'
+        Image: 'C:\Windows\System32\svchost.exe'
+    condition: selection
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/image_load/image_load_side_load_vmguestlib.yml
+++ b/rules/windows/image_load/image_load_side_load_vmguestlib.yml
@@ -1,0 +1,29 @@
+title: SCM DLL Sideload
+id: 70e8e9b4-6a93-4cb7-8cde-da69502e7aff
+status: experimental
+description: Detects DLL sideloading of DLLs that are loaded by the SCM for some services (IKE, IKEEXT, SessionEnv) which do not exists on a typical modern system
+references:
+    - https://decoded.avast.io/martinchlumecky/png-steganography/
+author: Nasreddine Bencherchali
+date: 2022/12/01
+tags:
+    - attack.defense_evasion
+    - attack.persistence
+    - attack.privilege_escalation
+    - attack.t1574.001
+    - attack.t1574.002
+logsource:
+    category: image_load
+    product: windows
+detection:
+    selection:
+        ImageLoaded|contains:
+            - '\VMware\VMware Tools\vmStatsProvider\win32'
+            - '\vmGuestLib.dll'
+        Image|endswith: '\Windows\System32\wbem\WmiApSrv.exe'
+    filter:
+        Signed: 'true'
+    condition: selection and not filter
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/image_load/image_load_side_load_vmguestlib.yml
+++ b/rules/windows/image_load/image_load_side_load_vmguestlib.yml
@@ -25,5 +25,5 @@ detection:
         Signed: 'true'
     condition: selection and not filter
 falsepositives:
-    - FP could occure if the legitimate version of vmGuestLib already exists
+    - FP could occure if the legitimate version of vmGuestLib already exists on the system
 level: medium

--- a/rules/windows/image_load/image_load_side_load_vmguestlib.yml
+++ b/rules/windows/image_load/image_load_side_load_vmguestlib.yml
@@ -17,7 +17,7 @@ logsource:
     product: windows
 detection:
     selection:
-        ImageLoaded|contains:
+        ImageLoaded|contains|all:
             - '\VMware\VMware Tools\vmStatsProvider\win32'
             - '\vmGuestLib.dll'
         Image|endswith: '\Windows\System32\wbem\WmiApSrv.exe'

--- a/rules/windows/image_load/image_load_side_load_vmguestlib.yml
+++ b/rules/windows/image_load/image_load_side_load_vmguestlib.yml
@@ -1,7 +1,7 @@
-title: SCM DLL Sideload
+title: VMGuestLib DLL Sideload
 id: 70e8e9b4-6a93-4cb7-8cde-da69502e7aff
 status: experimental
-description: Detects DLL sideloading of DLLs that are loaded by the SCM for some services (IKE, IKEEXT, SessionEnv) which do not exists on a typical modern system
+description: Detects DLL sideloading of VMGuestLib.dll by the WmiApSrv service.
 references:
     - https://decoded.avast.io/martinchlumecky/png-steganography/
 author: Nasreddine Bencherchali
@@ -25,5 +25,5 @@ detection:
         Signed: 'true'
     condition: selection and not filter
 falsepositives:
-    - Unknown
+    - FP could occure if the legitimate version of vmGuestLib already exists
 level: medium

--- a/rules/windows/image_load/image_load_susp_dll_load_system_process.yml
+++ b/rules/windows/image_load/image_load_susp_dll_load_system_process.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/hackerhouse-opensource/iscsicpl_bypassUAC (Idea)
 author: Nasreddine Bencherchali
 date: 2022/07/17
-modified: 2022/10/12
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.t1070
@@ -28,6 +28,12 @@ detection:
         - ImageLoaded|startswith:
             - 'C:\Program Files\'
             - 'C:\Program Files (x86)\'
+        - Image:
+            - 'C:\Windows\SysWOW64\rundll32.exe' # Typical for installers and updaters
+            - 'C:\Windows\System32\rundll32.exe' # Typical for installers and updaters
+        - CommandLine|contains|all:
+            - '\AppData\Local\Temp\' # Typical for installers and updaters
+            - '\setup.exe'
     filter_cleanmgr:
         # Example CLI that generates this event: C:\WINDOWS\system32\cleanmgr.exe /autocleanstoragesense /d C:
         # Sometimes the DLL gets loaded from %temp%

--- a/rules/windows/network_connection/net_connection_win_binary_susp_com.yml
+++ b/rules/windows/network_connection/net_connection_win_binary_susp_com.yml
@@ -6,9 +6,10 @@ references:
     - https://twitter.com/M_haggis/status/900741347035889665
     - https://twitter.com/M_haggis/status/1032799638213066752
     - https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/ransomware-hive-conti-avoslocker
+    - https://www.cisa.gov/uscert/ncas/alerts/aa22-321a
 author: Florian Roth
 date: 2018/08/30
-modified: 2022/08/09
+modified: 2022/12/02
 tags:
     - attack.lateral_movement
     - attack.t1105
@@ -33,6 +34,9 @@ detection:
             - 'anonfiles.com'
             - 'send.exploit.in'
             - 'transfer.sh'
+            - 'privatlab.net'
+            - 'privatlab.com'
+            - 'sendspace.com'
         Image|startswith:
             - 'C:\Windows\'
             - 'C:\Users\Public\'

--- a/rules/windows/process_creation/proc_creation_win_bitsadmin_download_susp_domain.yml
+++ b/rules/windows/process_creation/proc_creation_win_bitsadmin_download_susp_domain.yml
@@ -7,9 +7,10 @@ references:
     - https://isc.sans.edu/diary/22264
     - https://lolbas-project.github.io/lolbas/Binaries/Bitsadmin/
     - https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/ransomware-hive-conti-avoslocker
+    - https://www.cisa.gov/uscert/ncas/alerts/aa22-321a
 author: Florian Roth
 date: 2022/06/28
-modified: 2022/11/11
+modified: 2022/12/02
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -45,6 +46,9 @@ detection:
             - 'anonfiles.com'
             - 'send.exploit.in'
             - 'transfer.sh'
+            - 'privatlab.net'
+            - 'privatlab.com'
+            - 'sendspace.com'
     condition: all of selection_*
 fields:
     - CommandLine

--- a/rules/windows/process_creation/proc_creation_win_gpg4win_susp_usage.yml
+++ b/rules/windows/process_creation/proc_creation_win_gpg4win_susp_usage.yml
@@ -25,7 +25,7 @@ detection:
             - 'C:\Perflogs\'
             - 'C:\Windows\Temp\'
             - 'C:\temp'
-            - ''
+            #- ''
     condition: all of selection_*
 falsepositives:
     - Legitimate use

--- a/rules/windows/process_creation/proc_creation_win_gpg4win_susp_usage.yml
+++ b/rules/windows/process_creation/proc_creation_win_gpg4win_susp_usage.yml
@@ -1,0 +1,33 @@
+title: Gpg4Win Decrypt Files From Suspicious Locations
+id: e1e0b7d7-e10b-4ee4-ac49-a4bda05d320d
+status: experimental
+description: Detects usage of the Gpg4win to decrypt files located in suspicious locations from CLI
+references:
+    - https://blogs.vmware.com/security/2022/11/batloader-the-evasive-downloader-malware.html
+author: Nasreddine Bencherchali, X__Junior
+date: 2022/11/30
+tags:
+    - attack.command_and_control
+    - attack.t1219
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_metadata:
+        - Image|endswith:
+            - '\gpg2.exe'
+        - Product: 'GNU Privacy Guard (GnuPG)'
+        - Company: 'g10 Code GmbH'
+    selection_cli:
+        CommandLine|contains: '-passphrase'
+    selection_paths:
+        CommandLine|contains:
+            - '\AppData\Roaming\'
+            - 'C:\Perflogs\'
+            - 'C:\Windows\Temp\'
+            - 'C:\temp'
+            - ''
+    condition: all of selection_*
+falsepositives:
+    - Legitimate use
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_gpg4win_susp_usage.yml
+++ b/rules/windows/process_creation/proc_creation_win_gpg4win_susp_usage.yml
@@ -14,8 +14,7 @@ logsource:
     product: windows
 detection:
     selection_metadata:
-        - Image|endswith:
-            - '\gpg2.exe'
+        - Image|endswith: '\gpg2.exe'
         - Product: 'GNU Privacy Guard (GnuPG)'
         - Company: 'g10 Code GmbH'
     selection_cli:

--- a/rules/windows/process_creation/proc_creation_win_office_proxy_exec_wmic.yml
+++ b/rules/windows/process_creation/proc_creation_win_office_proxy_exec_wmic.yml
@@ -1,11 +1,12 @@
-title: Excel Proxy Executing Regsvr32 With Payload Alternate
-id: c0e1c3d5-4381-4f18-8145-2583f06a1fe5
+title: Office Processes Proxy Execution Through WMIC
+id: e1693bc8-7168-4eab-8718-cdcaa68a1738
+related:
+    - id: 9d1c72f5-43f0-4da5-9320-648cf2099dd0
+      type: obsoletes
+    - id: c0e1c3d5-4381-4f18-8145-2583f06a1fe5
+      type: obsoletes
 status: experimental
-description: |
-  Excel called wmic to finally proxy execute regsvr32 with the payload.
-  An attacker wanted to break suspicious parent-child chain (Office app spawns LOLBin).
-  But we have command-line in the event which allow us to "restore" this suspicious parent-child chain and detect it.
-  Monitor process creation with "wmic process call create" and LOLBins in command-line with parent Office application processes.
+description: Office application called wmic to proxye execution through a LOLBIN process. This is often used to break suspicious parent-child chain (Office app spawns LOLBin).
 references:
     - https://thedfirreport.com/2021/03/29/sodinokibi-aka-revil-ransomware/
     - https://github.com/vadim-hunter/Detection-Ideas-Rules/blob/02bcbfc2bfb8b4da601bb30de0344ae453aa1afe/Threat%20Intelligence/The%20DFIR%20Report/20210329_Sodinokibi_(aka_REvil)_Ransomware.yaml
@@ -22,28 +23,26 @@ logsource:
     product: windows
     category: process_creation
 detection:
-    #useful_information: add more LOLBins to the rules logic of your choice.
-    selection1:
+    selection_wmic:
+        - Image|endswith: '\wbem\WMIC.exe'
+        - OriginalFileName: 'wmic.exe'
+    selection_parent:
+        ParentImage|endswith:
+            - '\winword.exe'
+            - '\excel.exe'
+            - '\powerpnt.exe'
+        CommandLine|contains|all:
+            - 'process'
+            - 'create'
+            - 'call'
         CommandLine|contains:
+            # Add more suspicious LOLBINs as you see fit
             - 'regsvr32'
             - 'rundll32'
             - 'msiexec'
             - 'mshta'
             - 'verclsid'
-    selection2:
-        - Image|endswith: '\wbem\WMIC.exe'
-        - CommandLine|contains: 'wmic '
-    selection3:
-        ParentImage|endswith:
-            - '\winword.exe'
-            - '\excel.exe'
-            - '\powerpnt.exe'
-    selection4:
-        CommandLine|contains|all:
-            - 'process'
-            - 'create'
-            - 'call'
-    condition: all of selection*
+    condition: all of selection_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_tool_nircmd.yml
+++ b/rules/windows/process_creation/proc_creation_win_tool_nircmd.yml
@@ -8,7 +8,7 @@ references:
     - https://www.nirsoft.net/utils/nircmd2.html#using
 author: Florian Roth, Nasreddine Bencherchali
 date: 2022/01/24
-modified: 2022/08/08
+modified: 2022/11/30
 tags:
     - attack.execution
     - attack.t1569.002
@@ -18,7 +18,8 @@ logsource:
     product: windows
 detection:
     selection_org:
-        OriginalFileName: 'NirCmd.exe'
+        - Image|endswith: '\NirCmd.exe'
+        - OriginalFileName: 'NirCmd.exe'
     selection_cmd:
         CommandLine|contains:
             - ' execmd '

--- a/rules/windows/process_creation/proc_creation_win_wsudo_susp_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_wsudo_susp_execution.yml
@@ -1,0 +1,32 @@
+title: Wsudo Suspicious Execution
+id: bdeeabc9-ff2a-4a51-be59-bb253aac7891
+status: experimental
+description: Detects usage of wsudo (Windows Sudo Utility). Which is a tool that let the user execute programs with different permissions (System, Trusted Installer, Administrator...etc)
+references:
+    - https://github.com/M2Team/Privexec/
+author: Nasreddine Bencherchali
+date: 2022/12/02
+tags:
+    - attack.execution
+    - attack.privilege_escalation
+    - attack.t1059
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_metadata:
+        - Image|endswith: '\wsudo.exe'
+        - OriginalFileName: 'wsudo.exe'
+        - Description: 'Windows sudo utility'
+        - ParentImage|endswith: '\wsudo-bridge.exe'
+    selection_cli:
+        CommandLine|contains:
+            - '-u System'
+            - '-uSystem'
+            - '-u TrustedInstaller'
+            - '-uTrustedInstaller'
+            - ' --ti '
+    condition: 1 of selection_*
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
This PR covers the following:

- Fixes FP found in testing in the rule `9e9a9002-56c4-40fd-9eff-e4b09bfa5f6c`
- Deprecate both `c0e1c3d5-4381-4f18-8145-2583f06a1fe5` and `9d1c72f5-43f0-4da5-9320-648cf2099dd0` and create new rule `e1693bc8-7168-4eab-8718-cdcaa68a1738`
- Added new rules related to the use of `Wsudo.exe` and `Gpg4win`
- Added new rules related to DLL sideloading (see `Files Changed` section)
- Added more suspicious file-sharing domains the multiple rules (see `Files Changed` section)
