### PR TITLE
feat: test enhancements

### DIFF
--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1282,7 +1282,7 @@ class TestRules(unittest.TestCase):
             except:
                 pass
 
-        self.assertEqual(Fore.RED + "thor.yml configuration file located in 'tools/config/thor.yml' has a borken log source definition")
+        self.assertEqual("", [], Fore.RED + "thor.yml configuration file located in 'tools/config/thor.yml' has a borken log source definition")
 
 
 def get_mitre_data():

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1266,6 +1266,8 @@ class TestRules(unittest.TestCase):
                          "There are rules using condition without lowercase operator")
     
     def test_broken_thor_logsource_config(self):
+
+        faulty_config = False
         
         # This test check of the "thor.yml" config file has a missing "WinEventLog:" prefix in Windows log sources
         path_to_thor_config = "../tools/config/thor.yml"
@@ -1278,11 +1280,12 @@ class TestRules(unittest.TestCase):
                     sources_list = value['sources']
                     for i in sources_list:
                         if not i.startswith('WinEventLog:'):
+                            faulty_config = True
                             print(Fore.RED + "/tools/config/thor.yml config file has a broken source. Windows Eventlog sources must start with the keyword 'WinEventLog:'")
             except:
                 pass
 
-        self.assertEqual("", [], Fore.RED + "thor.yml configuration file located in 'tools/config/thor.yml' has a borken log source definition")
+        self.assertEqual(faulty_config, False, Fore.RED + "thor.yml configuration file located in 'tools/config/thor.yml' has a borken log source definition")
 
 
 def get_mitre_data():

--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -423,7 +423,7 @@ logsources:
     product: windows
     service: vhdmp
     sources:
-      - 'Microsoft-Windows-VHDMP/Operational'
+      - 'WinEventLog:Microsoft-Windows-VHDMP/Operational'
   windows-appxdeployment-server:
     product: windows
     service: appxdeployment-server

--- a/tools/config/thor.yml
+++ b/tools/config/thor.yml
@@ -423,7 +423,7 @@ logsources:
     product: windows
     service: vhdmp
     sources:
-      - 'WinEventLog:Microsoft-Windows-VHDMP/Operational'
+      - 'Microsoft-Windows-VHDMP/Operational'
   windows-appxdeployment-server:
     product: windows
     service: appxdeployment-server


### PR DESCRIPTION
This PR:

- Fixes an edge case in the `test_duplicate_detections` test. Where if a keyword rule uses the same selection name no field name. The YAML parser returns a `list` instead of `dict` which breaks the test.
- It also adds a new condition where if the log source is different we don't need to check for a duplicate because we assume that a different log source indicates a "new" rule.
- It introduces a new test specifically for `thor.yml` configuration. Where it checks if Windows event log sources start with the `WinEventLog:` keyword