### PR TITLE
Update proc_creation_win_rundll32_parent_explorer.yml

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
+++ b/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
@@ -1,12 +1,12 @@
 title: Rundll32 With Suspicious Parent Process
 id: 1723e720-616d-4ddc-ab02-f7e3685a4713
 status: experimental
-description: Detects suspicious start of rundll32.exe with a parent process of Explorer.exe. Variant of Raspberry Robin, as first reported by Red Canary.
+description: Detects suspicious start of rundll32.exe with a parent process of Explorer.exe. Variant of Raspberry Robin, as first reported by Red Canary.  Does not detect explorer executing rundll32.exe with a DLL already present in the system folder.
 references:
     - https://redcanary.com/blog/raspberry-robin/
     - https://thedfirreport.com/2022/09/26/bumblebee-round-two/
 author: CD_ROM_
-date: 2022/05/21
+date: 2022/12/15
 tags:
     - attack.defense_evasion
 logsource:
@@ -17,7 +17,9 @@ detection:
         Image|endswith: '\rundll32.exe'
         ParentImage|endswith: '\explorer.exe'
     filter:
-        CommandLine|contains: '\shell32.dll,OpenAs_RunDLL'
+        - CommandLine|contains: '\shell32.dll,OpenAs_RunDLL'
+        - CommandLine|contains: 'rundll32.exe" C:\Windows\System32\'
+        - CommandLine|contains: 'rundll32.exe C:\Windows\System32\'
     condition: selection and not filter
 fields:
     - Image

--- a/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
+++ b/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
@@ -18,9 +18,7 @@ detection:
         Image|endswith: '\rundll32.exe'
         ParentImage|endswith: '\explorer.exe'
     filter:
-        - CommandLine|contains: '\shell32.dll,OpenAs_RunDLL'
-        - CommandLine|contains: 'rundll32.exe" C:\Windows\System32\'
-        - CommandLine|contains: 'rundll32.exe C:\Windows\System32\'
+        CommandLine|contains: ' C:\Windows\System32\' # The space at the start is required
     condition: selection and not filter
 fields:
     - Image

--- a/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
+++ b/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
@@ -6,7 +6,8 @@ references:
     - https://redcanary.com/blog/raspberry-robin/
     - https://thedfirreport.com/2022/09/26/bumblebee-round-two/
 author: CD_ROM_
-date: 2022/12/15
+date: 2022/05/21
+modified: 2022/12/15
 tags:
     - attack.defense_evasion
 logsource:

--- a/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
+++ b/rules/windows/process_creation/proc_creation_win_rundll32_parent_explorer.yml
@@ -1,7 +1,7 @@
 title: Rundll32 With Suspicious Parent Process
 id: 1723e720-616d-4ddc-ab02-f7e3685a4713
 status: experimental
-description: Detects suspicious start of rundll32.exe with a parent process of Explorer.exe. Variant of Raspberry Robin, as first reported by Red Canary.  Does not detect explorer executing rundll32.exe with a DLL already present in the system folder.
+description: Detects suspicious start of rundll32.exe with a parent process of Explorer.exe. Variant of Raspberry Robin, as first reported by Red Canary. 
 references:
     - https://redcanary.com/blog/raspberry-robin/
     - https://thedfirreport.com/2022/09/26/bumblebee-round-two/


### PR DESCRIPTION
Remove the false positive of explorer.exe launching rundll32.exe to load a DLL already present on the system.  The specific false positive case we encountered was "CommandLine": "\"C:\\Windows\\System32\\rundll32.exe\" C:\\Windows\\System32\\LogiLDA.dll,LogiFetch".  The BumbleBee case loaded a DLL from the ISO so that should still be detected.