### PR TITLE
feat: enhance single item lists test

### DIFF
--- a/rules/application/antivirus/av_hacktool.yml
+++ b/rules/application/antivirus/av_hacktool.yml
@@ -19,8 +19,7 @@ detection:
             - 'HKTL'
             - 'SecurityTool'
             - 'ATK/'  # Sophos
-        - Signature|contains:
-            - 'Hacktool'
+        - Signature|contains: 'Hacktool'
     condition: selection
 fields:
     - FileName

--- a/rules/windows/builtin/system/win_system_service_install_hacktools.yml
+++ b/rules/windows/builtin/system/win_system_service_install_hacktools.yml
@@ -28,8 +28,7 @@ detection:
             - 'pwdump'
             - 'gsecdump'
             - 'cachedump'
-        - ImagePath|contains:
-            - 'bypass' # https://gist.github.com/tyranid/c24cfd1bd141d14d4925043ee7e03c82#file-scmuacbypass-cpp-L159
+        - ImagePath|contains: 'bypass' # https://gist.github.com/tyranid/c24cfd1bd141d14d4925043ee7e03c82#file-scmuacbypass-cpp-L159
     condition: service and selection
 falsepositives:
     - Unknown

--- a/rules/windows/file/file_event/file_event_win_hivenightmare_file_exports.yml
+++ b/rules/windows/file/file_event/file_event_win_hivenightmare_file_exports.yml
@@ -26,8 +26,7 @@ detection:
             - '\SAM-2023-'  # C++ version
             - '\SAM-haxx'   # Early C++ versions
             - '\Sam.save'   # PowerShell version
-        - TargetFilename:
-            - 'C:\windows\temp\sam'  # C# version of HiveNightmare
+        - TargetFilename: 'C:\windows\temp\sam'  # C# version of HiveNightmare
     condition: selection
 fields:
     - CommandLine

--- a/rules/windows/image_load/image_load_abusing_azure_browser_sso.yml
+++ b/rules/windows/image_load/image_load_abusing_azure_browser_sso.yml
@@ -30,8 +30,7 @@ detection:
             - '\AppData\Local\Microsoft\OneDrive\OneDrive.exe'
             - '\msedgewebview2.exe'
             - '\OneDrive.exe'
-        - Image|startswith:
-            - 'C:\Program Files (x86)\Microsoft\EdgeWebView\Application\'
+        - Image|startswith: 'C:\Program Files (x86)\Microsoft\EdgeWebView\Application\'
         - Image: null
     condition: selection_dll and not filter_legit
 falsepositives:

--- a/rules/windows/image_load/image_load_susp_python_image_load.yml
+++ b/rules/windows/image_load/image_load_susp_python_image_load.yml
@@ -18,8 +18,7 @@ detection:
     selection:
         Description: 'Python Core'
     filter_generic:
-        - Image|contains:
-            - 'Python'  # FPs with python38.dll, python.exe etc.
+        - Image|contains: 'Python'  # FPs with python38.dll, python.exe etc.
         - Image|startswith:
             - 'C:\Program Files\'
             - 'C:\Program Files (x86)\'

--- a/rules/windows/network_connection/net_connection_win_rdp_reverse_tunnel.yml
+++ b/rules/windows/network_connection/net_connection_win_rdp_reverse_tunnel.yml
@@ -22,10 +22,8 @@ detection:
         Initiated: 'true'
         SourcePort: 3389
     selection2:
-        - DestinationIp|startswith:
-            - '127.'
-        - DestinationIp:
-            - '::1'
+        - DestinationIp|startswith: '127.'
+        - DestinationIp: '::1'
     condition: selection and selection2
 falsepositives:
     - Unknown

--- a/rules/windows/network_connection/net_connection_win_rundll32_net_connections.yml
+++ b/rules/windows/network_connection/net_connection_win_rundll32_net_connections.yml
@@ -43,8 +43,7 @@ detection:
             - '51.103.' # Microsoft range, caused some FPs
             - '51.104.' # Microsoft range, caused some FPs
             - '51.105.' # Microsoft range, caused some FPs
