### PR TITLE
fix: rename links from old repo to SigmaHQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sigma is for log files what [Snort](https://www.snort.org/) is for network traff
 
 This repository contains:
 
-1. Sigma rule specification in the [Wiki](https://github.com/Neo23x0/sigma/wiki/Specification)
+1. Sigma rule specification in the [Sigma-Specification](https://github.com/SigmaHQ/sigma-specification) repository
 2. Open repository for sigma signatures in the `./rules` subfolder
 3. A converter named `sigmac` located in the `./tools/` sub folder that generates search queries for different SIEM systems from Sigma rules
 
@@ -52,7 +52,7 @@ See the first slide deck that I prepared for a private conference in mid January
 
 # Specification
 
-The specifications can be found in the [Wiki](https://github.com/Neo23x0/sigma/wiki/Specification).
+The specifications can be found in the [Sigma-Specification](https://github.com/SigmaHQ/sigma-specification) repository.
 
 The current specification is a proposal. Feedback is requested.
 
@@ -69,7 +69,7 @@ Florian wrote a short [rule creation tutorial](https://www.nextron-systems.com/2
 3. Run `python sigmac --help` in folder `./tools` to get a help on the rule converter
 4. Convert a rule of your choice with `sigmac` like `./sigmac -t splunk -c config/generic/sysmon.yml ../rules/windows/process_creation/proc_creation_win_susp_whoami.yml`
 5. Convert a whole rule directory with `python sigmac -t splunk -r ../rules/proxy/`
-6. Check the `./tools/config` folder and the [wiki](https://github.com/Neo23x0/sigma/wiki/Converter-Tool-Sigmac) if you need custom field or log source mappings in your environment
+6. Check the `./tools/config` folder and the [Sigma-Specification](https://github.com/SigmaHQ/sigma-specification) repository if you need custom field or log source mappings in your environment
 
 ## Troubles / Troubleshooting / Help
 

--- a/rules-unsupported/driver_load_invoke_obfuscation_clip+_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_clip+_services.yml
@@ -9,7 +9,7 @@ author: Jonathan Cheong, oscd.community
 date: 2020/10/13
 modified: 2021/09/16
 references:
-     - https://github.com/Neo23x0/sigma/issues/1009 #(Task 26)
+     - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 26)
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules-unsupported/driver_load_invoke_obfuscation_stdin+_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_stdin+_services.yml
@@ -9,7 +9,7 @@ author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2021/09/17
 references:
-     - https://github.com/Neo23x0/sigma/issues/1009 #(Task 25)
+     - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 25)
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules-unsupported/driver_load_invoke_obfuscation_var+_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_var+_services.yml
@@ -9,7 +9,7 @@ author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2021/09/17
 references:
-     - https://github.com/Neo23x0/sigma/issues/1009 #(Task 24)
+     - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 24)
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules-unsupported/driver_load_invoke_obfuscation_via_compress_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_via_compress_services.yml
@@ -9,7 +9,7 @@ author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/03/08
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 19)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 19)
 logsource:
     product: windows
     category: driver_load

--- a/rules-unsupported/driver_load_invoke_obfuscation_via_rundll_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_via_rundll_services.yml
@@ -9,7 +9,7 @@ author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/03/08
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 23)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 23)
 logsource:
     product: windows
     category: driver_load

--- a/rules-unsupported/driver_load_invoke_obfuscation_via_stdin_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_via_stdin_services.yml
@@ -9,7 +9,7 @@ author: Nikita Nazarov, oscd.community
 date: 2020/10/12
 modified: 2021/09/18
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task28)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task28)
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules-unsupported/driver_load_invoke_obfuscation_via_use_clip_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_via_use_clip_services.yml
@@ -9,7 +9,7 @@ author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/04/26
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task29)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task29)
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules-unsupported/driver_load_invoke_obfuscation_via_use_mshta_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_via_use_mshta_services.yml
@@ -9,7 +9,7 @@ author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/03/08
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task31)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task31)
 logsource:
     product: windows
     category: driver_load

--- a/rules-unsupported/driver_load_invoke_obfuscation_via_use_rundll32_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_via_use_rundll32_services.yml
@@ -9,7 +9,7 @@ author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/03/08
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task30)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task30)
 logsource:
     product: windows
     category: driver_load

