### PR TITLE
feat: new rules and updates

### DIFF
--- a/rules-deprecated/windows/image_load_side_load_advapi32.yml
+++ b/rules-deprecated/windows/image_load_side_load_advapi32.yml
@@ -1,12 +1,12 @@
 title: Suspicious Load of Advapi31.dll
 id: d813d662-785b-42ca-8b4a-f7457d78d5a9
-status: test
+status: deprecated
 description: Detects the load of advapi31.dll by a process running in an uncommon folder
 references:
     - https://github.com/hlldz/Phant0m
 author: frack113
 date: 2022/02/03
-modified: 2022/02/11
+modified: 2023/03/15
 tags:
     - attack.defense_evasion
     - attack.t1070

--- a/rules-deprecated/windows/proc_creation_win_schtasks_user_temp.yml
+++ b/rules-deprecated/windows/proc_creation_win_schtasks_user_temp.yml
@@ -1,12 +1,12 @@
 title: Suspicious Add Scheduled Task From User AppData Temp
 id: 43f487f0-755f-4c2a-bce7-d6d2eec2fcf8
-status: experimental
+status: deprecated
 description: schtasks.exe create task from user AppData\Local\Temp
 references:
     - malware analyse https://www.joesandbox.com/analysis/514608/0/html#324415FF7D8324231381BAD48A052F85DF04
 author: frack113
 date: 2021/11/03
-modified: 2022/06/02
+modified: 2023/03/14
 tags:
     - attack.execution
     - attack.t1053.005

--- a/rules/windows/builtin/security/win_security_dpapi_domain_masterkey_backup_attempt.yml
+++ b/rules/windows/builtin/security/win_security_dpapi_domain_masterkey_backup_attempt.yml
@@ -6,7 +6,7 @@ references:
     - https://threathunterplaybook.com/hunts/windows/190620-DomainDPAPIBackupKeyExtraction/notebook.html
 author: Roberto Rodriguez @Cyb3rWard0g
 date: 2019/08/10
-modified: 2021/11/27
+modified: 2023/03/15
 tags:
     - attack.credential_access
     - attack.t1003.004
@@ -22,5 +22,5 @@ fields:
     - SubjectDomainName
     - SubjectUserName
 falsepositives:
-    - Unknown
-level: high
+    - If a computer is a member of a domain, DPAPI has a backup mechanism to allow unprotection of the data. Which will trigger this event.
+level: medium

--- a/rules/windows/builtin/security/win_security_lm_namedpipe.yml
+++ b/rules/windows/builtin/security/win_security_lm_namedpipe.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/menasec1/status/1104489274387451904
 author: Samir Bousseaden
 date: 2019/04/03
-modified: 2021/12/06
+modified: 2023/03/14
 tags:
     - attack.lateral_movement
     - attack.t1021.002
@@ -39,6 +39,7 @@ detection:
             - 'TermSrv_API_service'
             - 'MsFteWds'
             - 'sql\query'
+            - 'eventlog'
     condition: selection1 and not false_positives
 falsepositives:
     - Update the excluded named pipe to filter out any newly observed legit named pipe

--- a/rules/windows/builtin/security/win_security_susp_lsass_dump_generic.yml
+++ b/rules/windows/builtin/security/win_security_susp_lsass_dump_generic.yml
@@ -7,7 +7,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 author: Roberto Rodriguez, Teymur Kheirkhabarov, Dimitrios Slamaris, Mark Russinovich, Aleksey Potapov, oscd.community (update)
 date: 2019/11/01
-modified: 2022/11/13
+modified: 2023/03/13
 tags:
     - attack.credential_access
     - car.2019-04-004
@@ -39,7 +39,7 @@ detection:
         AccessList|contains:
             - '4484'
             - '4416'
-    filter1:
+    filter_specific:
         ProcessName|endswith:
             - '\wmiprvse.exe'
             - '\taskmgr.exe'
@@ -60,30 +60,28 @@ detection:
             - '\MRT.exe'         # MS Malware Removal Tool
             - 'RtkAudUService64' # https://medium.com/falconforce/the-curious-case-of-realtek-and-lsass-33fc0c8482ff
         ProcessName|startswith:
-            - C:\Windows\System32\
-            - C:\Windows\SysWow64\
-            - C:\Windows\SysNative\
-            - C:\Program Files\
-            - C:\Program Files (x86)\
-            - C:\Windows\Temp\asgard2-agent\
-            - C:\ProgramData\Microsoft\Windows Defender\Platform\
-    filter2:
+            - 'C:\Windows\System32\'
+            - 'C:\Windows\SysWow64\'
+            - 'C:\Windows\SysNative\'
+            - 'C:\Program Files\'
+            - 'C:\Program Files (x86)\'
+            - 'C:\Windows\Temp\asgard2-agent\'
+            - 'C:\ProgramData\Microsoft\Windows Defender\Platform\'
+    filter_generic:
         ProcessName|startswith: 'C:\Program Files'  # too many false positives with legitimate AV and EDR solutions
-    filter3:
-        ProcessName: 'C:\Windows\CCM\CcmExec.exe'
-    filter4:
+    filter_exact:
         ProcessName:
             - 'C:\Windows\System32\taskhostw.exe'
             - 'C:\Windows\System32\msiexec.exe'
