### PR TITLE
Rules update

### DIFF
--- a/rules/linux/auditd/lnx_auditd_modify_system_firewall.yml
+++ b/rules/linux/auditd/lnx_auditd_modify_system_firewall.yml
@@ -1,0 +1,35 @@
+title: Modify System Firewall
+id: 323ff3f5-0013-4847-bbd4-250b5edb62cc
+related:
+  - id: 53059bc0-1472-438b-956a-7508a94a91f0
+    type: similar
+status: experimental
+description: Detects removal of system firewall rules. Adversaries may only delete or modify a specific system firewall rule to bypass controls limiting network usage or access. 
+             Detection rules that match only disabling of firewalls will miss this.  
+references:
+    - https://attack.mitre.org/techniques/T1562/004/
+author: IAI
+date: 2023/03/06
+tags:
+    - attack.t1562.004
+    - attack.defense_evasion
+logsource:
+    product: linux
+    service: auditd
+detection:
+    selection1:
+        type: 'EXECVE'
+        a0: 'iptables'
+        a1|contains: 'DROP'
+    selection2:
+        type: 'EXECVE'
+        a0: 'firewall-cmd'
+        a1|contains: 'remove'
+    selection3:
+        type: 'EXECVE'
+        a0: 'ufw'
+        a1|contains: 'delete'
+    condition: 1 of selection*
+falsepositives:
+    - Admin activity
+level: high

--- a/rules/linux/auditd/lnx_auditd_modify_system_firewall.yml
+++ b/rules/linux/auditd/lnx_auditd_modify_system_firewall.yml
@@ -7,7 +7,7 @@ status: experimental
 description: Detects removal of system firewall rules. Adversaries may only delete or modify a specific system firewall rule to bypass controls limiting network usage or access. 
              Detection rules that match only disabling of firewalls will miss this.  
 references:
-    - https://attack.mitre.org/techniques/T1562/004/
+    - 'MITRE Attack technique T1562.004; https://attack.mitre.org/versions/v12/techniques/T1562/004/'
 author: IAI
 date: 2023/03/06
 tags:

--- a/rules/linux/auditd/lnx_auditd_unix_shell_configuration_modification.yml
+++ b/rules/linux/auditd/lnx_auditd_unix_shell_configuration_modification.yml
@@ -6,7 +6,7 @@ related:
 status: experimental
 description: Detect unix shell configuration modification. Adversaries may establish persistence through executing malicious commands triggered when a new shell is opened.
 references:
-    - 'MITRE Attack technique T1546.004; https://attack.mitre.org/techniques/T1546/004/'
+    - 'MITRE Attack technique T1546.004; https://attack.mitre.org/versions/v12/techniques/T1546/004/'
 author: IAI 
 date: 2023/03/06
 modified: 2023/03/26

--- a/rules/linux/auditd/lnx_auditd_unix_shell_configuration_modification.yml
+++ b/rules/linux/auditd/lnx_auditd_unix_shell_configuration_modification.yml
@@ -1,0 +1,44 @@
+title: Unix Shell Configuration Modification
+id: 
+status: experimental
+description: Detect unix shell configuration modification. Adversaries may establish persistence through executing malicious commands triggered when a new shell is opened.
+references:
+    - 'MITRE Attack technique T1546.004; https://attack.mitre.org/techniques/T1546/004/'
+author: IAI 
+date: 2023/03/06
+modified: 2023/03/26
+tags:
+    - attack.persistence
+    - attack.t1546.004
+logsource:
+    product: linux
+    service: auditd
+detection:
+    selection:
+        type: 'PATH'
+        name:
+            - '/etc/profile'
+            - '/etc/profile.d/*'
+            - '/etc/bash.bashrc'
+            - '/etc/zsh/zprofile'
+            - '/etc/zsh/zshrc'
+            - '/etc/zsh/zlogin'
+            - '/etc/zsh/zlogout'
+            - '/root/.bashrc'
+            - '/root/.bash_profile'
+            - '/root/.profile'
+            - '/root/.zshrc'
+            - '/root/.zprofile'
+            - '/home/*/.bashrc'
+            - '/home/*/.zshrc'
+            - '/home/*/.bash_profile'
+            - '/home/*/.zprofile'
+            - '/home/*/.profile'
+            - '/home/*/.bash_login'
+            - '/home/*/.bash_logout'
+            - '/home/*/.zlogin'
+            - '/home/*/.zlogout'
+    condition: selection
+falsepositives:
+    - Admin or User activity
+level: medium

--- a/rules/linux/auditd/lnx_auditd_unix_shell_configuration_modification.yml
+++ b/rules/linux/auditd/lnx_auditd_unix_shell_configuration_modification.yml
@@ -1,5 +1,8 @@
 title: Unix Shell Configuration Modification
-id: 
+id: a94cdd87-6c54-4678-a6cc-2814ffe5a13d
+related:
+  - id: e74e15cc-c4b6-4c80-b7eb-dfe49feb7fe9
+    type: derived
 status: experimental
 description: Detect unix shell configuration modification. Adversaries may establish persistence through executing malicious commands triggered when a new shell is opened.
 references:


### PR DESCRIPTION
### Summary of the Pull Request

This PR adds 2 new rules in /rules/linux/auditd:
lnx_auditd_unix_shell_configuration_modification.yml   (T1546.004)
lnx_auditd_modify_system_firewall.yml (T1562.004)

### Detailed Description of the Pull Request / Additional comments
This PR adds 2 new rules in /rules/linux/auditd.
The first new rule (T1546.004) aims to detect unix shell configuration modification. Adversaries may establish persistence through unix shell configuration modification, which may lead to executing malicious commands when a new shell is opened.
The second new rule (T1562.004) aims to detect  removal of system firewall rules. Adversaries may only delete or modify a specific system firewall rule to bypass controls limiting network usage or access. Detection rules that match only disabling of firewalls will miss this.

### Example Log Event (In Case of FP Fixes)
NA

###  Relevant Issues (In Case of Issue Fixes)
NA