--- a/rules-unsupported/driver_load_invoke_obfuscation_via_var++_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_via_var++_services.yml
@@ -9,7 +9,7 @@ author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
 modified: 2021/09/18
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task27)
 tags:
     - attack.defense_evasion
     - attack.t1027

--- a/rules/network/zeek/zeek_smb_converted_win_atsvc_task.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_atsvc_task.yml
@@ -1,12 +1,15 @@
 title: Remote Task Creation via ATSVC Named Pipe - Zeek
 id: dde85b37-40cd-4a94-b00c-0b8794f956b5
+related:
+    - id: f6de6525-4509-495a-8a82-1f8b0ed73a00
+      type: derived
 status: test
 description: Detects remote task creation via at.exe or API interacting with ATSVC namedpipe
 references:
-    - https://github.com/neo23x0/sigma/blob/d42e87edd741dd646db946f30964f331f92f50e6/rules/windows/builtin/win_atsvc_task.yml
+    - https://blog.menasec.net/2019/03/threat-hunting-25-scheduled-tasks-for.html
 author: 'Samir Bousseaden, @neu5rn'
 date: 2020/04/03
-modified: 2021/11/27
+modified: 2022/12/27
 tags:
     - attack.lateral_movement
     - attack.persistence
@@ -18,8 +21,8 @@ logsource:
     service: smb_files
 detection:
     selection:
-        path: \\\*\IPC$
-        name: atsvc
+        path: '\\\*\IPC$'
+        name: 'atsvc'
         #Accesses: '*WriteData*'
     condition: selection
 falsepositives:

--- a/rules/network/zeek/zeek_smb_converted_win_lm_namedpipe.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_lm_namedpipe.yml
@@ -1,12 +1,15 @@
 title: First Time Seen Remote Named Pipe - Zeek
 id: 021310d9-30a6-480a-84b7-eaa69aeb92bb
+related:
+    - id: 52d8b0c6-53d6-439a-9e41-52ad442ad9ad
+      type: derived
 status: test
 description: This detection excludes known namped pipes accessible remotely and notify on newly observed ones, may help to detect lateral movement and remote exec using named pipes
 references:
-    - https://github.com/neo23x0/sigma/blob/d42e87edd741dd646db946f30964f331f92f50e6/rules/windows/builtin/win_lm_namedpipe.yml
+    - https://twitter.com/menasec1/status/1104489274387451904
 author: Samir Bousseaden, @neu5ron, Tim Shelton
 date: 2020/04/02
-modified: 2022/10/10
+modified: 2022/12/27
 tags:
     - attack.lateral_movement
     - attack.t1021.002
@@ -14,9 +17,9 @@ logsource:
     product: zeek
     service: smb_files
 detection:
-    selection1:
-        path: \\\*\IPC$
-    selection2:
+    selection:
+        path: '\\\\\*\\IPC$' # Looking for the string \\*\IPC$
+    filter_keywords:
         - 'samr'
         - 'lsarpc'
         - 'winreg'
@@ -33,7 +36,7 @@ detection:
         - 'HydraLsPipe'
         - 'TermSrv_API_service'
         - 'MsFteWds'
-    condition: selection1 and not selection2
+    condition: selection and not 1 of filter_*
 falsepositives:
     - Update the excluded named pipe to filter out any newly observed legit named pipe
 level: high

--- a/rules/network/zeek/zeek_smb_converted_win_susp_psexec.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_susp_psexec.yml
@@ -1,12 +1,15 @@
 title: Suspicious PsExec Execution - Zeek
 id: f1b3a22a-45e6-4004-afb5-4291f9c21166
+related:
+    - id: c462f537-a1e3-41a6-b5fc-b2c2cef9bf82
+      type: derived
 status: test
 description: detects execution of psexec or paexec with renamed service name, this rule helps to filter out the noise if psexec is used for legit purposes or if attacker uses a different psexec client other than sysinternal one
 references:
-    - https://github.com/neo23x0/sigma/blob/d42e87edd741dd646db946f30964f331f92f50e6/rules/windows/builtin/win_susp_psexec.yml
+    - https://blog.menasec.net/2019/02/threat-hunting-3-detecting-psexec.html
 author: Samir Bousseaden, @neu5ron, Tim Shelton
 date: 2020/04/02
