### PR TITLE
Update proc_creation_macos_add_to_admin_group.yml

### DIFF
--- a/rules-deprecated/macos/proc_creation_macos_add_to_admin_group.yml
+++ b/rules-deprecated/macos/proc_creation_macos_add_to_admin_group.yml
@@ -1,6 +1,6 @@
 title: User Added To Admin Group - MacOS
 id: 0c1ffcf9-efa9-436e-ab68-23a9496ebf5b
-status: experimental
+status: deprecated
 description: Detects attempts to create and/or add an account to the admin group, thus granting admin privileges.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md#atomic-test-3---create-local-account-with-admin-privileges-using-sysadminctl-utility---macos
@@ -8,7 +8,7 @@ references:
     - https://ss64.com/osx/sysadminctl.html
 author: Sohan G (D4rkCiph3r)
 date: 2023/03/19
-modified: 2023/03/30
+modified: 2023/08/22
 tags:
     - attack.t1078.003
     - attack.initial_access
@@ -28,13 +28,6 @@ detection:
             - ' -append '
             - ' /Groups/admin '
             - ' GroupMembership '
-    selection_dseditgroup:
-        Image|endswith: '/dseditgroup'
-        CommandLine|contains|all:
-            - ' -o edit ' #edit operation
-            - ' -a ' #name of the record(username)
-            - ' -t ' #type of the record(usergroup)
-            - 'admin'
     condition: 1 of selection_*
 falsepositives:
     - Legitimate administration activities

--- a/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
@@ -27,6 +27,13 @@ detection:
             - ' -append '
             - ' /Groups/admin '
             - ' GroupMembership '
+    selection_dseditgroup:
+        Image|endswith: '/dseditgroup'
+        CommandLine|contains|all:
+            - ' -o edit ' #edit operation
+            - ' -a ' #name of the record(username)
+            - ' -t ' #type of the record(usergroup)
+            - 'admin'
     condition: 1 of selection_*
 falsepositives:
     - Legitimate administration activities

--- a/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_add_to_admin_group.yml
@@ -8,6 +8,7 @@ references:
     - https://ss64.com/osx/sysadminctl.html
 author: Sohan G (D4rkCiph3r)
 date: 2023/03/19
+modified: 2023/03/30
 tags:
     - attack.t1078.003
     - attack.initial_access

--- a/rules/macos/process_creation/proc_creation_macos_dscl_add_user_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_dscl_add_user_to_admin_group.yml
@@ -1,0 +1,30 @@
+title: User Added To Admin Group Via Dscl
+id: b743623c-2776-40e0-87b1-682b975d0ca5
+related:
+    - id: 0c1ffcf9-efa9-436e-ab68-23a9496ebf5b
+      type: obsoletes
+status: experimental
+description: Detects attempts to create and add an account to the admin group via "dscl"
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md#atomic-test-2---create-local-account-with-admin-privileges---macos
+    - https://ss64.com/osx/dscl.html
+author: Sohan G (D4rkCiph3r)
+date: 2023/03/19
+tags:
+    - attack.initial_access
+    - attack.privilege_escalation
+    - attack.t1078.003
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection: #adds to admin group
+        Image|endswith: '/dscl'
+        CommandLine|contains|all:
+            - ' -append '
+            - ' /Groups/admin '
+            - ' GroupMembership '
+    condition: selection
+falsepositives:
+    - Legitimate administration activities
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_dseditgroup_add_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_dseditgroup_add_to_admin_group.yml
@@ -1,4 +1,4 @@
-title: User Added To Admin Group - MacOS
+title: User Added To Admin Group Via DseditGroup
 id: 5d0fdb62-f225-42fb-8402-3dfe64da468a
 status: experimental
 description: Detects attempts to create and/or add an account to the admin group, thus granting admin privileges.

--- a/rules/macos/process_creation/proc_creation_macos_dseditgroup_add_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_dseditgroup_add_to_admin_group.yml
@@ -1,0 +1,28 @@
+title: User Added To Admin Group - MacOS
+id: 5d0fdb62-f225-42fb-8402-3dfe64da468a
+status: experimental
+description: Detects attempts to create and/or add an account to the admin group, thus granting admin privileges.
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md#atomic-test-5---add-a-newexisting-user-to-the-admin-group-using-dseditgroup-utility---macos
+    - https://ss64.com/osx/dseditgroup.html
+author: Sohan G (D4rkCiph3r)
+date: 2023/08/22
+tags:
+    - attack.initial_access
+    - attack.privilege_escalation
+    - attack.t1078.003
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection:
+        Image|endswith: '/dseditgroup'
+        CommandLine|contains|all:
+            - ' -o edit ' #edit operation
+            - ' -a ' # username
+            - ' -t user'
+            - 'admin' # Group name
+    condition: selection
+falsepositives:
+    - Legitimate administration activities
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_sysadminctl_add_user_to_admin_group.yml
+++ b/rules/macos/process_creation/proc_creation_macos_sysadminctl_add_user_to_admin_group.yml
@@ -1,0 +1,30 @@
+title: User Added To Admin Group Via Sysadminctl
+id: 652c098d-dc11-4ba6-8566-c20e89042f2b
+related:
+    - id: 0c1ffcf9-efa9-436e-ab68-23a9496ebf5b
+      type: obsoletes
+status: experimental
+description: Detects attempts to create and add an account to the admin group via "sysadminctl"
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1078.003/T1078.003.md#atomic-test-3---create-local-account-with-admin-privileges-using-sysadminctl-utility---macos
+    - https://ss64.com/osx/sysadminctl.html
+author: Sohan G (D4rkCiph3r)
+date: 2023/03/19
+tags:
+    - attack.initial_access
+    - attack.privilege_escalation
+    - attack.t1078.003
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection:
+        # Creates and adds new user to admin group
+        Image|endswith: '/sysadminctl'
+        CommandLine|contains|all:
+            - ' -addUser '
+            - ' -admin '
+    condition: selection
+falsepositives:
+    - Legitimate administration activities
+level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request
Restructured another detection from this rule "proc_creation_macos_enable_root_account.yml"(PR Pending) to here.

### Detailed Description of the Pull Request / Additional Comments
The built-in dseditgroup utility can be used to edit the group membership information in the macOS Directory Service.
Syntax: sudo dseditgroup -o {type of operation} -a {name of the record to add} -t {type of group to create or modify} {group to be added to}
Ex: sudo dseditgroup -o edit -a sigma -t user admin

### Example Log Event
NA

### Fixed Issues
NA

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