-    filter_games:
-        ProcessName|contains: '\SteamLibrary\steamapps\'
-    condition: 1 of selection_* and not 1 of filter*
-fields:
-    - ComputerName
-    - SubjectDomainName
-    - SubjectUserName
-    - ProcessName
-    - ProcessID
+            - 'C:\Windows\CCM\CcmExec.exe'
+    filter_sysmon:
+        ProcessName: 'C:\Windows\Sysmon64.exe'
+        AccessList: '%%4484'
+    filter_aurora:
+        ProcessName|startswith: 'C:\Windows\Temp\asgard2-agent-sc\aurora\'
+        ProcessName|endswith: '\aurora-agent-64.exe'
+        AccessList: '%%4484'
+    condition: 1 of selection_* and not 1 of filter_*
 falsepositives:
     - Legitimate software accessing LSASS process for legitimate reason; update the whitelist with it
 level: high

--- a/rules/windows/builtin/security/win_security_susp_lsass_dump_generic.yml
+++ b/rules/windows/builtin/security/win_security_susp_lsass_dump_generic.yml
@@ -81,6 +81,10 @@ detection:
         ProcessName|startswith: 'C:\Windows\Temp\asgard2-agent-sc\aurora\'
         ProcessName|endswith: '\aurora-agent-64.exe'
         AccessList: '%%4484'
+    filter_scenarioengine:
+        # Example: C:\a70de9569c3a5aa22184ef52a890177b\x64\SCENARIOENGINE.EXE
+        ProcessName|endswith: '\x64\SCENARIOENGINE.EXE'
+        AccessList: '%%4484'
     condition: 1 of selection_* and not 1 of filter_*
 falsepositives:
     - Legitimate software accessing LSASS process for legitimate reason; update the whitelist with it

--- a/rules/windows/builtin/security/win_security_susp_scheduled_task_delete_or_disable.yml
+++ b/rules/windows/builtin/security/win_security_susp_scheduled_task_delete_or_disable.yml
@@ -14,7 +14,7 @@ references:
     - https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4701
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/12/05
-modified: 2023/02/20
+modified: 2023/03/13
 tags:
     - attack.execution
     - attack.privilege_escalation
@@ -36,10 +36,8 @@ detection:
             - '\Windows\BitLocker'
             - '\Windows\WindowsBackup\'
             - '\Windows\WindowsUpdate\'
-            - '\Windows\UpdateOrchestrator\'
+            - '\Windows\UpdateOrchestrator\Schedule'
             - '\Windows\ExploitGuard'
-    filter_ac_power_download:
-        TaskName|contains: '\Windows\UpdateOrchestrator\AC Power Download'
     filter_sys_username:
         EventID: 4699
         SubjectUserName|endswith: '$'  # False positives during upgrades of Defender, where its tasks get removed and added

--- a/rules/windows/builtin/windefend/win_defender_disabled.yml
+++ b/rules/windows/builtin/windefend/win_defender_disabled.yml
@@ -24,4 +24,5 @@ detection:
     condition: selection
 falsepositives:
     - Administrator actions (should be investigated)
+    - Seen being triggered occasionally during Windows 8 Defender Updates
 level: high

--- a/rules/windows/file/file_event/file_event_win_shell_write_susp_files_extensions.yml
+++ b/rules/windows/file/file_event/file_event_win_shell_write_susp_files_extensions.yml
@@ -9,16 +9,13 @@ references:
     - Internal Research
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/12
-modified: 2022/09/27
+modified: 2023/03/14
 logsource:
     category: file_event
     product: windows
 detection:
-    selection:
+    selection_generic:
         Image|endswith:
-            - '\rundll32.exe'
-            #- '\svchost.exe' # Might generate some FP
-            #- '\dllhost.exe' # Too many FPs
             - '\smss.exe'
             - '\RuntimeBroker.exe'
             - '\sihost.exe'
@@ -36,7 +33,19 @@ detection:
             - '.hta'
             - '.iso'
             - '.dll'
-    condition: selection
+    selection_special:
+        Image|endswith:
+            - '\rundll32.exe'
+            - '\svchost.exe'
+            - '\dllhost.exe'
+        TargetFilename|endswith:
+            - '.bat'
+            - '.vbe'
+            - '.vbs'
+            - '.ps1'
+            - '.hta'
+            - '.iso'
+    condition: 1 of selection_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/image_load/image_load_side_load_aruba_networks_virtual_intranet_access.yml
+++ b/rules/windows/image_load/image_load_side_load_aruba_networks_virtual_intranet_access.yml
@@ -6,6 +6,7 @@ references:
     - https://twitter.com/wdormann/status/1616581559892545537?t=XLCBO9BziGzD7Bmbt8oMEQ&s=09
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/01/22
+modified: 2023/03/15
 tags:
     - attack.privilege_escalation
     - attack.persistence
@@ -41,4 +42,4 @@ detection:
     condition: selection and not filter
 falsepositives:
     - Unknown
-level: medium
+level: high

--- a/rules/windows/image_load/image_load_side_load_coregen.yml
+++ b/rules/windows/image_load/image_load_side_load_coregen.yml
@@ -17,7 +17,7 @@ detection:
     selection:
         Image|endswith: '\coregen.exe'
     filter:
-        ImageLoaded|startswith: 
+        ImageLoaded|startswith:
             - 'C:\Windows\System32\'
             - 'C:\Windows\SysWOW64\'
             - 'C:\Program Files\Microsoft Silverlight\'

--- a/rules/windows/image_load/image_load_side_load_dbgcore_dll.yml
+++ b/rules/windows/image_load/image_load_side_load_dbgcore_dll.yml
@@ -6,7 +6,7 @@ references:
     - https://hijacklibs.net/ # For list of DLLs that could be sideloaded (search for dlls mentioned here in there)
 author: Nasreddine Bencherchali (Nextron Systems), Wietze Beukema (project and research)
 date: 2022/10/25
