### PR TITLE
Modified rule to detect every possible way of rdrleakdiag execution

### DIFF
--- a/deprecated/windows/proc_creation_win_lolbin_rdrleakdiag.yml
+++ b/deprecated/windows/proc_creation_win_lolbin_rdrleakdiag.yml
@@ -1,10 +1,10 @@
 title: Process Memory Dumped Via RdrLeakDiag.EXE
 id: 6355a919-2e97-4285-a673-74645566340d
-status: experimental
+status: deprecated
 description: Detects uses of the rdrleakdiag.exe LOLOBIN utility to dump process memory
 references:
     - https://www.crowdstrike.com/blog/overwatch-exposes-aquatic-panda-in-possession-of-log-4-shell-exploit-tools/
-author: Florian Roth (Nextron Systems), Swachchhanda Shrawan Poudel
+author: Florian Roth (Nextron Systems)
 date: 2022/01/04
 modified: 2023/04/24
 tags:
@@ -15,22 +15,15 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection_img:
+    selection1:
         Image|endswith: '\rdrleakdiag.exe'
-        CommandLine|contains: 'fullmemdmp'
-    selection_cli_output:
-        CommandLine|contains:
-            - ' -o '
-            - ' /o '
-    selection_cli_process:
-        CommandLine|contains:
-            - ' -p '
-            - ' /p '
-    selection_cli_memdmp:
-         CommandLine|contains:
-            - '-fullmemdmp'
+        CommandLine|contains: '/fullmemdmp'
+    selection2:
+        CommandLine|contains|all:
             - '/fullmemdmp'
-    condition: selection_img or (all of selection_cli_*)
+            - ' /o '
+            - ' /p '
+    condition: selection1 or selection2
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_lolbin_rdrleakdiag.yml
+++ b/rules/windows/process_creation/proc_creation_win_lolbin_rdrleakdiag.yml
@@ -4,9 +4,9 @@ status: experimental
 description: Detects uses of the rdrleakdiag.exe LOLOBIN utility to dump process memory
 references:
     - https://www.crowdstrike.com/blog/overwatch-exposes-aquatic-panda-in-possession-of-log-4-shell-exploit-tools/
-author: Florian Roth (Nextron Systems)
+author: Florian Roth (Nextron Systems), Swachchhanda Shrawan Poudel
 date: 2022/01/04
-modified: 2023/02/13
+modified: 2023/04/24
 tags:
     - attack.defense_evasion
     - attack.t1036
@@ -15,15 +15,22 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection1:
+    selection_img:
         Image|endswith: '\rdrleakdiag.exe'
-        CommandLine|contains: '/fullmemdmp'
-    selection2:
-        CommandLine|contains|all:
-            - '/fullmemdmp'
+        CommandLine|contains: 'fullmemdmp'
+    selection_cli_output:
+        CommandLine|contains:
+            - ' -o '
             - ' /o '
+    selection_cli_process:
+        CommandLine|contains:
+            - ' -p '
             - ' /p '
-    condition: selection1 or selection2
+    selection_cli_memdmp:
+         CommandLine|contains:
+            - '-fullmemdmp'
+            - '/fullmemdmp'
+    condition: selection_img or (all of selection_cli_*)
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_rdrleakdiag_process_dumping.yml
+++ b/rules/windows/process_creation/proc_creation_win_rdrleakdiag_process_dumping.yml
@@ -1,12 +1,18 @@
-title: Process Dump via RdrLeakDiag.exe
+title: Process Memory Dump via RdrLeakDiag.EXE
 id: edadb1e5-5919-4e4c-8462-a9e643b02c4b
+related:
+    - id: 6355a919-2e97-4285-a673-74645566340d
+      type: obsoletes
 status: test
-description: Detects a process memory dump performed by RdrLeakDiag.exe
+description: Detects the use of the Microsoft Windows Resource Leak Diagnostic tool "rdrleakdiag.exe" to dump process memory
 references:
     - https://www.pureid.io/dumping-abusing-windows-credentials-part-1/
-author: Cedric MAURUGEON
+    - https://www.crowdstrike.com/blog/overwatch-exposes-aquatic-panda-in-possession-of-log-4-shell-exploit-tools/
+    - https://lolbas-project.github.io/lolbas/Binaries/Rdrleakdiag/
+    - https://twitter.com/0gtweet/status/1299071304805560321?s=21
+author: Cedric MAURUGEON, Florian Roth (Nextron Systems), Swachchhanda Shrawan Poudel, Nasreddine Bencherchali (Nextron Systems)
 date: 2021/09/24
-modified: 2022/10/09
+modified: 2023/04/24
 tags:
     - attack.credential_access
     - attack.t1003.001
@@ -14,10 +20,23 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
-        OriginalFileName: RdrLeakDiag.exe
-        CommandLine|contains: fullmemdmp
-    condition: selection
+    selection_img:
+        - Image|endswith: '\rdrleakdiag.exe'
+        - OriginalFileName: RdrLeakDiag.exe
+    selection_cli_dump:
+        CommandLine|contains:
+            - 'fullmemdmp'
+            - '/memdmp'
+            - '-memdmp'
+    selection_cli_output:
+        CommandLine|contains:
+            - ' -o '
+            - ' /o '
+    selection_cli_process:
+        CommandLine|contains:
+            - ' -p '
+            - ' /p '
+    condition: all of selection_cli_* or (selection_img and selection_cli_dump)
 falsepositives:
     - Unknown
 level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request
Modified rule to detect every possible way of rdrleakdiag execution while process dumping
<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->

### Detailed Description of the Pull Request / Additional Comments
The pre-existing rule only detects if  rdrleakdiag.exe is executed as similar to this command
 'rdrleakdiag.exe /p 832 /o c:\evil /fullmemdmp /wait 1'.

Same intended action could be performed by any of the command as given below:
1. rdrleakdiag.exe -p 832 -o c:\evil -fullmemdmp -wait 1
2. rdrleakdiag.exe -p 832 /o c:\evil /fullmemdmp -wait 1 (combination of both '-' and '/')

These commands cannot be detected by this rule. So, modifying the rule.


<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
N/A

### Fixed Issues

N/A

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
