### PR TITLE
Added support when flag is called another way while executing xsl…

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_wmic_xsl_script_processing.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_xsl_script_processing.yml
@@ -4,9 +4,9 @@ status: test
 description: Extensible Stylesheet Language (XSL) files are commonly used to describe the processing and rendering of data within XML files. Rule detects when adversaries abuse this functionality to execute arbitrary files while potentially bypassing application whitelisting defenses.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1220/T1220.md
-author: Timur Zinniatullin, oscd.community
+author: Timur Zinniatullin, oscd.community, Swachchhanda Shrawan Poudel
 date: 2019/10/21
-modified: 2021/11/29
+modified: 2023/04/21
 tags:
     - attack.defense_evasion
     - attack.t1220
@@ -16,20 +16,22 @@ logsource:
 detection:
     selection_wmic:
         Image|endswith: '\wmic.exe'
-        CommandLine|contains: '/format'     # wmic process list /FORMAT /?
+        CommandLine|contains: 
+            - '/format'     # wmic process list /FORMAT /?
+            - '-format'     # wmic process list -FORMAT /?
     selection_msxsl:
         Image|endswith: '\msxsl.exe'
     false_positives:
         CommandLine|contains:
-            - '/Format:List'
-            - '/Format:htable'
-            - '/Format:hform'
-            - '/Format:table'
-            - '/Format:mof'
-            - '/Format:value'
-            - '/Format:rawxml'
-            - '/Format:xml'
-            - '/Format:csv'
+            - 'Format:List'
+            - 'Format:htable'
+            - 'Format:hform'
+            - 'Format:table'
+            - 'Format:mof'
+            - 'Format:value'
+            - 'Format:rawxml'
+            - 'Format:xml'
+            - 'Format:csv'
     condition: (selection_wmic and not false_positives) or selection_msxsl
 falsepositives:
     - WMIC.exe FP depend on scripts and administrative methods used in the monitored environment.


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request
Added support for when flag is called another way while executing xsl file from wmic
<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->

### Detailed Description of the Pull Request / Additional Comments

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->
The previous rule only detects the command  that is similar to 'wmic process list /FORMAT:evil[.]xsl' but same command can be executed by 'wmic process list -FORMAT:evil[.]xsl' which is now detected by this current rule.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
N/A

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
