### PR TITLE
FP: filters out erl.exe running handle.exe with elevated privileges

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_cmd.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_cmd.yml
@@ -36,7 +36,10 @@ detection:
         OriginalFileName: 'PowerShell.EXE'
         CommandLine|contains: '-ExecutionPolicy Restricted -Command Write-Host'
     filter_erl:
-        ParentImage|endswith: '\bin\erl.exe' # example: C:\Program Files\erl-23.2\erts-11.1.4\bin\erl.exe" -service_event ErlSrv_RabbitMQ -nohup -sname rabbit@localhost -s rabbit boot -boot start_sasl +W w +MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30 +P 1048576 +t 5000000 +stbt db +zdbbl 128000 +sbwt none +sbwtdcpu none +sbwtdio none -kernel inet_dist_listen_min 25672 -kernel inet_dist_listen_max 25672 -lager crash_log false -lager handlers []
+        # Example:
+        #   C:\Program Files\erl-23.2\erts-11.1.4\bin\erl.exe" -service_event ErlSrv_RabbitMQ -nohup -sname rabbit@localhost -s rabbit boot -boot start_sasl +W w +MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30 +P 1048576 +t 5000000 +stbt db +zdbbl 128000 +sbwt none +sbwtdcpu none +sbwtdio none -kernel inet_dist_listen_min 25672 -kernel inet_dist_listen_max 25672 -lager crash_log false -lager handlers []
+        ParentImage|startswith: 'C:\Program Files\erl-'
+        ParentImage|endswith: '\bin\erl.exe'
     condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_susp_cmd.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_cmd.yml
@@ -4,9 +4,9 @@ status: experimental
 description: Detects when a shell program such as the windows Command Prompt or PowerShell is launched with system privileges.
 references:
     - https://github.com/Wh04m1001/SysmonEoP
-author: frack113
+author: frack113, Tim Shelton
 date: 2022/12/05
-modified: 2022/12/07
+modified: 2022/12/28
 tags:
     - attack.privilege_escalation
     - attack.defense_evasion
@@ -35,6 +35,8 @@ detection:
         ParentCommandLine|contains: '-m:appraiser.dll -f:DoScheduledTelemetryRun'
         OriginalFileName: 'PowerShell.EXE'
         CommandLine|contains: '-ExecutionPolicy Restricted -Command Write-Host'
+    filter_erl:
+        ParentImage|endswith: '\bin\erl.exe' # example: C:\Program Files\erl-23.2\erts-11.1.4\bin\erl.exe" -service_event ErlSrv_RabbitMQ -nohup -sname rabbit@localhost -s rabbit boot -boot start_sasl +W w +MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30 +P 1048576 +t 5000000 +stbt db +zdbbl 128000 +sbwt none +sbwtdcpu none +sbwtdio none -kernel inet_dist_listen_min 25672 -kernel inet_dist_listen_max 25672 -lager crash_log false -lager handlers []
     condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_susp_cmd.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_cmd.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects when a shell program such as the windows Command Prompt or PowerShell is launched with system privileges.
 references:
     - https://github.com/Wh04m1001/SysmonEoP
-author: frack113, Tim Shelton
+author: frack113, Tim Shelton (update fp)
 date: 2022/12/05
 modified: 2022/12/28
 tags:


### PR DESCRIPTION
Example log:

2022-12-28 16:39:47 REDACTED Sysmon: 1: Process Create | RuleName=technique_id=T1059,technique_name=Command-Line Interface | UtcTime=2022-12-28 16:39:47.193 | ProcessGuid={9DDBFBCE-7153-63AC-7207-05000000B701} | ProcessId=8172 | Image=C:\Windows\System32\cmd.exe | FileVersion=6.3.9600.17415 (winblue_r4.141028-1500) | Description=Windows Command Processor | Company=Microsoft Corporation | OriginalFileName=Cmd.Exe | OriginalCommandLine=C:\Windows\system32\cmd.exe /c handle.exe /accepteula -s -p 1988 2&gt; nul | CommandLine=C:\Windows\system32\cmd.exe /c handle.exe /accepteula -s -p 1988 2&gt; nul | CurrentDirectory=E:\Working Share\rmqcluster_service\ | User=NT AUTHORITY\SYSTEM | LogonGuid={9DDBFBCE-92AD-639E-E703-000000000000} | LogonId=0x3e7 | TerminalSessionId=0 | IntegrityLevel=System | Hashes=SHA1=7C3D7281E1151FE4127923F4B4C3CD36438E1A12,MD5=F5AE03DE0AD60F5B17B82F2CD68402FE,SHA256=6F88FB88FFB0F1D5465C2826E5B4F523598B1B8378377C8378FFEBC171BAD18B,IMPHASH=77AED1ADAF24B344F08C8AD1432908C3 | ParentProcessGuid={9DDBFBCE-92B1-639E-2E00-00000000B701} | ParentProcessId=1988 | ParentImage=C:\Program Files\erl-23.2\erts-11.1.4\bin\erl.exe | OriginalParentCommandLine="C:\Program Files\erl-23.2\erts-11.1.4\bin\erl.exe" -service_event ErlSrv_RabbitMQ -nohup -sname rabbit@localhost -s "rabbit" boot -boot "start_sasl" +W w +MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30 +P 1048576 +t 5000000 +stbt db +zdbbl 128000 +sbwt none +sbwtdcpu none +sbwtdio none -kernel inet_dist_listen_min 25672 -kernel inet_dist_listen_max 25672 -lager crash_log false -lager handlers "[]" | ParentCommandLine="C:\Program Files\erl-23.2\erts-11.1.4\bin\erl.exe" -service_event ErlSrv_RabbitMQ -nohup -sname rabbit@localhost -s rabbit boot -boot start_sasl +W w +MBas ageffcbf +MHas ageffcbf +MBlmbcs 512 +MHlmbcs 512 +MMmcs 30 +P 1048576 +t 5000000 +stbt db +zdbbl 128000 +sbwt none +sbwtdcpu none +sbwtdio none -kernel inet_dist_listen_min 25672 -kernel inet_dist_listen_max 25672 -lager crash_log false -lager handlers [] | ParentCommandLineObfuscated=false | ParentCommandLineObfuscatedReason=Obfuscation character '"' detected and data size deviated 3.54. | ParentUser=NT AUTHORITY\SYSTEM | pid=1804 | level=29 | sys_version=5 | category=Process Create (rule: ProcessCreate) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=43322804 | app="sysmon64.exe" | tid=8300 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) 