### PR TITLE
fix: delete value-modifier in Search-Identifier

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_mstsc_run_local_rdp_file.yml
+++ b/rules/windows/process_creation/proc_creation_win_mstsc_run_local_rdp_file.yml
@@ -6,7 +6,8 @@ references:
     - https://www.blackhillsinfosec.com/rogue-rdp-revisiting-initial-access-methods/
     - https://blog.thickmints.dev/mintsights/detecting-rogue-rdp/
 author: Nasreddine Bencherchali (Nextron Systems), Christopher Peacock @securepeacock
-date: 2023/04/30
+date: 2023/04/18
+modified: 2023/04/30
 tags:
     - attack.command_and_control
     - attack.t1219

--- a/rules/windows/process_creation/proc_creation_win_mstsc_run_local_rdp_file.yml
+++ b/rules/windows/process_creation/proc_creation_win_mstsc_run_local_rdp_file.yml
@@ -6,7 +6,7 @@ references:
     - https://www.blackhillsinfosec.com/rogue-rdp-revisiting-initial-access-methods/
     - https://blog.thickmints.dev/mintsights/detecting-rogue-rdp/
 author: Nasreddine Bencherchali (Nextron Systems), Christopher Peacock @securepeacock
-date: 2023/04/18
+date: 2023/04/30
 tags:
     - attack.command_and_control
     - attack.t1219
@@ -17,8 +17,8 @@ detection:
     selection_img:
         - Image|endswith: '\mstsc.exe'
         - OriginalFileName: 'mstsc.exe'
-    selection_cli|endswith:
-        CommandLine|contains:
+    selection_cli:
+        CommandLine|endswith:
             - '.rdp'
             - '.rdp"'
     filter_optional_wsl:

--- a/rules/windows/process_creation/proc_creation_win_mstsc_run_local_rdp_file_susp_location.yml
+++ b/rules/windows/process_creation/proc_creation_win_mstsc_run_local_rdp_file_susp_location.yml
@@ -31,9 +31,9 @@ detection:
             - ':\Windows\Temp\'
             - ':\Windows\Tracing\'
             - '\AppData\Local\Temp\'
-            # - '\Desktop\' # Could be source of FP depending on the environement
-            - '\Downloads\' # Could be source of FP depending on the environement
+            # - '\Desktop\' # Could be source of FP depending on the environment
+            - '\Downloads\' # Could be source of FP depending on the environment
     condition: all of selection_*
 falsepositives:
-    - Likelihood is related to how often the paths are used in the environement
+    - Likelihood is related to how often the paths are used in the environment
 level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->
I noticed a typo when creating a query conversion script for [Hayabusa](https://github.com/Yamato-Security/hayabusa), so I fixed it.

### Summary of the Pull Request
- rules/windows/process_creation/proc_creation_win_mstsc_run_local_rdp_file.yml
  -  Deleted `value-modifier(endswith)` in `Search-Identifier`

- rules/windows/process_creation/proc_creation_win_mstsc_run_local_rdp_file_susp_location.yml
  -  Fixed comment typo 

<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->

### Detailed Description of the Pull Request / Additional Comments
The following commit seems to be the cause.
 - https://github.com/SigmaHQ/sigma/commit/83e352c52e45f15e6b9461f6a0f465f9fdbf60b2

My understanding is that a `Search-Identifier` should not have a `value-modifier` according to [sigma-specification doc](https://github.com/SigmaHQ/sigma-specification/blob/main/Sigma_specification.md#value-modifiers).
(I'm sorry if I misunderstood the specification.)

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

### Example Log Event
N/A
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues
N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)

Thanks for maintaining the rules :)
Regards.