### PR TITLE
Create proc_creation_macos_susp_browser_child_process.yml

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
@@ -1,0 +1,56 @@
+title: Suspicious Browser Child Process
+id: 0250638a-2b28-4541-86fc-ea4c558fa0c6
+status: experimental
+description: Detects suspicious child processes spun from browsers as parent process, as a result of web browser exploitation.
+references:
+    - https://fr.slideshare.net/codeblue_jp/cb19-recent-apt-attack-on-crypto-exchange-employees-by-heungsoo-kang
+    - https://github.com/elastic/detection-rules/blob/4312d8c9583be524578a14fe6295c3370b9a9307/rules/macos/execution_initial_access_suspicious_browser_childproc.toml
+author: Sohan G (D4rkCiph3r)
+date: 2023/02/18
+tags:
+    - attack.t1189
+    - attack.t1203
+    - attack.t1059
+    - attack.initial_access
+    - attack.execution
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection:
+        ParentImage|contains:
+            - 'Google Chrome'
+            - 'Google Chrome Helper'
+            - 'firefox'
+            - 'Opera'
+            - 'Safari'
+            - 'com.apple.WebKit.WebContent'
+            - 'Microsoft Edge'
+            - 'Tor Browser'
+        Image|endswith:
+            - '/sh'
+            - '/bash'
+            - '/dash'
+            - '/ksh'
+            - '/tcsh'
+            - '/zsh'
+            - '/curl'
+            - '/wget'
+            - '/python'
+            - '/perl'
+            - '/php'
+            - '/osascript'
+            - '/pwsh'
+    filter:
+        CommandLine|contains:
+            - '' #avoids alerting for the events which do not have command-line arguments
+            - '--defaults-torrc' #informs tor to use default config file
+            - '/Library/Application Support/Microsoft/MAU*/Microsoft AutoUpdate.app/Contents/MacOS/msupdate' #Microsoft AutoUpdate utility
+            - '/Volumes/Google Chrome/Google Chrome.app/Contents/Frameworks/*/Resources/install.sh' #install the Google Chrome browser
+            - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_preflight.sh' #updates the Google Chrome branding configuration files
+            - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_postflight.sh' #script that performs the post-installation tasks
+            - '/Users/*/Library/Application Support/Google/Chrome/recovery/*/ChromeRecovery'
+    condition: selection and not filter
+falsepositives:
+    - Legitimate browser install, update and recovery scripts
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
@@ -59,7 +59,7 @@ detection:
         #avoids alerting for the events which do not have command-line arguments
         - CommandLine: null
         - CommandLine: ''
-    condition: selection and not filter*
+    condition: selection and not 1 of filter_*
 falsepositives:
     - Legitimate browser install, update and recovery scripts
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
@@ -59,7 +59,7 @@ detection:
         #avoids alerting for the events which do not have command-line arguments
         - CommandLine: null
         - CommandLine: ''
-    condition: selection and not 1 of filter_*
+    condition: selection and not all of filter_*
 falsepositives:
     - Legitimate browser install, update and recovery scripts
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
@@ -1,65 +1,78 @@
-title: Suspicious Browser Child Process
+title: Suspicious Browser Child Process - MacOS
 id: 0250638a-2b28-4541-86fc-ea4c558fa0c6
 status: experimental
-description: Detects suspicious child processes spun from browsers as parent process, as a result of web browser exploitation.
+description: Detects suspicious child processes spawned from browsers. This could be a result of a potential web browser exploitation.
 references:
     - https://fr.slideshare.net/codeblue_jp/cb19-recent-apt-attack-on-crypto-exchange-employees-by-heungsoo-kang
     - https://github.com/elastic/detection-rules/blob/4312d8c9583be524578a14fe6295c3370b9a9307/rules/macos/execution_initial_access_suspicious_browser_childproc.toml
 author: Sohan G (D4rkCiph3r)
-date: 2023/02/18
+date: 2023/04/05
 tags:
+    - attack.initial_access
+    - attack.execution
     - attack.t1189
     - attack.t1203
     - attack.t1059
-    - attack.initial_access
-    - attack.execution
 logsource:
     category: process_creation
     product: macos
 detection:
     selection:
         ParentImage|contains:
-            - 'Google Chrome'
-            - 'Google Chrome Helper'
+            - 'com.apple.WebKit.WebContent'
             - 'firefox'
+            - 'Google Chrome Helper'
+            - 'Google Chrome'
+            - 'Microsoft Edge'
             - 'Opera'
             - 'Safari'
-            - 'com.apple.WebKit.WebContent'
-            - 'Microsoft Edge'
             - 'Tor Browser'
         Image|endswith:
-            - '/sh'
             - '/bash'
+            - '/curl'
             - '/dash'
             - '/ksh'
-            - '/tcsh'
-            - '/zsh'
-            - '/curl'
-            - '/wget'
-            - '/python'
+            - '/osascript'
             - '/perl'
             - '/php'
-            - '/osascript'
             - '/pwsh'
