### PR TITLE
Remove Logitech auto-updater false positive

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_service_stop.yml
+++ b/rules/windows/process_creation/proc_creation_win_service_stop.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects a windows service to be stopped
 author: Jakob Weinzettl, oscd.community, Nasreddine Bencherchali
 date: 2019/10/23
-modified: 2022/09/01
+modified: 2022/12/22
 tags:
     - attack.impact
     - attack.t1489

--- a/rules/windows/process_creation/proc_creation_win_service_stop.yml
+++ b/rules/windows/process_creation/proc_creation_win_service_stop.yml
@@ -29,7 +29,9 @@ detection:
             - '\pwsh.exe'
         CommandLine|contains: 'Stop-Service '
     filter:
-        CommandLine: 'sc  stop KSCWebConsoleMessageQueue' # kaspersky Security Center Web Console double space between sc and stop
+        CommandLine: 
+             - 'sc  stop KSCWebConsoleMessageQueue' # kaspersky Security Center Web Console double space between sc and stop
+             - 'sc  stop LGHUBUpdaterService' # Logitech LGHUB Updater Service
         User|contains: # covers many language settings
             - 'AUTHORI'
             - 'AUTORI'


### PR DESCRIPTION
This service gets stopped during the Logitech LGHUB auto-update process.  Specifically by this process:

```
	"CommandLine": "\"C:\\WINDOWS\\TEMP\\lghub_updater.exe\" --uninstall",
```