### PR TITLE
refactor: regex escapes in `|re` block(`{`, `}`, `"`, `backquote`)

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
@@ -9,6 +9,7 @@ references:
     - https://github.com/danielbohannon/Invoke-Obfuscation
 author: frack113
 date: 2022/12/27
+modified: 2022/12/30
 tags:
     - attack.defense_evasion
     - attack.t1027.009
@@ -23,10 +24,10 @@ detection:
         #   &('In'+'voke-Expressi'+'o'+'n') (.('New-Ob'+'jec'+'t') Net.WebClient).DownloadString
         #   &("{2}{3}{0}{4}{1}"-f 'e','Expression','I','nvok','-') (&("{0}{1}{2}"-f'N','ew-O','bject') Net.WebClient).DownloadString
         #   ${e`Nv:pATh}
-        - ScriptBlockText|re: '\w+\`(\w+|-|.)\`[\w+|\s]'
+        - ScriptBlockText|re: '\w+`(\w+|-|.)`[\w+|\s]'
         #- ScriptBlockText|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
-        - ScriptBlockText|re: '"({\d})+"\s*-f'
-        - ScriptBlockText|re: '\${((e|n|v)*`(e|n|v)*)+:path}|\${((e|n|v)*`(e|n|v)*)+:((p|a|t|h)*`(p|a|t|h)*)+}|\${env:((p|a|t|h)*`(p|a|t|h)*)+}'
+        - ScriptBlockText|re: '"(\{\d\})+"\s*-f'
+        - ScriptBlockText|re: '\$\{((e|n|v)*`(e|n|v)*)+:path\}|\$\{((e|n|v)*`(e|n|v)*)+:((p|a|t|h)*`(p|a|t|h)*)+\}|\$\{env:((p|a|t|h)*`(p|a|t|h)*)+\}'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
@@ -9,6 +9,7 @@ references:
     - https://github.com/danielbohannon/Invoke-Obfuscation
 author: frack113
 date: 2022/12/27
+modified: 2022/12/30
 tags:
     - attack.defense_evasion
     - attack.t1027.009
@@ -22,10 +23,10 @@ detection:
         #   &('In'+'voke-Expressi'+'o'+'n') (.('New-Ob'+'jec'+'t') Net.WebClient).DownloadString
         #   &("{2}{3}{0}{4}{1}"-f 'e','Expression','I','nvok','-') (&("{0}{1}{2}"-f'N','ew-O','bject') Net.WebClient).DownloadString
         #   ${e`Nv:pATh}
-        - CommandLine|re: '\w+\`(\w+|-|.)\`[\w+|\s]'
+        - CommandLine|re: '\w+`(\w+|-|.)`[\w+|\s]'
         #- CommandLine|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
-        - CommandLine|re: '\"({\d})+\"\s*-f'
-        - CommandLine|re: '\${((e|n|v)*`(e|n|v)*)+:path}|\${((e|n|v)*`(e|n|v)*)+:((p|a|t|h)*`(p|a|t|h)*)+}|\${env:((p|a|t|h)*`(p|a|t|h)*)+}'
+        - CommandLine|re: '"(\{\d\})+"\s*-f'
+        - CommandLine|re: '\$\{((e|n|v)*`(e|n|v)*)+:path\}|\$\{((e|n|v)*`(e|n|v)*)+:((p|a|t|h)*`(p|a|t|h)*)+\}|\$\{env:((p|a|t|h)*`(p|a|t|h)*)+\}'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
Thanks to this project, we currently use many sigma rules in [Hayabusa](https://github.com/Yamato-Security/hayabusa), Thank you very much :)

- related PR: https://github.com/SigmaHQ/sigma/pull/3825

I found some `|re` blocks have unneeded escapes as follows. So I removed unneeded escapes.
- `"` (double quote)
  - No escaping is required **as a regex**(May be needed **as an escape for String literals**)
- ` (backquote)
  - No escaping is required **as a regex**

I also found that the required escaping was not present. So I added escapes.
- `{` (left curly bracket)
- `}` (right curly bracket)

Most programming languages(`JavaScript`,`PHP`,`Python`...etc) ​​implicitly resolve it, but these regexes cause compile errors in strict language like `Java` and `Rust`. 

I'd appreciate it if you could fix them.
Regards.