### PR TITLE
feat: add `ignore-apply-modifier` option to `sigmac`

### DIFF
--- a/tools/sigma/configuration.py
+++ b/tools/sigma/configuration.py
@@ -93,7 +93,7 @@ class SigmaConfigurationChain(list):
 # Configuration
 class SigmaConfiguration:
     """Sigma converter configuration. Contains field mappings and logsource descriptions"""
-    def __init__(self, configyaml=None):
+    def __init__(self, configyaml=None, ignore_apply_modifier=None):
         if configyaml == None:
             self.config = None
             self.order = None
@@ -122,6 +122,7 @@ class SigmaConfiguration:
 
             self.logsources = list()
             self.backend = None
+            self.ignore_apply_modifier = ignore_apply_modifier
 
     def get_fieldmapping(self, fieldname):
         """Return mapped fieldname if mapping defined or field name given in parameter value"""
@@ -156,6 +157,7 @@ class SigmaConfiguration:
         """Get index condition if index field name is configured"""
         if self.backend is not None:
             return self.backend.index_field
+
 
 class SigmaLogsourceConfiguration:
     """Contains the definition of a log source"""

--- a/tools/sigma/parser/collection.py
+++ b/tools/sigma/parser/collection.py
@@ -29,13 +29,14 @@ class SigmaCollectionParser:
     * reset: resets global attributes from previous set_global statements
     * repeat: takes attributes from this YAML document, merges into previous rule YAML and regenerates the rule
     """
-    def __init__(self, content, config=None, rulefilter=None, filename=None):
+    def __init__(self, content, config=None, rulefilter=None, filename=None, ignore_apply_modifier=None):
         if config is None:
             from sigma.configuration import SigmaConfiguration
             config = SigmaConfiguration()
         self.yamls = yaml.safe_load_all(content)
         globalyaml = dict()
         self.parsers = list()
+        self.ignore_apply_modifier  = ignore_apply_modifier
         prevrule = None
         if filename:
             try:
@@ -65,12 +66,12 @@ class SigmaCollectionParser:
                 newrule = copy.deepcopy(prevrule)
                 deep_update_dict(newrule, yamldoc)
                 if rulefilter is None or rulefilter is not None and not rulefilter.match(newrule):
-                    self.parsers.append(SigmaParser(newrule, config))
+                    self.parsers.append(SigmaParser(newrule, config, ignore_apply_modifier))
                     prevrule = newrule
             else:
                 deep_update_dict(yamldoc, globalyaml)
                 if rulefilter is None or rulefilter is not None and rulefilter.match(yamldoc):
-                    self.parsers.append(SigmaParser(yamldoc, config))
+                    self.parsers.append(SigmaParser(yamldoc, config, ignore_apply_modifier))
                     prevrule = yamldoc
         self.config = config
 

--- a/tools/sigma/sigmac.py
+++ b/tools/sigma/sigmac.py
@@ -134,6 +134,7 @@ def set_argparser():
     argparser.add_argument("--backend-help", action=ActionBackendHelp, help="Print backend options")
     argparser.add_argument("--defer-abort", "-d", action="store_true", help="Don't abort on parse or conversion errors, proceed with next rule. The exit code from the last error is returned")
     argparser.add_argument("--ignore-backend-errors", "-I", action="store_true", help="Only return error codes for parse errors and ignore errors for rules that cause backend errors. Useful, when you want to get as much queries as possible.")
+    argparser.add_argument("--ignore-apply-modifier", "-ia", help="Outputs the value as is, ignoring the automatic transformation of the value by the modifier. Multiple values can be specified with commas.")
     argparser.add_argument("--shoot-yourself-in-the-foot", action="store_true", help=argparse.SUPPRESS)
     argparser.add_argument("--verbose", "-v", action="store_true", help="Be verbose")
     argparser.add_argument("--debug", "-D", action="store_true", help="Debugging output")
@@ -322,7 +323,7 @@ def main():
                 f = sigmafile
             else:
                 f = sigmafile.open(encoding='utf-8')
-            parser = SigmaCollectionParser(f, sigmaconfigs, rulefilter, sigmafile)
+            parser = SigmaCollectionParser(f, sigmaconfigs, rulefilter, sigmafile, cmdargs.ignore_apply_modifier)
             backend.setYmlFileName(str(sigmafile))
             results = parser.generate(backend)
 


### PR DESCRIPTION
Our team uses sigma rules and `sigmac` heavily in [Hayabusa](https://github.com/Yamato-Security/hayabusa), thank you so much :)

I think it would be better to be able to choose whether to disable the conversion by modifier, so I implemented it. 
What do you think?

### Summary of the Pull Request

Added `-ignore-apply-modifier` option to `sigmac`.
User will be able to choose whether to disable  the conversion by `startswith`/`endswith`/`contains`... etc modifier.

### Detailed Description of the Pull Request 

Currently, rules with modifiers such as `startswith`/`endswith`/`contains` are automatically convert value according to the logic in the code below
https://github.com/SigmaHQ/sigma/blob/master/tools/sigma/parser/modifiers/transform.py

The above conversion process cannot be disabled by the user(in my understanding. sorry if I misunderstood)
However, there are cases in which user doesn't want the value to be converted.

For example ...
In general, wildcards and regular expression string matching are slow, and standard String method such as `startswith`/`endswith`/`contains` are much faster.(e.g. Rust standard String method ... [starts_with](https://doc.rust-lang.org/std/string/struct.String.html#method.starts_with), [ends_with](https://doc.rust-lang.org/std/string/struct.String.html#method.ends_with), [contains](https://doc.rust-lang.org/std/string/struct.String.html#method.contains))

#### Current behavior
Running `sigmac` regardless of the options automatically performs the following conversions:
- `CommandLine|startswith: C:\Windows` -> `C:\Windows*`
- `CommandLine|endswith: powershell.exe` -> `*powershell.exe`
- `CommandLine|contains: nodepad.exe` -> `*notepad.exe*`
- `CommandLine|base64offset|contains: FromBase64String` -> `*<base64 encoded string>*`

Example command:
```
python3 ./sigmac -t splunk -c config/generic/sysmon.yml ../rules/windows/process_creation/proc_creation_win_cscript_vbs.yml
((EventID="1" Image="*\\cscript.exe" CommandLine="*.vbs*"))
```

#### This PR behavior
Running `sigmac` with new option `--ignore-apply-modifier "contains,statrswith,endswith,base64offset"` then output value as is.
- `CommandLine|startswith: C:\Windows` -> `C:\Windows`
- `CommandLine|endswith: powershell.exe` -> `powershell.exe`
- `CommandLine|contains: nodepad.exe` -> `notepad.exe`
- `CommandLine|base64offset|contains: FromBase64String` -> `FromBase64String`

Example command:

```
python3 ./sigmac -t splunk -c config/generic/sysmon.yml --ignore-apply-modifier "endswith,contains" ../rules/windows/process_creation/proc_creation_win_cscript_vbs.yml
((EventID="1" Image|endswith="\\cscript.exe" CommandLine|contains=".vbs"))
```

#### Other use cases

It is also possible to disable the convertion by modifiers that cause errors(such as https://github.com/SigmaHQ/sigma/issues/4002) and have the user implement the conversion process. I think that users who have not yet migrated to `pySigma` can also prevent conversion errors by using this option.

I would appreciate it if you could review.