### PR TITLE
fix: remove incorrect backslash escape(in `|re` block)

### DIFF
--- a/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_obfuscated_iex.yml
+++ b/rules/windows/powershell/powershell_module/posh_pm_invoke_obfuscation_obfuscated_iex.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/danielbohannon/Invoke-Obfuscation/blob/f20e7f843edd0a3a7716736e9eddfa423395dd26/Out-ObfuscatedStringCommand.ps1#L873-L888
 author: Daniel Bohannon (@Mandiant/@FireEye), oscd.community
 date: 2019/11/08
-modified: 2022/11/27
+modified: 2022/12/31
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -25,9 +25,9 @@ detection:
         - Payload|re: '\$ShellId\[\s*\d{1,3}\s*\]\s*\+\s*\$ShellId\['
         - Payload|re: '\$env:Public\[\s*\d{1,3}\s*\]\s*\+\s*\$env:Public\['
         - Payload|re: '\$env:ComSpec\[(\s*\d{1,3}\s*,){2}'
-        - Payload|re: '\\\\*mdr\\\\*\W\s*\)\.Name'
+        - Payload|re: '\*mdr\*\W\s*\)\.Name'
         - Payload|re: '\$VerbosePreference\.ToString\('
-        - Payload|re: '\String\]\s*\$VerbosePreference'
+        - Payload|re: '\[String\]\s*\$VerbosePreference'
     condition: selection_payload
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_obfuscated_iex.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_invoke_obfuscation_obfuscated_iex.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/danielbohannon/Invoke-Obfuscation/blob/f20e7f843edd0a3a7716736e9eddfa423395dd26/Out-ObfuscatedStringCommand.ps1#L873-L888
 author: 'Daniel Bohannon (@Mandiant/@FireEye), oscd.community'
 date: 2019/11/08
-modified: 2022/11/27
+modified: 2022/12/31
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -22,7 +22,7 @@ detection:
         - ScriptBlockText|re: '\$ShellId\[\s*\d{1,3}\s*\]\s*\+\s*\$ShellId\['
         - ScriptBlockText|re: '\$env:Public\[\s*\d{1,3}\s*\]\s*\+\s*\$env:Public\['
         - ScriptBlockText|re: '\$env:ComSpec\[(\s*\d{1,3}\s*,){2}'
-        - ScriptBlockText|re: '\\\\*mdr\\\\*\W\s*\)\.Name'
+        - ScriptBlockText|re: '\*mdr\*\W\s*\)\.Name'
         - ScriptBlockText|re: '\$VerbosePreference\.ToString\('
     condition: selection_iex
 falsepositives:

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_obfuscated_iex_commandline.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_obfuscated_iex_commandline.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/danielbohannon/Invoke-Obfuscation/blob/f20e7f843edd0a3a7716736e9eddfa423395dd26/Out-ObfuscatedStringCommand.ps1#L873-L888
 author: 'Daniel Bohannon (@Mandiant/@FireEye), oscd.community'
 date: 2019/11/08
-modified: 2021/11/27
+modified: 2021/12/31
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -21,9 +21,9 @@ detection:
         - CommandLine|re: '\$ShellId\[\s*\d{1,3}\s*\]\s*\+\s*\$ShellId\['
         - CommandLine|re: '\$env:Public\[\s*\d{1,3}\s*\]\s*\+\s*\$env:Public\['
         - CommandLine|re: '\$env:ComSpec\[(\s*\d{1,3}\s*,){2}'
-        - CommandLine|re: '\\\\*mdr\\\\*\W\s*\)\.Name'
+        - CommandLine|re: '\*mdr\*\W\s*\)\.Name'
         - CommandLine|re: '\$VerbosePreference\.ToString\('
-        - CommandLine|re: '\\\\String\]\s*\$VerbosePreference'
+        - CommandLine|re: '\[String\]\s*\$VerbosePreference'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_obfuscated_iex_commandline.yml
+++ b/rules/windows/process_creation/proc_creation_win_invoke_obfuscation_obfuscated_iex_commandline.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/danielbohannon/Invoke-Obfuscation/blob/f20e7f843edd0a3a7716736e9eddfa423395dd26/Out-ObfuscatedStringCommand.ps1#L873-L888
 author: 'Daniel Bohannon (@Mandiant/@FireEye), oscd.community'
 date: 2019/11/08
-modified: 2021/12/31
+modified: 2022/12/31
 tags:
     - attack.defense_evasion
     - attack.t1027


### PR DESCRIPTION
Thank you for all your hard work in 2022 :)

I fixed an incorrect backslash-escaped regex that may have been intended to simply escape an asterisk(to not act as a quantifier).

I would appreciate it if you could review.
Regards.