### PR TITLE
Update proc_creation_macos_create_account.yml

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_create_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_create_account.yml
@@ -4,9 +4,10 @@ status: test
 description: Detects the creation of a new user account. Such accounts may be used for persistence that do not require persistent remote access tools to be deployed on the system.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1136.001/T1136.001.md
+    - https://ss64.com/osx/sysadminctl.html
 author: Alejandro Ortuno, oscd.community
 date: 2020/10/06
-modified: 2021/11/27
+modified: 2023/02/18
 tags:
     - attack.t1136.001
     - attack.persistence
@@ -14,10 +15,18 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection:
+    selection1:
         Image|endswith: '/dscl'
         CommandLine|contains: 'create'
-    condition: selection
+    selection2:
+        CommandLine|contains|all:
+            - 'sysadminctl'
+            - 'addUser'
+    selection3:
+        CommandLine|contains:
+            - 'sudo'
+            - 'interactive'
+    condition: selection1 or (selection2 and selection3)
 falsepositives:
     - Legitimate administration activities
 level: low

--- a/rules/macos/process_creation/proc_creation_macos_create_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_create_account.yml
@@ -15,13 +15,13 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection1:
+    selection_dscl:
         Image|endswith: '/dscl'
         CommandLine|contains: 'create'
-    selection2:
+    selection_sysadminctl:
         Image|endswith: '/sysadminctl'
         CommandLine|contains: 'addUser'
-    condition: selection1 or selection2
+    condition: 1 of selection_*
 falsepositives:
     - Legitimate administration activities
 level: low

--- a/rules/macos/process_creation/proc_creation_macos_create_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_create_account.yml
@@ -21,12 +21,8 @@ detection:
     selection2:
         CommandLine|contains|all:
             - 'sysadminctl'
-            - 'addUser'
-    selection3:
-        CommandLine|contains:
-            - 'sudo'
-            - 'interactive'
-    condition: selection1 or (selection2 and selection3)
+            - '-addUser'
+    condition: selection1 or selection2
 falsepositives:
     - Legitimate administration activities
 level: low

--- a/rules/macos/process_creation/proc_creation_macos_create_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_create_account.yml
@@ -19,9 +19,8 @@ detection:
         Image|endswith: '/dscl'
         CommandLine|contains: 'create'
     selection2:
-        CommandLine|contains|all:
-            - 'sysadminctl'
-            - '-addUser'
+        Image|endswith: '/sysadminctl'
+        CommandLine|contains: 'addUser'
     condition: selection1 or selection2
 falsepositives:
     - Legitimate administration activities


### PR DESCRIPTION
## Summary of the Pull Request:
The pull request adds a new procedure to the existing rule/detection

## Detailed Description of the Pull Request / Additional comments: 

The new user can also be created using built-in sysadminctl utility in macOS Ex: 
sysadminctl interactive -addUser janedoe -fullName Jane -password pass123! -admin [OR]
sudo sysadminctl -addUser janedoe -fullName Jane -password pass123! -admin

## Example Log Event (In Case of FP Fixes)
NA

## Relevant Issues (In Case of Issue Fixes)
NA