### PR TITLE
chore: update pipe-notation rules status to unsupported

### DIFF
--- a/rules-unsupported/dns_query_win_possible_dns_rebinding.yml
+++ b/rules-unsupported/dns_query_win_possible_dns_rebinding.yml
@@ -1,12 +1,12 @@
 title: Possible DNS Rebinding
 id: eb07e747-2552-44cd-af36-b659ae0958e4
-status: test
+status: unsupported
 description: Detects several different DNS-answers by one domain with IPs from internal and external networks. Normally, DNS-answer contain TTL >100. (DNS-record will saved in host cache for a while TTL).
 references:
     - https://medium.com/@brannondorsey/attacking-private-networks-from-the-internet-with-dns-rebinding-ea7098a2d325
 author: Ilyas Ochkov, oscd.community
 date: 2019/10/25
-modified: 2021/11/27
+modified: 2023/02/24
 tags:
     - attack.initial_access
     - attack.t1189

--- a/rules-unsupported/image_load_mimikatz_inmemory_detection.yml
+++ b/rules-unsupported/image_load_mimikatz_inmemory_detection.yml
@@ -1,12 +1,12 @@
 title: Mimikatz In-Memory
 id: c0478ead-5336-46c2-bd5e-b4c84bc3a36e
-status: test
+status: unsupported
 description: Detects certain DLL loads when Mimikatz gets executed
 references:
     - https://securityriskadvisors.com/blog/post/detecting-in-memory-mimikatz/
 author: sigma
 date: 2017/03/13
-modified: 2021/11/27
+modified: 2023/02/24
 tags:
     - attack.s0002
     - attack.t1003

--- a/rules-unsupported/posh_ps_cl_invocation_lolscript_count.yml
+++ b/rules-unsupported/posh_ps_cl_invocation_lolscript_count.yml
@@ -1,13 +1,13 @@
 title: Execution via CL_Invocation.ps1 (2 Lines)
 id: f588e69b-0750-46bb-8f87-0e9320d57536
-status: test
+status: unsupported
 description: Detects Execution via SyncInvoke in CL_Invocation.ps1 module
 references:
     - https://lolbas-project.github.io/lolbas/Scripts/Cl_invocation/
     - https://twitter.com/bohops/status/948061991012327424
 author: oscd.community, Natalia Shornikova
 date: 2020/10/14
-modified: 2022/12/25
+modified: 2023/02/24
 tags:
     - attack.defense_evasion
     - attack.t1216

--- a/rules-unsupported/posh_ps_cl_mutexverifiers_lolscript_count.yml
+++ b/rules-unsupported/posh_ps_cl_mutexverifiers_lolscript_count.yml
@@ -1,13 +1,13 @@
 title: Execution via CL_Mutexverifiers.ps1 (2 Lines)
 id: 6609c444-9670-4eab-9636-fe4755a851ce
-status: test
+status: unsupported
 description: Detects Execution via runAfterCancelProcess in CL_Mutexverifiers.ps1 module
 references:
     - https://lolbas-project.github.io/lolbas/Scripts/CL_mutexverifiers/
     - https://twitter.com/pabraeken/status/995111125447577600
 author: oscd.community, Natalia Shornikova
 date: 2020/10/14
-modified: 2022/12/25
+modified: 2023/02/24
 tags:
     - attack.defense_evasion
     - attack.t1216

--- a/rules-unsupported/proc_creation_win_correlation_apt_silence_downloader_v3.yml
+++ b/rules-unsupported/proc_creation_win_correlation_apt_silence_downloader_v3.yml
@@ -1,10 +1,10 @@
 title: Silence.Downloader V3
 id: 170901d1-de11-4de7-bccb-8fa13678d857
-status: test
+status: unsupported
 description: Detects Silence downloader. These commands are hardcoded into the binary.
 author: Alina Stepchenkova, Roman Rezvukhin, Group-IB, oscd.community
 date: 2019/11/01
-modified: 2021/11/27
+modified: 2023/02/24
 tags:
     - attack.persistence
     - attack.t1547.001

--- a/rules-unsupported/proc_creation_win_correlation_apt_turla_commands_medium.yml
+++ b/rules-unsupported/proc_creation_win_correlation_apt_turla_commands_medium.yml
@@ -1,12 +1,12 @@
 title: Automated Turla Group Lateral Movement
 id: 75925535-ca97-4e0a-a850-00b5c00779dc