-        - CommandLine|contains:
-            - 'PcaSvc.dll,PcaPatchSdbTask'
+        - CommandLine|contains: 'PcaSvc.dll,PcaPatchSdbTask'
     filter_update_processes:
         ParentImage: 'C:\Windows\System32\svchost.exe'
         RemoteAddress|endswith: ':443'

--- a/rules/windows/network_connection/net_connection_win_susp_prog_location_network_connection.yml
+++ b/rules/windows/network_connection/net_connection_win_susp_prog_location_network_connection.yml
@@ -27,10 +27,8 @@ detection:
             - '\Windows\Fonts\'
             - '\Windows\IME\'
             - '\Windows\addins\'
-        - Image|endswith:
-            - '\$Recycle.bin'
-        - Image|startswith:
-            - 'C:\Perflogs\'
+        - Image|endswith: '\$Recycle.bin'
+        - Image|startswith: 'C:\Perflogs\'
     false_positive1:
         Image|startswith: 'C:\Users\Public\IBM\ClientSolutions\Start_Programs\' # IBM Client Solutions Default Location
     condition: selection and not 1 of false_positive*

--- a/rules/windows/powershell/powershell_script/posh_ps_set_policies_to_unsecure_level.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_set_policies_to_unsecure_level.yml
@@ -25,8 +25,7 @@ detection:
             - 'bypass'
             - 'RemoteSigned'
     filter:
-        - ParentImage:
-            - 'C:\ProgramData\chocolatey\choco.exe'
+        - ParentImage: 'C:\ProgramData\chocolatey\choco.exe'
         - ScriptBlockText|contains:
             - "(New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')"
             - "(New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')"

--- a/rules/windows/process_creation/proc_creation_win_apt_hurricane_panda.yml
+++ b/rules/windows/process_creation/proc_creation_win_apt_hurricane_panda.yml
@@ -20,8 +20,7 @@ detection:
             - 'localgroup'
             - 'admin'
             - '/add'
-        - CommandLine|contains:
-            - '\Win64.exe'
+        - CommandLine|contains: '\Win64.exe'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_mmc_spawn_shell.yml
+++ b/rules/windows/process_creation/proc_creation_win_mmc_spawn_shell.yml
@@ -27,8 +27,7 @@ detection:
             - '\bash.exe'
             - '\reg.exe'
             - '\regsvr32.exe'
-        - Image|contains:
-            - '\BITSADMIN'
+        - Image|contains: '\BITSADMIN'
     condition: all of selection*
 fields:
     - CommandLine

--- a/rules/windows/process_creation/proc_creation_win_mshta_spawn_shell.yml
+++ b/rules/windows/process_creation/proc_creation_win_mshta_spawn_shell.yml
@@ -30,8 +30,7 @@ detection:
             - '\bash.exe'
             - '\reg.exe'
             - '\regsvr32.exe'
-        - Image|contains:
-            - '\BITSADMIN'
+        - Image|contains: '\BITSADMIN'
     condition: all of selection*
 fields:
     - CommandLine

--- a/rules/windows/registry/registry_event/registry_event_mal_flowcloud.yml
+++ b/rules/windows/registry/registry_event/registry_event_mal_flowcloud.yml
@@ -19,8 +19,7 @@ detection:
             - 'HKLM\HARDWARE\{804423C2-F490-4ac3-BFA5-13DEDE63A71A}'
             - 'HKLM\HARDWARE\{A5124AF5-DF23-49bf-B0ED-A18ED3DEA027}'
             - 'HKLM\HARDWARE\{2DB80286-1784-48b5-A751-B6ED1F490303}'
-        - TargetObject|startswith:
-            - 'HKLM\SYSTEM\Setup\PrintResponsor\'
+        - TargetObject|startswith: 'HKLM\SYSTEM\Setup\PrintResponsor\'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/registry/registry_set/registry_set_susp_reg_persist_explorer_run.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_reg_persist_explorer_run.yml
@@ -25,8 +25,7 @@ detection:
             - 'C:\Temp\'
             - 'C:\Users\Public\'
             - 'C:\Users\Default\'
-        - Details|contains:
-            - '\AppData\'
+        - Details|contains: '\AppData\'
     condition: selection and selection2
 fields:
     - Image

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -838,32 +838,59 @@ class TestRules(unittest.TestCase):
                          "There are rules with non-conform 'logsource' fields. Please check: https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide#log-source")
 
     def test_selection_list_one_value(self):
