### PR TITLE
Expand rule support and bug fix for LimaCharlie

### DIFF
--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -558,7 +558,7 @@ class LimaCharlieBackend(BaseBackend):
                 result = {
                     "op": "matches",
                     "path": fieldname,
-                    "re": re.compile(value),
+                    "re": str(value),
                 }
                 if self._postOpMapper is not None:
                     result = self._postOpMapper(result)

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -138,6 +138,20 @@ _allFieldMappings = {
             postOpMapper = _mapProcessCreationOperations,
             isCaseSensitive = []
         ),
+        "windows/dns_query/": SigmaLCConfig(
+            topLevelParams = {
+                "event": "DNS_REQUEST",
+            },
+            preConditions = None,
+            fieldMappings = {
+                "QueryName": "event/DOMAIN_NAME",
+                "Image": "event/FILE_PATH",
+            },
+            isAllStringValues = False,
+            keywordField = None,
+            postOpMapper = None,
+            isCaseSensitive = []
+        ),
         "dns//": SigmaLCConfig(
             topLevelParams = {
                 "event": "DNS_REQUEST",
@@ -151,7 +165,7 @@ _allFieldMappings = {
             postOpMapper = None,
             isCaseSensitive = []
         ),
-        "linux//": SigmaLCConfig(
+        "linux/process_creation/": SigmaLCConfig(
             topLevelParams = {
                 "events": [
                     "NEW_PROCESS",
@@ -164,9 +178,36 @@ _allFieldMappings = {
             fieldMappings = {
                 "exe": "event/FILE_PATH",
                 "type": None,
+                "CommandLine": "event/COMMAND_LINE",
+                "Image": "event/FILE_PATH",
+                "ParentImage": "event/PARENT/FILE_PATH",
+                "ParentCommandLine": "event/PARENT/COMMAND_LINE",
+                "User": "event/USER_NAME",
+                "OriginalFileName": "event/ORIGINAL_FILE_NAME",
+                "OriginalFilename": "event/ORIGINAL_FILE_NAME",
             },
             isAllStringValues = False,
             keywordField = 'event/COMMAND_LINE',
+            postOpMapper = None,
+            isCaseSensitive = ['event/FILE_PATH']
+        ),
+        "linux/file_event/": SigmaLCConfig(
+            topLevelParams = {
+                "events": [
+                    "FILE_CREATE",
+                    "FILE_DELETE",
+                    "FILE_MODIFIED",
+                    "NEW_DOCUMENT",
+                ]
+            },
+            preConditions = {
+                "op": "is linux",
+            },
+            fieldMappings = {
+                "TargetFilename": "event/FILE_PATH",
+            },
+            isAllStringValues = False,
+            keywordField = None,
             postOpMapper = None,
             isCaseSensitive = ['event/FILE_PATH']
         ),
@@ -254,6 +295,8 @@ _allFieldMappings = {
             topLevelParams = {
                 "events": [
                     "FILE_CREATE",
+                    "FILE_DELETE",
+                    "FILE_MODIFIED",
                     "NEW_DOCUMENT",
                 ]
             },

--- a/tools/sigma/backends/limacharlie.py
+++ b/tools/sigma/backends/limacharlie.py
@@ -250,6 +250,24 @@ _allFieldMappings = {
             postOpMapper = _mapProcessCreationOperations,
             isCaseSensitive = ['event/FILE_PATH']
         ),
+        "macos/file_event/": SigmaLCConfig(
+            topLevelParams = {
+                "events": [
+                    "FILE_CREATE",
+                    "NEW_DOCUMENT",
+                ]
+            },
+            preConditions = {
+                "op": "is mac",
+            },
+            fieldMappings = {
+                "TargetFilename": "event/FILE_PATH",
+            },
+            isAllStringValues = False,
+            keywordField = None,
+            postOpMapper = None,
+            isCaseSensitive = ['event/FILE_PATH']
+        ),
     },
     "artifact": {
         "windows//": SigmaLCConfig(


### PR DESCRIPTION
Expand rules supported for LimaCharlie:
- Windows DNS Queries
- Linux Process Creation (enhanced support)
- Linux File Events
- macOS File Events

Also: fixing a bug in the evaluation of some regular expressions.