### PR TITLE
fix :`deprecated` status typo

### DIFF
--- a/rules-deprecated/windows/proc_creation_win_renamed_psexec.yml
+++ b/rules-deprecated/windows/proc_creation_win_renamed_psexec.yml
@@ -1,6 +1,6 @@
 title: Renamed PsExec
 id: a7a7e0e5-1d57-49df-9c58-9fe5bc0346a2
-status: depreactaed
+status: deprecated
 description: Detects the execution of a renamed PsExec often used by attackers or malware
 references:
     - https://www.trendmicro.com/vinfo/hk-en/security/news/cybercrime-and-digital-threats/megacortex-ransomware-spotted-attacking-enterprise-networks

--- a/rules-deprecated/windows/proc_creation_win_renamed_psexec.yml
+++ b/rules-deprecated/windows/proc_creation_win_renamed_psexec.yml
@@ -6,7 +6,7 @@ references:
     - https://www.trendmicro.com/vinfo/hk-en/security/news/cybercrime-and-digital-threats/megacortex-ransomware-spotted-attacking-enterprise-networks
 author: Florian Roth (Nextron Systems)
 date: 2019/05/21
-modified: 2023/01/18
+modified: 2023/03/04
 tags:
     - car.2013-05-009
     - attack.defense_evasion


### PR DESCRIPTION
Thank you so much for maintaining rules, I found a typo and fixed it :)

### Summary of the Pull Request

Fixed typo in rule `status` field.
 - `depreactaed` -> `deprecated`

### Detailed Description of the Pull Request / Additional Comments

None

### Example Log Event

None

### Fixed Issues

None

### SigmaHQ Rule Creation Conventions

None