### PR TITLE
Remove Trailing space

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_cmd_read_contents.yml
+++ b/rules/windows/process_creation/proc_creation_win_cmd_read_contents.yml
@@ -18,11 +18,11 @@ detection:
         - Image|endswith: '\cmd.exe'
     selection_read:
         - ParentCommandLine|contains|all:
-            - 'cmd '
+            - 'cmd'
             - '/r '
             - '<'
         - CommandLine|contains|all:
-            - 'cmd '
+            - 'cmd'
             - '/r '
             - '<'
     condition: all of selection_*

--- a/rules/windows/process_creation/proc_creation_win_cmd_read_contents.yml
+++ b/rules/windows/process_creation/proc_creation_win_cmd_read_contents.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/40b77d63808dd4f4eafb83949805636735a1fd15/atomics/T1059.003/T1059.003.md
 author: frack113
 date: 2022/08/20
+modified: 2023/02/10
 tags:
     - attack.execution
     - attack.t1059.003


### PR DESCRIPTION
The trailing space causes this rule not to trigger when the extension is used (cmd.exe), eg: 
CommandLine: "C:\Windows\system32\cmd.exe" /r < "C:\Users\Administrator\desktop\test.txt"