### PR TITLE
Create proc_creation_macos_suspicious_applet_behaviour.yml

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
+++ b/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
@@ -1,16 +1,14 @@
-title: Suspicious Osacompile Run By Applet Or Osascript
+title: Potentially Suspicious Osacompile Execution By Applet/Osascript
 id: a753a6af-3126-426d-8bd0-26ebbcb92254
 status: experimental
-description: | 
-    Detects suspicious applet or osascript started a command-line with osacompile.
-    Malware can use legitimate apps /Contents/MacOS/ directory to drop the payload
+description: Detects suspicious applet or osascript executing a potential suspicious OSA command with "osacompile".
 references:
     - https://redcanary.com/blog/mac-application-bundles/
-author: Sohan G (D4rkCiph3r), Red Canary (idea)
-date: 2023/03/20
+author: Sohan G (D4rkCiph3r), Red Canary (Idea)
+date: 2023/04/03
 tags:
-    - attack.t1059.002
     - attack.execution
+    - attack.t1059.002
 logsource:
     category: process_creation
     product: macos

--- a/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
+++ b/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
@@ -1,7 +1,9 @@
-title: Suspicious Applet Behaviour
+title: Suspicious Osacompile Run By Applet Or Osascript
 id: a753a6af-3126-426d-8bd0-26ebbcb92254
 status: experimental
-description: Detects suspicious applet or command-line OSA behaviour probably dropped by malware into legitimate apps /Contents/MacOS/ directory
+description: | 
+    Detects suspicious applet or osascript started a command-line with osacompile.
+    Malware can use legitimate apps /Contents/MacOS/ directory to drop the payload
 references:
     - https://redcanary.com/blog/mac-application-bundles/
 author: Sohan G (D4rkCiph3r), Red Canary (idea)

--- a/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
+++ b/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
@@ -13,14 +13,13 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection:
+    selection_applet:
         ParentImage|endswith:
             - '/applet '
             - '/osascript '
-    cli:
         CommandLine|contains:
             - 'osacompile'
-    condition: selection and cli
+    condition: selection_applet
 falsepositives:
     - Unknown
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
+++ b/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
@@ -13,13 +13,13 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection_applet:
+    selection:
         ParentImage|endswith:
             - '/applet '
             - '/osascript '
         CommandLine|contains:
             - 'osacompile'
-    condition: selection_applet
+    condition: selection
 falsepositives:
     - Unknown
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
+++ b/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
@@ -13,13 +13,16 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection:
+    selection_applet:
         ParentImage|endswith:
             - '/applet '
+    selection_osascript:
+        ParentImage|endswith:
             - '/osascript '
+    cli:
         CommandLine|contains:
             - 'osacompile'
-    condition: selection
+    condition: 1 of selection_* and cli
 falsepositives:
     - Unknown
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
+++ b/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
@@ -1,0 +1,26 @@
+title: Suspicious Applet Behaviour
+id: a753a6af-3126-426d-8bd0-26ebbcb92254
+status: experimental
+description: Detects suspicious applet or command-line OSA behaviour probably dropped by malware into legitimate apps /Contents/MacOS/ directory
+references:
+    - https://redcanary.com/blog/mac-application-bundles/
+author: Sohan G (D4rkCiph3r), Red Canary (idea)
+date: 2023/03/20
+tags:
+    - attack.t1059.002
+    - attack.execution
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection:
+        ParentImage|endswith:
+            - '/applet '
+            - '/osascript '
+    cli:
+        CommandLine|contains:
+            - 'osacompile'
+    condition: selection and cli
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
+++ b/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
@@ -1,7 +1,7 @@
-title: Potentially Suspicious Osacompile Execution By Applet/Osascript
+title: Osacompile Execution By Potentially Suspicious Applet/Osascript
 id: a753a6af-3126-426d-8bd0-26ebbcb92254
 status: experimental
-description: Detects suspicious applet or osascript executing a potential suspicious OSA command with "osacompile".
+description: Detects potential suspicious applet or osascript executing "osacompile".
 references:
     - https://redcanary.com/blog/mac-application-bundles/
 author: Sohan G (D4rkCiph3r), Red Canary (Idea)

--- a/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
+++ b/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
@@ -15,8 +15,8 @@ logsource:
 detection:
     selection:
         ParentImage|endswith:
-            - '/applet '
-            - '/osascript '
+            - '/applet'
+            - '/osascript'
         CommandLine|contains: 'osacompile'
     condition: selection
 falsepositives:

--- a/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
+++ b/rules/macos/process_creation/proc_creation_macos_suspicious_applet_behaviour.yml
@@ -13,16 +13,12 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection_applet:
+    selection:
         ParentImage|endswith:
             - '/applet '
-    selection_osascript:
-        ParentImage|endswith:
             - '/osascript '
-    cli:
-        CommandLine|contains:
-            - 'osacompile'
-    condition: 1 of selection_* and cli
+        CommandLine|contains: 'osacompile'
+    condition: selection
 falsepositives:
     - Unknown
 level: medium


### PR DESCRIPTION
### Summary of the Pull Request
New rule for suspicious applet/OSA behaviour

### Detailed Description of the Pull Request / Additional Comments
This rule detects suspicious applet or command-line OSA behaviour probably dropped by malware into legitimate app's "/Contents/MacOS/" directory.
Refer: https://redcanary.com/blog/mac-application-bundles/ (XCSSET)

### Example Log Event
NA

### Fixed Issues
NA

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
