### PR TITLE
FP: varonis running system shell cmd

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_cmd.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_cmd.yml
@@ -48,6 +48,11 @@ detection:
         CommandLine|contains|all:
             - ' -taskid '
             - ' -name asgard2-agent '
+    filter_varonis:
+        # Example:
+        #  Parent Command:   C:\Program Files (x86)\Varonis\DatAdvantage\GridCollector\VrnsRealTimeAlertsSvc.exe" /appid 000000ad-cb03-500b-9459-c46d000000ad
+        #  Command: C:\Windows\system32\cmd.exe /c C:\Program Files "(x86)\Varonis\DatAdvantage\GridCollector\handle_scopes.cmd C:\Collector" Working Share\VaronisWorkDirectoryCollector
+        ParentImage: 'C:\Program Files (x86)\Varonis\DatAdvantage\GridCollector\VrnsRealTimeAlertsSvc.exe'
     condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown


### PR DESCRIPTION
Example:

```
2023-01-03 23:10:14 REDACTED Sysmon: 1: Process Create | RuleName=technique_id=T1059,technique_name=Command-Line Interface | UtcTime=2023-01-03 23:10:14.218 | ProcessGuid={C3F79229-B5D6-63B4-FB97-3F0000004500} | ProcessId=27508 | Image=C:\Windows\SysWOW64\cmd.exe | FileVersion=10.0.14393.0 (rs1_release.160715-1616) | Description=Windows Command Processor | Company=Microsoft Corporation | OriginalFileName=Cmd.Exe | OriginalCommandLine=C:\Windows\system32\cmd.exe /c ""C:\Program Files (x86)\Varonis\DatAdvantage\GridCollector\handle_scopes.cmd" "C:\Collector Working Share\VaronisWorkDirectoryCollector"" | CommandLine=C:\Windows\system32\cmd.exe /c C:\Program Files "(x86)\Varonis\DatAdvantage\GridCollector\handle_scopes.cmd C:\Collector" Working Share\VaronisWorkDirectoryCollector | CurrentDirectory=C:\Program Files (x86)\Varonis\DatAdvantage\GridCollector\ | User=NT AUTHORITY\SYSTEM | LogonGuid={C3F79229-952B-6317-E703-000000000000} | LogonId=0x3e7 | TerminalSessionId=0 | IntegrityLevel=System | Hashes=SHA1=A4D7B99EB716919BB47448E135D489A1100BA70C,MD5=0FEC5F30E705EADAEA5E9144F2FB12DC,SHA256=614CA7B627533E22AA3E5C3594605DC6FE6F000B0CC2B845ECE47CA60673EC7F,IMPHASH=B20DE9D5F257E3C5BDD2834F89FC042A | ParentProcessGuid={C3F79229-9552-6317-AF00-000000004500} | ParentProcessId=8456 | ParentImage=C:\Program Files (x86)\Varonis\DatAdvantage\GridCollector\VrnsRealTimeAlertsSvc.exe | OriginalParentCommandLine="C:\Program Files (x86)\Varonis\DatAdvantage\GridCollector\VrnsRealTimeAlertsSvc.exe" /appid 000000ad-cb03-500b-9459-c46d000000ad | ParentCommandLine="C:\Program Files (x86)\Varonis\DatAdvantage\GridCollector\VrnsRealTimeAlertsSvc.exe" /appid 000000ad-cb03-500b-9459-c46d000000ad | ParentUser=NT AUTHORITY\SYSTEM | pid=1732 | level=29 | sys_version=5 | category=Process Create (rule: ProcessCreate) | op=Info | Microsoft-Windows-Sysmon/Operational=true | key=0x8000000000000000 | id=29803023 | app="C:\Windows\sysmon64.exe" | tid=4068 | channel="Microsoft-Windows-Sysmon/Operational" | pid_user="NT AUTHORITY\SYSTEM" | sid=S-1-5-18 | account type=User | type=notice(4) 
```