### PR TITLE
Update proxy_download_susp_tlds_whitelist.yml

### DIFF
--- a/rules/proxy/proxy_download_susp_tlds_blacklist.yml
+++ b/rules/proxy/proxy_download_susp_tlds_blacklist.yml
@@ -1,5 +1,8 @@
-title: Download from Suspicious TLD
+title: Download from Suspicious TLD - Blacklist
 id: 00d0b5ab-1f55-4120-8e83-487c0a7baf19
+related:
+    - id: b5de2919-b74a-4805-91a7-5049accbaefe
+      type: similar
 status: test
 description: Detects download of certain file types from hosts in suspicious TLDs
 references:
@@ -9,7 +12,7 @@ references:
     - https://krebsonsecurity.com/2018/06/bad-men-at-work-please-dont-click/
 author: Florian Roth
 date: 2017/11/07
-modified: 2021/11/27
+modified: 2023/01/09
 tags:
     - attack.initial_access
     - attack.t1566

--- a/rules/proxy/proxy_download_susp_tlds_blacklist.yml
+++ b/rules/proxy/proxy_download_susp_tlds_blacklist.yml
@@ -1,4 +1,4 @@
-title: Download from Suspicious TLD - Blacklist
+title: Download From Suspicious TLD - Blacklist
 id: 00d0b5ab-1f55-4120-8e83-487c0a7baf19
 related:
     - id: b5de2919-b74a-4805-91a7-5049accbaefe

--- a/rules/proxy/proxy_download_susp_tlds_whitelist.yml
+++ b/rules/proxy/proxy_download_susp_tlds_whitelist.yml
@@ -1,5 +1,8 @@
-title: Download From Suspicious TLD
+title: Download From Suspicious TLD - Whitelist
 id: b5de2919-b74a-4805-91a7-5049accbaefe
+related:
+    - id: 00d0b5ab-1f55-4120-8e83-487c0a7baf19
+      type: similar
 status: test
 description: Detects executable downloads from suspicious remote systems
 author: Florian Roth

--- a/rules/proxy/proxy_download_susp_tlds_whitelist.yml
+++ b/rules/proxy/proxy_download_susp_tlds_whitelist.yml
@@ -1,10 +1,10 @@
-title: Download from Suspicious TLD
+title: Download From Suspicious TLD
 id: b5de2919-b74a-4805-91a7-5049accbaefe
 status: test
 description: Detects executable downloads from suspicious remote systems
 author: Florian Roth
 date: 2017/03/13
-modified: 2021/11/27
+modified: 2023/01/09
 tags:
     - attack.initial_access
     - attack.t1566

--- a/rules/proxy/proxy_download_susp_tlds_whitelist.yml
+++ b/rules/proxy/proxy_download_susp_tlds_whitelist.yml
@@ -1,4 +1,4 @@
-title: Download EXE from Suspicious TLD
+title: Download from Suspicious TLD
 id: b5de2919-b74a-4805-91a7-5049accbaefe
 status: test
 description: Detects executable downloads from suspicious remote systems


### PR DESCRIPTION
This rule checks for more than just EXE downloads so changed the title. The description is fine. New title matches the blacklist version, and if it's desired to have both have a different titles, I recommend putting 'inclusion' and 'exclusion'.