### PR TITLE
Change rules using all of required-lists to |all

### DIFF
--- a/rules/linux/builtin/auth/lnx_auth_pwnkit_local_privilege_escalation.yml
+++ b/rules/linux/builtin/auth/lnx_auth_pwnkit_local_privilege_escalation.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/wdormann/status/1486161836961579020
 author: Sreeman
 date: 2022/01/26
-modified: 2023/01/06
+modified: 2023/01/23
 tags:
     - attack.privilege_escalation
     - attack.t1548.001
@@ -15,10 +15,11 @@ logsource:
     service: auth
 detection:
     keywords:
-        - 'pkexec'
-        - 'The value for environment variable XAUTHORITY contains suscipious content'
-        - '[USER=root] [TTY=/dev/pts/0]'
-    condition: all of keywords
+        '|all':
+            - 'pkexec'
+            - 'The value for environment variable XAUTHORITY contains suscipious content'
+            - '[USER=root] [TTY=/dev/pts/0]'
+    condition: keywords
 falsepositives:
     - Unknown
 level: high

--- a/rules/linux/builtin/lnx_nimbuspwn_privilege_escalation_exploit.yml
+++ b/rules/linux/builtin/lnx_nimbuspwn_privilege_escalation_exploit.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/Immersive-Labs-Sec/nimbuspwn
 author: Bhabesh Raj
 date: 2022/05/04
-modified: 2023/01/06
+modified: 2023/01/23
 tags:
     - attack.privilege_escalation
     - attack.t1068
@@ -15,10 +15,11 @@ logsource:
     product: linux
 detection:
     keywords:
-        - 'networkd-dispatcher'
-        - 'Error handling notification for interface'
-        - '../../'
-    condition: all of keywords
+        '|all':
+            - 'networkd-dispatcher'
+            - 'Error handling notification for interface'
+            - '../../'
+    condition: keywords
 falsepositives:
     - Unknown
 level: high

--- a/rules/network/cisco/bgp/cisco_bgp_md5_auth_failed.yml
+++ b/rules/network/cisco/bgp/cisco_bgp_md5_auth_failed.yml
@@ -6,6 +6,7 @@ references:
     - https://www.blackhat.com/presentations/bh-usa-03/bh-us-03-convery-franz-v3.pdf
 author: Tim Brown
 date: 2023/01/09
+modified: 2023/01/23
 tags:
     - attack.initial_access
     - attack.persistence
@@ -22,9 +23,10 @@ logsource:
     definition: 'Requirements: cisco bgp logs need to be enabled and ingested'
 detection:
     keywords_bgp_cisco:
-        - ':179' # Protocol
-        - 'IP-TCP-3-BADAUTH'
-    condition: all of keywords_bgp_cisco
+        '|all':
+            - ':179' # Protocol
+            - 'IP-TCP-3-BADAUTH'
+    condition: keywords_bgp_cisco
 fields:
     - tcpConnLocalAddress
     - tcpConnRemAddress

--- a/rules/network/huawei/bgp/huawei_bgp_auth_failed.yml
+++ b/rules/network/huawei/bgp/huawei_bgp_auth_failed.yml
@@ -6,6 +6,7 @@ references:
     - https://www.blackhat.com/presentations/bh-usa-03/bh-us-03-convery-franz-v3.pdf
 author: Tim Brown
 date: 2023/01/09
+modified: 2023/01/23
 tags:
     - attack.initial_access
     - attack.persistence
@@ -22,9 +23,10 @@ logsource:
     definition: 'Requirements: huawei bgp logs need to be enabled and ingested'
 detection:
     keywords_bgp_huawei:
-        - ':179' # Protocol
-        - 'BGP_AUTH_FAILED'
-    condition: all of keywords_bgp_huawei
+        '|all':
+            - ':179' # Protocol
+            - 'BGP_AUTH_FAILED'
+    condition: keywords_bgp_huawei
 fields:
     - host
     - PeeId

--- a/rules/network/juniper/bgp/juniper_bgp_missing_md5.yml
+++ b/rules/network/juniper/bgp/juniper_bgp_missing_md5.yml
@@ -6,6 +6,7 @@ references:
     - https://www.blackhat.com/presentations/bh-usa-03/bh-us-03-convery-franz-v3.pdf
 author: Tim Brown
 date: 2023/01/09
+modified: 2023/01/23
 tags:
     - attack.initial_access
     - attack.persistence
@@ -22,9 +23,10 @@ logsource:
     definition: 'Requirements: juniper bgp logs need to be enabled and ingested'
 detection:
     keywords_bgp_juniper:
-        - ':179' # Protocol
-        - 'missing MD5 digest'
-    condition: all of keywords_bgp_juniper
+        '|all':
+            - ':179' # Protocol
+            - 'missing MD5 digest'
+    condition: keywords_bgp_juniper
 fields:
     - host
 falsepositives:

