### PR TITLE
corrected eventSource on aws_enum_buckets.yml file

### DIFF
--- a/rules/cloud/aws/aws_enum_buckets.yml
+++ b/rules/cloud/aws/aws_enum_buckets.yml
@@ -19,7 +19,7 @@ logsource:
     service: cloudtrail
 detection:
     selection:
-        eventSource: 'ec2.amazonaws.com'
+        eventSource: 's3.amazonaws.com'
         eventName: 'ListBuckets'
     filter:
         type: 'AssumedRole'


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### In aws_enum_buckets.yml rule, eventSource should be s3.amazonaws.com instead of ec2.amazonaws.com since ec2 doesn't have ListBuckets event.

<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->

### In aws_enum_buckets.yml rule, eventSource should be s3.amazonaws.com instead of ec2.amazonaws.com since ec2 doesn't have ListBuckets event.

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
