### PR TITLE
fix: explicitly escape `{` to make it clear that it is a literal 

### DIFF
--- a/rules-unsupported/windows/driver_load_invoke_obfuscation_via_stdin_services.yml
+++ b/rules-unsupported/windows/driver_load_invoke_obfuscation_via_stdin_services.yml
@@ -20,7 +20,7 @@ logsource:
     category: driver_load
 detection:
     selection:
-        ImagePath|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\${?input).*&&.*"'
+        ImagePath|re: '(?i).*(set).*&&\s?set.*(environment|invoke|\$?\{?input).*&&.*"'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules-unsupported/windows/driver_load_invoke_obfuscation_via_stdin_services.yml
+++ b/rules-unsupported/windows/driver_load_invoke_obfuscation_via_stdin_services.yml
@@ -7,7 +7,7 @@ description: Detects Obfuscated Powershell via Stdin in Scripts
 status: unsupported
 author: Nikita Nazarov, oscd.community
 date: 2020/10/12
-modified: 2021/09/18
+modified: 2023/04/23
 references:
     - https://github.com/SigmaHQ/sigma/issues/1009 #(Task28)
 tags:


### PR DESCRIPTION
### Summary of the Pull Request
I noticed that  `{` was not escaped in some yml `|re` block.
This will cause regex compilation errors in programming languages ​​such as Rust, Java and .NET, So I escaped `{` explicitly.

ref: [Character Escapes in .NET](https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-escapes-in-regular-expressions#character-escapes-in-net)

### Detailed Description of the Pull Request / Additional Comments
I've created a PR for a similar fix before, but I overlooked it then :( 
- #3737
- #3837
<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

I understand that the status of this rule is unsupported...
but I thought it would be better if it was a valid regex, so I created a PR. I'd appreciate it if you could fix them.
Regards.