-modified: 2022/10/10
+modified: 2022/12/27
 tags:
     - attack.lateral_movement
     - attack.t1021.002
@@ -14,7 +17,7 @@ logsource:
     product: zeek
     service: smb_files
 detection:
-    selection1:
+    selection:
         path|contains|all:
             - '\\'
             - '\IPC$'
@@ -22,9 +25,9 @@ detection:
             - '-stdin'
             - '-stdout'
             - '-stderr'
-    selection2:
-        name|startswith: 'PSEXESVC' #
-    condition: selection1 and not selection2
+    filter:
+        name|startswith: 'PSEXESVC'
+    condition: selection and not filter
 falsepositives:
     - Unknown
 level: high

--- a/rules/network/zeek/zeek_smb_converted_win_susp_raccess_sensitive_fext.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_susp_raccess_sensitive_fext.yml
@@ -1,9 +1,10 @@
 title: Suspicious Access to Sensitive File Extensions - Zeek
 id: 286b47ed-f6fe-40b3-b3a8-35129acd43bc
+related:
+    - id: 91c945bc-2ad1-4799-a591-4d00198a1215
+      type: derived
 status: test
 description: Detects known sensitive file extensions via Zeek
-references:
-    - https://github.com/neo23x0/sigma/blob/d42e87edd741dd646db946f30964f331f92f50e6/rules/windows/builtin/win_susp_raccess_sensitive_fext.yml
 author: 'Samir Bousseaden, @neu5ron'
 date: 2020/04/02
 modified: 2021/11/27

--- a/rules/network/zeek/zeek_smb_converted_win_transferring_files_with_credential_data.yml
+++ b/rules/network/zeek/zeek_smb_converted_win_transferring_files_with_credential_data.yml
@@ -1,9 +1,12 @@
 title: Transferring Files with Credential Data via Network Shares - Zeek
 id: 2e69f167-47b5-4ae7-a390-47764529eff5
+related:
+    - id: 910ab938-668b-401b-b08c-b596e80fdca5
+      type: similar
 status: test
 description: Transferring files with well-known filenames (sensitive files with credential data) using network shares
 references:
-    - https://github.com/neo23x0/sigma/blob/373424f14574facf9e261d5c822345a282b91479/rules/windows/builtin/win_transferring_files_with_credential_data_via_network_shares.yml
+    - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 author: '@neu5ron, Teymur Kheirkhabarov, oscd.community'
 date: 2020/04/02
 modified: 2021/11/27

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_clip_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_clip_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated use of Clip.exe to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 26)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 26)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
 modified: 2022/11/27

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_stdin_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_stdin_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated use of stdin to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 25)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 25)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/11/29

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_var_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_var_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated use of Environment Variables to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/11/29

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_via_compress_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_via_compress_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via COMPRESS OBFUSCATION
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 19)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 19)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/11/29

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_via_rundll_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_via_rundll_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via RUNDLL LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 23)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 23)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/11/29

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_via_stdin_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_via_stdin_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via Stdin in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task28)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task28)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/12
 modified: 2022/11/29

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_via_use_clip_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_via_use_clip_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via use Clip.exe in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task29)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task29)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/11/29

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_via_use_mshta_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_via_use_mshta_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via use MSHTA in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task31)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task31)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/11/29

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_via_use_rundll32_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_via_use_rundll32_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via use Rundll32 in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task30)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task30)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/11/29

--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_via_var_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_via_var_services_security.yml
@@ -6,7 +6,7 @@ related:
 status: test
 description: Detects Obfuscated Powershell via VAR++ LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
 modified: 2022/11/29

--- a/rules/windows/builtin/security/win_security_possible_dc_shadow.yml
+++ b/rules/windows/builtin/security/win_security_possible_dc_shadow.yml
@@ -1,9 +1,11 @@
 title: Possible DC Shadow Attack
 id: 32e19d25-4aed-4860-a55a-be99cb0bf7ed
+related:
+    - id: 611eab06-a145-4dfa-a295-3ccc5c20f59a
+      type: derived
 status: experimental
 description: Detects DCShadow via create new SPN
 references:
