### PR TITLE
fix: One value of imagePath was wrong

### DIFF
--- a/rules/windows/builtin/system/win_system_invoke_obfuscation_clip_services.yml
+++ b/rules/windows/builtin/system/win_system_invoke_obfuscation_clip_services.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/SigmaHQ/sigma/issues/1009  #(Task 26)
 author: Jonathan Cheong, oscd.community
 date: 2020/10/13
-modified: 2022/11/27
+modified: 2023/02/20
 tags:
     - attack.defense_evasion
     - attack.t1027
@@ -21,7 +21,7 @@ detection:
         EventID: 7045
         ImagePath|contains|all:
             - 'cmd'
-            - 'clip'
+            - '&&'
             - 'clipboard]::'
     condition: selection
 falsepositives:


### PR DESCRIPTION
## Summary of the Pull Request

[Updated wrong value of ImagePath]

## Detailed Description of the Pull Request / Additional Comments

[it was "clip" that is already covered by "clipboard]::".

Real value is "&&" .]

## Example Log Event (In Case of FP Fixes)

**N/A**

## Relevant Issues (In Case of Issue Fixes)

**Reference: 
Sigma Rule Id: 4edf51e1-cb83-4e1a-bc39-800e396068e3 Link: [Invoke-Obfuscation CLIP+ Launcher - Security](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/security/win_security_invoke_obfuscation_clip_services_security.yml)**
