### PR TITLE
Add new rule to detect a new admin role assignment in Okta

### DIFF
--- a/rules/cloud/okta/okta_admin_role_assignment_created.yml
+++ b/rules/cloud/okta/okta_admin_role_assignment_created.yml
@@ -1,6 +1,6 @@
 title: Okta Admin Role Assignment Created
 id: 139bdd4b-9cd7-49ba-a2f4-744d0a8f5d8c
-status: test
+status: experimental
 description: Detects when a new admin role assignment is created
 references:
     - https://developer.okta.com/docs/reference/api/system-log/

--- a/rules/cloud/okta/okta_admin_role_assignment_created.yml
+++ b/rules/cloud/okta/okta_admin_role_assignment_created.yml
@@ -1,7 +1,7 @@
 title: Okta Admin Role Assignment Created
 id: 139bdd4b-9cd7-49ba-a2f4-744d0a8f5d8c
 status: experimental
-description: Detects when a new admin role assignment is created
+description: `Detects when a new admin role assignment is created. Which could be a sign of privilege escalation or persistence`
 references:
     - https://developer.okta.com/docs/reference/api/system-log/
     - https://developer.okta.com/docs/reference/api/event-types/

--- a/rules/cloud/okta/okta_admin_role_assignment_created.yml
+++ b/rules/cloud/okta/okta_admin_role_assignment_created.yml
@@ -14,7 +14,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype: iam.resourceset.bindings.add
+        eventtype: 'iam.resourceset.bindings.add'
     condition: selection
 falsepositives:
     - Legitimate creation of a new admin role assignment

--- a/rules/cloud/okta/okta_admin_role_assignment_created.yml
+++ b/rules/cloud/okta/okta_admin_role_assignment_created.yml
@@ -1,7 +1,7 @@
 title: Okta Admin Role Assignment Created
 id: 139bdd4b-9cd7-49ba-a2f4-744d0a8f5d8c
 status: experimental
-description: `Detects when a new admin role assignment is created. Which could be a sign of privilege escalation or persistence`
+description: Detects when a new admin role assignment is created. Which could be a sign of privilege escalation or persistence
 references:
     - https://developer.okta.com/docs/reference/api/system-log/
     - https://developer.okta.com/docs/reference/api/event-types/


### PR DESCRIPTION
Hey,
There is an option under Okta to create a new Admin Role Assignment and then assign it to a user/group.
This event type should be monitored/hunted because if you are monitoring for specific admin role assignments or specific high-privileged groups, you can miss it.