### PR TITLE
remove duplicate reference urls

### DIFF
--- a/rules/application/rpc_firewall/rpc_firewall_atsvc_recon.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_atsvc_recon.yml
@@ -6,7 +6,6 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/d1058a28-7e02-4948-8b8d-4a347fa64931
     - https://github.com/zeronetworks/rpcfirewall
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-TSCH.md
-    - https://github.com/zeronetworks/rpcfirewall
     - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01

--- a/rules/windows/file/file_event/file_event_win_net_cli_artefact.yml
+++ b/rules/windows/file/file_event/file_event_win_net_cli_artefact.yml
@@ -12,7 +12,6 @@ references:
     - https://github.com/olafhartong/sysmon-modular/blob/fa1ae53132403d262be2bbd7f17ceea7e15e8c78/11_file_create/include_dotnet.xml
     - https://web.archive.org/web/20221026202428/https://gist.github.com/code-scrap/d7f152ffcdb3e0b02f7f394f5187f008
     - https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html
-    - https://bohops.com/2021/03/16/investigating-net-clr-usage-log-tampering-techniques-for-edr-evasion/
 author: frack113, omkar72, oscd.community, Wojciech Lesicki
 date: 2022/11/18
 modified: 2023/02/23


### PR DESCRIPTION
### Summary of the Pull Request

Remove duplicate reference URLs

### Detailed Description of the Pull Request / Additional Comments

Remove duplicate reference URLs from `rules/application/rpc_firewall/rpc_firewall_atsvc_recon.yml` and `rules/windows/file/file_event/file_event_win_net_cli_artefact.yml`

### Example Log Event

n/a

### Fixed Issues

n/a

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
