### PR TITLE
Add missing lolbin OSBinaries

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_lolbin_runexehelper.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_runexehelper.yml
@@ -1,7 +1,7 @@
 title: Lolbin Runexehelper Use As Proxy
 id: cd71385d-fd9b-4691-9b98-2b1f7e508714
 status: experimental
-description: Detect use of runexehelper.exe as proxy to launch another program
+description: Detect usage of the "runexehelper.exe" binary as a proxy to launch other programs
 references:
     - https://twitter.com/0gtweet/status/1206692239839289344
     - https://lolbas-project.github.io/lolbas/Binaries/Runexehelper/
@@ -10,7 +10,6 @@ date: 2022/12/29
 tags:
     - attack.defense_evasion
     - attack.t1218
-    - attack.execution
 logsource:
     category: process_creation
     product: windows
@@ -19,5 +18,5 @@ detection:
         ParentImage|endswith: '\runexehelper.exe'
     condition: selection
 falsepositives:
-    - Legit usage of scripts
+    - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_runexehelper.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_runexehelper.yml
@@ -18,11 +18,6 @@ detection:
     selection:
         ParentImage|endswith: '\runexehelper.exe'
     condition: selection
-fields:
-    - CommandLine
-    - CurrentDirectory 
-    - ParentCommandLine
-    - USer
 falsepositives:
     - Legit usage of scripts
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_runexehelper.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_runexehelper.yml
@@ -1,0 +1,28 @@
+title: Lolbin Runexehelper Use As Proxy
+id: cd71385d-fd9b-4691-9b98-2b1f7e508714
+status: experimental
+description: Detect use of runexehelper.exe as proxy to launch another program
+references:
+    - https://twitter.com/0gtweet/status/1206692239839289344
+    - https://lolbas-project.github.io/lolbas/Binaries/Runexehelper/
+author: frack113
+date: 2022/12/29
+tags:
+    - attack.defense_evasion
+    - attack.t1218
+    - attack.execution
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        ParentImage|endswith: '\runexehelper.exe'
+    condition: selection
+fields:
+    - CommandLine
+    - CurrentDirectory 
+    - ParentCommandLine
+    - USer
+falsepositives:
+    - Legit usage of scripts
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_ssh.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_ssh.yml
@@ -1,0 +1,34 @@
+title: Lolbin Ssh.exe Use As Proxy
+id: 7d6d30b8-5b91-4b90-a891-46cccaf29598
+status: experimental
+description: Detect use of ssh.exe as proxy to launch another program
+references:
+    - https://lolbas-project.github.io/lolbas/Binaries/Ssh/
+author: frack113
+date: 2022/12/29
+tags:
+    - attack.defense_evasion
+    - attack.t1218
+    - attack.execution
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_ssh_img:
+        - Image|endswith: '\ssh.exe'
+        - ImageFileName: 'ssh.exe'
+    selection_ssh_cmd: 
+        CommandLine|contains: 'localhost'
+        CommandLine|endswith: '.exe'
+    selection_parent:
+        ParentImage: 'C:\Windows\System32\OpenSSH\sshd.exe'
+        #ParentCommandLine: '"C:\Windows\System32\OpenSSH\sshd.exe" -R'
+    condition: all of selection_ssh_* or selection_parent
+fields:
+    - CommandLine
+    - CurrentDirectory 
+    - ParentCommandLine
+    - USer
+falsepositives:
+    - Legit usage of scripts
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_ssh.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_ssh.yml
@@ -1,7 +1,7 @@
 title: Lolbin Ssh.exe Use As Proxy
 id: 7d6d30b8-5b91-4b90-a891-46cccaf29598
 status: experimental
-description: Detect use of ssh.exe as proxy to launch another program
+description: Detect usage of the "ssh.exe" binary as a proxy to launch other programs
 references:
     - https://lolbas-project.github.io/lolbas/Binaries/Ssh/
 author: frack113
@@ -9,7 +9,6 @@ date: 2022/12/29
 tags:
     - attack.defense_evasion
     - attack.t1218
-    - attack.execution
 logsource:
     category: process_creation
     product: windows
@@ -19,5 +18,5 @@ detection:
         #ParentCommandLine: '"C:\Windows\System32\OpenSSH\sshd.exe" -R'
     condition: selection
 falsepositives:
-    - Legit usage of scripts
+    - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_ssh.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_ssh.yml
@@ -14,21 +14,10 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection_ssh_img:
-        - Image|endswith: '\ssh.exe'
-        - ImageFileName: 'ssh.exe'
-    selection_ssh_cmd: 
-        CommandLine|contains: 'localhost'
-        CommandLine|endswith: '.exe'
-    selection_parent:
+    selection:
         ParentImage: 'C:\Windows\System32\OpenSSH\sshd.exe'
         #ParentCommandLine: '"C:\Windows\System32\OpenSSH\sshd.exe" -R'
-    condition: all of selection_ssh_* or selection_parent
-fields:
-    - CommandLine
-    - CurrentDirectory 
-    - ParentCommandLine
-    - USer
+    condition: selection
 falsepositives:
     - Legit usage of scripts
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_unregmp2.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_unregmp2.yml
@@ -9,7 +9,6 @@ date: 2022/12/29
 tags:
     - attack.defense_evasion
     - attack.t1218
-    - attack.execution
 logsource:
     category: process_creation
     product: windows
@@ -21,5 +20,5 @@ detection:
         CommandLine|contains: ' /HideWMP'
     condition: all of selection_*
 falsepositives:
-    - Legit usage of scripts
+    - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_unregmp2.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_unregmp2.yml
@@ -1,7 +1,7 @@
 title: Lolbin Unregmp2.exe Use As Proxy
 id: 727454c0-d851-48b0-8b89-385611ab0704
 status: experimental
-description: Detect use of unregmp2.exe as proxy to launch a custom wmpnscfg.exe
+description: Detect usage of the "unregmp2.exe" binary as a proxy to launch a custom version of "wmpnscfg.exe"
 references:
     - https://lolbas-project.github.io/lolbas/Binaries/Unregmp2/
 author: frack113
@@ -20,11 +20,6 @@ detection:
     selection_cmd:
         CommandLine|contains: ' /HideWMP'
     condition: all of selection_*
-fields:
-    - CommandLine
-    - CurrentDirectory 
-    - ParentCommandLine
-    - User
 falsepositives:
     - Legit usage of scripts
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_unregmp2.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_unregmp2.yml
@@ -1,0 +1,30 @@
+title: Lolbin Unregmp2.exe Use As Proxy
+id: 727454c0-d851-48b0-8b89-385611ab0704
+status: experimental
+description: Detect use of unregmp2.exe as proxy to launch a custom wmpnscfg.exe
+references:
+    - https://lolbas-project.github.io/lolbas/Binaries/Unregmp2/
+author: frack113
+date: 2022/12/29
+tags:
+    - attack.defense_evasion
+    - attack.t1218
+    - attack.execution
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+       - Image|endswith: '\unregmp2.exe'
+       - OriginalFileName: 'unregmp2.exe'
+    selection_cmd:
+        CommandLine|contains: ' /HideWMP'
+    condition: all of selection_*
+fields:
+    - CommandLine
+    - CurrentDirectory 
+    - ParentCommandLine
+    - User
+falsepositives:
+    - Legit usage of scripts
+level: medium


### PR DESCRIPTION
Missing rules for OSBinaries lolbin
- Runexehelper.yml (LOLBAS\yml\OSBinaries)
- Ssh.yml (LOLBAS\yml\OSBinaries)
- Unregmp2.yml (LOLBAS\yml\OSBinaries)