### PR TITLE
refactor: remove unneeded backslash escape in character class(in `|re` block)

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_lolbin_diantz_ads.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_diantz_ads.yml
@@ -6,7 +6,7 @@ references:
     - https://lolbas-project.github.io/lolbas/Binaries/Diantz/
 author: frack113
 date: 2021/11/26
-modified: 2022/12/25
+modified: 2022/12/31
 tags:
     - attack.defense_evasion
     - attack.t1564.004
@@ -18,7 +18,7 @@ detection:
         CommandLine|contains|all:
             - diantz.exe
             - .cab
-        CommandLine|re: ':[^\\\\]'
+        CommandLine|re: ':[^\\]'
     condition: selection
 falsepositives:
     - Very Possible

--- a/rules/windows/process_creation/proc_creation_win_lolbin_extrac32_ads.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_extrac32_ads.yml
@@ -18,7 +18,7 @@ detection:
         CommandLine|contains|all:
             - extrac32.exe
             - .cab
-        CommandLine|re: ':[^\\\\]'
+        CommandLine|re: ':[^\\]'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_lolbin_extrac32_ads.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_extrac32_ads.yml
@@ -6,7 +6,7 @@ references:
     - https://lolbas-project.github.io/lolbas/Binaries/Extrac32/
 author: frack113
 date: 2021/11/26
-modified: 2022/12/25
+modified: 2022/12/30
 tags:
     - attack.defense_evasion
     - attack.t1564.004

--- a/rules/windows/process_creation/proc_creation_win_regedit_import_keys.yml
+++ b/rules/windows/process_creation/proc_creation_win_regedit_import_keys.yml
@@ -7,7 +7,7 @@ references:
     - https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 author: Oddvar Moe, Sander Wiebing, oscd.community
 date: 2020/10/07
-modified: 2022/07/07
+modified: 2022/12/31
 tags:
     - attack.t1112
     - attack.defense_evasion
@@ -30,7 +30,7 @@ detection:
             - ' -a '
             - ' -c '
     filter_2:
-        CommandLine|re: ':[^ \\\\]'     # to avoid intersection with ADS rule
+        CommandLine|re: ':[^ \\]'     # to avoid intersection with ADS rule
     condition: selection and not all of filter*
 fields:
     - ParentImage

--- a/rules/windows/process_creation/proc_creation_win_regedit_import_keys_ads.yml
+++ b/rules/windows/process_creation/proc_creation_win_regedit_import_keys_ads.yml
@@ -7,7 +7,7 @@ references:
     - https://gist.github.com/api0cradle/cdd2d0d0ec9abb686f0e89306e277b8f
 author: Oddvar Moe, Sander Wiebing, oscd.community
 date: 2020/10/12
-modified: 2021/11/27
+modified: 2021/12/31
 tags:
     - attack.t1112
     - attack.defense_evasion
@@ -21,7 +21,7 @@ detection:
             - ' /i '
             - '.reg'
     selection_2:
-        CommandLine|re: ':[^ \\\\]'
+        CommandLine|re: ':[^ \\]'
     filter:
         CommandLine|contains:
             - ' /e '

--- a/rules/windows/process_creation/proc_creation_win_regini.yml
+++ b/rules/windows/process_creation/proc_creation_win_regini.yml
@@ -8,7 +8,7 @@ references:
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/regini
 author: Eli Salem, Sander Wiebing, oscd.community
 date: 2020/10/08
-modified: 2022/05/09
+modified: 2022/12/31
 tags:
     - attack.t1112
     - attack.defense_evasion
@@ -20,7 +20,7 @@ detection:
         - Image|endswith: '\regini.exe'
         - OriginalFileName: 'REGINI.EXE'
     filter:
-        CommandLine|re: ':[^ \\\\]' # to avoid intersection with ADS rule
+        CommandLine|re: ':[^ \\]' # to avoid intersection with ADS rule
     condition: selection and not filter
 fields:
     - ParentImage

--- a/rules/windows/process_creation/proc_creation_win_regini_ads.yml
+++ b/rules/windows/process_creation/proc_creation_win_regini_ads.yml
@@ -8,7 +8,7 @@ references:
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/regini
 author: Eli Salem, Sander Wiebing, oscd.community
 date: 2020/10/12
-modified: 2022/05/09
+modified: 2022/12/31
 tags:
     - attack.t1112
     - attack.defense_evasion
@@ -20,7 +20,7 @@ detection:
         - Image|endswith: '\regini.exe'
         - OriginalFileName: 'REGINI.EXE'
     selection_re:
-        CommandLine|re: ':[^ \\\\]'
+        CommandLine|re: ':[^ \\]'
     condition: selection and selection_re
 fields:
     - ParentImage


### PR DESCRIPTION
Thank you for maintaining Sigma :)

I noticed that  some rule(`|re` block) has unneeded `\`(backslash) in the character class, so I removed it.
In this case the unneeded backslash doesn't affect the matching process, but I fixed it to make the regex more readable.

Related commit: https://github.com/SigmaHQ/sigma/commit/143744bc128b8de17f74b7a5c50ccf4a06cb9a5a
FIY: https://docs.python.org/3/library/re.html

I would appreciate it if you could review.
Regards.