### PR TITLE
ADS stored DLL execution using Rundll32

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
+++ b/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
@@ -15,7 +15,7 @@ logsource:
 detection:
     selection:
         Image|endswith: '\rundll32.exe'
-        CommandLine|re: '\w:\\.+\..+:.+\.dll.*,\w+'
+        CommandLine|re: 'exe\s+\w:\\.+\..+:.+\.dll.*,\w+'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
+++ b/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
@@ -15,7 +15,7 @@ logsource:
 detection:
     selection:
         Image|endswith: '\rundll32.exe'
-        CommandLine|re: '.+\:.+\..+\:.+\..+\,.+$'
+        CommandLine|re: '\w:\\.+\..+:.+\.dll.*,\w+'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
+++ b/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
@@ -5,7 +5,7 @@ description: Detects execution of rundll32 where the DLL being called is stored 
 references:
     - https://lolbas-project.github.io/lolbas/Binaries/Rundll32
 author: Harjot Singh, '@cyb3rjy0t'
-date: 2023/01/11
+date: 2023/01/21
 tags:
     - attack.defense_evasion
     - attack.t1564.004
@@ -15,7 +15,10 @@ logsource:
 detection:
     selection:
         Image|endswith: '\rundll32.exe'
-        CommandLine|re: '[Rr][Uu][Nn][Dd][Ll][Ll]32.+:'
+        # Example:
+        #   rundll32 "C:\ads\file.txt:ADSDLL.dll",DllMain
+        # Note: This doesn't cover the use case where a full path for the DLL isn't used. As it requires a more expensive regex
+        CommandLine|re: '[Rr][Uu][Nn][Dd][Ll][Ll]32.+\w:.+:'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
+++ b/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
@@ -1,7 +1,7 @@
-title: Suspicious Alternate Data Stream Execution Via RunDLL32
+title: Potential Rundll32 Execution With DLL Stored In ADS
 id: 9248c7e1-2bf3-4661-a22c-600a8040b446
 status: experimental
-description: Execution of DLL's stored in alternate data stream using RunDLL32
+description: Detects execution of rundll32 where the DLL being called is stored in an Alternate Data Stream (ADS).
 references:
     - https://lolbas-project.github.io/lolbas/Binaries/Rundll32
 author: Harjot Singh, '@cyb3rjy0t'
@@ -15,7 +15,7 @@ logsource:
 detection:
     selection:
         Image|endswith: '\rundll32.exe'
-        CommandLine|re: 'rundll32.*\w:\\.+\..+:.+\.dll.*,\w+'
+        CommandLine|re: '[Rr][Uu][Nn][Dd][Ll][Ll]32.+:'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
+++ b/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
@@ -1,0 +1,22 @@
+title: Suspicious Alternate Data Stream Execution Via RunDLL32
+id: 9248c7e1-2bf3-4661-a22c-600a8040b446
+status: experimental
+description: Execution of DLL's stored in alternate data stream using RunDLL32
+references:
+    - https://lolbas-project.github.io/lolbas/Binaries/Rundll32
+author: Harjot Singh, '@cyb3rjy0t'
+date: 2023/01/11
+tags:
+    - attack.defense_evasion
+    - attack.t1564.004
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\rundll32.exe'
+        CommandLine|re: '.+\:.+\..+\:.+\..+\,.+$'
+    condition: selection
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
+++ b/rules/windows/process_creation/proc_creation_win_ads_stored_dll_execution_rundll32.yml
@@ -15,7 +15,7 @@ logsource:
 detection:
     selection:
         Image|endswith: '\rundll32.exe'
-        CommandLine|re: 'exe\s+\w:\\.+\..+:.+\.dll.*,\w+'
+        CommandLine|re: 'rundll32.*\w:\\.+\..+:.+\.dll.*,\w+'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
This rule will detect the execution of DLL's using Rundll32 stored in ADS