### PR TITLE
Create proc_creation_macos_add_to_admin_group.yml

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
@@ -1,7 +1,7 @@
 title: Create/Add (to) a admin group
 id: 0c1ffcf9-efa9-436e-ab68-23a9496ebf5b
 status: experimental
-description: Detects suspicious attempts to create and/or add an account to the admin group, thus creating privileged user profile.
+description: Detects suspicious attempts to create and/or add an account to the admin group, thus granting admin privileges
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md#atomic-test-3---create-local-account-with-admin-privileges-using-sysadminctl-utility---macos
     - https://ss64.com/osx/dscl.html
@@ -29,5 +29,5 @@ detection:
             - ' GroupMembership '
     condition: 1 of selection_*
 falsepositives:
-    - Legitimate administration activities
+    - Legitimate administration activities (very rare)
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
@@ -1,7 +1,7 @@
-title: Suspicious Inclusion To Admin Group 
+title: User Added To Admin Group - MacOS
 id: 0c1ffcf9-efa9-436e-ab68-23a9496ebf5b
 status: experimental
-description: Detects suspicious attempts to create and/or add an account to the admin group, thus granting admin privileges
+description: Detects attempts to create and/or add an account to the admin group, thus granting admin privileges.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md#atomic-test-3---create-local-account-with-admin-privileges-using-sysadminctl-utility---macos
     - https://ss64.com/osx/dscl.html
@@ -29,5 +29,5 @@ detection:
             - ' GroupMembership '
     condition: 1 of selection_*
 falsepositives:
-    - Legitimate administration activities (very rare)
+    - Legitimate administration activities
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
@@ -1,4 +1,4 @@
-title: Create or add an account to admin group
+title: Suspicious Inclusion To Admin Group 
 id: 0c1ffcf9-efa9-436e-ab68-23a9496ebf5b
 status: experimental
 description: Detects suspicious attempts to create and/or add an account to the admin group, thus granting admin privileges

--- a/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
@@ -1,0 +1,33 @@
+title: Create/Add (to) a admin group
+id: 0c1ffcf9-efa9-436e-ab68-23a9496ebf5b
+status: experimental
+description: Detects suspicious attempts to create and/or add an account to the admin group, thus creating privileged user profile.
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md#atomic-test-3---create-local-account-with-admin-privileges-using-sysadminctl-utility---macos
+    - https://ss64.com/osx/dscl.html
+    - https://ss64.com/osx/sysadminctl.html
+author: Sohan G (D4rkCiph3r)
+date: 2023/03/19
+tags:
+    - attack.t1078.003
+    - attack.initial_access
+    - attack.privilege_escalation
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_sysadminctl: #creates and adds new user to admin group
+        Image|endswith: '/sysadminctl'
+        CommandLine|contains|all:
+            - ' -addUser '
+            - ' -admin '
+    selection_dscl: #adds to admin group
+        Image|endswith: '/dscl'
+        CommandLine|contains|all:
+            - ' -append '
+            - ' /Groups/admin '
+            - ' GroupMembership '
+    condition: 1 of selection_*
+falsepositives:
+    - Legitimate administration activities
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
@@ -1,4 +1,4 @@
-title: Create/Add (to) a admin group
+title: Create or add an account to admin group
 id: 0c1ffcf9-efa9-436e-ab68-23a9496ebf5b
 status: experimental
 description: Detects suspicious attempts to create and/or add an account to the admin group, thus granting admin privileges


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request
New rule for adding an account new/existing to the admin group, thus granting admin privileges.

### Detailed Description of the Pull Request / Additional Comments
1. Using sysadminctl, it can be used to create and add to the admin group at one go.
2. Using dscl, if there is an existing user, it can be added to the admin group by modifying the "GroupMembership" attribute.
Refer: https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md

### Example Log Event
NA (It is very rare for administration team to use custom scripts which uses these utilities to create and add an account to the admin group.

### Fixed Issues
NA

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
