### PR TITLE
Create proc_creation_macos_enable_root_account.yml

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_dsenableroot_enable_root_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_dsenableroot_enable_root_account.yml
@@ -1,16 +1,13 @@
-title: Enable the Root Account
+title: Root Account Enable Via Dsenableroot
 id: 821bcf4d-46c7-4b87-bc57-9509d3ba7c11
 status: experimental
-description: Detects attempts to enable/add an account to the admin group, thus granting the root privilege
+description: Detects attempts to enable the root account via "dsenableroot"
 references:
-    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md
+    - https://github.com/redcanaryco/atomic-red-team/blob/b27a3cb25025161d49ac861cb216db68c46a3537/atomics/T1078.003/T1078.003.md
     - https://github.com/elastic/detection-rules/blob/4312d8c9583be524578a14fe6295c3370b9a9307/rules/macos/persistence_enable_root_account.toml
     - https://ss64.com/osx/dsenableroot.html
-    - https://ss64.com/osx/dseditgroup.html
-    - https://ss64.com/osx/dscl.html
 author: Sohan G (D4rkCiph3r)
-date: 2023/02/18
-modified: 2023/03/30
+date: 2023/08/22
 tags:
     - attack.t1078
     - attack.t1078.001
@@ -21,11 +18,11 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection_root:
+    selection:
         Image|endswith: '/dsenableroot'
-    filter_root:
+    filter_main_disable:
         CommandLine|contains: ' -d '
-    condition: selection_root and not filter_root
+    condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
@@ -20,22 +20,11 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection_ds_cl:
-        Image|endswith: '/dscl'
-        CommandLine|contains|all:
-            - '-append' #appends the user
-            - '/Groups/admin'
-    selection_ds_editgroup:
-        Image|endswith: '/dseditgroup'
-        CommandLine|contains|all:
-            - '-a' #name of the record(username)
-            - '-t' #type of the record(usergroup)
-            - 'admin'
     selection_root:
         Image|endswith: '/dsenableroot'
     filter_root:
         CommandLine|contains: ' -d '
-    condition: (selection_root and not filter_root) or 1 of selection_ds_*
+    condition: selection_root and not filter_root
 falsepositives:
     - Unknown
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
@@ -3,7 +3,7 @@ id: 821bcf4d-46c7-4b87-bc57-9509d3ba7c11
 status: experimental
 description: Detects attempts to enable/add an account to the admin group, thus granting the root privilege
 references:
-    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.001/T1078.001.md
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md
     - https://github.com/elastic/detection-rules/blob/4312d8c9583be524578a14fe6295c3370b9a9307/rules/macos/persistence_enable_root_account.toml
     - https://ss64.com/osx/dsenableroot.html
     - https://ss64.com/osx/dseditgroup.html
@@ -13,29 +13,29 @@ date: 2023/02/18
 tags:
     - attack.t1078
     - attack.t1078.001
+    - attack.t1078.003
     - attack.initial_access
     - attack.persistence
 logsource:
     category: process_creation
     product: macos
 detection:
-    selection1:
-        Image|endswith:
-            - '/dseditgroup'
-            - '/dscl'
-    selection2:
+    selection_dscl:
+        Image|endswith: '/dscl'
         CommandLine|contains:
+            - '-append' #appends the user
             - '/Groups/admin'
+    selection_dseditgroup:
+        Image|endswith: '/dseditgroup'
+        CommandLine|contains|all:
+            - '-a' #name of the record(username)
+            - '-t' #type of the record(usergroup)
             - 'admin'
-    selection3:
-        CommandLine|contains:
-            - 'append'
-            - ' -a '
-    selection4:
+    selection_dsenableroot:
         Image|endswith: '/dsenableroot'
     filter:
         CommandLine|contains: ' -d '
-    condition: (selection1 and selection2 and selection3) or (selection4 and not filter)
+    condition: (selection_dsenableroot and not filter) or 1 of selection*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
@@ -1,0 +1,41 @@
+title: Enable the Root Account
+id: 821bcf4d-46c7-4b87-bc57-9509d3ba7c11
+status: experimental
+description: Detects attempts to enable/add an account to the admin group, thus granting the root privilege
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.001/T1078.001.md
+    - https://github.com/elastic/detection-rules/blob/4312d8c9583be524578a14fe6295c3370b9a9307/rules/macos/persistence_enable_root_account.toml
+    - https://ss64.com/osx/dsenableroot.html
+    - https://ss64.com/osx/dseditgroup.html
+    - https://ss64.com/osx/dscl.html
+author: Sohan G (D4rkCiph3r)
+date: 2023/02/18
+tags:
+    - attack.t1078
+    - attack.t1078.001
+    - attack.initial_access
+    - attack.persistence
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection1:
+        Image|endswith:
+            - '/dseditgroup'
+            - '/dscl'
+    selection2:
+        CommandLine|contains:
+            - '/Groups/admin'
+            - 'admin'
+    selection3:
+        CommandLine|contains:
+            - 'append'
+            - ' -a '
+    selection4:
+        Image|endswith: '/dsenableroot'
+    filter:
+        CommandLine|contains: ' -d '
+    condition: (selection1 and selection2 and selection3) or (selection4 and not filter)
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
@@ -10,6 +10,7 @@ references:
     - https://ss64.com/osx/dscl.html
 author: Sohan G (D4rkCiph3r)
 date: 2023/02/18
+modified: 2023/03/30
 tags:
     - attack.t1078
     - attack.t1078.001

--- a/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_enable_root_account.yml
@@ -20,22 +20,22 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection_dscl:
+    selection_ds_cl:
         Image|endswith: '/dscl'
-        CommandLine|contains:
+        CommandLine|contains|all:
             - '-append' #appends the user
             - '/Groups/admin'
-    selection_dseditgroup:
+    selection_ds_editgroup:
         Image|endswith: '/dseditgroup'
         CommandLine|contains|all:
             - '-a' #name of the record(username)
             - '-t' #type of the record(usergroup)
             - 'admin'
-    selection_dsenableroot:
+    selection_root:
         Image|endswith: '/dsenableroot'
-    filter:
+    filter_root:
         CommandLine|contains: ' -d '
-    condition: (selection_dsenableroot and not filter) or 1 of selection*
+    condition: (selection_root and not filter_root) or 1 of selection_ds_*
 falsepositives:
     - Unknown
 level: medium


### PR DESCRIPTION
## Summary of the Pull Request
The pull request adds a new rule for macOS (T1078, T1078.001)

## Detailed Description of the Pull Request / Additional comments

The rule helps detect attempts to enable/add an account to the admin group, thus granting the root privilege using various utilities such as dsenableroot

## Example Log Event (In Case of FP Fixes)
NA

## Relevant Issues (In Case of Issue Fixes)
NA