### PR TITLE
chore: update pipfile.lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -758,11 +758,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1",
-                "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"
+                "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5",
+                "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"
             ],
             "index": "pypi",
-            "version": "==5.4.3"
+            "version": "==7.2.1"
         },
         "pytz": {
             "hashes": [


### PR DESCRIPTION
### Summary of the Pull Request

Upgrade the Pytest library to the latest version which removes their dependency on py. Also as a side note `py` library can't be upgraded as it's already using the latest version

### Detailed Description of the Pull Request / Additional Comments

<!--
A detailed description of the pull request and any additional comments or context
-->
N/A

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
N/A

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
