### PR TITLE
chore: remove unnecessary provider_name filter for security log

### DIFF
--- a/rules/windows/builtin/security/win_security_invoke_obfuscation_clip_services_security.yml
+++ b/rules/windows/builtin/security/win_security_invoke_obfuscation_clip_services_security.yml
@@ -22,7 +22,6 @@ logsource:
     definition: The 'System Security Extension' audit subcategory need to be enabled to log the EID 4697
 detection:
     selection:
-        Provider_Name: 'Microsoft-Windows-Security-Auditing'
         EventID: 4697
         ServiceFileName|contains|all:
             - 'cmd'

--- a/rules/windows/builtin/security/win_security_transf_files_with_cred_data_via_network_shares.yml
+++ b/rules/windows/builtin/security/win_security_transf_files_with_cred_data_via_network_shares.yml
@@ -20,7 +20,6 @@ logsource:
     service: security
 detection:
     selection:
-        Provider_Name: Microsoft-Windows-Security-Auditing
         EventID: 5145
         RelativeTargetName|contains:
             - '\mimidrv'

--- a/rules/windows/builtin/security/win_security_user_added_to_local_administrators.yml
+++ b/rules/windows/builtin/security/win_security_user_added_to_local_administrators.yml
@@ -15,7 +15,6 @@ logsource:
     service: security
 detection:
     selection:
-        Provider_Name: Microsoft-Windows-Security-Auditing
         EventID: 4732
     selection_group1:
         TargetUserName|startswith: 'Administr'

--- a/rules/windows/builtin/security/win_security_user_couldnt_call_priv_service_lsaregisterlogonprocess.yml
+++ b/rules/windows/builtin/security/win_security_user_couldnt_call_priv_service_lsaregisterlogonprocess.yml
@@ -16,7 +16,6 @@ logsource:
     service: security
 detection:
     selection:
-        Provider_Name: Microsoft-Windows-Security-Auditing
         EventID: 4673
         Service: 'LsaRegisterLogonProcess()'
         Keywords: '0x8010000000000000'     #failure

--- a/rules/windows/builtin/security/win_security_user_creation.yml
+++ b/rules/windows/builtin/security/win_security_user_creation.yml
@@ -15,7 +15,6 @@ logsource:
     service: security
 detection:
     selection:
-        Provider_Name: Microsoft-Windows-Security-Auditing
         EventID: 4720
     condition: selection
 fields:

--- a/rules/windows/builtin/security/win_security_user_driver_loaded.yml
+++ b/rules/windows/builtin/security/win_security_user_driver_loaded.yml
@@ -21,7 +21,6 @@ logsource:
     service: security
 detection:
     selection_1:
-        Provider_Name: Microsoft-Windows-Security-Auditing
         EventID: 4673
         PrivilegeList: 'SeLoadDriverPrivilege'
         Service: '-'

--- a/rules/windows/builtin/security/win_security_vssaudit_secevent_source_registration.yml
+++ b/rules/windows/builtin/security/win_security_vssaudit_secevent_source_registration.yml
@@ -15,7 +15,6 @@ logsource:
     service: security
 detection:
     selection:
-        Provider_Name: Microsoft-Windows-Security-Auditing
         AuditSourceName: VSSAudit
         EventID:
             - 4904

--- a/rules/windows/builtin/security/win_security_wmiprvse_wbemcomn_dll_hijack.yml
+++ b/rules/windows/builtin/security/win_security_wmiprvse_wbemcomn_dll_hijack.yml
@@ -17,7 +17,6 @@ logsource:
     service: security
 detection:
     selection:
-        Provider_Name: Microsoft-Windows-Security-Auditing
         EventID: 5145
         RelativeTargetName|endswith: '\wbem\wbemcomn.dll'
     filter:


### PR DESCRIPTION
### Summary of the Pull Request

Windows security log has unique IDs, no provider_name restrictions needed.

### Detailed Description of the Pull Request / Additional Comments
I didn't change the modified date, as the change should not really have an impact on the detection logic.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
