### PR TITLE
Create proc_creation_win_rhadamanthys_dll_launch.yml

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_rhadamanthys_dll_launch.yml
+++ b/rules/windows/process_creation/proc_creation_win_rhadamanthys_dll_launch.yml
@@ -17,17 +17,12 @@ logsource:
     product: windows
 detection:
     selection_rundll32:
-        - Description: 'Windows host process (Rundll32)'
         - OriginalFileName: 'RUNDLL32.EXE'
-        - Image|endswith:
-            - '\rundll32.exe'
-        - CommandLine|contains: 'rundll32'
+        - Image|endswith: '\rundll32.exe'
     selection_dll:
-        CommandLine|contains:
-            - 'nsis_uns'
+        CommandLine|contains: 'nsis_uns'
     selection_export_function:
-        CommandLine|contains:
-            - 'PrintUIEntry'
+        CommandLine|contains: 'PrintUIEntry'
     condition: all of selection_*
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_rhadamanthys_dll_launch.yml
+++ b/rules/windows/process_creation/proc_creation_win_rhadamanthys_dll_launch.yml
@@ -1,0 +1,34 @@
+title: Rhadamanthys Stealer Module Launch via Rundll32
+id: 5cdbc2e8-86dd-43df-9a1a-200d4745fba5
+status: experimental
+description: Detect use of Rundll32 to launch an NSIS module that serves as the main stealer capability of Rhadamanthys infostealer, as observed in reports and samples in early 2023
+references:
+    - https://elis531989.medium.com/dancing-with-shellcodes-analyzing-rhadamanthys-stealer-3c4986966a88
+    - https://blog.cyble.com/2023/01/12/rhadamanthys-new-stealer-spreading-through-google-ads/
+    - https://www.joesandbox.com/analysis/790122/0/html
+    - https://twitter.com/anfam17/status/1607477672057208835
+author: TropChaud
+date: 2023/01/26
+tags:
+    - attack.defense_evasion
+    - attack.t1218.011
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_rundll32:
+        - Description: 'Windows host process (Rundll32)'
+        - OriginalFileName: 'RUNDLL32.EXE'
+        - Image|endswith:
+            - '\rundll32.exe'
+        - CommandLine|contains: 'rundll32'
+    selection_dll:
+        CommandLine|contains:
+            - 'nsis_uns'
+    selection_export_function:
+        CommandLine|contains:
+            - 'PrintUIEntry'
+    condition: all of selection_*
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_rhadamanthys_dll_launch.yml
+++ b/rules/windows/process_creation/proc_creation_win_rhadamanthys_dll_launch.yml
@@ -1,7 +1,7 @@
 title: Rhadamanthys Stealer Module Launch via Rundll32
 id: 5cdbc2e8-86dd-43df-9a1a-200d4745fba5
 status: experimental
-description: Detect use of Rundll32 to launch an NSIS module that serves as the main stealer capability of Rhadamanthys infostealer, as observed in reports and samples in early 2023
+description: Detects the use of Rundll32 to launch an NSIS module that serves as the main stealer capability of Rhadamanthys infostealer, as observed in reports and samples in early 2023
 references:
     - https://elis531989.medium.com/dancing-with-shellcodes-analyzing-rhadamanthys-stealer-3c4986966a88
     - https://blog.cyble.com/2023/01/12/rhadamanthys-new-stealer-spreading-through-google-ads/


### PR DESCRIPTION
I hoped to use a wildcard in line 27 but couldn't get it to work as expected during testing. Ideally the line would read `- 'nsis_uns*.dll'` to tighten up the logic.

A log based on a dummy file used during testing read as follows: `CommandLine: rundll32.exe "C:\Users\User\AppData\Roaming\temp\nsis_uns1d03518.dll",PrintUIEntry`

But I could only get the rule to match using the shortened version seen here in this commit, as opposed to the version with the wildcard - any advice? Thanks!