-modified: 2022/10/28
+modified: 2023/03/15
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -28,9 +28,9 @@ detection:
             - 'C:\Windows\SystemTemp\'
             - 'C:\Program Files (x86)\'
             - 'C:\Program Files\'
-    filter_steam:
-        ImageLoaded|endswith: '\Steam\bin\cef\cef.win7x64\dbgcore.dll'
+    #filter_steam:
+    #    ImageLoaded|endswith: '\Steam\bin\cef\cef.win7x64\dbgcore.dll'
     condition: selection and not 1 of filter_*
 falsepositives:
     - Legitimate applications loading their own versions of the DLL mentioned in this rule
-level: medium
+level: high

--- a/rules/windows/image_load/image_load_side_load_dbghelp_dll.yml
+++ b/rules/windows/image_load/image_load_side_load_dbghelp_dll.yml
@@ -6,7 +6,7 @@ references:
     - https://hijacklibs.net/ # For list of DLLs that could be sideloaded (search for dlls mentioned here in there)
 author: Nasreddine Bencherchali (Nextron Systems), Wietze Beukema (project and research)
 date: 2022/10/25
-modified: 2022/10/28
+modified: 2023/03/15
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -36,4 +36,4 @@ detection:
     condition: selection and not 1 of filter_*
 falsepositives:
     - Legitimate applications loading their own versions of the DLL mentioned in this rule
-level: medium
+level: high

--- a/rules/windows/image_load/image_load_side_load_from_non_system_location.yml
+++ b/rules/windows/image_load/image_load_side_load_from_non_system_location.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/XForceIR/SideLoadHunter/blob/cc7ef2e5d8908279b0c4cee4e8b6f85f7b8eed52/SideLoads/README.md # XForceIR (SideLoadHunter Project), Chris Spehn (research WFH Dridex)
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/14
-modified: 2023/02/28
+modified: 2023/03/15
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -468,4 +468,4 @@ detection:
     condition: selection and not 1 of filter_*
 falsepositives:
     - Legitimate applications loading their own versions of the DLLs mentioned in this rule
-level: medium
+level: high

--- a/rules/windows/image_load/image_load_side_load_office_dlls.yml
+++ b/rules/windows/image_load/image_load_side_load_office_dlls.yml
@@ -6,6 +6,7 @@ references:
     - https://hijacklibs.net/ # For list of DLLs that could be sideloaded (search for dlls mentioned here in there)
 author: Nasreddine Bencherchali (Nextron Systems), Wietze Beukema (project and research)
 date: 2022/08/17
+modified: 2023/03/15
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -27,4 +28,4 @@ detection:
     condition: selection and not filter
 falsepositives:
     - Unlikely
-level: medium
+level: high

--- a/rules/windows/image_load/image_load_side_load_rcdll.yml
+++ b/rules/windows/image_load/image_load_side_load_rcdll.yml
@@ -6,6 +6,7 @@ references:
     - https://www.trendmicro.com/en_us/research/23/c/iron-tiger-sysupdate-adds-linux-targeting.html
 author: X__Junior
 date: 2023/03/13
+modified: 2023/03/15
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
@@ -24,4 +25,4 @@ detection:
     condition: selection and not filter
 falsepositives:
     - Unknown
-level: medium
+level: high

--- a/rules/windows/image_load/image_load_side_load_wazuh.yml
+++ b/rules/windows/image_load/image_load_side_load_wazuh.yml
@@ -6,6 +6,7 @@ references:
     - https://www.trendmicro.com/en_us/research/23/c/iron-tiger-sysupdate-adds-linux-targeting.html
 author: X__Junior
 date: 2023/03/13
+modified: 2023/03/15
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -28,4 +29,4 @@ detection:
     condition: selection and not filter
 falsepositives:
     - Unknown
-level: medium
+level: high

--- a/rules/windows/process_access/proc_access_win_susp_proc_access_lsass_susp_source.yml
+++ b/rules/windows/process_access/proc_access_win_susp_proc_access_lsass_susp_source.yml
@@ -10,7 +10,7 @@ references:
     - http://security-research.dyndns.org/pub/slides/FIRST2017/FIRST-2017_Tom-Ueltschi_Sysmon_FINAL_notes.pdf
 author: Florian Roth (Nextron Systems)
 date: 2021/11/27
-modified: 2022/11/01
+modified: 2023/03/14
 tags:
     - attack.credential_access
     - attack.t1003.001
@@ -108,6 +108,10 @@ detection:
         SourceImage|startswith: 'C:\Users\'
         SourceImage|endswith: \AppData\Local\Keybase\keybase.exe
         GrantedAccess: '0x1fffff'
+    filter_avira:
+        SourceImage|contains: '\AppData\Local\Temp\is-'
+        SourceImage|endswith: '.tmp\avira_system_speedup.tmp'
+        GrantedAccess: '0x1410'
     condition: selection and not 1 of filter*
 fields:
     - User

--- a/rules/windows/process_creation/proc_creation_win_attrib_hiding_files.yml
+++ b/rules/windows/process_creation/proc_creation_win_attrib_hiding_files.yml
@@ -7,7 +7,7 @@ references:
     - https://www.uptycs.com/blog/lolbins-are-no-laughing-matter
 author: Sami Ruohonen
 date: 2019/01/16
-modified: 2022/11/11
+modified: 2023/03/14
 tags:
     - attack.defense_evasion
     - attack.t1564.001
@@ -30,4 +30,4 @@ detection:
 falsepositives:
     - IgfxCUIService.exe hiding *.cui files via .bat script (attrib.exe a child of cmd.exe and igfxCUIService.exe is the parent of the cmd.exe)
     - Msiexec.exe hiding desktop.ini