-    filter_gen:
+            - '/python'
+            - '/sh'
+            - '/tcsh'
+            - '/wget'
+            - '/zsh'
+    filter_main_generic:
+        CommandLine|contains: '--defaults-torrc' # Informs tor to use default config file
+    filter_main_ms_autoupdate:
+        CommandLine|contains: '/Library/Application Support/Microsoft/MAU*/Microsoft AutoUpdate.app/Contents/MacOS/msupdate' # Microsoft AutoUpdate utility
+    filter_main_chrome:
+        ParentImage|contains:
+            - 'Google Chrome Helper'
+            - 'Google Chrome'
         CommandLine|contains:
-            - '--defaults-torrc' #informs tor to use default config file
-            - '/Library/Application Support/Microsoft/MAU*/Microsoft AutoUpdate.app/Contents/MacOS/msupdate' #Microsoft AutoUpdate utility
-            - '/Volumes/Google Chrome/Google Chrome.app/Contents/Frameworks/*/Resources/install.sh' #install the Google Chrome browser
-            - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_preflight.sh' #updates the Google Chrome branding configuration files
-            - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_postflight.sh' #script that performs the post-installation tasks
-            - 'IOPlatformExpertDevice' #retrieves the IOPlatformUUID (parent process - Microsoft Edge)
-            - 'hw.model' #retrieves model name of the computer's hardware (parent process - Microsoft Edge)
-    filter_chromerecovery:
+            - '/Volumes/Google Chrome/Google Chrome.app/Contents/Frameworks/*/Resources/install.sh' # Install the Google Chrome browser
+            - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_preflight.sh' # Updates the Google Chrome branding configuration files
+            - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_postflight.sh' # Script that performs the post-installation tasks
+    filter_main_ms_edge:
+        ParentImage|contains: 'Microsoft Edge'
+        CommandLine|contains:
+            - 'IOPlatformExpertDevice' # Retrieves the IOPlatformUUID (parent process - Microsoft Edge)
+            - 'hw.model' # Retrieves model name of the computer's hardware (parent process - Microsoft Edge)
+    filter_main_chromerecovery:
+        ParentImage|contains:
+            - 'Google Chrome Helper'
+            - 'Google Chrome'
         CommandLine|contains|all:
             - '/Users/'
             - '/Library/Application Support/Google/Chrome/recovery/'
             - '/ChromeRecovery'
-    filter_null:
-        #avoids alerting for the events which do not have command-line arguments
-        - CommandLine: null
-        - CommandLine: ''
-    condition: selection and not all of filter_*
+    filter_optional_null:
+        # Aoids alerting for the events which do not have command-line arguments
+        CommandLine: null
+    filter_optional_empty:
+        # Aoids alerting for the events which do not have command-line arguments
+        CommandLine: ''
+    condition: selection and not 1 of filter_main_* and not 1 of filter_optional_*
 falsepositives:
     - Legitimate browser install, update and recovery scripts
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
@@ -41,16 +41,23 @@ detection:
             - '/php'
             - '/osascript'
             - '/pwsh'
-    filter:
+    filter_gen:
         CommandLine|contains:
-            - '' #avoids alerting for the events which do not have command-line arguments
             - '--defaults-torrc' #informs tor to use default config file
             - '/Library/Application Support/Microsoft/MAU*/Microsoft AutoUpdate.app/Contents/MacOS/msupdate' #Microsoft AutoUpdate utility
             - '/Volumes/Google Chrome/Google Chrome.app/Contents/Frameworks/*/Resources/install.sh' #install the Google Chrome browser
             - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_preflight.sh' #updates the Google Chrome branding configuration files
             - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_postflight.sh' #script that performs the post-installation tasks
-            - '/Users/*/Library/Application Support/Google/Chrome/recovery/*/ChromeRecovery'
-    condition: selection and not filter
+    filter_chromerecovery:
+        CommandLine|contains|all:
+            - '/Users/'
+            - '/Library/Application Support/Google/Chrome/recovery/'
+            - '/ChromeRecovery'
+    filter_null:
+        #avoids alerting for the events which do not have command-line arguments
+        - CommandLine: null
+        - CommandLine: ''
+    condition: selection and not filter*
 falsepositives:
     - Legitimate browser install, update and recovery scripts
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_browser_child_process.yml
@@ -48,6 +48,8 @@ detection:
             - '/Volumes/Google Chrome/Google Chrome.app/Contents/Frameworks/*/Resources/install.sh' #install the Google Chrome browser
             - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_preflight.sh' #updates the Google Chrome branding configuration files
             - '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/*/Resources/keystone_promote_postflight.sh' #script that performs the post-installation tasks
+            - 'IOPlatformExpertDevice' #retrieves the IOPlatformUUID (parent process - Microsoft Edge)
+            - 'hw.model' #retrieves model name of the computer's hardware (parent process - Microsoft Edge)
     filter_chromerecovery:
         CommandLine|contains|all:
             - '/Users/'


### PR DESCRIPTION
## Summary of the Pull Request:

The pull request adds a new rule for macOS (T1189, T1203, T1059)

## Detailed Description of the Pull Request / Additional comments: 

The rule helps detect suspicious child processes spun from browsers as parent process, as a result of web browser exploitation, this includes few legitimate activity - browser scripts related to installations, updates and recovery.

## Example Log Event (In Case of FP Fixes)
NA

## Relevant Issues (In Case of Issue Fixes)
NA