-    - https://github.com/Neo23x0/sigma/blob/ec5bb710499caae6667c7f7311ca9e92c03b9039/rules/windows/builtin/win_dcsync.yml
     - https://twitter.com/gentilkiwi/status/1003236624925413376
     - https://gist.github.com/gentilkiwi/dcc132457408cf11ad2061340dcb53c2
     - https://blog.alsid.eu/dcshadow-explained-4510f52fc19d

--- a/rules/windows/builtin/security/win_security_susp_raccess_sensitive_fext.yml
+++ b/rules/windows/builtin/security/win_security_susp_raccess_sensitive_fext.yml
@@ -1,5 +1,8 @@
 title: Suspicious Access to Sensitive File Extensions
 id: 91c945bc-2ad1-4799-a591-4d00198a1215
+related:
+    - id: 286b47ed-f6fe-40b3-b3a8-35129acd43bc
+      type: similar
 status: test
 description: Detects known sensitive file extensions accessed on a network share
 author: Samir Bousseaden

--- a/rules/windows/builtin/security/win_security_transf_files_with_cred_data_via_network_shares.yml
+++ b/rules/windows/builtin/security/win_security_transf_files_with_cred_data_via_network_shares.yml
@@ -1,5 +1,8 @@
 title: Transferring Files with Credential Data via Network Shares
 id: 910ab938-668b-401b-b08c-b596e80fdca5
+related:
+    - id: 2e69f167-47b5-4ae7-a390-47764529eff5
+      type: similar
 status: test
 description: Transferring files with well-known filenames (sensitive files with credential data) using network shares
 references:

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_clip_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_clip_services.yml
@@ -3,7 +3,7 @@ id: f7385ee2-0e0c-11eb-adc1-0242ac120002
 status: experimental
 description: Detects Obfuscated use of Clip.exe to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 26)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 26)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
 modified: 2022/11/27

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_stdin_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_stdin_services.yml
@@ -3,7 +3,7 @@ id: 72862bf2-0eb1-11eb-adc1-0242ac120002
 status: experimental
 description: Detects Obfuscated use of stdin to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 25)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 25)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/11/29

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_var_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_var_services.yml
@@ -3,7 +3,7 @@ id: 8ca7004b-e620-4ecb-870e-86129b5b8e75
 status: experimental
 description: Detects Obfuscated use of Environment Variables to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/11/29

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_via_compress_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_via_compress_services.yml
@@ -3,7 +3,7 @@ id: 175997c5-803c-4b08-8bb0-70b099f47595
 status: experimental
 description: Detects Obfuscated Powershell via COMPRESS OBFUSCATION
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 19)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 19)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/11/29

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_via_rundll_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_via_rundll_services.yml
@@ -3,7 +3,7 @@ id: 11b52f18-aaec-4d60-9143-5dd8cc4706b9
 status: experimental
 description: Detects Obfuscated Powershell via RUNDLL LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 23)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 23)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/11/29

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_via_stdin_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_via_stdin_services.yml
@@ -3,7 +3,7 @@ id: 487c7524-f892-4054-b263-8a0ace63fc25
 status: experimental
 description: Detects Obfuscated Powershell via Stdin in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task28)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task28)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/12
 modified: 2022/11/29

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_via_use_clip_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_via_use_clip_services.yml
@@ -3,7 +3,7 @@ id: 63e3365d-4824-42d8-8b82-e56810fefa0c
 status: experimental
 description: Detects Obfuscated Powershell via use Clip.exe in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task29)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task29)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/11/29

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_via_use_mshta_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_via_use_mshta_services.yml
@@ -3,7 +3,7 @@ id: 7e9c7999-0f9b-4d4a-a6ed-af6d553d4af4
 status: experimental
 description: Detects Obfuscated Powershell via use MSHTA in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task31)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task31)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/11/29

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_via_use_rundll32_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_via_use_rundll32_services.yml
@@ -3,7 +3,7 @@ id: 641a4bfb-c017-44f7-800c-2aee0184ce9b
 status: experimental
 description: Detects Obfuscated Powershell via use Rundll32 in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task30)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task30)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/11/29

--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_via_var_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_via_var_services.yml
@@ -3,7 +3,7 @@ id: 14bcba49-a428-42d9-b943-e2ce0f0f7ae6
 status: experimental
 description: Detects Obfuscated Powershell via VAR++ LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
 modified: 2022/11/29

