### PR TITLE
Added external remote service logon from public IP rule.

### DIFF
--- a/rules/windows/builtin/security/win_security_successful_external_remote_rdp_login.yml
+++ b/rules/windows/builtin/security/win_security_successful_external_remote_rdp_login.yml
@@ -23,15 +23,15 @@ detection:
     selection:
         EventID: 4624
         LogonType: 10
-    filter_username:
+    filter:
         SubjectUserName: '-'
-    filter_src_ip:
-        - IpAddress|cidr: 10.0.0.0/8
-        - IpAddress|cidr: 172.16.0.0/12
-        - IpAddress|cidr: 192.168.0.0/16
-        - IpAddress|cidr: 224.0.0.0/4
-        - IpAddress|cidr: 127.0.0.0/8
-    condition: selection and not filter_username and not filter_src_ip
+        IpAddress|cidr:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+            - 224.0.0.0/4
+            - 127.0.0.0/8
+    condition: selection and not filter
 falsepositives:
     - Legitimate or intentional inbound connections from public IP addresses on RDP or SMB ports.
 level: medium

--- a/rules/windows/builtin/security/win_security_successful_external_remote_rdp_login.yml
+++ b/rules/windows/builtin/security/win_security_successful_external_remote_rdp_login.yml
@@ -1,5 +1,8 @@
-title: External Remote Service Logon from Public IP
+title: External Remote RDP Logon from Public IP
 id: 259a9cdf-c4dd-4fa2-b243-2269e5ab18a2
+related:
+    - id: 78d5cab4-557e-454f-9fb9-a222bd0d5edc
+      type: derived
 status: experimental
 description: Detects successful logon from public IP address via RDP, SMB, etc. This can indicate a publicly-exposed RDP or SMB port.
 references:
@@ -19,9 +22,7 @@ logsource:
 detection:
     selection:
         EventID: 4624
-        LogonType:
-            - 3 # Network logon such as SMB
-            - 10 # RemoteInteractive logon such as RDP
+        LogonType: 10
     filter_username:
         SubjectUserName: '-'
     filter_src_ip:

--- a/rules/windows/builtin/security/win_security_successful_external_remote_rdp_login.yml
+++ b/rules/windows/builtin/security/win_security_successful_external_remote_rdp_login.yml
@@ -4,7 +4,7 @@ related:
     - id: 78d5cab4-557e-454f-9fb9-a222bd0d5edc
       type: derived
 status: experimental
-description: Detects successful logon from public IP address via RDP, SMB, etc. This can indicate a publicly-exposed RDP or SMB port.
+description: Detects successful logon from public IP address via RDP. This can indicate a publicly-exposed RDP port.
 references:
     - https://www.inversecos.com/2020/04/successful-4624-anonymous-logons-to.html
     - https://twitter.com/Purp1eW0lf/status/1616144561965002752
@@ -33,5 +33,5 @@ detection:
             - 127.0.0.0/8
     condition: selection and not filter
 falsepositives:
-    - Legitimate or intentional inbound connections from public IP addresses on RDP or SMB ports.
+    - Legitimate or intentional inbound connections from public IP addresses on the RDP port.
 level: medium

--- a/rules/windows/builtin/security/win_security_successful_external_remote_smb_login.yml
+++ b/rules/windows/builtin/security/win_security_successful_external_remote_smb_login.yml
@@ -23,15 +23,15 @@ detection:
     selection:
         EventID: 4624
         LogonType: 3
-    filter_username:
+    filter:
         SubjectUserName: '-'
-    filter_src_ip:
-        - IpAddress|cidr: 10.0.0.0/8
-        - IpAddress|cidr: 172.16.0.0/12
-        - IpAddress|cidr: 192.168.0.0/16
-        - IpAddress|cidr: 224.0.0.0/4
-        - IpAddress|cidr: 127.0.0.0/8
-    condition: selection and not filter_username and not filter_src_ip
+        IpAddress|cidr:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+            - 224.0.0.0/4
+            - 127.0.0.0/8
+    condition: selection and not filter
 falsepositives:
     - Legitimate or intentional inbound connections from public IP addresses on RDP or SMB ports.
 level: high

--- a/rules/windows/builtin/security/win_security_successful_external_remote_smb_login.yml
+++ b/rules/windows/builtin/security/win_security_successful_external_remote_smb_login.yml
@@ -4,7 +4,7 @@ related:
     - id: 259a9cdf-c4dd-4fa2-b243-2269e5ab18a2
       type: derived
 status: experimental
-description: Detects successful logon from public IP address via RDP, SMB, etc. This can indicate a publicly-exposed RDP or SMB port.
+description: Detects successful logon from public IP address via SMB. This can indicate a publicly-exposed SMB port.
 references:
     - https://www.inversecos.com/2020/04/successful-4624-anonymous-logons-to.html
     - https://twitter.com/Purp1eW0lf/status/1616144561965002752
@@ -33,5 +33,5 @@ detection:
             - 127.0.0.0/8
     condition: selection and not filter
 falsepositives:
-    - Legitimate or intentional inbound connections from public IP addresses on RDP or SMB ports.
+    - Legitimate or intentional inbound connections from public IP addresses on the SMB port.
 level: high

