### PR TITLE
moved multi-line condition to single line for rules that use `count`

### DIFF
--- a/rules/windows/builtin/security/win_security_susp_failed_logons_single_process.yml
+++ b/rules/windows/builtin/security/win_security_susp_failed_logons_single_process.yml
@@ -7,7 +7,7 @@ references:
     - https://www.trimarcsecurity.com/single-post/2018/05/06/trimarc-research-detecting-password-spraying-with-security-event-auditing
 author: Mauricio Velazco
 date: 2021/06/01
-modified: 2022/10/09
+modified: 2023/03/13
 tags:
     - attack.t1110.003
     - attack.initial_access
@@ -22,8 +22,7 @@ detection:
     filter:
         ProcessName: '-'
     timeframe: 24h
-    condition:
-        - selection1 and not filter | count(TargetUserName) by ProcessName > 10
+    condition: 'selection1 and not filter | count(TargetUserName) by ProcessName > 10'
 falsepositives:
     - Terminal servers
     - Jump servers

--- a/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_kerberos.yml
+++ b/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_kerberos.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.splunk.com/Documentation/ESSOC/3.22.0/stories/UseCase#Active_directory_password_spraying
 author: Mauricio Velazco, frack113
 date: 2021/06/01
-modified: 2022/10/09
+modified: 2023/03/13
 tags:
     - attack.t1110.003
     - attack.initial_access
@@ -21,8 +21,7 @@ detection:
     filter_computer:
         TargetUserName|endswith: '$'
     timeframe: 24h
-    condition:
-        - selection and not filter_computer | count(TargetUserName) by IpAddress > 10
+    condition: 'selection and not filter_computer | count(TargetUserName) by IpAddress > 10'
 falsepositives:
     - Vulnerability scanners
     - Misconfigured systems

--- a/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_kerberos2.yml
+++ b/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_kerberos2.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.splunk.com/Documentation/ESSOC/3.22.0/stories/UseCase#Active_directory_password_spraying
 author: Mauricio Velazco, frack113
 date: 2021/06/01
-modified: 2022/10/09
+modified: 2023/03/13
 tags:
     - attack.t1110.003
     - attack.initial_access
@@ -21,8 +21,7 @@ detection:
     filter_computer:
         TargetUserName|endswith: '$'
     timeframe: 24h
-    condition:
-        - selection and not filter_computer | count(TargetUserName) by IpAddress > 10
+    condition: 'selection and not filter_computer | count(TargetUserName) by IpAddress > 10'
 falsepositives:
     - Vulnerability scanners
     - Misconfigured systems

--- a/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_kerberos3.yml
+++ b/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_kerberos3.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.splunk.com/Documentation/ESSOC/3.22.0/stories/UseCase#Active_directory_password_spraying
 author: Mauricio Velazco, frack113
 date: 2021/06/01
-modified: 2022/10/09
+modified: 2023/03/13
 tags:
     - attack.t1110.003
     - attack.initial_access
@@ -21,8 +21,7 @@ detection:
     filter_computer:
         TargetUserName|endswith: '$'
     timeframe: 24h
-    condition:
-        - selection and not filter_computer | count(TargetUserName) by IpAddress > 10
+    condition: 'selection and not filter_computer | count(TargetUserName) by IpAddress > 10'
 falsepositives:
     - Vulnerability scanners
     - Misconfigured systems

--- a/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_ntlm.yml
+++ b/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_ntlm.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.splunk.com/Documentation/ESSOC/3.22.0/stories/UseCase#Active_directory_password_spraying
 author: Mauricio Velazco
 date: 2021/06/01
-modified: 2022/10/09
+modified: 2023/03/13
 tags:
     - attack.t1110.003
     - attack.initial_access
@@ -21,8 +21,7 @@ detection:
     filter:
         TargetUserName: '*$'
     timeframe: 24h
-    condition:
-        - selection1 and not filter | count(TargetUserName) by Workstation > 10
+    condition: 'selection1 and not filter | count(TargetUserName) by Workstation > 10'
 falsepositives:
     - Terminal servers
     - Jump servers

--- a/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_ntlm2.yml
+++ b/rules/windows/builtin/security/win_security_susp_failed_logons_single_source_ntlm2.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.splunk.com/Documentation/ESSOC/3.22.0/stories/UseCase#Active_directory_password_spraying
 author: Mauricio Velazco
 date: 2021/06/01
-modified: 2022/10/09
+modified: 2023/03/13
 tags:
     - attack.t1110.003
     - attack.initial_access
@@ -21,8 +21,7 @@ detection:
     filter:
         TargetUserName: '*$'
     timeframe: 24h
-    condition:
-        - selection1 and not filter | count(TargetUserName) by Workstation > 10
+    condition: 'selection1 and not filter | count(TargetUserName) by Workstation > 10'
 falsepositives:
     - Terminal servers
     - Jump servers


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

This PR changes multi-line condition statements to a single line for maximum compatibility with backends.

### Detailed Description of the Pull Request / Additional Comments

For some reason, several sigma rules that use `count` put the condition statement on the next line. Example:
```
    condition: 
        - selection1 and not filter | count(TargetUserName) by ProcessName > 10
```
This causes parsing errors for certain backends. 
In my limited testing, it works as a single line with and even without single quotes.  I decided to add single quotes just in case.
Example: `condition: 'selection1 and not filter | count(TargetUserName) by ProcessName > 10'`

### Example Log Event

N/A

### Fixed Issues

This will get rid of parsing errors for some backends.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
