### PR TITLE
Add reg.exe to 'Potential Defense Evasion Via Rename Of Highly Relevant Binaries'

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_renamed_binary_highly_relevant.yml
+++ b/rules/windows/process_creation/proc_creation_win_renamed_binary_highly_relevant.yml
@@ -52,6 +52,7 @@ detection:
             - 'rundll32.exe'
             - 'cmstp.exe'
             - 'msiexec.exe'
+            - 'reg.exe'
     filter:
         Image|endswith:
             - '\powershell.exe'
@@ -69,6 +70,7 @@ detection:
             - '\rundll32.exe'
             - '\cmstp.exe'
             - '\msiexec.exe'
+            - '\reg.exe'
     condition: selection and not filter
 falsepositives:
     - Custom applications use renamed binaries adding slight change to binary name. Typically this is easy to spot and add to whitelist

--- a/rules/windows/process_creation/proc_creation_win_renamed_binary_highly_relevant.yml
+++ b/rules/windows/process_creation/proc_creation_win_renamed_binary_highly_relevant.yml
@@ -21,7 +21,7 @@ references:
     - https://threatresearch.ext.hp.com/svcready-a-new-loader-reveals-itself/
 author: Matthew Green - @mgreen27, Florian Roth (Nextron Systems), frack113
 date: 2019/06/15
-modified: 2023/01/23
+modified: 2023/03/01
 tags:
     - attack.defense_evasion
     - attack.t1036.003


### PR DESCRIPTION

### Summary of the Pull Request

Reg.exe for Qakbot defense evasion.

### Detailed Description of the Pull Request / Additional Comments
Renamed reg.exe was used by Qakbot to import reg keys.
https://github.com/pr0xylife/Qakbot/blob/main/Qakbot_BB17_28.02.2023.txt 
`xcopy  C:\Windows\\\\\\system32\\\\\\reg.exe C:\Users\Admin\AppData\Local\Temp\glanduleHoratory.exe /h /s /e`

Tested on 52B sysmon events and no false positives. 

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
