### PR TITLE
Split selection clause into two

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_system_network_discovery.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_system_network_discovery.yml
@@ -14,7 +14,7 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection1:
+    selection_img:
         Image|endswith:
             - '/firewall-cmd'
             - '/ufw'
@@ -25,9 +25,9 @@ detection:
             - '/ifconfig'
             - '/systemd-resolve'
             - '/route'
-    selection2:
+    selection_cli:
         CommandLine|contains: '/etc/resolv.conf'
-    condition: selection1 or selection2
+    condition: 1 of selection_*
 falsepositives:
     - Legitimate administration activities
 level: informational

--- a/rules/linux/process_creation/proc_creation_lnx_system_network_discovery.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_system_network_discovery.yml
@@ -14,8 +14,8 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection:
-        - Image|endswith:
+    selection1:
+        Image|endswith:
             - '/firewall-cmd'
             - '/ufw'
             - '/iptables'
@@ -25,8 +25,9 @@ detection:
             - '/ifconfig'
             - '/systemd-resolve'
             - '/route'
-        - CommandLine|contains: '/etc/resolv.conf'
-    condition: selection
+    selection2:
+        CommandLine|contains: '/etc/resolv.conf'
+    condition: selection1 or selection2
 falsepositives:
     - Legitimate administration activities
 level: informational


### PR DESCRIPTION
### Summary of the Pull Request

Split selection clause into two. Both filters in the same selection would require seeing `/etc/resolv.conf` and `ifconfig` within the same process creation.

### Detailed Description of the Pull Request / Additional Comments

The filters are in an array which _may_ be a lesser known feature in Sigma to make OR'ed statements within the same selection, but it is definitely less readable this way. If this is not a logic fix, it would definitely be a readability one.

### Example Log Event
N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

N/A
