### PR TITLE
Add win_firewall_as_add_rule_susp_folder

### DIFF
--- a/rules/windows/builtin/firewall_as/win_firewall_as_add_rule_susp_folder.yml
+++ b/rules/windows/builtin/firewall_as/win_firewall_as_add_rule_susp_folder.yml
@@ -24,10 +24,12 @@ detection:
     filter_block:
         Action: 2
     filter_valid_appdata_app:
-         # Add more
+         # Don't hesitate to contribute
          ApplicationPath|endswith:
              - 'AppData\local\microsoft\teams\current\teams.exe'
+             - 'AppData\Local\Keybase\keybase.exe'
+             - 'AppData\Local\Programs\Messenger\Messenger.exe'
     condition: selection and not 1 of filter_*
 falsepositives:
-    - Unknown
+    - Any legitimate application that runs from the AppData user directory
 level: high

--- a/rules/windows/builtin/firewall_as/win_firewall_as_add_rule_susp_folder.yml
+++ b/rules/windows/builtin/firewall_as/win_firewall_as_add_rule_susp_folder.yml
@@ -1,10 +1,10 @@
-title: New Firewall Rule Added For Suspicius Folder
+title: New Firewall Exception Rule Added For A Suspicious Folder
 id: 9e2575e7-2cb9-4da1-adc8-ed94221dca5e
 related:
     - id: cde0a575-7d3d-4a49-9817-b8004a7bf105
       type: derived
 status: experimental
-description: Detects when a rule has been added to the Windows Firewall exception list for a suspicius folder
+description: Detects the addition of a rule to the Windows Firewall exception list where the application resides in a suspicious folder
 references:
     - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/dd364427(v=ws.10)
     - https://app.any.run/tasks/7123e948-c91e-49e0-a813-00e8d72ab393/#
@@ -22,4 +22,6 @@ detection:
     filter_block:
         Action: 2
     condition: selection and not 1 of filter_*
+falsepositives:
+    - Unknown
 level: high

--- a/rules/windows/builtin/firewall_as/win_firewall_as_add_rule_susp_folder.yml
+++ b/rules/windows/builtin/firewall_as/win_firewall_as_add_rule_susp_folder.yml
@@ -1,0 +1,25 @@
+title: New Firewall Rule Added For Suspicius Folder
+id: 9e2575e7-2cb9-4da1-adc8-ed94221dca5e
+related:
+    - id: cde0a575-7d3d-4a49-9817-b8004a7bf105
+      type: derived
+status: experimental
+description: Detects when a rule has been added to the Windows Firewall exception list for a suspicius folder
+references:
+    - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-r2-and-2008/dd364427(v=ws.10)
+    - https://app.any.run/tasks/7123e948-c91e-49e0-a813-00e8d72ab393/#
+author: frack113
+date: 2023/02/26
+logsource:
+    product: windows
+    service: firewall-as
+detection:
+    selection:
+        EventID: 2004
+        ApplicationPath|contains:
+            - '\AppData\'
+            - '\temp\'
+    filter_block:
+        Action: 2
+    condition: selection and not 1 of filter_*
+level: high

--- a/rules/windows/builtin/firewall_as/win_firewall_as_add_rule_susp_folder.yml
+++ b/rules/windows/builtin/firewall_as/win_firewall_as_add_rule_susp_folder.yml
@@ -15,12 +15,18 @@ logsource:
     service: firewall-as
 detection:
     selection:
-        EventID: 2004
+        EventID: 
+            - 2004 # Windows 10
+            - 2071 # Windows 10 and 11
         ApplicationPath|contains:
             - '\AppData\'
             - '\temp\'
     filter_block:
         Action: 2
+    filter_valid_appdata_app:
+         # Add more
+         ApplicationPath|endswith:
+             - 'AppData\local\microsoft\teams\current\teams.exe'
     condition: selection and not 1 of filter_*
 falsepositives:
     - Unknown


### PR DESCRIPTION
### Summary of the Pull Request

Add a simple rule from app.any.run sandox 

### Detailed Description of the Pull Request / Additional Comments

Cover the result of the commandline
`netsh  advfirewall firewall add rule name="Z0BAZwxx" dir=in action=allow program="C:\Users\admin\AppData\Roaming\Z0BAZwxx\nypezi.exe"`


### Example Log Event
```xml
<EventData>
  <Data Name="RuleId">{5A12AFB7-AEB7-46D5-A609-919D98079CA4}</Data> 
  <Data Name="RuleName">Z0BAZwxx</Data> 
  <Data Name="Origin">1</Data> 
  <Data Name="ApplicationPath">C:\Users\admin\AppData\Roaming\Z0BAZwxx\nypezi.exe</Data> 
  <Data Name="ServiceName" /> 
  <Data Name="Direction">1</Data> 
  <Data Name="Protocol">256</Data> 
  <Data Name="LocalPorts" /> 
  <Data Name="RemotePorts" /> 
  <Data Name="Action">3</Data> 
  <Data Name="Profiles">2147483647</Data> 
  <Data Name="LocalAddresses">*</Data> 
  <Data Name="RemoteAddresses">*</Data> 
  <Data Name="RemoteMachineAuthorizationList" /> 
  <Data Name="RemoteUserAuthorizationList" /> 
  <Data Name="EmbeddedContext" /> 
  <Data Name="Flags">1</Data> 
  <Data Name="Active">1</Data> 
  <Data Name="EdgeTraversal">0</Data> 
  <Data Name="LooseSourceMapped">0</Data> 
  <Data Name="SecurityOptions">0</Data> 
  <Data Name="ModifyingUser">S-1-5-21-2360441858-3879321942-2637521084-500</Data> 
  <Data Name="ModifyingApplication">C:\Windows\System32\netsh.exe</Data> 
  <Data Name="SchemaVersion">542</Data> 
  <Data Name="RuleStatus">65536</Data> 
  <Data Name="LocalOnlyMapped">0</Data> 
</EventData>
```

### Fixed Issues

None

### SigmaHQ Rule Creation Conventions

None