-level: low
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_attrib_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_attrib_system.yml
@@ -1,17 +1,17 @@
-title: Set Windows System File with Attrib
+title: Set Files as System Files Using Attrib.EXE
 id: bb19e94c-59ae-4c15-8c12-c563d23fe52b
 related:
     - id: efec536f-72e8-4656-8960-5e85d091345b
       type: similar
 status: experimental
-description: Marks a file as a system file using the attrib.exe utility
+description: Detects the execution of "attrib" with the "+s" flag to mark files as system files
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1564.001/T1564.001.md#atomic-test-3---create-windows-system-file-with-attrib
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/attrib
     - https://unit42.paloaltonetworks.com/unit42-sure-ill-take-new-combojack-malware-alters-clipboards-steal-cryptocurrency/
 author: frack113
 date: 2022/02/04
-modified: 2022/11/11
+modified: 2023/03/14
 tags:
     - attack.defense_evasion
     - attack.t1564.001

--- a/rules/windows/process_creation/proc_creation_win_attrib_system_susp_paths.yml
+++ b/rules/windows/process_creation/proc_creation_win_attrib_system_susp_paths.yml
@@ -1,18 +1,18 @@
-title: Set Suspicious Files as System Files Using Attrib
+title: Set Suspicious Files as System Files Using Attrib.EXE
 id: efec536f-72e8-4656-8960-5e85d091345b
 related:
     - id: bb19e94c-59ae-4c15-8c12-c563d23fe52b
       type: derived
 status: experimental
 description: |
-    Detects the usage of attrib with the "+s" option to set suspicious scripts or executables as system files to hide them from users and make them unable to be deleted with simple rights. The rule limits the search to specific extensions and directories to avoid FPs
+    Detects the usage of attrib with the "+s" option to set scripts or executables located in suspicious locations as system files to hide them from users and make them unable to be deleted with simple rights. The rule limits the search to specific extensions and directories to avoid FPs
 references:
     - https://app.any.run/tasks/c28cabc8-a19f-40f3-a78b-cae506a5c0d4
     - https://app.any.run/tasks/cfc8870b-ccd7-4210-88cf-a8087476a6d0
     - https://unit42.paloaltonetworks.com/unit42-sure-ill-take-new-combojack-malware-alters-clipboards-steal-cryptocurrency/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/06/28
-modified: 2022/11/11
+modified: 2023/03/14
 tags:
     - attack.defense_evasion
     - attack.t1564.001
@@ -36,10 +36,12 @@ detection:
     selection_ext:
         CommandLine|contains:
             - '.bat'
+            - '.dll'
+            - '.exe'
+            - '.hta'
             - '.ps1'
             - '.vbe'
             - '.vbs'
-            - '.exe'
     filter:
         CommandLine|contains|all:
             - '\Windows\TEMP\'

--- a/rules/windows/process_creation/proc_creation_win_csvde_export.yml
+++ b/rules/windows/process_creation/proc_creation_win_csvde_export.yml
@@ -1,7 +1,7 @@
 title: Active Directory Structure Export Via Csvde.EXE
 id: e5d36acd-acb4-4c6f-a13f-9eb203d50099
 status: experimental
-description: Detects execution of "csvde.exe" in order to export organizational Active Directory structure.
+description: Detects the execution of "csvde.exe" in order to export organizational Active Directory structure.
 references:
     - https://www.cybereason.com/blog/research/operation-ghostshell-novel-rat-targets-global-aerospace-and-telecoms-firms
     - https://web.archive.org/web/20180725233601/https://www.pwc.co.uk/cyber-security/pdf/cloud-hopper-annex-b-final.pdf

--- a/rules/windows/process_creation/proc_creation_win_csvde_export.yml
+++ b/rules/windows/process_creation/proc_creation_win_csvde_export.yml
@@ -1,0 +1,27 @@
+title: Active Directory Structure Export Via Csvde.EXE
+id: e5d36acd-acb4-4c6f-a13f-9eb203d50099
+status: experimental
+description: Detects execution of "csvde.exe" in order to export organizational Active Directory structure.
+references:
+    - https://www.cybereason.com/blog/research/operation-ghostshell-novel-rat-targets-global-aerospace-and-telecoms-firms
+    - https://web.archive.org/web/20180725233601/https://www.pwc.co.uk/cyber-security/pdf/cloud-hopper-annex-b-final.pdf
+    - https://businessinsights.bitdefender.com/deep-dive-into-a-backdoordiplomacy-attack-a-study-of-an-attackers-toolkit
+author: Nasreddine Bencherchali (Nextron Systems)
+date: 2023/03/14
+tags:
+    - attack.exfiltration
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\csvde.exe'
+        - OriginalFileName: 'csvde.exe'
+    selection_remote:
+        CommandLine|contains: ' -f'
+    filter_import:
+        CommandLine|contains: ' -i'
+    condition: all of selection_* and not 1 of filter_*
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_fltmc_unload_driver.yml
+++ b/rules/windows/process_creation/proc_creation_win_fltmc_unload_driver.yml
@@ -10,6 +10,7 @@ references:
     - https://www.cybereason.com/blog/threat-analysis-report-lockbit-2.0-all-paths-lead-to-ransom
 author: Nasreddine Bencherchali
 date: 2023/02/13
+modified: 2023/03/14
 tags:
     - attack.defense_evasion
     - attack.t1070
@@ -24,7 +25,10 @@ detection:
         - OriginalFileName: 'fltMC.exe'
     selection_cli:
         CommandLine|contains: 'unload'
