### PR TITLE
Added new rule that identifies the creation of a scheduled job by usi…

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_schtasks_schedule_via_masqueraded_xml_file.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_schedule_via_masqueraded_xml_file.yml
@@ -1,0 +1,52 @@
+title: Suspicious Scheduled Task Creation via Masqueraded XML File
+id: dd2a821e-3b07-4d3b-a9ac-929fe4c6ca0c
+status: experimental
+description: Identifies the creation of a scheduled job by using an XML file without the extension of '.xml'. This behavior is typical of an attacker attempting to develop persistence while remaining undetected.
+references:
+    - https://docs.microsoft.com/en-us/windows/win32/taskschd/daily-trigger-example--xml-
+    - https://github.com/elastic/protections-artifacts/blob/main/behavior/rules/persistence_suspicious_scheduled_task_creation_via_masqueraded_xml_file.toml
+author: Elastic (author), Swachchhanda Shrawan Poudel
+date: 2023/04/20
+modified: 2023/04/20
+tags:
+    - attack.Defense Evasion
+    - attack.T1036.005
+    - attack.T1053.005
+    - attack.Persistence
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection_1:
+        - OriginalFileName: 'schtasks.exe'
+        - Image|endswith: '\schtasks.exe'
+    selection_2:
+        CommandLine|contains:
+            - '/create'
+            - '-create'
+    selection_3:
+        CommandLine|contains:
+            - '/xml'
+            - '-xml'
+    filter_1:
+        CommandLine|contains:
+            - '.xml'
+    filter_2:
+        system_integrity:
+            IntegrityLevel: 'System'
+    filter_3:
+        ParentImage|contains:
+            - ':\ProgramData\OEM\UpgradeTool\CareCenter_*\BUnzip\Setup_msi.exe'
+            - ':\Program Files\Axis Communications\AXIS Camera Station\SetupActions.exe'
+            - ':\Program Files\Axis Communications\AXIS Device Manager\AdmSetupActions.exe'
+            - ':\Program Files (x86)\Zemana\AntiMalware\AntiMalware.exe'
+            - ':\Program Files\Dell\SupportAssist\pcdrcui.exe'
+    filter_4:
+        ParentImage|endswith:
+            - '\rundll32.exe'
+        ParentCommandLine|contains:
+            - ':\WINDOWS\Installer\MSI*.tmp,zzzzInvokeManagedCustomActionOutOfProc'
+    condition: (all of selection_*) and not (all of filter_*)
+falsepositives:
+    - Unknown
+level: low

--- a/rules/windows/process_creation/proc_creation_win_schtasks_schedule_via_masqueraded_xml_file.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_schedule_via_masqueraded_xml_file.yml
@@ -1,49 +1,50 @@
 title: Suspicious Scheduled Task Creation via Masqueraded XML File
 id: dd2a821e-3b07-4d3b-a9ac-929fe4c6ca0c
 status: experimental
-description: Identifies the creation of a scheduled job by using an XML file without the extension of '.xml'. This behavior is typical of an attacker attempting to develop persistence while remaining undetected.
+description: Detects the creation of a scheduled task using the "-XML" flag with a file without the '.xml' extension. This behavior could be indicative of potential defense evasion attempt during persistence
 references:
     - https://docs.microsoft.com/en-us/windows/win32/taskschd/daily-trigger-example--xml-
-    - https://github.com/elastic/protections-artifacts/blob/main/behavior/rules/persistence_suspicious_scheduled_task_creation_via_masqueraded_xml_file.toml
-author: Elastic (author), Swachchhanda Shrawan Poudel
+    - https://github.com/elastic/protections-artifacts/blob/084067123d3328a823b1c3fdde305b694275c794/behavior/rules/persistence_suspicious_scheduled_task_creation_via_masqueraded_xml_file.toml
+author: Swachchhanda Shrawan Poudel, Elastic (idea)
 date: 2023/04/20
-modified: 2023/04/20
 tags:
     - attack.defense_evasion
     - attack.persistence
     - attack.t1036.005
     - attack.t1053.005
-    
 logsource:
     product: windows
     category: process_creation
 detection:
-    selection_1:
-        - OriginalFileName: 'schtasks.exe'
+    selection_img:
         - Image|endswith: '\schtasks.exe'
-    selection_2:
+        - OriginalFileName: 'schtasks.exe'
+    selection_cli_create:
         CommandLine|contains:
             - '/create'
             - '-create'
