### PR TITLE
fix: remove unneeded double backslash escape

### DIFF
--- a/rules/windows/pipe_created/pipe_created_mal_cobaltstrike_re.yml
+++ b/rules/windows/pipe_created/pipe_created_mal_cobaltstrike_re.yml
@@ -7,7 +7,7 @@ references:
     - https://gist.github.com/MHaggis/6c600e524045a6d49c35291a21e10752
 author: Florian Roth
 date: 2021/07/30
-modified: 2022/12/03
+modified: 2022/12/31
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
@@ -18,25 +18,25 @@ logsource:
     definition: 'Note that you have to configure logging for Named Pipe Events in Sysmon config (Event ID 17 and Event ID 18). The basic configuration is in popular sysmon configuration (https://github.com/SwiftOnSecurity/sysmon-config), but it is worth verifying. You can also use other repo, e.g. https://github.com/Neo23x0/sysmon-config, https://github.com/olafhartong/sysmon-modular You can also use other repo, e.g. https://github.com/Neo23x0/sysmon-config, https://github.com/olafhartong/sysmon-modular. How to test detection? You can always use Cobalt Strike, but also you can check powershell script from this site https://svch0st.medium.com/guide-to-named-pipes-and-hunting-for-cobalt-strike-pipes-dc46b2c5f575'
 detection:
     selection:
-        - PipeName|re: '\\\\mojo\.5688\.8052\.(?:183894939787088877|35780273329370473)[0-9a-f]{2}'
-        - PipeName|re: '\\\\wkssvc_?[0-9a-f]{2}'
-        - PipeName|re: '\\\\ntsvcs[0-9a-f]{2}'
-        - PipeName|re: '\\\\DserNamePipe[0-9a-f]{2}'
-        - PipeName|re: '\\\\SearchTextHarvester[0-9a-f]{2}'
-        - PipeName|re: '\\\\mypipe-(?:f|h)[0-9a-f]{2}'
-        - PipeName|re: '\\\\windows\.update\.manager[0-9a-f]{2,3}'
-        - PipeName|re: '\\\\ntsvcs_[0-9a-f]{2}'
-        - PipeName|re: '\\\\scerpc_?[0-9a-f]{2}'
-        - PipeName|re: '\\\\PGMessagePipe[0-9a-f]{2}'
-        - PipeName|re: '\\\\MsFteWds[0-9a-f]{2}'
-        - PipeName|re: '\\\\f4c3[0-9a-f]{2}'
-        - PipeName|re: '\\\\fullduplex_[0-9a-f]{2}'
-        - PipeName|re: '\\\\msrpc_[0-9a-f]{4}'
-        - PipeName|re: '\\\\win\\\\msrpc_[0-9a-f]{2}'
-        - PipeName|re: '\\\\f53f[0-9a-f]{2}'
-        - PipeName|re: '\\\\rpc_[0-9a-f]{2}'
-        - PipeName|re: '\\\\spoolss_[0-9a-f]{2}'
-        - PipeName|re: '\\\\Winsock2\\\\CatalogChangeListener-[0-9a-f]{3}-0,'
+        - PipeName|re: '\\mojo\.5688\.8052\.(?:183894939787088877|35780273329370473)[0-9a-f]{2}'
+        - PipeName|re: '\\wkssvc_?[0-9a-f]{2}'
+        - PipeName|re: '\\ntsvcs[0-9a-f]{2}'
+        - PipeName|re: '\\DserNamePipe[0-9a-f]{2}'
+        - PipeName|re: '\\SearchTextHarvester[0-9a-f]{2}'
+        - PipeName|re: '\\mypipe-(?:f|h)[0-9a-f]{2}'
+        - PipeName|re: '\\windows\.update\.manager[0-9a-f]{2,3}'
+        - PipeName|re: '\\ntsvcs_[0-9a-f]{2}'
+        - PipeName|re: '\\scerpc_?[0-9a-f]{2}'
+        - PipeName|re: '\\PGMessagePipe[0-9a-f]{2}'
+        - PipeName|re: '\\MsFteWds[0-9a-f]{2}'
+        - PipeName|re: '\\f4c3[0-9a-f]{2}'
+        - PipeName|re: '\\fullduplex_[0-9a-f]{2}'
+        - PipeName|re: '\\msrpc_[0-9a-f]{4}'
+        - PipeName|re: '\\win\\msrpc_[0-9a-f]{2}'
+        - PipeName|re: '\\f53f[0-9a-f]{2}'
+        - PipeName|re: '\\rpc_[0-9a-f]{2}'
+        - PipeName|re: '\\spoolss_[0-9a-f]{2}'
+        - PipeName|re: '\\Winsock2\\CatalogChangeListener-[0-9a-f]{3}-0,'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_access/proc_access_win_cobaltstrike_bof_injection_pattern.yml
+++ b/rules/windows/process_access/proc_access_win_cobaltstrike_bof_injection_pattern.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/boku7/spawn
 author: Christian Burkard
 date: 2021/08/04
-modified: 2022/10/09
+modified: 2022/12/31
 tags:
     - attack.execution
     - attack.t1106
@@ -18,7 +18,7 @@ logsource:
     product: windows
 detection:
     selection:
-        CallTrace|re: '^C:\\\\Windows\\\\SYSTEM32\\\\ntdll\\.dll\+[a-z0-9]{4,6}\|C:\\\\Windows\\\\System32\\\\KERNELBASE\\.dll\+[a-z0-9]{4,6}\|UNKNOWN\([A-Z0-9]{16}\)$'
+        CallTrace|re: '^C:\\Windows\\SYSTEM32\\ntdll\.dll\+[a-z0-9]{4,6}\|C:\\Windows\\System32\\KERNELBASE\.dll\+[a-z0-9]{4,6}\|UNKNOWN\([A-Z0-9]{16}\)$'
         GrantedAccess:
             - '0x1028'
             - '0x1fffff'


### PR DESCRIPTION
Hello, Thank you so much for your prompt response :)

It seems that some rule for cobaltstrike intended to detect **single** backslash(not double backslash), so I fixed it.

ref: 
https://labs.withsecure.com/publications/detecting-cobalt-strike-default-modules-via-named-pipe-analysis
https://medium.com/falconforce/falconfriday-direct-system-calls-and-cobalt-strike-bofs-0xff14-741fa8e1bdd6

I would appreciate it if you could review.
Regards.