### PR TITLE
proc_creation_win_copy_browser_data fix FP

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_copy_browser_data.yml
+++ b/rules/windows/process_creation/proc_creation_win_copy_browser_data.yml
@@ -12,6 +12,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1555.003/T1555.003.md
 author: Nasreddine Bencherchali
 date: 2022/12/23
+modified: 2023/01/29
 tags:
     - attack.credential_access
     - attack.t1555.003
@@ -22,10 +23,10 @@ detection:
     selection_cmd:
         - CommandLine|contains:
             - 'copy-item'
-            - 'copy'
+            - 'copy '
             - 'cpi '
             - ' cp '
-            - 'move'
+            - 'move '
             - 'move-item'
             - ' mi '
             - ' mv '


### PR DESCRIPTION
add a space for the cli command `move` and `copy` to avoid FP

close #3968 