### PR TITLE
New Rule: Suspicious Use of Rcedit Utility to Alter Executable Metadata

### DIFF
--- a/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
+++ b/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
@@ -34,4 +34,4 @@ detection:
     condition: selection1 and selection2
 falsepositives:
     - Unknown
-level: high
+level: medium

--- a/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
+++ b/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
@@ -1,0 +1,37 @@
+title: Suspicious Use of rcedit utility
+id: 0c92f2e6-f08f-4b73-9216-ecb0ca634689
+status: experimental
+description: Detects the suspicious child use of rcedit to potentially alter executable PE metadata properties, which could conceal efforts to rename system utilities for defense evasion.
+references:
+    - https://security.stackexchange.com/questions/210843/is-it-possible-to-change-original-filename-of-an-exe
+    - https://www.virustotal.com/gui/file/02e8e8c5d430d8b768980f517b62d7792d690982b9ba0f7e04163cbc1a6e7915
+    - https://github.com/electron/rcedit
+author: Micah Babinski
+date: 2022/12/11
+tags:
+    - attack.defense_evasion
+    - attack.t1036.003
+    - attack.t1036
+    - attack.t1027.005
+    - attack.t1027
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection1:
+        Image|endswith:
+            - '\rcedit-x64.exe'
+            - '\rcedit-x86.exe'
+        CommandLine|contains: '--set-resource-string'
+    selection2:
+        CommandLine|contains:
+            - 'OriginalFileName'
+            - 'CompanyName'
+            - 'FileDescription'
+            - 'ProductName'
+            - 'ProductVersion'
+            - 'LegalCopyright'
+    condition: selection1 and selection2
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
+++ b/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
@@ -1,7 +1,7 @@
-title: Suspicious Use of rcedit utility
+title: Suspicious Use of Rcedit Utility to Alter Executable Metadata
 id: 0c92f2e6-f08f-4b73-9216-ecb0ca634689
 status: experimental
-description: Detects the suspicious child use of rcedit to potentially alter executable PE metadata properties, which could conceal efforts to rename system utilities for defense evasion.
+description: Detects the suspicious use of rcedit to potentially alter executable PE metadata properties, which could conceal efforts to rename system utilities for defense evasion.
 references:
     - https://security.stackexchange.com/questions/210843/is-it-possible-to-change-original-filename-of-an-exe
     - https://www.virustotal.com/gui/file/02e8e8c5d430d8b768980f517b62d7792d690982b9ba0f7e04163cbc1a6e7915

--- a/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
+++ b/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
@@ -1,4 +1,4 @@
-title: Potential Metadata Tamper Using Rcedit
+title: Potential PE Metadata Tamper Using Rcedit
 id: 0c92f2e6-f08f-4b73-9216-ecb0ca634689
 status: experimental
 description: Detects the use of rcedit to potentially alter executable PE metadata properties, which could conceal efforts to rename system utilities for defense evasion.

--- a/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
+++ b/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
@@ -25,8 +25,7 @@ detection:
         - Description: 'Edit resources of exe'
         - Product: 'rcedit'
     selection_flags:
-        CommandLine|contains:
-            - '--set-' # Covers multiple edit commands such as "--set-resource-string" or "--set-version-string"
+        CommandLine|contains: '--set-' # Covers multiple edit commands such as "--set-resource-string" or "--set-version-string"
     selection_attributes:
         CommandLine|contains:
             - 'OriginalFileName'

--- a/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
+++ b/rules/windows/process_creation/proc_creation_susp_rcedit_execution.yml
@@ -1,7 +1,7 @@
-title: Suspicious Use of Rcedit Utility to Alter Executable Metadata
+title: Potential Metadata Tamper Using Rcedit
 id: 0c92f2e6-f08f-4b73-9216-ecb0ca634689
 status: experimental
-description: Detects the suspicious use of rcedit to potentially alter executable PE metadata properties, which could conceal efforts to rename system utilities for defense evasion.
+description: Detects the use of rcedit to potentially alter executable PE metadata properties, which could conceal efforts to rename system utilities for defense evasion.
 references:
     - https://security.stackexchange.com/questions/210843/is-it-possible-to-change-original-filename-of-an-exe
     - https://www.virustotal.com/gui/file/02e8e8c5d430d8b768980f517b62d7792d690982b9ba0f7e04163cbc1a6e7915
@@ -18,12 +18,16 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection1:
-        Image|endswith:
+    selection_img:
+        - Image|endswith:
             - '\rcedit-x64.exe'
             - '\rcedit-x86.exe'
-        CommandLine|contains: '--set-resource-string'
-    selection2:
+        - Description: 'Edit resources of exe'
+        - Product: 'rcedit'
+    selection_flags:
+        CommandLine|contains:
+            - '--set-' # Covers multiple edit commands such as "--set-resource-string" or "--set-version-string"
+    selection_attributes:
         CommandLine|contains:
             - 'OriginalFileName'
             - 'CompanyName'
@@ -31,7 +35,7 @@ detection:
             - 'ProductName'
             - 'ProductVersion'
             - 'LegalCopyright'
-    condition: selection1 and selection2
+    condition: all of selection_*
 falsepositives:
-    - Unknown
+    - Legitimate use of the tool by administrators or users to update metadata of a binary
 level: medium


### PR DESCRIPTION
Rcedit can be used to modify the properties of an executable like OriginalFileName, Description, and other properties that are used to detect renamed binaries. If one were to search for "how to modify Windows PE OriginalFilename property" this tool pops right up. See https://security.stackexchange.com/questions/210843/is-it-possible-to-change-original-filename-of-an-exe.