-    selection_3:
+    selection_cli_xml:
         CommandLine|contains:
             - '/xml'
             - '-xml'
-    filter_1:
+    filter_main_extension_xml:
         CommandLine|contains: '.xml'
-    filter_2:
+    filter_main_system_process:
         IntegrityLevel: 'System'
-    filter_3:
-        ParentImage|contains:
+    filter_main_rundll32:
+        ParentImage|endswith: '\rundll32.exe'
+        ParentCommandLine|contains|all:
+            - ':\WINDOWS\Installer\MSI'
+            - '.tmp,zzzzInvokeManagedCustomActionOutOfProc'
+    filter_optional_third_party:
+        ParentImage|endswith:
+            # Consider removing any tools that you don't use to avoid blind spots
             - ':\ProgramData\OEM\UpgradeTool\CareCenter_*\BUnzip\Setup_msi.exe'
             - ':\Program Files\Axis Communications\AXIS Camera Station\SetupActions.exe'
             - ':\Program Files\Axis Communications\AXIS Device Manager\AdmSetupActions.exe'
             - ':\Program Files (x86)\Zemana\AntiMalware\AntiMalware.exe'
             - ':\Program Files\Dell\SupportAssist\pcdrcui.exe'
-    filter_4:
-        ParentImage|endswith: '\rundll32.exe'
-        ParentCommandLine|contains: ':\WINDOWS\Installer\MSI*.tmp,zzzzInvokeManagedCustomActionOutOfProc'
-    condition: (all of selection_*) and not (all of filter_*)
+    condition: all of selection_* and not 1 of filter_main_* and not 1 of filter_optional_*
 falsepositives:
     - Unknown
-level: low
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_schtasks_schedule_via_masqueraded_xml_file.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_schedule_via_masqueraded_xml_file.yml
@@ -32,8 +32,7 @@ detection:
         CommandLine|contains:
             - '.xml'
     filter_2:
-        system_integrity:
-            IntegrityLevel: 'System'
+        IntegrityLevel: 'System'
     filter_3:
         ParentImage|contains:
             - ':\ProgramData\OEM\UpgradeTool\CareCenter_*\BUnzip\Setup_msi.exe'

--- a/rules/windows/process_creation/proc_creation_win_schtasks_schedule_via_masqueraded_xml_file.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_schedule_via_masqueraded_xml_file.yml
@@ -9,10 +9,11 @@ author: Elastic (author), Swachchhanda Shrawan Poudel
 date: 2023/04/20
 modified: 2023/04/20
 tags:
-    - attack.Defense Evasion
-    - attack.T1036.005
-    - attack.T1053.005
-    - attack.Persistence
+    - attack.defense_evasion
+    - attack.persistence
+    - attack.t1036.005
+    - attack.t1053.005
+    
 logsource:
     product: windows
     category: process_creation
@@ -29,8 +30,7 @@ detection:
             - '/xml'
             - '-xml'
     filter_1:
-        CommandLine|contains:
-            - '.xml'
+        CommandLine|contains: '.xml'
     filter_2:
         IntegrityLevel: 'System'
     filter_3:
@@ -41,10 +41,8 @@ detection:
             - ':\Program Files (x86)\Zemana\AntiMalware\AntiMalware.exe'
             - ':\Program Files\Dell\SupportAssist\pcdrcui.exe'
     filter_4:
-        ParentImage|endswith:
-            - '\rundll32.exe'
-        ParentCommandLine|contains:
-            - ':\WINDOWS\Installer\MSI*.tmp,zzzzInvokeManagedCustomActionOutOfProc'
+        ParentImage|endswith: '\rundll32.exe'
+        ParentCommandLine|contains: ':\WINDOWS\Installer\MSI*.tmp,zzzzInvokeManagedCustomActionOutOfProc'
     condition: (all of selection_*) and not (all of filter_*)
 falsepositives:
     - Unknown


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

<!--
**Please note that this Section is required and must be filled**
-->
This pull request adds a new detection rule that identifies the creation of a scheduled job by using an XML file without the extension of '.xml'.

### Detailed Description of the Pull Request / Additional Comments

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->
The proposed Sigma rule searches for events related to the creation of scheduled jobs using an XML file without the extension of '.xml'. This behavior is typical of attackers trying to develop persistence by disguising the file extension to evade detection. 

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
N/A

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
N/A
### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