-    condition: all of selection_*
+    filter_avira:
+        # ParentImage: C:\Users\ciadmin\AppData\Local\Temp\is-URCLK.tmp\endpoint-protection-installer-x64.tmp
+        CommandLine|endswith: 'unload rtp_filesystem_filter'
+    condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_ldifde_export.yml
+++ b/rules/windows/process_creation/proc_creation_win_ldifde_export.yml
@@ -1,7 +1,7 @@
 title: Active Directory Structure Export Via Ldifde.EXE
 id: 4f7a6757-ff79-46db-9687-66501a02d9ec
 status: experimental
-description: Detects execution of "ldifde.exe" in order to export organizational Active Directory structure.
+description: Detects the execution of "ldifde.exe" in order to export organizational Active Directory structure.
 references:
     - https://businessinsights.bitdefender.com/deep-dive-into-a-backdoordiplomacy-attack-a-study-of-an-attackers-toolkit
     - https://www.documentcloud.org/documents/5743766-Global-Threat-Report-2019.html

--- a/rules/windows/process_creation/proc_creation_win_ldifde_export.yml
+++ b/rules/windows/process_creation/proc_creation_win_ldifde_export.yml
@@ -1,0 +1,28 @@
+title: Active Directory Structure Export Via Ldifde.EXE
+id: 4f7a6757-ff79-46db-9687-66501a02d9ec
+status: experimental
+description: Detects execution of "ldifde.exe" in order to export organizational Active Directory structure.
+references:
+    - https://businessinsights.bitdefender.com/deep-dive-into-a-backdoordiplomacy-attack-a-study-of-an-attackers-toolkit
+    - https://www.documentcloud.org/documents/5743766-Global-Threat-Report-2019.html
+    - https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731033(v=ws.11)
+author: Nasreddine Bencherchali (Nextron Systems)
+date: 2023/03/14
+tags:
+    - attack.exfiltration
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_ldif:
+        - Image|endswith: '\ldifde.exe'
+        - OriginalFileName: 'ldifde.exe'
+    selection_cmd:
+        CommandLine|contains|all:
+            - '-f'
+    filter_import:
+        CommandLine|contains: ' -i'
+    condition: all of selection_* and not 1 of filter_*
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_ldifde_export.yml
+++ b/rules/windows/process_creation/proc_creation_win_ldifde_export.yml
@@ -18,8 +18,7 @@ detection:
         - Image|endswith: '\ldifde.exe'
         - OriginalFileName: 'ldifde.exe'
     selection_cmd:
-        CommandLine|contains|all:
-            - '-f'
+        CommandLine|contains: '-f'
     filter_import:
         CommandLine|contains: ' -i'
     condition: all of selection_* and not 1 of filter_*

--- a/rules/windows/process_creation/proc_creation_win_ldifde_file_load.yml
+++ b/rules/windows/process_creation/proc_creation_win_ldifde_file_load.yml
@@ -1,32 +1,32 @@
-title: Suspicious Ldifde Command Usage
+title: Import LDAP Data Interchange Format File Via Ldifde.EXE
 id: 6f535e01-ca1f-40be-ab8d-45b19c0c8b7f
 status: experimental
 description: |
-    Detects the use of Ldifde.exe with specific command line arguments to potentially load an LDIF file containing HTTP-based arguments.
-    Ldifde.exe is present, by default, on domain controllers and only requires user-level authentication to execute.
+    Detects the execution of "Ldifde.exe" with the import flag "-i". The can be abused to include HTTP-based arguments which will allow the arbitrary download of files from a remote server.
 references:
     - https://twitter.com/0gtweet/status/1564968845726580736
     - https://strontic.github.io/xcyclopedia/library/ldifde.exe-979DE101F5059CEC1D2C56967CA2BAC0.html
-    - https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731033(v=ws.11)
+    - https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731033(v=ws.11)
 author: '@gott_cyber'
 date: 2022/09/02
+modified: 2023/03/14
 tags:
     - attack.command_and_control
-    - attack.t1105
     - attack.defense_evasion
     - attack.t1218
+    - attack.t1105
 logsource:
     category: process_creation
     product: windows
 detection:
-    selection_ldif:
+    selection_img:
         - Image|endswith: '\ldifde.exe'
-        - OriginalFileName: ldifde.exe.mui
-    selection_cmd:
+        - OriginalFileName: 'ldifde.exe'
+    selection_cli:
         CommandLine|contains|all:
             - '-i'
             - '-f'
     condition: all of selection_*
 falsepositives:
-    - Unknown
+    - Since the content of the files are Unknown, false positives are expected
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_ldifde_file_load.yml
+++ b/rules/windows/process_creation/proc_creation_win_ldifde_file_load.yml
@@ -28,5 +28,5 @@ detection:
             - '-f'
     condition: all of selection_*
 falsepositives:
-    - Since the content of the files are Unknown, false positives are expected
+    - Since the content of the files are unknown, false positives are expected
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_lolbin_dotnet_dump.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_dotnet_dump.yml
@@ -1,0 +1,25 @@
+title: Process Memory Dump Via Dotnet-Dump
+id: 53d8d3e1-ca33-4012-adf3-e05a4d652e34
+status: experimental
+description: Detects the execution of "dotnet-dump" with the "collect" flag. The execution could indicate potential process dumping of critical processes such as LSASS
+references:
+    - https://learn.microsoft.com/en-us/dotnet/core/diagnostics/dotnet-dump#dotnet-dump-collect
+    - https://twitter.com/bohops/status/1635288066909966338
+author: Nasreddine Bencherchali (Nextron Systems)
+date: 2023/03/14
+tags:
+    - attack.defense_evasion
+    - attack.t1218
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\dotnet-dump.exe'
+        - OriginalFileName: 'dotnet-dump.dll'
+    selection_cli:
+        CommandLine|contains: 'collect'
+    condition: all of selection_*
+falsepositives:
+    - Process dumping is the expected behavior of the tool. So false positives are expected in legitimate usage. The PID/Process Name of the process being dumped needs to be investigated
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_powershell_snapins_hafnium.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_snapins_hafnium.yml
@@ -6,9 +6,9 @@ references:
     - https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities/
     - https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers/
     - https://www.intrinsec.com/apt27-analysis/
