### PR TITLE
fix: sigmac conversion error with `base64offset|contains` rule

### DIFF
--- a/tools/sigma/parser/modifiers/transform.py
+++ b/tools/sigma/parser/modifiers/transform.py
@@ -24,6 +24,7 @@ class SigmaContainsModifier(ListOrStringModifierMixin, SigmaTransformModifier):
     """Add *-wildcard before and after all string(s)"""
     identifier = "contains"
     active = True
+    valid_input_types = ListOrStringModifierMixin.valid_input_types + (NodeSubexpression,)
 
     def apply_str(self, val):
         try:


### PR DESCRIPTION
## Summary 
`sigmac` conversion failed with a rule which has `base64offset|contains`, so I fixed it.

## Detailed Description of the Pull Request
Explicitly define `valid_input_types = NodeSubexpression` in `SigmaContainsModifier` class.
- Because `SigmaBase64OffsetModifier` return `NodeSubexpression`,
- then following validation failed if `SigmaContainsModifier` class not define `valid_input_types = NodeSubexpression`
  - https://github.com/SigmaHQ/sigma/blob/0.22/tools/sigma/parser/modifiers/base.py#L44-L52

## Fixed Issues 
- Fixed https://github.com/SigmaHQ/sigma/issues/4063