+    
+        def treat_list(file, values, valid_, selection_name):
+            # rule with only list of Keywords term
+            if len(values) == 1 and not isinstance(values[0], str):
+                print(
+                    Fore.RED + "Rule {} has the selection ({}) with a list of only 1 element in detection".format(file, key)
+                )
+                valid_ = False
+            elif isinstance(values[0], dict):
+                valid_ = treat_dict(file, values, valid_, selection_name)
+            return valid_
+
+        def treat_dict(file, values, valid_, selection_name):
+            if isinstance(values, list):
+                for dict_ in values:
+                    for key_ in dict_.keys():
+                        if isinstance(dict_[key_], list):
+                            if len(dict_[key_]) == 1:
+                                print(
+                                    Fore.RED + "Rule {} has the selection ({}/{}) with a list of only 1 value in detection".format(file, selection_name, key_)
+                                    )
+                                valid_ = False
+            else:
+                dict_ = values
+                for key_ in dict_.keys():
+                    if isinstance(dict_[key_], list):
+                        if len(dict_[key_]) == 1:
+                            print(
+                                Fore.RED + "Rule {} has the selection ({}/{}) with a list of only 1 value in detection".format(file, selection_name, key_)
+                                )
+                            valid_ = False
+            return valid_
+
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             detection = self.get_rule_part(
                 file_path=file, part_name="detection")
             if detection:
+                
                 valid = True
                 for key in detection:
+                    values = detection[key]
                     if isinstance(detection[key], list):
-                        # rule with only list of Keywords term
-                        if len(detection[key]) == 1 and not isinstance(detection[key][0], str):
-                            print(
-                                Fore.RED + "Rule {} has the selection ({}) with a list of only 1 element in detection".format(file, key))
-                            valid = False
+                        valid = treat_list(file, values, valid, key)
+                    
                     if isinstance(detection[key], dict):
-                        for sub_key in detection[key]:
-                            # split in 2 if as get a error "int has not len()"
-                            if isinstance(detection[key][sub_key], list):
-                                if len(detection[key][sub_key]) == 1:
-                                    print(
-                                        Fore.RED + "Rule {} has the selection ({}/{}) with a list of only 1 value in detection".format(file, key, sub_key))
-                                    valid = False
+                        valid = treat_dict(file, values, valid, key)
+
                     if not valid:
                         faulty_rules.append(file)
-
+                        
         self.assertEqual(faulty_rules, [], Fore.RED +
-                         "There are rules using list with only 1 element")
+                            "There are rules using list with only 1 element")
 
     def test_unused_selection(self):
         faulty_rules = []


### PR DESCRIPTION
This PR fixes a bug in the test where the usage of a field with `or`/`-` operator inside the selection would skip the test. And one could write single-item lists.

The fix is done by looking if items parsed from the selection are lists or dict. Here is an example

```yml
selection:
        - Image|contains:
            # - '\ProgramData\'  # too many false positives, e.g. with Webex for Windows
            - '\Users\All Users\'
            - '\Users\Default\'
            - '\Users\Public\'
            - '\Users\Contacts\'
            - '\Users\Searches\'
            - '\config\systemprofile\'
            - '\Windows\Fonts\'
            - '\Windows\IME\'
            - '\Windows\addins\'
        - Image|endswith: '\$Recycle.bin'
        - Image|startswith: 'C:\Perflogs\'
```

When this is parsed we get the following

```python
[{'Image|contains': ['\\Users\\All Users\\', '\\Users\\Default\\', '\\Users\\Public\\', '\\Users\\Contacts\\', '\\Users\\Searches\\', '\\config\\systemprofile\\', '\\Windows\\Fonts\\', '\\Windows\\IME\\', '\\Windows\\addins\\']}, {'Image|endswith': ['\\$Recycle.bin']}, {'Image|startswith': ['C:\\Perflogs\\']}]

{'Image|startswith': 'C:\\Users\\Public\\IBM\\ClientSolutions\\Start_Programs\\'}

selection and not 1 of false_positive*
```

The `selection` is a list of dict instead of the expected dict. The code handles this case by extracting the dict and applying the old logic.