### PR TITLE
Create proc_creation_macos_persistence_via_plistbuddy.yml

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_persistence_via_plistbuddy.yml
+++ b/rules/macos/process_creation/proc_creation_macos_persistence_via_plistbuddy.yml
@@ -1,4 +1,4 @@
-title: Persistence establishment using PlistBuddy
+title: Persistence Establishment Using PlistBuddy
 id: 65d506d3-fcfe-4071-b4b2-bcefe721bbbb
 status: experimental
 description: Detects suspicious persistence achieved using LaunchAgents or LaunchDaemons via PlistBuddy utility

--- a/rules/macos/process_creation/proc_creation_macos_persistence_via_plistbuddy.yml
+++ b/rules/macos/process_creation/proc_creation_macos_persistence_via_plistbuddy.yml
@@ -1,0 +1,31 @@
+title: Persistence establishment using PlistBuddy
+id: 65d506d3-fcfe-4071-b4b2-bcefe721bbbb
+status: experimental
+description: Detects suspicious persistence achieved using LaunchAgents or LaunchDaemons via PlistBuddy utility
+references:
+    - https://redcanary.com/blog/clipping-silver-sparrows-wings/
+    - https://www.manpagez.com/man/8/PlistBuddy/
+author: Sohan G (D4rkCiph3r)
+date: 2023/02/18
+tags:
+    - attack.t1543.001 
+    - attack.t1543.004
+    - attack.persistence
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection1:
+        Image|endswith: '/PlistBuddy'
+    selection2:
+        CommandLine|contains:
+            - 'LaunchAgents'
+            - 'LaunchDaemons'
+    selection3:
+        CommandLine|contains|all:
+            - 'RunAtLoad'
+            - 'true'
+    condition: all of selection*
+falsepositives:
+    - Unknown
+level: high

--- a/rules/macos/process_creation/proc_creation_macos_persistence_via_plistbuddy.yml
+++ b/rules/macos/process_creation/proc_creation_macos_persistence_via_plistbuddy.yml
@@ -1,31 +1,29 @@
-title: Persistence Establishment Using PlistBuddy
+title: Potential Persistence Via PlistBuddy
 id: 65d506d3-fcfe-4071-b4b2-bcefe721bbbb
 status: experimental
-description: Detects suspicious persistence achieved using LaunchAgents or LaunchDaemons via PlistBuddy utility
+description: Detects potential persistence activity using LaunchAgents or LaunchDaemons via the PlistBuddy utility
 references:
     - https://redcanary.com/blog/clipping-silver-sparrows-wings/
     - https://www.manpagez.com/man/8/PlistBuddy/
 author: Sohan G (D4rkCiph3r)
 date: 2023/02/18
 tags:
+    - attack.persistence
     - attack.t1543.001 
     - attack.t1543.004
-    - attack.persistence
 logsource:
     category: process_creation
     product: macos
 detection:
-    selection1:
+    selection:
         Image|endswith: '/PlistBuddy'
-    selection2:
-        CommandLine|contains:
-            - 'LaunchAgents'
-            - 'LaunchDaemons'
-    selection3:
         CommandLine|contains|all:
             - 'RunAtLoad'
             - 'true'
-    condition: all of selection*
+        CommandLine|contains:
+            - 'LaunchAgents'
+            - 'LaunchDaemons'
+    condition: selection
 falsepositives:
     - Unknown
 level: high


### PR DESCRIPTION
## Summary of the Pull Request
The pull request adds a new rule for macOS (T1543.001, T1543.004)

## Detailed Description of the Pull Request / Additional comments
The rule helps detect suspicious persistence achieved using LaunchAgents or LaunchDaemons via PlistBuddy utility CLI parameters.

## Example Log Event (In Case of FP Fixes)
NA

## Relevant Issues (In Case of Issue Fixes)
NA