--- a/rules/windows/file/file_event/file_event_win_powershell_exploit_scripts.yml
+++ b/rules/windows/file/file_event/file_event_win_powershell_exploit_scripts.yml
@@ -1,9 +1,11 @@
 title: Malicious PowerShell Commandlet Names
 id: f331aa1f-8c53-4fc3-b083-cc159bc971cb
+related:
+    - id: 89819aa4-bbd6-46bc-88ec-c7f7fe30efa6
+      type: similar
 status: test
 description: Detects the creation of known powershell scripts for exploitation
 references:
-    - https://raw.githubusercontent.com/Neo23x0/sigma/f35c50049fa896dff91ff545cb199319172701e8/rules/windows/powershell/powershell_malicious_commandlets.yml
     - https://github.com/PowerShellMafia/PowerSploit
     - https://github.com/NetSPI/PowerUpSQL
     - https://github.com/CsEnox/EventViewer-UACBypass

--- a/rules/windows/pipe_created/pipe_created_mal_cobaltstrike.yml
+++ b/rules/windows/pipe_created/pipe_created_mal_cobaltstrike.yml
@@ -5,7 +5,7 @@ description: Detects the creation of a named pipe as used by CobaltStrike
 references:
     - https://twitter.com/d4rksystem/status/1357010969264873472
     - https://labs.f-secure.com/blog/detecting-cobalt-strike-default-modules-via-named-pipe-analysis/
-    - https://github.com/Neo23x0/sigma/issues/253
+    - https://github.com/SigmaHQ/sigma/issues/253
     - https://blog.cobaltstrike.com/2021/02/09/learn-pipe-fitting-for-all-of-your-offense-projects/
     - https://redcanary.com/threat-detection-report/threats/cobalt-strike/
 author: Florian Roth, Wojciech Lesicki

--- a/rules/windows/pipe_created/pipe_created_mal_namedpipes.yml
+++ b/rules/windows/pipe_created/pipe_created_mal_namedpipes.yml
@@ -43,7 +43,7 @@ detection:
             - '\NamePipe_MoreWindows'  # Cloud Hopper - RedLeaves
             - '\pcheap_reuse'  # Pipe used by Equation Group malware
             - '\gruntsvc' # Covenant default
-            # - '\status_*' # CS default  https://github.com/Neo23x0/sigma/issues/253
+            # - '\status_*' # CS default  https://github.com/SigmaHQ/sigma/issues/253
             - '\583da945-62af-10e8-4902-a8f205c72b2e'  # SolarWinds SUNBURST malware
             - '\bizkaz'  # Snatch Ransomware
             - '\svcctl' #Crackmapexec smbexec default

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_clip.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_clip.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated use of Clip.exe to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 26)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 26)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
 modified: 2022/12/02

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_stdin.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_stdin.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated use of stdin to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 25)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 25)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/12/02

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_var.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_var.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated use of Environment Variables to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/12/02

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_compress.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_compress.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via COMPRESS OBFUSCATION
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 19)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 19)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_rundll.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_rundll.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via RUNDLL LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 23)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 23)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_stdin.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_stdin.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via Stdin in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task28)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task28)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/12
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_use_clip.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_use_clip.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via use Clip.exe in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task29)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task29)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_use_mhsta.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_use_mhsta.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via use MSHTA in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task31)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task31)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/08
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_use_rundll32.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via use Rundll32 in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009
+    - https://github.com/SigmaHQ/sigma/issues/1009
 author: Nikita Nazarov, oscd.community
 date: 2019/10/08
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_var.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_via_var.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detects Obfuscated Powershell via VAR++ LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
 modified: 2022/12/02

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_clip.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_clip.yml
@@ -3,7 +3,7 @@ id: 73e67340-0d25-11eb-adc1-0242ac120002
 status: experimental
 description: Detects Obfuscated use of Clip.exe to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 26)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 26)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
 modified: 2022/12/02

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_stdin.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_stdin.yml
@@ -3,7 +3,7 @@ id: 779c8c12-0eb1-11eb-adc1-0242ac120002
 status: experimental
 description: Detects Obfuscated use of stdin to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 25)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 25)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/12/03

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_var.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_var.yml
@@ -3,7 +3,7 @@ id: 0adfbc14-0ed1-11eb-adc1-0242ac120002
 status: experimental
 description: Detects Obfuscated use of Environment Variables to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/12/02

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_compress.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_compress.yml
@@ -3,7 +3,7 @@ id: 20e5497e-331c-4cd5-8d36-935f6e2a9a07
 status: experimental
 description: Detects Obfuscated Powershell via COMPRESS OBFUSCATION
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 19)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 19)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_rundll.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_rundll.yml
@@ -3,7 +3,7 @@ id: e6cb92b4-b470-4eb8-8a9d-d63e8583aae0
 status: experimental
 description: Detects Obfuscated Powershell via RUNDLL LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 23)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 23)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_stdin.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_stdin.yml
