### PR TITLE
feat: enhance unused selection test

### DIFF
--- a/rules/windows/builtin/security/win_security_susp_scheduled_task_creation.yml
+++ b/rules/windows/builtin/security/win_security_susp_scheduled_task_creation.yml
@@ -6,6 +6,7 @@ references:
     - https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4698
 author: Nasreddine Bencherchali
 date: 2022/12/05
+modified: 2022/12/07
 tags:
     - attack.execution
     - attack.privilege_escalation
@@ -16,7 +17,7 @@ logsource:
     service: security
     definition: 'The Advanced Audit Policy setting Object Access > Audit Other Object Access Events has to be configured to allow this detection. We also recommend extracting the Command field from the embedded XML in the event data.'
 detection:
-    selection:
+    selection_eid:
         EventID: 4698
     selection_paths:
         TaskContent|contains:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -882,8 +882,12 @@ class TestRules(unittest.TestCase):
                     continue
                 if selection == "timeframe":
                     continue
-                if selection in condition:
+
+                # remove special keywords
+                condition_list = condition.replace("not ", '').replace("1 of ", '').replace("all of ", '').replace(' or ', ' ').replace(' and ', ' ').replace('(', '').replace(')', '').split(" ")
+                if selection in condition_list:
                     continue
+
                 # find all wildcards in condition
                 found = False
                 for wildcard_selection in wildcard_selections.findall(condition):


### PR DESCRIPTION
This PR aims to fix a bug in the `test_unused_selection` test where if `selections` name is included in the condition. Where not included in the test. 

For example, if you use `sel` as a selection name and a condition of `all of selection_*`. The test will consider `sel` as part of `selection_` and skip it.

The fix removes special keywords from the condition and converts it to a list to do an exact match. 