### PR TITLE
chore: rollback previous state of the rule

### DIFF
--- a/rules/windows/builtin/msexchange/win_exchange_proxyshell_mailbox_export.yml
+++ b/rules/windows/builtin/msexchange/win_exchange_proxyshell_mailbox_export.yml
@@ -6,7 +6,7 @@ references:
     - https://blog.orange.tw/2021/08/proxylogon-a-new-attack-surface-on-ms-exchange-part-1.html
 author: Florian Roth (Nextron Systems), Rich Warren, Christian Burkard (Nextron Systems)
 date: 2021/08/09
-modified: 2022/10/26
+modified: 2023/02/28
 tags:
     - attack.persistence
     - attack.t1505.003
@@ -18,13 +18,13 @@ detection:
         - 'New-MailboxExportRequest'
         - ' -Mailbox '
     export_params:
-        - '-FilePath "\\\\' # We care about any share location
+        - '-FilePath "\\\\' # We care about any share location.
         - '.aspx'
     role_assignment:
         - 'New-ManagementRoleAssignment'
         - ' -Role "Mailbox Import Export"'
         - ' -User '
-    condition: all of export_* or role_assignment
+    condition: (all of export_command and export_params) or all of role_assignment
 falsepositives:
     - Unlikely
 level: critical


### PR DESCRIPTION
### Summary of the Pull Request

This PR fixes an issue found with the rule `516376b4-05cd-4122-bae0-ad7641c38d48`

### Detailed Description of the Pull Request / Additional Comments

When updating the aforementioned rule in #3646 a typo/misunderstanding of the logic occurred where the condition now is broken. This PR rolls back the condition to a working state as it was intended in the original commit https://github.com/SigmaHQ/sigma/commit/1c919c07c77fccd8999825735ec2fe878122d4bf

### Example Log Event

N/A

### Fixed Issues

Fixes #4083

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
