### PR TITLE
Create proc_creation_macos_susp_installer_child_process.yml

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_installer_susp_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_installer_susp_child_process.yml
@@ -10,7 +10,7 @@ date: 2023/02/18
 tags:
     - attack.t1059
     - attack.t1059.007
-    - attack.t1071 
+    - attack.t1071
     - attack.t1071.001
     - attack.execution
     - attack.command_and_control
@@ -40,5 +40,5 @@ detection:
             - 'postinstall'
     condition: selection_installer
 falsepositives:
-    - Legitimate software uses the scripts(preinstall, postinstall)
+    - Legitimate software uses the scripts (preinstall, postinstall)
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
@@ -1,0 +1,46 @@
+title: Suspicious Installer Package child process
+id: e0cfaecd-602d-41af-988d-f6ccebb2af26
+status: experimental
+description: Detects the execution of suspicious child processes from macOS installer package parent process. This includes osascript, JXA, curl and wget amongst other interpreters
+references:
+    - https://redcanary.com/blog/clipping-silver-sparrows-wings/
+    - https://github.com/elastic/detection-rules/blob/4312d8c9583be524578a14fe6295c3370b9a9307/rules/macos/execution_installer_package_spawned_network_event.toml
+author: Sohan G (D4rkCiph3r)
+date: 2023/02/18
+tags:
+    - attack.t1059
+    - attack.t1059.007
+    - attack.t1071 
+    - attack.t1071.001
+    - attack.execution
+    - attack.command_and_controls
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection1:
+        ParentImage|contains:
+            - 'package_script_service'
+            - 'installer'
+    selection2:
+        Image|endswith:
+            - '/sh'
+            - '/bash'
+            - '/dash'
+            - '/python'
+            - '/ruby'
+            - '/perl'
+            - '/php'
+            - '/javascript'
+            - '/osascript'
+            - '/tclsh'
+            - '/curl'
+            - '/wget'
+    selection3:
+        CommandLine|contains:
+            - 'preinstall'
+            - 'postinstall'
+    condition: all of selection*
+falsepositives:
+    - Legitimate software uses the scripts(preinstall, postinstall)
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
@@ -19,9 +19,9 @@ logsource:
     product: macos
 detection:
     selection_installer:
-        ParentImage|contains:
-            - 'package_script_service'
-            - 'installer'
+        ParentImage|endswith:
+            - '/package_script_service'
+            - '/installer'
         Image|endswith:
             - '/sh'
             - '/bash'

--- a/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
@@ -18,11 +18,10 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection1:
+    selection_installer:
         ParentImage|contains:
             - 'package_script_service'
             - 'installer'
-    selection2:
         Image|endswith:
             - '/sh'
             - '/bash'
@@ -36,11 +35,10 @@ detection:
             - '/tclsh'
             - '/curl'
             - '/wget'
-    selection3:
         CommandLine|contains:
             - 'preinstall'
             - 'postinstall'
-    condition: all of selection*
+    condition: selection_installer
 falsepositives:
     - Legitimate software uses the scripts(preinstall, postinstall)
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
@@ -13,7 +13,7 @@ tags:
     - attack.t1071 
     - attack.t1071.001
     - attack.execution
-    - attack.command_and_controls
+    - attack.command_and_control
 logsource:
     category: process_creation
     product: macos

--- a/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_installer_child_process.yml
@@ -1,4 +1,4 @@
-title: Suspicious Installer Package child process
+title: Suspicious Installer Package Child Process
 id: e0cfaecd-602d-41af-988d-f6ccebb2af26
 status: experimental
 description: Detects the execution of suspicious child processes from macOS installer package parent process. This includes osascript, JXA, curl and wget amongst other interpreters


### PR DESCRIPTION
## Summary of the Pull Request
The pull request adds a new rule for macOS (T1059, T1059.007, T1071, T1071.001)

## Detailed Description of the Pull Request / Additional comments

The rule helps detect the execution of suspicious child processes from macOS installer package parent process. This includes osascript, JXA, curl and wget amongst other interpreters. The legitimate softwares also use scripts(preinstall and postinstall). Baselining or application allow-listing monitoring helps reduce the false positives

## Example Log Event (In Case of FP Fixes)
NA

## Relevant Issues (In Case of Issue Fixes)
NA