### PR TITLE
Add posh_ps_susp_set_alias

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_susp_set_alias.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_susp_set_alias.yml
@@ -1,7 +1,7 @@
-title: Suspicious Powershell Alias
+title: Potential PowerShell Obfuscation Using Alias Cmdlets
 id: 96cd126d-f970-49c4-848a-da3a09f55c55
 status: experimental
-description: Detects Set-Alias or New-Alias that can be use to obfuscate powershell scripts
+description: Detects Set-Alias or New-Alias cmdlet usage. Which can be use as a mean to obfuscate PowerShell scripts
 references:
     - https://github.com/1337Rin/Swag-PSO
 author: frack113
@@ -16,24 +16,11 @@ logsource:
     category: ps_script
     definition: 'Requirements: Script Block Logging must be enabled'
 detection:
-    selection_cmdlet:
+    selection:
         ScriptBlockText|contains:
             - 'Set-Alias '
             - 'New-Alias '
-    selection_name:
-        ScriptBlockText|contains:
-            - '-Name '
-            - '-Nam '
-            - '-Na '
-            - '-N '
-    selection_value:
-        ScriptBlockText|contains:
-            - '-Value '
-            - '-Valu '
-            - '-Val '
-            - '-Va '
-            - '-V '
-    condition: all of selection_*
+    condition: selection
 falsepositives:
     - Unknown
 level: low

--- a/rules/windows/powershell/powershell_script/posh_ps_susp_set_alias.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_susp_set_alias.yml
@@ -1,0 +1,39 @@
+title: Suspicious Powershell Alias
+id: 96cd126d-f970-49c4-848a-da3a09f55c55
+status: experimental
+description: Detects Set-Alias or New-Alias that can be use to obfuscate powershell scripts
+references:
+    - https://github.com/1337Rin/Swag-PSO
+author: frack113
+date: 2023/01/08
+tags:
+    - attack.defense_evasion
+    - attack.execution
+    - attack.t1027
+    - attack.t1059.001 
+logsource:
+    product: windows
+    category: ps_script
+    definition: 'Requirements: Script Block Logging must be enabled'
+detection:
+    selection_cmdlet:
+        ScriptBlockText|contains:
+            - 'Set-Alias '
+            - 'New-Alias '
+    selection_name:
+        ScriptBlockText|contains:
+            - '-Name '
+            - '-Nam '
+            - '-Na '
+            - '-N '
+    selection_value:
+        ScriptBlockText|contains:
+            - '-Value '
+            - '-Valu '
+            - '-Val '
+            - '-Va '
+            - '-V '
+    condition: all of selection_*
+falsepositives:
+    - Unknown
+level: low


### PR DESCRIPTION
I have downgradre my first rule to low because : 
- if I make it too strict I will only capture this script not the technique
- If I make to lacy  I will get mamy FP.

Script Block Logging get all the script. To be effective I need only a log of the set-alias execution.