### PR TITLE
fix `endswith` modifier typo

### DIFF
--- a/rules-unsupported/driver_load_invoke_obfuscation_via_compress_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_via_compress_services.yml
@@ -7,7 +7,7 @@ description: Detects Obfuscated Powershell via COMPRESS OBFUSCATION
 status: unsupported
 author: Timur Zinniatullin, oscd.community
 date: 2020/10/18
-modified: 2022/03/08
+modified: 2023/03/04
 references:
     - https://github.com/SigmaHQ/sigma/issues/1009 #(Task 19)
 logsource:

--- a/rules-unsupported/driver_load_invoke_obfuscation_via_compress_services.yml
+++ b/rules-unsupported/driver_load_invoke_obfuscation_via_compress_services.yml
@@ -21,7 +21,7 @@ detection:
         ImagePath|contains:
             - 'system.io.compression.deflatestream'
             - 'system.io.streamreader'
-        ImagePath|endswitch: 'readtoend'
+        ImagePath|endswith: 'readtoend'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
### Summary of the Pull Request

Fixed modifier typo. `endswitch` -> `endswith`

### Detailed Description of the Pull Request / Additional Comments

None

### Example Log Event

None

### Fixed Issues

None

### SigmaHQ Rule Creation Conventions

None