--- a/rules/windows/builtin/msexchange/win_exchange_proxylogon_oabvirtualdir.yml
+++ b/rules/windows/builtin/msexchange/win_exchange_proxylogon_oabvirtualdir.yml
@@ -6,7 +6,7 @@ references:
     - https://bi-zone.medium.com/hunting-down-ms-exchange-attacks-part-1-proxylogon-cve-2021-26855-26858-27065-26857-6e885c5f197c
 author: Florian Roth
 date: 2021/08/09
-modified: 2023/01/06
+modified: 2023/01/23
 tags:
     - attack.t1587.001
     - attack.resource_development
@@ -15,14 +15,15 @@ logsource:
     service: msexchange-management
 detection:
     keywords_cmdlet:
-        - 'OabVirtualDirectory'
-        - ' -ExternalUrl '
+        '|all':
+            - 'OabVirtualDirectory'
+            - ' -ExternalUrl '
     keywords_params:
         - 'eval(request'
         - 'http://f/<script'
         - '"unsafe"};'
         - 'function Page_Load()'
-    condition: all of keywords_cmdlet and keywords_params
+    condition: keywords_cmdlet and keywords_params
 falsepositives:
     - Unlikely
 level: critical

--- a/rules/windows/builtin/msexchange/win_exchange_proxyshell_certificate_generation.yml
+++ b/rules/windows/builtin/msexchange/win_exchange_proxyshell_certificate_generation.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/GossiTheDog/status/1429175908905127938
 author: Max Altgelt
 date: 2021/08/23
-modified: 2023/01/06
+modified: 2023/01/23
 tags:
     - attack.persistence
     - attack.t1505.003
@@ -15,16 +15,17 @@ logsource:
     product: windows
 detection:
     keywords_export_command:
-        - 'New-ExchangeCertificate'
-        - ' -GenerateRequest'
-        - ' -BinaryEncoded'
-        - ' -RequestFile'
+        '|all':
+            - 'New-ExchangeCertificate'
+            - ' -GenerateRequest'
+            - ' -BinaryEncoded'
+            - ' -RequestFile'
     keywords_export_params:
         - '\\\\localhost\\C$'
         - '\\\\127.0.0.1\\C$'
         - 'C:\\inetpub'
         - '.aspx'
-    condition: all of keywords_export_command and keywords_export_params
+    condition: keywords_export_command and keywords_export_params
 falsepositives:
     - Unlikely
 level: critical

--- a/rules/windows/builtin/msexchange/win_exchange_proxyshell_remove_mailbox_export.yml
+++ b/rules/windows/builtin/msexchange/win_exchange_proxyshell_remove_mailbox_export.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/rapid7/metasploit-framework/blob/1416b5776d963f21b7b5b45d19f3e961201e0aed/modules/exploits/windows/http/exchange_proxyshell_rce.rb#L430
 author: Christian Burkard
 date: 2021/08/27
-modified: 2023/01/06
+modified: 2023/01/23
 tags:
     - attack.defense_evasion
     - attack.t1070
@@ -15,10 +15,11 @@ logsource:
     product: windows
 detection:
     keywords:
-        - 'Remove-MailboxExportRequest'
-        - ' -Identity '
-        - ' -Confirm "False"'
-    condition: all of keywords
+        '|all':
+            - 'Remove-MailboxExportRequest'
+            - ' -Identity '
+            - ' -Confirm "False"'
+    condition: keywords
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/builtin/msexchange/win_exchange_set_oabvirtualdirectory_externalurl.yml
+++ b/rules/windows/builtin/msexchange/win_exchange_set_oabvirtualdirectory_externalurl.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/OTR_Community/status/1371053369071132675
 author: Jose Rodriguez @Cyb3rPandaH
 date: 2021/03/15
-modified: 2023/01/06
+modified: 2023/01/23
 tags:
     - attack.persistence
     - attack.t1505.003
@@ -15,11 +15,12 @@ logsource:
     service: msexchange-management
 detection:
     keywords:
-        - 'Set-OabVirtualDirectory'
-        - 'ExternalUrl'
-        - 'Page_Load'
-        - 'script'
-    condition: all of keywords
+        '|all':
+            - 'Set-OabVirtualDirectory'
+            - 'ExternalUrl'
+            - 'Page_Load'
+            - 'script'
+    condition: keywords
 falsepositives:
     - Unknown
 level: high


### PR DESCRIPTION
When a Sigma rule writer wants to create a list of values where all of them must be matched for the rule to trigger, the approach used previously was to have an `all of` condition for a single selector. However, this has now changed, and the new approach is to use an empty key and the |all modifier (i.e., `'|all'`).

This commit (tries to) identify all the rules that used the old approach and modifies them to use the new approach instead.

See SigmaHQ/sigma-specification#53 for further discussion.