-author: FPT.EagleEye, Nasreddine Bencherchali
+author: FPT.EagleEye, Nasreddine Bencherchali (Nextron Systems)
 date: 2021/03/03
-modified: 2022/12/09
+modified: 2023/03/14
 tags:
     - attack.execution
     - attack.t1059.001
@@ -31,10 +31,11 @@ detection:
         CommandLine|contains:
             - 'Microsoft.Exchange.Powershell.Snapin'
             - 'Microsoft.Exchange.Management.PowerShell.SnapIn'
-    condition: all of selection_*
-fields:
-    - CommandLine
-    - ParentCommandLine
+    filter_msiexec:
+        # ParentCommandLine: C:\Windows\System32\MsiExec.exe -Embedding C9138ECE2536CB4821EB5F55D300D88E E Global\MSI0000
+        ParentImage: 'C:\Windows\System32\msiexec.exe'
+        CommandLine|contains: '$exitcode=0 $exserver=Get-ExchangeServer ([Environment]::MachineName) -ErrorVariable exerr'
+    condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_rundll32_executable_invalid_extension.yml
+++ b/rules/windows/process_creation/proc_creation_win_rundll32_executable_invalid_extension.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/mrd0x/status/1481630810495139841?s=12
 author: Tim Shelton, Florian Roth (Nextron Systems), Yassine Oukessou (fix + fp)
 date: 2022/01/13
-modified: 2023/02/09
+modified: 2023/03/13
 logsource:
     category: process_creation
     product: windows
@@ -19,6 +19,8 @@ detection:
     filter_generic:
         - CommandLine|contains: '.dll'
         - CommandLine: ''
+    filter_parent_null:
+        CommandLine: 'C:\Windows\system32\rundll32.exe C:\Windows\system32\inetcpl.cpl,ClearMyTracksByProcess'
     filter_iexplorer:
         ParentImage|endswith: ':\Program Files\Internet Explorer\iexplore.exe'
         CommandLine|contains: '.cpl'
@@ -41,6 +43,12 @@ detection:
         ParentImage|contains: '\AppData\Local\Microsoft\EdgeUpdate\Install\{'
         ParentImage|endswith: '\setup.exe'
         ParentCommandLine|contains: '\setup.exe" --install-archive="C:\Users\'
+    filter_avira:
+        CommandLine|contains|all:
+            - 'C:\Windows\Installer\MSI'
+            - '.tmp'
+            - 'zzzzInvokeManagedCustomActionOutOfProc'
+            - 'Avira.OE.Setup'
     condition: selection and not 1 of filter_*
 fields:
     - Image

--- a/rules/windows/process_creation/proc_creation_win_schtasks_env_folder.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_env_folder.yml
@@ -1,5 +1,8 @@
 title: Suspicious Schtasks From Env Var Folder
 id: 81325ce1-be01-4250-944f-b4789644556f
+related:
+    - id: 43f487f0-755f-4c2a-bce7-d6d2eec2fcf8 # TODO: Recreate after baseline
+      type: derived
 status: experimental
 description: Detects Schtask creations that point to a suspicious folder or an environment variable often used by malware
 references:
@@ -7,7 +10,7 @@ references:
     - https://www.joesandbox.com/analysis/514608/0/html#324415FF7D8324231381BAD48A052F85DF04
 author: Florian Roth (Nextron Systems)
 date: 2022/02/21
-modified: 2022/09/18
+modified: 2023/03/14
 tags:
     - attack.execution
     - attack.t1053.005
@@ -40,6 +43,29 @@ detection:
             - 'update_task.xml'
             - '/Create /TN TVInstallRestore /TR'
         - ParentCommandLine|contains: 'unattended.ini'
+    filter_avira_install:
+        # Comment out this filter if you dont use AVIRA
+        CommandLine|contains|all:
+            - '/Create /Xml "C:\Users\'
+            - '\AppData\Local\Temp\.CR.'
+            - 'Avira_Security_Installation.xml'
+    filter_avira_other:
+        # Comment out this filter if you dont use AVIRA
+        CommandLine|contains|all:
+            - '/Create /F /TN'
+            - '/Xml '
+            - '\AppData\Local\Temp\is-'
+            - 'Avira_'
+        CommandLine|contains:
+            - '.tmp\UpdateFallbackTask.xml'
+            - '.tmp\WatchdogServiceControlManagerTimeout.xml'
+            - '.tmp\SystrayAutostart.xml'
+            - '.tmp\MaintenanceTask.xml'
+    filter_klite_codec:
+        CommandLine|contains|all:
+            - '\AppData\Local\Temp\'
+            - '/Create /TN "klcp_update" /XML '
+            - '\klcp_update_task.xml'
     condition: ( all of selection1* or all of selection2* ) and not 1 of filter*
 falsepositives:
     - Benign scheduled tasks creations or executions that happen often during software installations

--- a/rules/windows/process_creation/proc_creation_win_schtasks_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_system.yml
@@ -7,6 +7,7 @@ references:
     - https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/schtasks
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/28
+modified: 2023/03/14
 tags:
     - attack.execution
     - attack.persistence