--- a/rules/windows/builtin/security/win_security_successful_external_remote_smb_login.yml
+++ b/rules/windows/builtin/security/win_security_successful_external_remote_smb_login.yml
@@ -1,0 +1,37 @@
+title: External Remote SMB Logon from Public IP
+id: 78d5cab4-557e-454f-9fb9-a222bd0d5edc
+related:
+    - id: 259a9cdf-c4dd-4fa2-b243-2269e5ab18a2
+      type: derived
+status: experimental
+description: Detects successful logon from public IP address via RDP, SMB, etc. This can indicate a publicly-exposed RDP or SMB port.
+references:
+    - https://www.inversecos.com/2020/04/successful-4624-anonymous-logons-to.html
+    - https://twitter.com/Purp1eW0lf/status/1616144561965002752
+author: Micah Babinski, @micahbabinski
+date: 2023/01/19
+tags:
+    - attack.initial_access
+    - attack.credential_access
+    - attack.t1133
+    - attack.t1078
+    - attack.t1110
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4624
+        LogonType: 3
+    filter_username:
+        SubjectUserName: '-'
+    filter_src_ip:
+        - IpAddress|cidr: 10.0.0.0/8
+        - IpAddress|cidr: 172.16.0.0/12
+        - IpAddress|cidr: 192.168.0.0/16
+        - IpAddress|cidr: 224.0.0.0/4
+        - IpAddress|cidr: 127.0.0.0/8
+    condition: selection and not filter_username and not filter_src_ip
+falsepositives:
+    - Legitimate or intentional inbound connections from public IP addresses on RDP or SMB ports.
+level: high

--- a/rules/windows/builtin/security/win_security_successful_external_remote_svc_login.yml
+++ b/rules/windows/builtin/security/win_security_successful_external_remote_svc_login.yml
@@ -22,15 +22,15 @@ detection:
         LogonType:
             - 3 # Network logon such as SMB
             - 10 # RemoteInteractive logon such as RDP
+    filter_username:
+        SubjectUserName: '-'
     filter_src_ip:
         - IpAddress|cidr: 10.0.0.0/8
         - IpAddress|cidr: 172.16.0.0/12
         - IpAddress|cidr: 192.168.0.0/16
         - IpAddress|cidr: 224.0.0.0/4
         - IpAddress|cidr: 127.0.0.0/8
-    filter_username:
-        SubjectUserName: null
-    condition: selection and not all of filter*
+    condition: selection and not filter_username and not filter_src_ip
 falsepositives:
     - Legitimate or intentional inbound connections from public IP addresses on RDP or SMB ports.
 level: medium

--- a/rules/windows/builtin/security/win_security_successful_external_remote_svc_login.yml
+++ b/rules/windows/builtin/security/win_security_successful_external_remote_svc_login.yml
@@ -1,0 +1,36 @@
+title: External Remote Service Logon from Public IP
+id: 259a9cdf-c4dd-4fa2-b243-2269e5ab18a2
+status: experimental
+description: Detects successful logon from public IP address via RDP, SMB, etc. This can indicate a publicly-exposed RDP or SMB port.
+references:
+    - https://www.inversecos.com/2020/04/successful-4624-anonymous-logons-to.html
+    - https://twitter.com/Purp1eW0lf/status/1616144561965002752
+author: Micah Babinski, @micahbabinski
+date: 2023/01/19
+tags:
+    - attack.initial_access
+    - attack.credential_access
+    - attack.t1133
+    - attack.t1078
+    - attack.t1110
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4624
+        LogonType:
+            - 3 # Network logon such as SMB
+            - 10 # RemoteInteractive logon such as RDP
+    filter_src_ip:
+        - IpAddress|cidr: 10.0.0.0/8
+        - IpAddress|cidr: 172.16.0.0/12
+        - IpAddress|cidr: 192.168.0.0/16
+        - IpAddress|cidr: 224.0.0.0/4
+        - IpAddress|cidr: 127.0.0.0/8
+    filter_username:
+        SubjectUserName: null
+    condition: selection and not all of filter*
+falsepositives:
+    - Legitimate or intentional inbound connections from public IP addresses on RDP or SMB ports.
+level: medium

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1169,7 +1169,7 @@ class TestRules(unittest.TestCase):
     #     self.assertEqual(faulty_rules, [], Fore.RED + "There are rules with common typos in field names.")
 
     def test_unknown_value_modifier(self):
-        known_modifiers = ["contains", "startswith", "endswith", "all", "base64offset", "base64", "utf16le", "utf16be", "wide", "utf16", "windash", "re"]
+        known_modifiers = ["contains", "startswith", "endswith", "all", "base64offset", "base64", "utf16le", "utf16be", "wide", "utf16", "windash", "re", "cidr"]
         faulty_rules = []
         for file in self.yield_next_rule_file_path(self.path_to_rules):
             detection = self.get_rule_part(file_path=file, part_name="detection")


### PR DESCRIPTION
Inspired by Dray Agha's recent [post](https://twitter.com/Purp1eW0lf/status/1616144561965002752) about publicly-exposed sensitive ports allowing successful logins. I believe successful login events from public IPs, with logon type of 3 or 10, and an Account Name populated, will be of interest to defenders. I checked the existing rules repository and didn't see a rule covering this activity.

Thanks for considering this! All the best.