### PR TITLE
Adding in integrity level for Microsoft Defender backend

### DIFF
--- a/tools/sigma/backends/mdatp.py
+++ b/tools/sigma/backends/mdatp.py
@@ -89,6 +89,7 @@ class WindowsDefenderATPBackend(SingleTextQueryBackend):
                 "ParentName": ("InitiatingProcessFileName", self.default_value_mapping),
                 "ParentProcessName": ("InitiatingProcessFileName", self.default_value_mapping),
                 "ParentImage": ("InitiatingProcessFolderPath", self.default_value_mapping),
+                "IntegrityLevel": ("ProcessIntegrityLevel", self.default_value_mapping),
                 "SourceImage": ("InitiatingProcessFolderPath", self.default_value_mapping),
                 "TargetImage": ("FolderPath", self.default_value_mapping),
                 "User": (self.decompose_user, ),


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

<!--
This pull request adds a process integrity field to Microsoft Defender backend. 
-->

### Detailed Description of the Pull Request / Additional Comments

<!--
While not seen frequently in Sigma rules, the integrity level kicks an error in Microsoft Defender engine when this field exists. This addition accurately represents the integrity level in Defender: https://learn.microsoft.com/en-us/microsoft-365/security/defender/advanced-hunting-deviceprocessevents-table?view=o365-worldwide

While I understand backends in this project are less supported now in favor of pySigma, I plan to work on pySigma in tandem for a Defender conversion engine at some point. 
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
https://github.com/alexmcdonald1124/sigma/blob/86f54f77944ec56b2944390f8af263b4e3eeee8e/tools/sigma/backends/mdatp.py#L92
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