-status: test
+status: unsupported
 description: Detects automated lateral movement by Turla group
 references:
     - https://securelist.com/the-epic-turla-operation/65545/
 author: Markus Neis
 date: 2017/11/07
-modified: 2022/12/02
+modified: 2023/02/24
 tags:
     - attack.g0010
     - attack.execution

--- a/rules-unsupported/proc_creation_win_correlation_dnscat2_powershell_implementation.yml
+++ b/rules-unsupported/proc_creation_win_correlation_dnscat2_powershell_implementation.yml
@@ -1,6 +1,6 @@
 title: DNSCat2 Powershell Implementation Detection Via Process Creation
 id: b11d75d6-d7c1-11ea-87d0-0242ac130003
-status: test
+status: unsupported
 description: The PowerShell implementation of DNSCat2 calls nslookup to craft queries. Counting nslookup processes spawned by PowerShell will show hundreds or thousands of instances if PS DNSCat2 is active locally.
 references:
     - https://github.com/lukebaggett/dnscat2-powershell
@@ -8,7 +8,7 @@ references:
     - https://ragged-lab.blogspot.com/2020/06/it-is-always-dns-powershell-edition.html
 author: Cian Heasley
 date: 2020/08/08
-modified: 2022/07/14
+modified: 2023/02/24
 tags:
     - attack.command_and_control
     - attack.t1071

--- a/rules-unsupported/proc_creation_win_correlation_multiple_susp_cli.yml
+++ b/rules-unsupported/proc_creation_win_correlation_multiple_susp_cli.yml
@@ -1,12 +1,12 @@
 title: Quick Execution of a Series of Suspicious Commands
 id: 61ab5496-748e-4818-a92f-de78e20fe7f1
-status: experimental
+status: unsupported
 description: Detects multiple suspicious process in a limited timeframe
 references:
     - https://car.mitre.org/wiki/CAR-2013-04-002
 author: juju4
 date: 2019/01/16
-modified: 2022/07/14
+modified: 2023/02/24
 tags:
     - car.2013-04-002
     - attack.execution

--- a/rules-unsupported/proc_creation_win_correlation_susp_builtin_commands_recon.yml
+++ b/rules-unsupported/proc_creation_win_correlation_susp_builtin_commands_recon.yml
@@ -1,6 +1,6 @@
 title: Reconnaissance Activity Using BuiltIn Commands
 id: 2887e914-ce96-435f-8105-593937e90757
-status: test
+status: unsupported
 description: Detects execution of a set of builtin commands often used in recon stages by different attack groups
 references:
     - https://twitter.com/haroonmeer/status/939099379834658817
@@ -8,7 +8,7 @@ references:
     - https://www.fireeye.com/blog/threat-research/2016/05/targeted_attacksaga.html
 author: Florian Roth (Nextron Systems), Markus Neis
 date: 2018/08/22
-modified: 2022/10/05
+modified: 2023/02/24
 tags:
     - attack.discovery
     - attack.t1087

--- a/rules-unsupported/win_security_global_catalog_enumeration.yml
+++ b/rules-unsupported/win_security_global_catalog_enumeration.yml
@@ -1,12 +1,12 @@
 title: Enumeration via the Global Catalog
 id: 619b020f-0fd7-4f23-87db-3f51ef837a34
-status: experimental
+status: unsupported
 description: Detects enumeration of the global catalog (that can be performed using BloodHound or others AD reconnaissance tools). Adjust Threshold according to domain width.
 references:
     - https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-5156
 author: Chakib Gzenayi (@Chak092), Hosni Mribah
 date: 2020/05/11
-modified: 2022/08/15
+modified: 2023/02/24
 tags:
     - attack.discovery
     - attack.t1087.002

--- a/rules-unsupported/win_security_rare_schtasks_creations.yml
+++ b/rules-unsupported/win_security_rare_schtasks_creations.yml
@@ -1,10 +1,10 @@
 title: Rare Schtasks Creations
 id: b0d77106-7bb0-41fe-bd94-d1752164d066
-status: test
+status: unsupported
 description: Detects rare scheduled tasks creations that only appear a few times per time frame and could reveal password dumpers, backdoor installs or other types of malicious code
 author: Florian Roth (Nextron Systems)
 date: 2017/03/23
-modified: 2021/11/27
+modified: 2023/02/24
 tags:
     - attack.execution
     - attack.privilege_escalation

