### PR TITLE
fix web_cve_2021_26858_iis_rce.yml (all of -> "|all")

### DIFF
--- a/rules/web/webserver_generic/web_cve_2021_26858_iis_rce.yml
+++ b/rules/web/webserver_generic/web_cve_2021_26858_iis_rce.yml
@@ -6,7 +6,7 @@ references:
     - https://bi-zone.medium.com/hunting-down-ms-exchange-attacks-part-1-proxylogon-cve-2021-26855-26858-27065-26857-6e885c5f197c
 author: frack113
 date: 2021/08/10
-modified: 2023/01/04
+modified: 2023/04/26
 logsource:
     product: windows
     service: iis
@@ -21,7 +21,7 @@ detection:
             - 'VirtualDirectory'
         cs-username|endswith: '$'
     keywords:
-        "|all":
+        '|all':
             - 'POST'
             - 200
             - '/ecp/DDI/DDIService.svc/SetObject'

--- a/rules/web/webserver_generic/web_cve_2021_26858_iis_rce.yml
+++ b/rules/web/webserver_generic/web_cve_2021_26858_iis_rce.yml
@@ -21,13 +21,14 @@ detection:
             - 'VirtualDirectory'
         cs-username|endswith: '$'
     keywords:
-        - 'POST'
-        - 200
-        - '/ecp/DDI/DDIService.svc/SetObject'
-        - 'schema=Reset'
-        - 'VirtualDirectory'
-        - '$'
-    condition: selection or all of keywords
+        "|all":
+            - 'POST'
+            - 200
+            - '/ecp/DDI/DDIService.svc/SetObject'
+            - 'schema=Reset'
+            - 'VirtualDirectory'
+            - '$'
+    condition: selection or keywords
 falsepositives:
     - Unlikely
 level: critical


### PR DESCRIPTION

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->
@is3ka1 and I noticed a weird behavior from this rule. And after digging deeper, we found that
when using `all of` in condition, it works differently for map and list in sigma and sigmac.
In this file, the `all of` will be translated to `OR` but it should be `AND`.
Use `"|all"` fixes this.

Ref:
- https://github.com/SigmaHQ/sigma/pull/3952
- https://github.com/SigmaHQ/sigma-specification/discussions/53


### Detailed Description of the Pull Request / Additional Comments

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

Use `"|all"` in `keywords` and remove `all of` from `condition`.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
