### PR TITLE
Misentered Okta password logged in alternateId vulnerability

### DIFF
--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -7,10 +7,10 @@ description: |
 references:
     - https://developer.okta.com/docs/reference/api/system-log/
     - https://www.mitiga.io/blog/how-okta-passwords-can-be-compromised-uncovering-a-risk-to-user-data
-    - https://support.okta.com/help/s/article/What-special-characters-are-accepted-by-the-Okta-password
+    - https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-create-character-restriction.htm
 author: kelnage
 date: 2023/04/03
-modified: 2023/04/03
+modified: 2023/04/04
 tags:
     - attack.credential_access
     - attack.t1552
@@ -20,22 +20,12 @@ logsource:
 detection:
     selection:
         legacyeventtype: core.user_auth.login_failed
-        actor_alternateid|re|all:
-            # The following check for Okta's password complexity requirements
-            # You may need to adapt them based on your specific Okta config
-            - .*[a-z].*  # A lowercase character
-            - .*[A-Z].*  # An uppercase character
-            - .*\d.*     # A number
-            # A symbol/special character
-            - .*[\"!\#\$%\&'’\(\)\*\+,\-\./\\:;<=>\?@\[\]\^_`\{\|\}\~].*
     filters:
-        actor_alternateid:
-            - 0oa*  # Service account names start with 0oa
-            - '*@okta.com'  # Okta service accounts
-            # Uncomment the below check and set the Domain placeholder to your
-            # Organisation's Okta login domain for more accurate filter
-            # - '*@%Domain%'
+        # Okta service account names start with 0oa
+        # Email addresses are the default format for Okta usernames, so attempt
+        # to exclude alternateIds that look like valid emails
+        actor_alternateid|re: '(0oa.*|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,10})'
     condition: selection and not filters
 falsepositives:
-    - Failed login attempts with a valid username that meets the password complexity requirements
+    - Failed login attempts by a valid username that does not match the above regular expression
 level: low

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -37,7 +37,5 @@ detection:
             # - '*@%Domain%'
     condition: selection and not filters
 falsepositives:
-    - |
-        Failed login attempts with a valid username that meets the password
-        complexity requirements
+    - Failed login attempts with a valid username that meets the password complexity requirements
 level: low

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -28,4 +28,5 @@ detection:
     condition: selection and not filters
 falsepositives:
     - Failed login attempts by a valid username that does not match the above regular expression
+    - (False negative) Failed login attempts with a password that looks like a valid email address
 level: low

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -1,8 +1,9 @@
 title: Okta Password in AlternateID Field
 id: 91b76b84-8589-47aa-9605-c837583b82a9
-status: test
-description: Detects when a user has potentially entered their password into the
-  username field, which will cause the password to be retained in log files
+status: experimental
+description: |
+    Detects when a user has potentially entered their password into the
+    username field, which will cause the password to be retained in log files
 references:
     - https://developer.okta.com/docs/reference/api/system-log/
     - https://www.mitiga.io/blog/how-okta-passwords-can-be-compromised-uncovering-a-risk-to-user-data
@@ -25,15 +26,18 @@ detection:
             - .*[a-z].*  # A lowercase character
             - .*[A-Z].*  # An uppercase character
             - .*\d.*     # A number
-            - .*[\"!\#\$%\&'’\(\)\*\+,\-\./\\:;<=>\?@\[\]\^_`\{\|\}\~].*  # A symbol
+            # A symbol/special character
+            - .*[\"!\#\$%\&'’\(\)\*\+,\-\./\\:;<=>\?@\[\]\^_`\{\|\}\~].*
     filters:
         actor_alternateid:
             - 0oa*  # Service account names start with 0oa
+            - '*@okta.com'  # Okta service accounts
             # Uncomment the below check and set the Domain placeholder to your
             # Organisation's Okta login domain for more accurate filter
             # - '*@%Domain%'
     condition: selection and not filters
 falsepositives:
-    - Failed login attempts with a valid username that meets the password
+    - |
+      Failed login attempts with a valid username that meets the password
       complexity requirements
 level: low

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -38,6 +38,6 @@ detection:
     condition: selection and not filters
 falsepositives:
     - |
-      Failed login attempts with a valid username that meets the password
-      complexity requirements
+        Failed login attempts with a valid username that meets the password
+        complexity requirements
 level: low

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -1,0 +1,38 @@
+title: Okta Password in AlternateID Field
+id: 91b76b84-8589-47aa-9605-c837583b82a9
+status: test
+description: Detects when a user has potentially entered their password into the
+  username field, which will cause the password to be retained in log files
+references:
+    - https://developer.okta.com/docs/reference/api/system-log/
+    - https://www.mitiga.io/blog/how-okta-passwords-can-be-compromised-uncovering-a-risk-to-user-data
+author: kelnage
+date: 2023/04/03
+modified: 2023/04/03
+tags:
+    - attack.credential_access
+    - attack.t1552
+logsource:
+    product: okta
+    service: okta
+detection:
+    selection:
+        legacyeventtype: core.user_auth.login_failed
+        actor_alternateid|re|all:
+            # The following check for Okta's password complexity requirements
+            # You may need to adapt them based on your specific Okta config
+            - .*[a-z].*  # A lowercase character
+            - .*[A-Z].*  # An uppercase character
+            - .*\d.*     # A number
+            - .*[\"!\#\$%\&'’\(\)\*\+,\-\./\\:;<=>\?@\[\]\^_`\{\|\}\~].*  # A symbol
+    filters:
+        actor_alternateid:
+            - 0oa*  # Service account names start with 0oa
+            # Uncomment the below check and set the Domain placeholder to your
+            # Organisation's Okta login domain for more accurate defeat
+            # - '*@%Domain%'
+    condition: selection and not filters
+falsepositives:
+    - Failed login attempts with a valid username that meets the password
+      complexity requirements
+level: low

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -31,4 +31,4 @@ detection:
     condition: selection and not filter_main
 falsepositives:
     - Unlikely
-level: low
+level: high

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -6,6 +6,7 @@ description: Detects when a user has potentially entered their password into the
 references:
     - https://developer.okta.com/docs/reference/api/system-log/
     - https://www.mitiga.io/blog/how-okta-passwords-can-be-compromised-uncovering-a-risk-to-user-data
+    - https://support.okta.com/help/s/article/What-special-characters-are-accepted-by-the-Okta-password
 author: kelnage
 date: 2023/04/03
 modified: 2023/04/03
@@ -29,7 +30,7 @@ detection:
         actor_alternateid:
             - 0oa*  # Service account names start with 0oa
             # Uncomment the below check and set the Domain placeholder to your
-            # Organisation's Okta login domain for more accurate defeat
+            # Organisation's Okta login domain for more accurate filter
             # - '*@%Domain%'
     condition: selection and not filters
 falsepositives:

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -1,16 +1,15 @@
-title: Okta Password in AlternateID Field
+title: Potential Okta Password in AlternateID Field
 id: 91b76b84-8589-47aa-9605-c837583b82a9
 status: experimental
 description: |
     Detects when a user has potentially entered their password into the
-    username field, which will cause the password to be retained in log files
+    username field, which will cause the password to be retained in log files.
 references:
     - https://developer.okta.com/docs/reference/api/system-log/
     - https://www.mitiga.io/blog/how-okta-passwords-can-be-compromised-uncovering-a-risk-to-user-data
     - https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-create-character-restriction.htm
 author: kelnage
 date: 2023/04/03
-modified: 2023/04/04
 tags:
     - attack.credential_access
     - attack.t1552
@@ -19,7 +18,7 @@ logsource:
     service: okta
 detection:
     selection:
-        legacyeventtype: core.user_auth.login_failed
+        legacyeventtype: 'core.user_auth.login_failed'
     filter_main:
         # Okta service account names start with 0oa
         # Email addresses are the default format for Okta usernames, so attempt

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -24,6 +24,8 @@ detection:
         # Okta service account names start with 0oa
         # Email addresses are the default format for Okta usernames, so attempt
         # to exclude alternateIds that look like valid emails
+        # If your Okta configuration uses different character restrictions, you
+        # will need to update this regular expression to reflect that
         actor_alternateid|re: '(0oa.*|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,10})'
     condition: selection and not filters
 falsepositives:

--- a/rules/cloud/okta/okta_password_in_alternateid_field.yml
+++ b/rules/cloud/okta/okta_password_in_alternateid_field.yml
@@ -20,15 +20,15 @@ logsource:
 detection:
     selection:
         legacyeventtype: core.user_auth.login_failed
-    filters:
+    filter_main:
         # Okta service account names start with 0oa
         # Email addresses are the default format for Okta usernames, so attempt
         # to exclude alternateIds that look like valid emails
         # If your Okta configuration uses different character restrictions, you
-        # will need to update this regular expression to reflect that
-        actor_alternateid|re: '(0oa.*|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,10})'
-    condition: selection and not filters
+        # will need to update this regular expression to reflect that or disable the rule for your environment
+        # Possible false negatives are failed login attempts with a password that looks like a valid email address
+        actor_alternateid|re: '(^0oa.*|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,10})'
+    condition: selection and not filter_main
 falsepositives:
-    - Failed login attempts by a valid username that does not match the above regular expression
-    - (False negative) Failed login attempts with a password that looks like a valid email address
+    - Unlikely
 level: low

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -143,7 +143,7 @@ class TestRules(unittest.TestCase):
                 check_if_list_contain_duplicates(item, depth, special)
             elif type(item) == dict and depth <= MAX_DEPTH:
                 for keys, sub_item in item.items():
-                    if "|base64" in keys: # Covers both "base64" and "base64offset" modifiers
+                    if "|base64" in keys or "|re" in keys: # Covers both "base64" and "base64offset" modifiers, and "re" modifier
                         check_list_or_recurse_on_dict(sub_item, depth + 1, True)
                     else:
                         check_list_or_recurse_on_dict(sub_item, depth + 1, special)
@@ -153,6 +153,7 @@ class TestRules(unittest.TestCase):
                 # We use a list comprehension to convert all the element to lowercase. Since we don't care about casing in SIGMA except for the following modifiers
                 #   - "base64offset"
                 #   - "base64"
+                #   - "re"
                 if special:
                     item_ = item
                 else:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->

Add a Sigma rule to detect Okta passwords potentially appearing in log files

### Detailed Description of the Pull Request / Additional Comments

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

Per [this blog post](https://www.mitiga.io/blog/how-okta-passwords-can-be-compromised-uncovering-a-risk-to-user-data) from Mitiga, Okta passwords may be accidentally entered into the username field of Okta, and in doing so, will cause the password to be retained in log files. This rule attempts to detect such occurrences.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

Pretty printed for readability, with some anonymisation of irrelevant details such as IPs, IDs, location, etc.

```json
{
   "actor" : {
      "alternateId" : "T3stingMitig4Valid!",
      "displayName" : "unknown",
      "id" : "unknown",
      "type" : "User"
   },
   "authenticationContext" : {
      "externalSessionId" : "unknown"
   },
   "client" : {
      "device" : "Computer",
      "geographicalContext" : {
         "city" : "London",
         "country" : "GB",
         "geolocation" : {
            "lat" : 51,
            "lon" : 0
         },
         "postalCode" : "XX",
         "state" : "England"
      },
      "ipAddress" : "XX.XX.XX.XX",
      "userAgent" : {
         "browser" : "FIREFOX",
         "os" : "Ubuntu",
         "rawUserAgent" : "Mozilla/5.0..."
      },
      "zone" : "null"
   },
   "debugContext" : {
      "debugData" : {
         "dtHash" : "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
         "loginResult" : "VERIFICATION_ERROR",
         "requestId" : "XXXXXXXXXXXXXXXXXXXXXXXXXXX",
         "requestUri" : "/api/v1/authn",
         "threatSuspected" : "false",
         "url" : "/api/v1/authn?"
      }
   },
   "displayMessage" : "User login to Okta",
   "eventType" : "user.session.start",
   "legacyEventType" : "core.user_auth.login_failed",
   "outcome" : {
      "reason" : "VERIFICATION_ERROR",
      "result" : "FAILURE"
   },
   "published" : "2023-04-04T09:36:52.427Z",
   "request" : {
      "ipChain" : [
         {
            "geographicalContext" : {
               "city" : "London",
               "country" : "United Kingdom",
               "geolocation" : {
                  "lat" : 51,
                  "lon" : 0
               },
               "postalCode" : "XX",
               "state" : "England"
            },
            "ip" : "XX.XX.XX.XX",
            "version" : "V4"
         }
      ]
   },
   "securityContext" : {},
   "severity" : "INFO",
   "transaction" : {
      "detail" : {},
      "id" : "XXXXXXXXXXXXXXXXXXXXXXXXXXX",
      "type" : "WEB"
   },
   "uuid" : "3b0dba50-d2cc-11ed-a99c-915dab54fffc",
   "version" : "0"
}
```

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

The Sigma test for duplicate filters `test_look_for_duplicate_filters` was failing this rule as it was not treating regular expression values (i.e., with the modifier `|re`) as being case-sensitive, but it should, at least according to [the Sigma specification](https://github.com/SigmaHQ/sigma-specification/blob/main/Sigma_specification.md#general).

I deliberately kept the two case-sensitive filters separate to make it easier for rule users to customise the rule to match their password complexity requirements in Okta.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
  - Done!
