### PR TITLE
Fix workflow warning

### DIFF
--- a/rules/windows/builtin/security/win_security_service_installation_by_unusal_client.yml
+++ b/rules/windows/builtin/security/win_security_service_installation_by_unusal_client.yml
@@ -10,6 +10,7 @@ references:
     - https://twitter.com/SBousseaden/status/1490608838701166596
 author: Tim Rauch
 date: 2022/09/15
+modified: 2022/12/04
 tags:
     - attack.privilege_escalation
     - attack.t1543
@@ -21,8 +22,8 @@ detection:
     selection:
         EventID: 4697
     selection_pid:
-        - ClientProcessId: '0'
-        - ParentProcessId: '0'
+        - ClientProcessId: 0
+        - ParentProcessId: 0
     condition: all of selection*
 falsepositives:
     - Unknown

--- a/rules/windows/builtin/system/win_system_lpe_indicators_tabtip.yml
+++ b/rules/windows/builtin/system/win_system_lpe_indicators_tabtip.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/antonioCoco/JuicyPotatoNG
 author: Florian Roth
 date: 2022/10/07
+modified: 2022/12/04
 tags:
     - attack.execution
     - attack.t1557.001
@@ -16,7 +17,7 @@ detection:
     selection:
         EventID: 10001
         param1: 'C:\Program Files\Common Files\microsoft shared\ink\TabTip.exe'  # is the Binary starting/started
-        param2: '2147943140'                                                     # is ERROR id
+        param2: 2147943140                                                       # is ERROR id
         param3: '{054AAE20-4BEA-4347-8A35-64A533254A9D}'                         # is DCOM Server
     condition: selection
 falsepositives:

--- a/rules/windows/builtin/system/win_system_system_service_installation_by_unusal_client.yml
+++ b/rules/windows/builtin/system/win_system_system_service_installation_by_unusal_client.yml
@@ -9,6 +9,7 @@ references:
     - https://www.elastic.co/guide/en/security/current/windows-service-installed-via-an-unusual-client.html
 author: Tim Rauch
 date: 2022/09/15
+modified: 2022/12/04
 tags:
     - attack.privilege_escalation
     - attack.t1543
@@ -19,7 +20,7 @@ detection:
     selection:
         Provider_Name: 'Service Control Manager'
         EventID: 7045
-        ProcessId: '0'
+        ProcessId: 0
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_susp_wermgr.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_wermgr.yml
@@ -1,5 +1,5 @@
 title: Suspicious WERMGR Process Patterns
-id: CBEC226F-63D9-4ECA-9F52-DFB6652F24DF
+id: 396f6630-f3ac-44e3-bfc8-1b161bc00c4e
 status: experimental
 description: Detects suspicious Windows Error Reporting manager (wermgr.exe) process patterns - suspicious parents / children, execution folders, command lines etc.
 references:
@@ -7,6 +7,7 @@ references:
     - https://www.echotrail.io/insights/search/wermgr.exe
 author: Florian Roth
 date: 2022/10/14
+modified: 2022/12/04
 logsource:
     category: process_creation
     product: windows


### PR DESCRIPTION
Fix error find in the workflow.

- proc_creation_win_susp_wermgr.yml had the used `id` than another rule but in uppercase 😄 
- fix integer / string.
