### PR TITLE
refactor: remove unnesessary escape(in |re block)

### DIFF
--- a/rules/windows/pipe_created/pipe_created_mal_cobaltstrike_re.yml
+++ b/rules/windows/pipe_created/pipe_created_mal_cobaltstrike_re.yml
@@ -7,7 +7,7 @@ references:
     - https://gist.github.com/MHaggis/6c600e524045a6d49c35291a21e10752
 author: Florian Roth
 date: 2021/07/30
-modified: 2022/10/09
+modified: 2022/12/03
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
@@ -23,7 +23,7 @@ detection:
         - PipeName|re: '\\\\ntsvcs[0-9a-f]{2}'
         - PipeName|re: '\\\\DserNamePipe[0-9a-f]{2}'
         - PipeName|re: '\\\\SearchTextHarvester[0-9a-f]{2}'
-        - PipeName|re: '\\\\mypipe\-(?:f|h)[0-9a-f]{2}'
+        - PipeName|re: '\\\\mypipe-(?:f|h)[0-9a-f]{2}'
         - PipeName|re: '\\\\windows\.update\.manager[0-9a-f]{2,3}'
         - PipeName|re: '\\\\ntsvcs_[0-9a-f]{2}'
         - PipeName|re: '\\\\scerpc_?[0-9a-f]{2}'

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_stdin.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_stdin.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Neo23x0/sigma/issues/1009  #(Task 25)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
-modified: 2022/11/29
+modified: 2022/12/03
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -18,7 +18,7 @@ logsource:
     definition: Script block logging must be enabled
 detection:
     selection_4104:
-        ScriptBlockText|re: '.*cmd.{0,5}(?:\/c|\/r).+powershell.+(?:\$?\{?input\}?|noexit).+\"'
+        ScriptBlockText|re: '.*cmd.{0,5}(?:/c|/r).+powershell.+(?:\$?\{?input\}?|noexit).+"'
     condition: selection_4104
 falsepositives:
     - Unknown


### PR DESCRIPTION
Thank you for maintaining Sigma :)
I'm sorry I didn't notice it when I made the PR #3744. I have also removed unnecessary escaping, same as #3744.