### PR TITLE
Detection for LSASS Shtinkering

### DIFF
--- a/rules/windows/file/file_event/file_event_lsass_shtinkering.yml
+++ b/rules/windows/file/file_event/file_event_lsass_shtinkering.yml
@@ -1,0 +1,23 @@
+title: Suspicious LSASS Dump using LSASS Shtinkering
+id: 6902955a-01b7-432c-b32a-6f5f81d8f625
+status: experimental
+description: LSASS Shtinkering is a technique where using Windows Error Reporting, LSASS can be dumped.
+references:
+    - https://github.com/deepinstinct/Lsass-Shtinkering
+author: '@pbssubhash'
+modified: 2022/12/08
+tags:
+    - attack.credential_access
+logsource:
+    product: windows
+    category: file_event
+detection:
+    selection:
+        TargetFilename|contains|all: 
+          - 'lsass.exe'
+          - 'C:\Windows\System32\config\systemprofile\AppData\Local\CrashDumps'
+        TargetFilename|endswith: '.dmp'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/process_creation/proc_creation_lsass_shtinkering.yml
+++ b/rules/windows/process_creation/proc_creation_lsass_shtinkering.yml
@@ -1,0 +1,32 @@
+title: Suspicious LSASS Dumping using Windows Error Reporting
+id: 9a4ccd1a-3526-4d99-b980-9f9c5d3a6ff3
+status: experimental
+description: LSASS Shtinkering is a technique where using Windows Error Reporting, LSASS can be dumped.
+references:
+    - https://github.com/deepinstinct/Lsass-Shtinkering
+author: '@pbssubhash'
+date: 2022/12/08
+modified: 2022/12/08
+tags:
+    - attack.credential_access
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        - Image|endswith: '\Werfault.exe'
+        - OriginalFileName: 'WerFault.Exe'
+        - CommandLine|contains:
+          - '-u '
+          - '-p'
+          - '-ip '
+          - '-s '
+          # C:\Windows\system32\Werfault.exe -u -p 744 -ip 1112 -s 244
+    selection_parent:
+        ParentImage|endswith: '\7zFM.exe'
+    filter_lsass:
+        ParentImage|endswith: 'C:\Windows\System32\lsass.exe'
+    condition: selection and not filter_lsass
+falsepositives:
+    - Windows Error Reporting might have similar behavior and in that case, check the process associated with "-ip" parameter in CommandLine.
+level: high

--- a/rules/windows/registry/registry_add/registry_add_usermode_dumping_enabled.yml
+++ b/rules/windows/registry/registry_add/registry_add_usermode_dumping_enabled.yml
@@ -1,0 +1,23 @@
+title: Adding of a registry key for LSASS Shtinkering
+id: 33efc23c-6ea2-4503-8cfe-bdf82ce8f718
+status: experimental
+description: Detects when an attacker adds a registry key that's required to perform LSASS Shtinkering attack.
+references:
+    - https://github.com/deepinstinct/Lsass-Shtinkering
+author: '@pbssubhash'
+date: 2022/12/08
+modified: 2022/12/08
+tags:
+    - attack.credential_access
+logsource:
+    category: registry_add
+    product: windows
+detection:
+    selection:
+        EventType: CreateKey
+        TargetObject|contains:
+            - '\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps'
+    condition: selection
+falsepositives:
+    - Legitimate usage of enabling user mode dumping (Not seen in the wild)
+level: high

--- a/rules/windows/registry/registry_set/registry_set_lsass_usermode_dumping_lsass_shtinkering.yml
+++ b/rules/windows/registry/registry_set/registry_set_lsass_usermode_dumping_lsass_shtinkering.yml
@@ -1,0 +1,24 @@
+title: Setting of a registry key's value for LSASS Shtinkering
+id: 33efc23c-6ea2-4503-8cfe-bdf82ce8f718
+status: experimental
+description: Detects when an attacker adds a registry key that's required to perform LSASS Shtinkering attack.
+references:
+    - https://github.com/deepinstinct/Lsass-Shtinkering
+author: '@pbssubhash'
+date: 2022/12/08
+modified: 2022/12/08
+tags:
+    - attack.credential_access
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        EventType: SetValue
+        TargetObject:
+            - HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps
+        Details: 2
+    condition: selection
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
4 rules to detect 
- Process creation of Windows Error Reporting that enables the dumping 
- Creation of a registry key - that's a pre-requisite for the attack
- Setting of the registry key - that's a pre-requisite for the attack
- Creation of a lsass dmp file when dumped using NT Authority\System