### PR TITLE
Fix typo in command line argument

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_lolbin_dump64.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_dump64.yml
@@ -19,7 +19,7 @@ detection:
     procdump_flags:
         CommandLine|contains:
             - ' -ma '
-            - 'accpeteula'
+            - 'accepteula'
     filter:
         Image|contains: '\Installer\Feedback\dump64.exe'
     condition: ( selection and not filter ) or ( selection and procdump_flags )


### PR DESCRIPTION
### Summary of the Pull Request

Fixes a typo in a command line argument in `rules/windows/process_creation/proc_creation_win_lolbin_dump64.yml`

### Detailed Description of the Pull Request / Additional Comments

`accpeteula` should be `accepteula`