### PR TITLE
Create proc_creation_macos_enable_guest_account.yml

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_enable_guest_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_enable_guest_account.yml
@@ -1,0 +1,22 @@
+title: Enable the Guest Account
+status: experimental
+description: Detects attempts to enable the guest account using the sysadminctl utility
+references:
+    - https://ss64.com/osx/sysadminctl.html
+author: Sohan G (D4rkCiph3r)
+date: 2023/02/18
+tags:
+    - attack.t1078
+    - attack.t1078.001
+    - attack.initial_access
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection:
+        Image|endswith: '/sysadminctl'
+        CommandLine|contains: 'guestAccount on' #by default the guest account is not active
+    condition: selection
+falsepositives:
+    - Unknown
+level: low

--- a/rules/macos/process_creation/proc_creation_macos_enable_guest_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_enable_guest_account.yml
@@ -1,4 +1,5 @@
 title: Enable the Guest Account
+id: d7329412-13bd-44ba-a072-3387f804a106
 status: experimental
 description: Detects attempts to enable the guest account using the sysadminctl utility
 references:

--- a/rules/macos/process_creation/proc_creation_macos_sysadminctl_enable_guest_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_sysadminctl_enable_guest_account.yml
@@ -1,4 +1,4 @@
-title: Enable the Guest Account
+title: Guest Account Enabled Via Sysadminctl
 id: d7329412-13bd-44ba-a072-3387f804a106
 status: experimental
 description: Detects attempts to enable the guest account using the sysadminctl utility
@@ -7,16 +7,19 @@ references:
 author: Sohan G (D4rkCiph3r)
 date: 2023/02/18
 tags:
+    - attack.initial_access
     - attack.t1078
     - attack.t1078.001
-    - attack.initial_access
 logsource:
     category: process_creation
     product: macos
 detection:
     selection:
         Image|endswith: '/sysadminctl'
-        CommandLine|contains: 'guestAccount on' #by default the guest account is not active
+        CommandLine|contains|all:
+            # By default the guest account is not active
+            - ' -guestAccount'
+            - ' on'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
## Summary of the Pull Request
The pull request adds a new rule for macOS (T1078, T1078.001)

## Detailed Description of the Pull Request / Additional comments

The rule helps detect attempts to enable the guest account using the sysadminctl utility. The guest account is inactive by default.

## Example Log Event (In Case of FP Fixes)
NA

## Relevant Issues (In Case of Issue Fixes)
NA