--- a/rules-unsupported/win_security_susp_failed_logons_explicit_credentials.yml
+++ b/rules-unsupported/win_security_susp_failed_logons_explicit_credentials.yml
@@ -1,12 +1,12 @@
 title: Password Spraying via Explicit Credentials
 id: 196a29c2-e378-48d8-ba07-8a9e61f7fab9
-status: test
+status: unsupported
 description: Detects a single user failing to authenticate to multiple users using explicit credentials.
 references:
     - https://docs.splunk.com/Documentation/ESSOC/3.22.0/stories/UseCase#Active_directory_password_spraying
 author: Mauricio Velazco, Zach Mathis
 date: 2021/06/01
-modified: 2023/01/27
+modified: 2023/02/24
 tags:
     - attack.t1110.003
     - attack.initial_access

--- a/rules-unsupported/win_security_susp_failed_logons_single_source.yml
+++ b/rules-unsupported/win_security_susp_failed_logons_single_source.yml
@@ -1,13 +1,10 @@
-title: Failed NTLM Logins with Different Accounts from Single Source System
-id: 6309ffc4-8fa2-47cf-96b8-a2f72e58e538
-related:
-    - id: e98374a6-e2d9-4076-9b5c-11bdb2569995
-      type: derived
-status: test
+title: Failed Logins with Different Accounts from Single Source System
+id: e98374a6-e2d9-4076-9b5c-11bdb2569995
+status: unsupported
 description: Detects suspicious failed logins with different user accounts from a single source system
 author: Florian Roth (Nextron Systems)
 date: 2017/01/10
-modified: 2022/11/26
+modified: 2023/02/24
 tags:
     - attack.persistence
     - attack.privilege_escalation
@@ -16,12 +13,13 @@ logsource:
     product: windows
     service: security
 detection:
-    selection2:
-        EventID: 4776
+    selection1:
+        EventID:
+            - 529
+            - 4625
         TargetUserName: '*'
-        Workstation: '*'
-    timeframe: 24h
-    condition: selection2 | count(TargetUserName) by Workstation > 3
+        WorkstationName: '*'
+    condition: selection1 | count(TargetUserName) by WorkstationName > 3
 falsepositives:
     - Terminal servers
     - Jump servers

--- a/rules-unsupported/win_security_susp_failed_logons_single_source2.yml
+++ b/rules-unsupported/win_security_susp_failed_logons_single_source2.yml
@@ -1,10 +1,13 @@
-title: Failed Logins with Different Accounts from Single Source System
-id: e98374a6-e2d9-4076-9b5c-11bdb2569995
-status: test
+title: Failed NTLM Logins with Different Accounts from Single Source System
+id: 6309ffc4-8fa2-47cf-96b8-a2f72e58e538
+related:
+    - id: e98374a6-e2d9-4076-9b5c-11bdb2569995
+      type: derived
+status: unsupported
 description: Detects suspicious failed logins with different user accounts from a single source system
 author: Florian Roth (Nextron Systems)
 date: 2017/01/10
-modified: 2022/10/09
+modified: 2023/02/24
 tags:
     - attack.persistence
     - attack.privilege_escalation
@@ -13,13 +16,12 @@ logsource:
     product: windows
     service: security
 detection:
-    selection1:
-        EventID:
-            - 529
-            - 4625
+    selection2:
+        EventID: 4776
         TargetUserName: '*'
-        WorkstationName: '*'
-    condition: selection1 | count(TargetUserName) by WorkstationName > 3
+        Workstation: '*'
+    timeframe: 24h
+    condition: selection2 | count(TargetUserName) by Workstation > 3
 falsepositives:
     - Terminal servers
     - Jump servers

--- a/rules-unsupported/win_security_susp_failed_remote_logons_single_source.yml
+++ b/rules-unsupported/win_security_susp_failed_remote_logons_single_source.yml
@@ -1,12 +1,12 @@
 title: Multiple Users Remotely Failing To Authenticate From Single Source
 id: add2ef8d-dc91-4002-9e7e-f2702369f53a
-status: test
+status: unsupported
 description: Detects a source system failing to authenticate against a remote host with multiple users.
 references:
     - https://docs.splunk.com/Documentation/ESSOC/3.22.0/stories/UseCase#Active_directory_password_spraying
 author: Mauricio Velazco
 date: 2021/06/01