@@ -26,13 +27,18 @@ detection:
         CommandLine|contains:
             - 'NT AUT' # This covers the usual NT AUTHORITY\SYSTEM
             - ' SYSTEM ' # SYSTEM is a valid value for schtasks hence it gets it's own value with space
-    filter:
+    filter_teamviewer:
         # FP from test set in SIGMA
         ParentImage|contains|all:
             - '\AppData\Local\Temp\'
             - 'TeamViewer_.exe'
         Image|endswith: '\schtasks.exe'
         CommandLine|contains: '/TN TVInstallRestore'
+    filter_avira:
+        CommandLine|contains:
+            - '/Create /F /RU System /SC WEEKLY /TN AviraSystemSpeedupVerify /TR '
+            - 'C:\Program Files (x86)\Avira\System Speedup\setup\avira_speedup_setup.exe'
+            - '/VERIFY /VERYSILENT /NOSTART /NODOTNET /NORESTART" /RL HIGHEST'
     condition: all of selection_* and not filter
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_schtasks_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_system.yml
@@ -39,7 +39,7 @@ detection:
             - '/Create /F /RU System /SC WEEKLY /TN AviraSystemSpeedupVerify /TR '
             - 'C:\Program Files (x86)\Avira\System Speedup\setup\avira_speedup_setup.exe'
             - '/VERIFY /VERYSILENT /NOSTART /NODOTNET /NORESTART" /RL HIGHEST'
-    condition: all of selection_* and not filter
+    condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_susp_elevated_system_shell.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_elevated_system_shell.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Wh04m1001/SysmonEoP
 author: frack113, Tim Shelton (update fp)
 date: 2022/12/05
-modified: 2023/01/24
+modified: 2023/03/14
 tags:
     - attack.privilege_escalation
     - attack.defense_evasion
@@ -62,8 +62,11 @@ detection:
         ParentImage|endswith: '\invcol.exe'
         ParentCommandLine|contains: 'C:\ProgramData\Dell\UpdateService\'
         Image|endswith: '\cmd.exe'
-    filter_empty_parent1:  # Most probably SetupHost.exe during Windows updates/upgrades; See comment on rule id: f4bbd493-b796-416e-bbf2-121235348529
-        CommandLine: "powershell.exe -ExecutionPolicy Restricted -Command Write-Host 'Final result: 1';"
+    filter_empty_parent_1:
+        CommandLine: "powershell.exe -ExecutionPolicy Restricted -Command Write-Host 'Final result: 1';"  # Most probably SetupHost.exe during Windows updates/upgrades; See comment on rule id: f4bbd493-b796-416e-bbf2-121235348529
+    filter_empty_parent_2:
+        Image|endswith: '\cmd.exe'
+        CommandLine|contains: '/d /c C:\Windows\system32\silcollector.cmd'
     condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_adexplorer_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_adexplorer_execution.yml
@@ -1,0 +1,28 @@
+title: Active Directory Database Snapshot Via ADExplorer
+id: 9212f354-7775-4e28-9c9f-8f0a4544e664
+related:
+    - id: ef61af62-bc74-4f58-b49b-626448227652
+      type: derived
+status: experimental
+description: Detects the execution of Sysinternals ADExplorer with the "-snapshot" flag in order to save a local copy of the active directory database.
+references:
+    - https://www.documentcloud.org/documents/5743766-Global-Threat-Report-2019.html
+author: Nasreddine Bencherchali (Nextron Systems)
+date: 2023/03/14
+tags:
+    - attack.credential_access
+    - attack.t1552.001
+    - attack.t1003.003
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\ADExplorer.exe'
+        - OriginalFileName: 'AdExp'
+    selection_cli:
+        CommandLine|contains: 'snapshot'
+    condition: all of selection_*
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_adexplorer_susp_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_adexplorer_susp_execution.yml
@@ -1,4 +1,4 @@
-title: Active Directory Database Snapshot Via ADExplorer
+title: Suspicious Active Directory Database Snapshot Via ADExplorer
 id: ef61af62-bc74-4f58-b49b-626448227652
 related:
     - id: 9212f354-7775-4e28-9c9f-8f0a4544e664

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_adexplorer_susp_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_adexplorer_susp_execution.yml
@@ -4,7 +4,7 @@ related:
     - id: 9212f354-7775-4e28-9c9f-8f0a4544e664
       type: derived
 status: experimental
-description: Detects the execution of Sysinternals ADExplorer with the "-snapshot" flag in order to save a local copy of the active directory database.
+description: Detects the execution of Sysinternals ADExplorer with the "-snapshot" flag in order to save a local copy of the active directory database to a suspicious directory.
 references:
     - https://www.documentcloud.org/documents/5743766-Global-Threat-Report-2019.html
 author: Nasreddine Bencherchali (Nextron Systems)

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_adexplorer_susp_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_adexplorer_susp_execution.yml
@@ -1,0 +1,35 @@
+title: Active Directory Database Snapshot Via ADExplorer
+id: ef61af62-bc74-4f58-b49b-626448227652
+related:
+    - id: 9212f354-7775-4e28-9c9f-8f0a4544e664
+      type: derived
+status: experimental
+description: Detects the execution of Sysinternals ADExplorer with the "-snapshot" flag in order to save a local copy of the active directory database.
+references:
+    - https://www.documentcloud.org/documents/5743766-Global-Threat-Report-2019.html
+author: Nasreddine Bencherchali (Nextron Systems)
+date: 2023/03/14
+tags:
+    - attack.credential_access
+    - attack.t1552.001
+    - attack.t1003.003
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\ADExplorer.exe'
+        - OriginalFileName: 'AdExp'
+    selection_flag:
+        CommandLine|contains: 'snapshot'
+    selection_paths:
+        CommandLine|contains:
+            # TODO: Add more suspicious paths
+            - '\Downloads\'
+            - '\Users\Public\'
+            - '\AppData\'
+            - '\Windows\Temp\'
+    condition: all of selection_*
+falsepositives:
+    - Unknown
+level: high

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_eula_accepted.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_eula_accepted.yml
@@ -4,7 +4,7 @@ related:
     - id: 25ffa65d-76d8-4da5-a832-3f2b0136e133
       type: derived
 status: experimental
