### PR TITLE
Add recursive type check to avoid having illegal types inside of a list

### DIFF
--- a/tools/sigma/parser/modifiers/base.py
+++ b/tools/sigma/parser/modifiers/base.py
@@ -49,7 +49,19 @@ class SigmaModifier(object):
 
     def validate(self):
         """Validate if modifier is applicable to value. Expects that value is stored in self.value."""
-        return any(( isinstance(self.value, t) for t in self.valid_input_types ))
+        return any(( self.isinstance_recursive(self.value, t) for t in self.valid_input_types ))
+
+    def isinstance_recursive(self, value: object, value_type: type) -> bool:
+        """Validate values inside of a list or a tuple"""
+        if not isinstance(value, value_type):
+            return False
+
+        if isinstance(value, (list, tuple, )):
+            for val in value:
+                if not any(( self.isinstance_recursive(val, t) for t in self.valid_input_types)):
+                    return False
+
+        return True
 
     def apply(self):
         """

--- a/tools/sigma/parser/modifiers/mixins.py
+++ b/tools/sigma/parser/modifiers/mixins.py
@@ -29,9 +29,13 @@ class ListOrStringModifierMixin(object):
     * apply_str(str) returns string without modifications
     """
     valid_input_types = (list, tuple, str, )
+    iterable_types = (list, tuple, ConditionBase, NodeSubexpression)
+
+    def valid_value_types(self):
+        return tuple(t for t in self.valid_input_types if t not in self.iterable_types)
 
     def apply(self):
-        if isinstance(self.value, (list, tuple, ConditionBase, NodeSubexpression)):
+        if isinstance(self.value, self.iterable_types):
             return self.apply_list(self.value)
         else:
             return self.apply_str(self.value)
@@ -41,7 +45,7 @@ class ListOrStringModifierMixin(object):
         if isinstance(l, (list, tuple)):
             l = [
                 self.apply_str(v)
-                if isinstance(v, str)
+                if isinstance(v, self.valid_value_types())
                 else self.apply_list(v)
                 for v in l ]
             rl = list()

--- a/tools/sigma/parser/modifiers/mixins.py
+++ b/tools/sigma/parser/modifiers/mixins.py
@@ -28,7 +28,7 @@ class ListOrStringModifierMixin(object):
     * apply_list() calls apply_str(str) for each value and returns list with all results.
     * apply_str(str) returns string without modifications
     """
-    valid_input_types = (list, tuple, str, )
+    valid_input_types = (list, tuple, str, ConditionBase, NodeSubexpression)
     iterable_types = (list, tuple, ConditionBase, NodeSubexpression)
 
     def valid_value_types(self):

--- a/tools/sigma/parser/modifiers/transform.py
+++ b/tools/sigma/parser/modifiers/transform.py
@@ -75,6 +75,10 @@ class SigmaAllValuesModifier(SigmaTransformModifier):
             cond.add(val)
         return cond
 
+    def validate(self):
+        """Override default validate to avoid checking type recursively"""
+        return any(( isinstance(self.value, t) for t in self.valid_input_types  ))
+
 class SigmaBase64Modifier(ListOrStringModifierMixin, SigmaTransformModifier):
     """Encode strings with Base64"""
     identifier = "base64"

--- a/tools/sigma/parser/rule.py
+++ b/tools/sigma/parser/rule.py
@@ -16,7 +16,7 @@
 
 import re
 from .exceptions import SigmaParseError
-from .condition import SigmaConditionTokenizer, SigmaConditionParser, ConditionAND, ConditionOR, ConditionNULLValue, SigmaSearchValueAsIs
+from .condition import NodeSubexpression, SigmaConditionTokenizer, SigmaConditionParser, ConditionAND, ConditionOR, ConditionNULLValue, SigmaSearchValueAsIs
 from .modifiers import apply_modifiers
 
 class SigmaParser:
@@ -91,6 +91,10 @@ class SigmaParser:
                     fieldname = key
                 mapping = self.config.get_fieldmapping(fieldname)
                 if isinstance(value, (ConditionAND, ConditionOR)):    # value is condition node (by transformation modifier)
+                    value.items = [ mapping.resolve(key, item, self) for item in value.items ]
+                    cond.add(value)
+                elif isinstance(value, NodeSubexpression):
+                    value = value.items
                     value.items = [ mapping.resolve(key, item, self) for item in value.items ]
                     cond.add(value)
                 else:           # plain value or something unexpected (caught by backends)


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

<!--
A short summary of your pull request
-->

This Pull Request aims to fix some issues due to type check:

- Add recursive type check for list values
- Update apply_list to avoid returning None if value is bytes

### Detailed Description of the Pull Request / Additional Comments

<!--
A detailed description of the pull request and any additional comments or context
-->

In base **SigmaModifier** class the **validate** function does not work recursively.

**SigmaContainsModifier** only accept list, tuple or string but it will accept list values containing integer, resulting in processed data containing None in **apply_list**.

So the first goal of this PR is to prevent that from happening, by checking type of the value recursively.


Furthermore, in the **apply_list** method of **ListOrStringModifierMixin** class, list of bytes will result in a call of **apply_list** on a byte object. This call will return None as the instance check is only made on list, tuple, NodeSubexpression, ConditionOR and ConditionAND.

In **apply_list** method, it may be a good idea to check on all valid_input_types (currently made on string only) defined by the **SigmaModifier** subclass. It will allow list of bytes to be processed properly.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

Following sigma rules generates request with None values:

```yaml
title: Rule PR
description: Some description
author: tehtris-siem
detection:
  selection_main:
    EventID|contains|all:
      - 4625
      - '4624'
  condition: selection_main
level: low
```

```yaml
title: Rule PR
description: Some description
author: tehtris-siem
detection:
  selection_main:
    EventID|wide|base64:
      - '4625'
      - '4624'
  condition: selection_main
level: low
```

These kind of rules should at least be rejected to avoid generating request which differs from the yaml rule or does not make sense.

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
