### PR TITLE
Create proxy_susp_ipfs_cred_harvest.yml

### DIFF
--- a/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
+++ b/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
@@ -1,20 +1,20 @@
-title: Suspicious Network Communication with Interplanetary File System (IPFS)
+title: Suspicious Network Communication With IPFS
 status: experimental
 description: Detects connections to interplanetary file system (IPFS) containing a users email address which mirrors behaviours observed in recent phishing campaigns leveraging IPFS to host credential harvesting webpages.
 references:
     - https://blog.talosintelligence.com/ipfs-abuse/
-    - //https://github.com/Cisco-Talos/IOCs/tree/main/2022/11
+    - https://github.com/Cisco-Talos/IOCs/tree/main/2022/11
     - https://isc.sans.edu/diary/IPFS%20phishing%20and%20the%20need%20for%20correctly%20set%20HTTP%20security%20headers/29638
 author: Gavin Knapp
 date: 2023/03/16
 tags:
     - attack.credential_access
     - attack.t1056
+    - IPFS
 logsource:
     category: proxy
 detection:
     selection:
-        c-uri|contains: 'ipfs.io/ipfs/'
         cs-uri|re: '(?i)ipfs.io/ipfs.+\..+@.+\..+'
     condition: selection
 falsepositives:

--- a/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
+++ b/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
@@ -1,0 +1,22 @@
+title: Suspicious Network Communication with Interplanetary File System (IPFS)
+status: experimental
+description: Detects connections to interplanetary file system (IPFS) containing a users email address which mirrors behaviours observed in recent phishing campaigns leveraging IPFS to host credential harvesting webpages.
+references:
+    - https://blog.talosintelligence.com/ipfs-abuse/
+    - //https://github.com/Cisco-Talos/IOCs/tree/main/2022/11
+    - https://isc.sans.edu/diary/IPFS%20phishing%20and%20the%20need%20for%20correctly%20set%20HTTP%20security%20headers/29638
+author: Gavin Knapp
+date: 2023/03/16
+tags:
+    - attack.credential_access
+    - attack.t1056
+logsource:
+    category: proxy
+detection:
+    selection:
+        c-uri|contains: 'ipfs.io/ipfs/'
+        cs-uri|re: '(?i)ipfs.io/ipfs.+\..+@.+\..+'
+    condition: selection
+falsepositives:
+    - Legitimate use of IPFS being used in the organiation. However the cs-uri regex looking for a user email will likely negate this.
+level: low

--- a/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
+++ b/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
@@ -1,7 +1,7 @@
 title: Suspicious Network Communication With IPFS
 id: eb6c2004-1cef-427f-8885-9042974e5eb6
 status: experimental
-description: Detects connections to interplanetary file system (IPFS) containing a users email address which mirrors behaviours observed in recent phishing campaigns leveraging IPFS to host credential harvesting webpages.
+description: Detects connections to interplanetary file system (IPFS) containing a user's email address which mirrors behaviours observed in recent phishing campaigns leveraging IPFS to host credential harvesting webpages.
 references:
     - https://blog.talosintelligence.com/ipfs-abuse/
     - https://github.com/Cisco-Talos/IOCs/tree/main/2022/11

--- a/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
+++ b/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
@@ -4,7 +4,7 @@ status: experimental
 description: Detects connections to interplanetary file system (IPFS) containing a user's email address which mirrors behaviours observed in recent phishing campaigns leveraging IPFS to host credential harvesting webpages.
 references:
     - https://blog.talosintelligence.com/ipfs-abuse/
-    - https://github.com/Cisco-Talos/IOCs/tree/main/2022/11
+    - https://github.com/Cisco-Talos/IOCs/tree/80caca039988252fbb3f27a2e89c2f2917f582e0/2022/11
     - https://isc.sans.edu/diary/IPFS%20phishing%20and%20the%20need%20for%20correctly%20set%20HTTP%20security%20headers/29638
 author: Gavin Knapp
 date: 2023/03/16

--- a/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
+++ b/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
@@ -1,4 +1,5 @@
 title: Suspicious Network Communication With IPFS
+id: eb6c2004-1cef-427f-8885-9042974e5eb6
 status: experimental
 description: Detects connections to interplanetary file system (IPFS) containing a users email address which mirrors behaviours observed in recent phishing campaigns leveraging IPFS to host credential harvesting webpages.
 references:

--- a/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
+++ b/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
@@ -15,7 +15,7 @@ logsource:
     category: proxy
 detection:
     selection:
-        cs-uri|re: '(?i)ipfs.io/ipfs.+\..+@.+\..+'
+        cs-uri|re: '(?i)(ipfs\.io/|ipfs\.io\s).+\..+@.+\.[a-z]+'
     condition: selection
 falsepositives:
     - Legitimate use of IPFS being used in the organisation. However the cs-uri regex looking for a user email will likely negate this.

--- a/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
+++ b/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
@@ -18,5 +18,5 @@ detection:
         cs-uri|re: '(?i)ipfs.io/ipfs.+\..+@.+\..+'
     condition: selection
 falsepositives:
-    - Legitimate use of IPFS being used in the organiation. However the cs-uri regex looking for a user email will likely negate this.
+    - Legitimate use of IPFS being used in the organisation. However the cs-uri regex looking for a user email will likely negate this.
 level: low

--- a/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
+++ b/rules/web/proxy_generic/proxy_susp_ipfs_cred_harvest.yml
@@ -11,7 +11,6 @@ date: 2023/03/16
 tags:
     - attack.credential_access
     - attack.t1056
-    - IPFS
 logsource:
     category: proxy
 detection:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

<!--
A short summary of your pull request
-->

This pull request is to propose a new rule that can be used to hunt for possible post phishing communication with a credential harvesting page hosted on the interplanetary file system (IPFS)

### Detailed Description of the Pull Request / Additional Comments

<!--
A detailed description of the pull request and any additional comments or context
-->

The intent of the rule is to look for network connections to IPFS via the proxy where the URI contains the characteristics observed in recent post phishing activity. The rule was tested with a Microsoft Sentinel conversion.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

Url in logs:

hxxpsx//ipfs.io/ipfs/QmSejSajLFEhYUHT6v45tbtajmRzJf5XTrv9kMA1?filename=next.hum.html#me@me.com
hxxpsx//ipfs.io/ipfs/QmbQopz8dyJFHszxty67ui8CMx1mqCp85neyL6D?filename=P%20O%20NN%20Y%20TT%20R%20SS.html#bill.bob@b.com

Example IPFS URI

/ipfs/QmbQopz8dyJFHszxty67ui8CMx1mqCp85neyL6D?filename=P%20O%20NN%20Y%20TT%20R%20SS.html#bill.bob@b.com

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