-description: Detects commandline flags that contain the 'accepteula' flag which could be a sign of execution of one of the Sysinternals tools
+description: Detects command lines that contain the 'accepteula' flag which could be a sign of execution of one of the Sysinternals tools
 references:
     - https://twitter.com/Moti_B/status/1008587936735035392
 author: Markus Neis
@@ -24,5 +24,5 @@ detection:
     condition: selection
 falsepositives:
     - Legitimate use of SysInternals tools
-    - Programs that use the same commandline
+    - Programs that use the same command line flag
 level: low

--- a/rules/windows/registry/registry_set/registry_set_disable_winevt_logging.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_winevt_logging.yml
@@ -5,9 +5,9 @@ description: Detects tampering with the "Enabled" registry key in order to disab
 references:
     - https://twitter.com/WhichbufferArda/status/1543900539280293889
     - https://github.com/DebugPrivilege/CPP/blob/c39d365617dbfbcb01fffad200d52b6239b2918c/Windows%20Defender/RestoreDefenderConfig.cpp
-author: frack113, Nasreddine Bencherchali
+author: frack113, Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/04
-modified: 2023/01/18
+modified: 2023/03/14
 tags:
     - attack.defense_evasion
     - attack.t1562.002
@@ -32,6 +32,7 @@ detection:
             - '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-ASN1\'
             - '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-Kernel-AppCompat\'
             - '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-Runtime\Error\'
+            - '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-CAPI2/Operational\'
     filter_trusted_installer:
         Image: C:\Windows\servicing\TrustedInstaller.exe
         TargetObject|contains: '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-Compat-Appraiser'

--- a/rules/windows/registry/registry_set/registry_set_susp_printer_driver.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_printer_driver.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/SBousseaden/status/1410545674773467140
 author: Florian Roth (Nextron Systems)
 date: 2020/07/01
-modified: 2022/09/21
+modified: 2023/03/14
 tags:
     - attack.privilege_escalation
     - attack.t1574
@@ -27,6 +27,8 @@ detection:
         TargetObject|contains:
             - '\VNC Printer (PS)\'
             - '\VNC Printer (UD)\'
+    filter_pdf24:
+        TargetObject|contains: '\Version-3\PDF24\'
     condition: selection and not 1 of filter_*
 falsepositives:
     - Alerts on legitimate printer drivers that do not set any more details in the Manufacturer value

--- a/rules/windows/registry/registry_set/registry_set_windows_defender_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_windows_defender_tamper.yml
@@ -22,7 +22,7 @@ logsource:
     product: windows
     category: registry_set
 detection:
-    root:
+    selection_main:
         EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows Defender\'
     selection_dword_1:
@@ -43,7 +43,7 @@ detection:
             - '\SpyNet\SubmitSamplesConsent'
             - '\MpEngine\MpEnablePus'
         Details: 'DWORD (0x00000000)'
-    condition: ( root and 1 of selection_* ) and not 1 of filter*
+    condition: selection_main and 1 of selection_dword_*
 falsepositives:
     - Administrator actions
 level: high

--- a/rules/windows/registry/registry_set/registry_set_windows_defender_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_windows_defender_tamper.yml
@@ -14,7 +14,7 @@ references:
     - https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/ransomware-hive-conti-avoslocker
 author: AlertIQ, Ján Trenčanský, frack113, Nasreddine Bencherchali
 date: 2022/08/01
-modified: 2022/12/05
+modified: 2023/03/14
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -43,10 +43,6 @@ detection:
             - '\SpyNet\SubmitSamplesConsent'
             - '\MpEngine\MpEnablePus'
         Details: 'DWORD (0x00000000)'
-    filter_msmpeng:
-        Image|contains|all:
-            - 'C:\ProgramData\Microsoft\Windows Defender\platform\'
-            - '\MsMpEng.exe'
     condition: ( root and 1 of selection_* ) and not 1 of filter*
 falsepositives:
     - Administrator actions


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

This PR adds:
- New rules.
- Fixes FP found in testing.
- Other quality of life changes.

<!--
A short summary of your pull request
-->

### Detailed Description of the Pull Request / Additional Comments

- Deprecated `43f487f0-755f-4c2a-bce7-d6d2eec2fcf8` for now since it overlaps with `81325ce1-be01-4250-944f-b4789644556f`. I'll re-introduce a separation in a later fix.
- Deprecated `d813d662-785b-42ca-8b4a-f7457d78d5a9` since the logic is flawed. Its looking for loads of `advapi32` from a non-typical location. But the DLL in question is a common DLL that can be used by any application. If we say its a Side-Loading rule then there is no public reference for `advapi32` being sideloaded. (If you find one we can keep it).
- I also removed the filter from `0eb46774-f1ab-4a74-8238-1155855f2263` since `defender` disabling those keys should be investigated.
- Increased the `level` of some DLL sideloading rules to `high`
<!--
A detailed description of the pull request and any additional comments or context
-->

### Example Log Event

N/A
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