-modified: 2022/10/09
+modified: 2023/02/24
 tags:
     - attack.t1110.003
     - attack.initial_access

--- a/rules-unsupported/win_security_susp_multiple_files_renamed_or_deleted.yml
+++ b/rules-unsupported/win_security_susp_multiple_files_renamed_or_deleted.yml
@@ -1,12 +1,12 @@
 title: Suspicious Multiple File Rename Or Delete Occurred
 id: 97919310-06a7-482c-9639-92b67ed63cf8
-status: test
+status: unsupported
 description: Detects multiple file rename or delete events occurrence within a specified period of time by a same user (these events may signalize about ransomware activity).
 references:
     - https://www.manageengine.com/data-security/how-to/how-to-detect-ransomware-attacks.html
 author: Vasiliy Burov, oscd.community
 date: 2020/10/16
-modified: 2021/11/27
+modified: 2023/02/24
 tags:
     - attack.impact
     - attack.t1486

--- a/rules-unsupported/win_security_susp_samr_pwset.yml
+++ b/rules-unsupported/win_security_susp_samr_pwset.yml
@@ -1,12 +1,12 @@
 title: Possible Remote Password Change Through SAMR
 id: 7818b381-5eb1-4641-bea5-ef9e4cfb5951
-status: test
+status: unsupported
 description: |
   Detects a possible remote NTLM hash change through SAMR API SamiChangePasswordUser() or SamSetInformationUser().
   "Audit User Account Management" in "Advanced Audit Policy Configuration" has to be enabled in your local security policy / GPO to see this events.
 author: Dimitrios Slamaris
 date: 2017/06/09
-modified: 2021/11/27
+modified: 2023/02/24
 tags:
     - attack.credential_access
     - attack.t1212

--- a/rules-unsupported/win_susp_failed_hidden_share_mount.yml
+++ b/rules-unsupported/win_susp_failed_hidden_share_mount.yml
@@ -1,13 +1,13 @@
 title: Failed Mounting of Hidden Share
 id: 1c3be8c5-6171-41d3-b792-cab6f717fcdb
-status: experimental
+status: unsupported
 description: Detects repeated failed (outgoing) attempts to mount a hidden share
 references:
     - https://twitter.com/moti_b/status/1032645458634653697
     - https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Cyber-Security/SiSyPHuS/AP10/Logging_Configuration_Guideline.pdf?__blob=publicationFile&v=5
 author: Fabian Franz
 date: 2022/08/30
-modified: 2022/08/30
+modified: 2023/02/24
 tags:
     - attack.t1021.002
     - attack.lateral_movement

--- a/rules-unsupported/win_system_rare_service_installs.yml
+++ b/rules-unsupported/win_system_rare_service_installs.yml
@@ -1,10 +1,10 @@
 title: Rare Service Installations
 id: 66bfef30-22a5-4fcd-ad44-8d81e60922ae
-status: test
+status: unsupported
 description: Detects rare service installs that only appear a few times per time frame and could reveal password dumpers, backdoor installs or other types of malicious services
 author: Florian Roth (Nextron Systems)
 date: 2017/03/08
-modified: 2022/03/21
+modified: 2023/02/24
 tags:
     - attack.persistence
     - attack.privilege_escalation

--- a/rules-unsupported/win_taskscheduler_rare_schtask_creation.yml
+++ b/rules-unsupported/win_taskscheduler_rare_schtask_creation.yml
@@ -1,10 +1,10 @@
 title: Rare Scheduled Task Creations
 id: b20f6158-9438-41be-83da-a5a16ac90c2b
-status: test
+status: unsupported
 description: This rule detects rare scheduled task creations. Typically software gets installed on multiple systems and not only on a few. The aggregation and count function selects tasks with rare names.
 author: Florian Roth (Nextron Systems)
 date: 2017/03/17
-modified: 2021/12/28
+modified: 2023/02/24
 tags:
     - attack.persistence
     - attack.s0111


### PR DESCRIPTION
### Summary of the Pull Request

This PR changes the status of rules using the old SIGMAC pipe notation (correlation) to `unsupported`

### Detailed Description of the Pull Request / Additional Comments

While the new correlation engine is still in dev the old pipe notation is considered as a deprecated feature and it's discouraged to contribute new rules using. By setting the rest of the rules using these notations future PRs will no longer accept rules using this but instead, defer to the new correlation.

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
