### PR TITLE
Add win_software_restriction_policies_block

### DIFF
--- a/rules/windows/builtin/application/win_software_restriction_policies_block.yml
+++ b/rules/windows/builtin/application/win_software_restriction_policies_block.yml
@@ -1,0 +1,27 @@
+title: Restricted Software Restriction Policies
+id: b4c8da4a-1c12-46b0-8a2b-0a8521d03442
+status: experimental
+description: Detects Software Restriction Policies (SRP) restriction message
+references:
+    - https://learn.microsoft.com/en-us/windows-server/identity/software-restriction-policies/software-restriction-policies
+author: frack113
+date: 2023/01/12
+tags:
+    - attack.execution
+    - attack.t1072 
+logsource:
+    product: windows
+    service: application
+detection:
+    selection:
+        Provider_Name: 'Microsoft-Windows-SoftwareRestrictionPolicies'  
+        EventID: 
+            - 865 # Access to %1 has been restricted by your Administrator by the default software restriction policy level
+            - 866 # Access to %1 has been restricted by your Administrator by location with policy rule %2 placed on path %3.
+            - 867 # Access to %1 has been restricted by your Administrator by software publisher policy.
+            - 868 # Access to %1 has been restricted by your Administrator by policy rule %2.
+            - 882 # Access to %1 has been restricted by your Administrator by policy rule %2.
+    condition: selection
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
Did not get appxdeployment-server but find a gem
```xlm
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
- <System>
  <Provider Name="Microsoft-Windows-SoftwareRestrictionPolicies" Guid="{7d29d58a-931a-40ac-8743-48c733045548}" /> 
  <EventID>865</EventID> 
  <Version>0</Version> 
  <Level>3</Level> 
  <Task>0</Task> 
  <Opcode>0</Opcode> 
  <Keywords>0x8000000000000000</Keywords> 
  <TimeCreated SystemTime="2023-01-12T16:08:06.6526249Z" /> 
  <EventRecordID>199</EventRecordID> 
  <Correlation /> 
  <Execution ProcessID="1192" ThreadID="7248" /> 
  <Channel>Application</Channel> 
  <Computer>DESKTOP-D7DCT5J.simu.local</Computer> 
  <Security UserID="S-1-5-21-2360441858-3879321942-2637521084-500" /> 
  </System>
- <UserData>
- <Path xmlns="http://schemas.microsoft.com/schemas/event/Microsoft.Windows/1.0.0.0">
  <AttemptedPath>C:\Users\ADMINI~1\AppData\Local\Temp\{A3631D35-CFA5-45F6-A65E-DAFA81C4CBE6}~setup\vcredist_x86.exe</AttemptedPath> 
  </Path>
  </UserData>
  </Event>
```