@@ -3,7 +3,7 @@ id: 86b896ba-ffa1-4fea-83e3-ee28a4c915c7
 status: experimental
 description: Detects Obfuscated Powershell via Stdin in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task28)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task28)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/12
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_use_clip.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_use_clip.yml
@@ -3,7 +3,7 @@ id: db92dd33-a3ad-49cf-8c2c-608c3e30ace0
 status: experimental
 description: Detects Obfuscated Powershell via use Clip.exe in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task29)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task29)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_use_mhsta.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_use_mhsta.yml
@@ -3,7 +3,7 @@ id: e55a5195-4724-480e-a77e-3ebe64bd3759
 status: experimental
 description: Detects Obfuscated Powershell via use MSHTA in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task31)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task31)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/08
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_use_rundll32.yml
@@ -3,7 +3,7 @@ id: a5a30a6e-75ca-4233-8b8c-42e0f2037d3b
 status: experimental
 description: Detects Obfuscated Powershell via use Rundll32 in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009
+    - https://github.com/SigmaHQ/sigma/issues/1009
 author: Nikita Nazarov, oscd.community
 date: 2019/10/08
 modified: 2022/11/29

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_var.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_via_var.yml
@@ -3,7 +3,7 @@ id: e54f5149-6ba3-49cf-b153-070d24679126
 status: experimental
 description: Detects Obfuscated Powershell via VAR++ LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
 modified: 2022/12/02

--- a/rules/windows/powershell/powershell_script/posh_ps_malicious_commandlets.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_malicious_commandlets.yml
@@ -1,6 +1,9 @@
 title: Malicious PowerShell Commandlets
 id: 89819aa4-bbd6-46bc-88ec-c7f7fe30efa6
-status: experimental
+related:
+    - id: f331aa1f-8c53-4fc3-b083-cc159bc971cb
+      type: similar
+status: test
 description: Detects Commandlet names from well-known PowerShell exploitation frameworks
 references:
     - https://adsecurity.org/?p=2921
@@ -13,7 +16,7 @@ references:
     - https://research.nccgroup.com/2022/06/06/shining-the-light-on-black-basta/ # Invoke-TotalExec
 author: Sean Metcalf (source), Florian Roth (rule), Bartlomiej Czyz @bczyz1 (update), oscd.community (update), Nasreddine Bencherchali (update), Tim Shelton (fp), Mustafa Kaan Demir (update), Georg Lauenstein (update)
 date: 2017/03/05
-modified: 2022/12/04
+modified: 2022/12/27
 tags:
     - attack.execution
     - attack.t1059.001

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_clip.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_clip.yml
@@ -3,7 +3,7 @@ id: b222df08-0e07-11eb-adc1-0242ac120002
 status: test
 description: Detects Obfuscated use of Clip.exe to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 26)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 26)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
 modified: 2022/11/17

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_stdin.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_stdin.yml
@@ -3,7 +3,7 @@ id: 6c96fc76-0eb1-11eb-adc1-0242ac120002
 status: test
 description: Detects Obfuscated use of stdin to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 25)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 25)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/11/17

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_var.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_var.yml
@@ -3,7 +3,7 @@ id: 27aec9c9-dbb0-4939-8422-1742242471d0
 status: test
 description: Detects Obfuscated use of Environment Variables to execute PowerShell
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009  #(Task 24)
+    - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 24)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/15
 modified: 2022/11/17

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_compress.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_compress.yml
@@ -3,7 +3,7 @@ id: 7eedcc9d-9fdb-4d94-9c54-474e8affc0c7
 status: test
 description: Detects Obfuscated Powershell via COMPRESS OBFUSCATION
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 19)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 19)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/03/07

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_rundll.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_rundll.yml
@@ -3,7 +3,7 @@ id: 056a7ee1-4853-4e67-86a0-3fd9ceed7555
 status: test
 description: Detects Obfuscated Powershell via RUNDLL LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task 23)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 23)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
 modified: 2022/03/07

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_stdin.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_stdin.yml
@@ -3,7 +3,7 @@ id: 9c14c9fa-1a63-4a64-8e57-d19280559490
 status: test
 description: Detects Obfuscated Powershell via Stdin in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task28)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task28)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/12
 modified: 2022/11/16

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_clip.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_clip.yml
@@ -3,7 +3,7 @@ id: e1561947-b4e3-4a74-9bdd-83baed21bdb5
 status: test
 description: Detects Obfuscated Powershell via use Clip.exe in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task29)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task29)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/09
 modified: 2022/11/16

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_mhsta.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_mhsta.yml
@@ -3,7 +3,7 @@ id: ac20ae82-8758-4f38-958e-b44a3140ca88
 status: test
 description: Detects Obfuscated Powershell via use MSHTA in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009   #(Task31)
+    - https://github.com/SigmaHQ/sigma/issues/1009   #(Task31)
 author: Nikita Nazarov, oscd.community
 date: 2020/10/08
 modified: 2022/03/08

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_rundll32.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_use_rundll32.yml
@@ -3,7 +3,7 @@ id: 36c5146c-d127-4f85-8e21-01bf62355d5a
 status: test
 description: Detects Obfuscated Powershell via use Rundll32 in Scripts
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009
+    - https://github.com/SigmaHQ/sigma/issues/1009
 author: Nikita Nazarov, oscd.community
 date: 2019/10/08
 modified: 2022/03/08

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_var.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_via_var.yml
@@ -3,7 +3,7 @@ id: e9f55347-2928-4c06-88e5-1a7f8169942e
 status: test
 description: Detects Obfuscated Powershell via VAR++ LAUNCHER
 references:
-    - https://github.com/Neo23x0/sigma/issues/1009 #(Task27)
+    - https://github.com/SigmaHQ/sigma/issues/1009 #(Task27)
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/13
 modified: 2022/11/16

--- a/tools/LONG_DESCRIPTION.md
+++ b/tools/LONG_DESCRIPTION.md
@@ -1,10 +1,10 @@
 # Sigma Tools
 
-This package contains the following tools for [Sigma](https://github.com/Neo23x0/sigma):
+This package contains the following tools for [Sigma](https://github.com/SigmaHQ/sigma):
 
-* sigmac: the Sigma converter
-* merge_sigma: Merge a Sigma collection into a minimal set of Sigma rules
-* sigma2misp: Import Sigma rules into MISP
-* sigma2attack: Create a MITRE ATT&CK® coverage map
-* sigma_similarity: Measure similarity of Sigma rules
-* sigma_uuid: Check Sigma identifiers
+* `sigmac`: the Sigma converter
+* `merge_sigma`: Merge a Sigma collection into a minimal set of Sigma rules
+* `sigma2misp`: Import Sigma rules into MISP
+* `sigma2attack`: Create a MITRE ATT&CK® coverage map
+* `sigma_similarity`: Measure similarity of Sigma rules
+* `sigma_uuid`: Check Sigma identifiers

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -18,7 +18,7 @@ setup(
     description='Tools for the Generic Signature Format for SIEM Systems',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/Neo23x0/sigma',
+    url='https://github.com/SigmaHQ/sigma',
     author='Sigma Project',
     author_email='thomas@patzke.org',
     license='LGPLv3',

--- a/tools/sigma/backends/uberagent.py
+++ b/tools/sigma/backends/uberagent.py
@@ -271,7 +271,7 @@ def get_parser_properties(sigmaparser):
 
 def write_file_header(f, level):
     f.write("#\n")
-    f.write("# The rules are generated from the Sigma GitHub repository at https://github.com/Neo23x0/sigma\n")
+    f.write("# The rules are generated from the Sigma GitHub repository at https://github.com/SigmaHQ/sigma\n")
     f.write("# Follow these steps to get the latest rules from the repository with Python\n")
     f.write("#    1. Clone the repository locally\n")
     f.write("#    2. Using a commandline, change working directory to the just cloned repository\n")


### PR DESCRIPTION
This PR replaces links that used the old repo name to the new one of SigmaHQ