### PR TITLE
refactor: use `'|all'` instead of using `all of` for a single selector.

### DIFF
--- a/deprecated/windows/powershell_suspicious_invocation_specific.yml
+++ b/deprecated/windows/powershell_suspicious_invocation_specific.yml
@@ -7,55 +7,61 @@ tags:
     - attack.t1059.001
 author: Florian Roth (Nextron Systems), Jonhnathan Ribeiro
 date: 2017/03/05
-modified: 2022/04/11
+modified: 2023/04/30
 logsource:
     product: windows
     service: powershell
     definition: Script block logging must be enabled for 4104, Module Logging must be enabled for 4103
 detection:
     convert_b64:
-        - '-nop'
-        - ' -w '
-        - 'hidden'
-        - ' -c '
-        - '[Convert]::FromBase64String'
+        '|all':
+            - '-nop'
+            - ' -w '
+            - 'hidden'
+            - ' -c '
+            - '[Convert]::FromBase64String'
     iex_selection:
-        - ' -w '
-        - 'hidden'
-        - '-noni'
-        - '-nop'
-        - ' -c '
-        - 'iex'
-        - 'New-Object'
+        '|all':
+            - ' -w '
+            - 'hidden'
+            - '-noni'
+            - '-nop'
+            - ' -c '
+            - 'iex'
+            - 'New-Object'
     enc_selection:
-        - ' -w '
-        - 'hidden'
-        - '-ep'
-        - 'bypass'
-        - '-Enc'
+        '|all':
+            - ' -w '
+            - 'hidden'
+            - '-ep'
+            - 'bypass'
+            - '-Enc'
     reg_selection:
-        - 'powershell'
-        - 'reg'
-        - 'add'
-        - 'HKCU\software\microsoft\windows\currentversion\run'
+        '|all':
+            - 'powershell'
+            - 'reg'
+            - 'add'
+            - 'HKCU\software\microsoft\windows\currentversion\run'
     webclient_selection:
-        - 'bypass'
-        - '-noprofile'
-        - '-windowstyle'
-        - 'hidden'
-        - 'new-object'
-        - 'system.net.webclient'
-        - '.download'
+         '|all':
+            - 'bypass'
+            - '-noprofile'
+            - '-windowstyle'
+            - 'hidden'
+            - 'new-object'
+            - 'system.net.webclient'
+            - '.download'
     iex_webclient:
-        - 'iex'
-        - 'New-Object'
-        - 'Net.WebClient'
-        - '.Download'
+        '|all':
+            - 'iex'
+            - 'New-Object'
+            - 'Net.WebClient'
+            - '.Download'
     filter_chocolatey:
         - "(New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1"
         - "(New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')"
         - 'Write-ChocolateyWarning'
-    condition: (all of convert_b64 or all of iex_selection or all of enc_selection or all of reg_selection or all of webclient_selection or all of iex_webclient) and not 1 of filter_*
+    condition: (convert_b64 or iex_selection or enc_selection or reg_selection or webclient_selection or iex_webclient) and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high

--- a/deprecated/windows/powershell_suspicious_invocation_specific.yml
+++ b/deprecated/windows/powershell_suspicious_invocation_specific.yml
@@ -7,20 +7,20 @@ tags:
     - attack.t1059.001
 author: Florian Roth (Nextron Systems), Jonhnathan Ribeiro
 date: 2017/03/05
-modified: 2023/04/30
+modified: 2023/05/04
 logsource:
     product: windows
     service: powershell
     definition: Script block logging must be enabled for 4104, Module Logging must be enabled for 4103
 detection:
-    convert_b64:
+    selection_convert_b64:
         '|all':
             - '-nop'
             - ' -w '
             - 'hidden'
             - ' -c '
             - '[Convert]::FromBase64String'
-    iex_selection:
+    selection_iex:
         '|all':
             - ' -w '
             - 'hidden'
@@ -29,20 +29,20 @@ detection:
             - ' -c '
             - 'iex'
             - 'New-Object'
-    enc_selection:
+    selection_enc:
         '|all':
             - ' -w '
             - 'hidden'
             - '-ep'
             - 'bypass'
             - '-Enc'
-    reg_selection:
+    selection_reg:
         '|all':
             - 'powershell'
             - 'reg'
             - 'add'
             - 'HKCU\software\microsoft\windows\currentversion\run'
-    webclient_selection:
+    selection_webclient:
          '|all':
             - 'bypass'
             - '-noprofile'
@@ -51,7 +51,7 @@ detection:
             - 'new-object'
             - 'system.net.webclient'
             - '.download'
-    iex_webclient:
+    selection_iex_webclient:
         '|all':
             - 'iex'
             - 'New-Object'
@@ -61,7 +61,7 @@ detection:
         - "(New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1"
         - "(New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')"
         - 'Write-ChocolateyWarning'
-    condition: (convert_b64 or iex_selection or enc_selection or reg_selection or webclient_selection or iex_webclient) and not 1 of filter_*
+    condition: 1 of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/linux/auditd/lnx_auditd_binary_padding.yml
+++ b/rules/linux/auditd/lnx_auditd_binary_padding.yml
@@ -19,14 +19,16 @@ detection:
     selection_execve:
         type: 'EXECVE'
     keywords_truncate:
-        - 'truncate'
-        - '-s'
+        '|all':
+            - 'truncate'
+            - '-s'
     keywords_dd:
-        - 'dd'
-        - 'if='
+        '|all':
+            - 'dd'
+            - 'if='
     keywords_filter:
         - 'of='
-    condition: selection_execve and (all of keywords_truncate or (all of keywords_dd and not keywords_filter))
+    condition: selection_execve and (keywords_truncate or (keywords_dd and not keywords_filter))
 falsepositives:
     - Unknown
 level: high

--- a/rules/linux/auditd/lnx_auditd_binary_padding.yml
+++ b/rules/linux/auditd/lnx_auditd_binary_padding.yml
@@ -6,9 +6,9 @@ description: |
     This rule detect using dd and truncate to add a junk data to file.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1027.001/T1027.001.md
-author: 'Igor Fits, oscd.community'
+author: Igor Fits, oscd.community
 date: 2020/10/13
-modified: 2023/01/06
+modified: 2023/05/03
 tags:
     - attack.defense_evasion
     - attack.t1027.001

--- a/rules/linux/auditd/lnx_auditd_find_cred_in_files.yml
+++ b/rules/linux/auditd/lnx_auditd_find_cred_in_files.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1552.001/T1552.001.md
 author: 'Igor Fits, oscd.community'
 date: 2020/10/15
-modified: 2023/01/06
+modified: 2023/04/30
 tags:
     - attack.credential_access
     - attack.t1552.001
@@ -17,9 +17,10 @@ detection:
     selection:
         type: 'EXECVE'
     keywords:
-        - 'grep'
-        - 'password'
-    condition: selection and all of keywords
+        '|all':
+            - 'grep'
+            - 'password'
+    condition: selection and keywords
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/builtin/msexchange/win_exchange_proxyshell_mailbox_export.yml
+++ b/rules/windows/builtin/msexchange/win_exchange_proxyshell_mailbox_export.yml
@@ -6,7 +6,7 @@ references:
     - https://blog.orange.tw/2021/08/proxylogon-a-new-attack-surface-on-ms-exchange-part-1.html
 author: Florian Roth (Nextron Systems), Rich Warren, Christian Burkard (Nextron Systems)
 date: 2021/08/09
-modified: 2023/02/28
+modified: 2023/04/30
 tags:
     - attack.persistence
     - attack.t1505.003
@@ -15,16 +15,18 @@ logsource:
     product: windows
 detection:
     export_command:
-        - 'New-MailboxExportRequest'
-        - ' -Mailbox '
+        '|all':
+            - 'New-MailboxExportRequest'
+            - ' -Mailbox '
     export_params:
         - '-FilePath "\\\\' # We care about any share location.
         - '.aspx'
     role_assignment:
-        - 'New-ManagementRoleAssignment'
-        - ' -Role "Mailbox Import Export"'
-        - ' -User '
-    condition: (all of export_command and export_params) or all of role_assignment
+        '|all':
+            - 'New-ManagementRoleAssignment'
+            - ' -Role "Mailbox Import Export"'
+            - ' -User '
+    condition: (export_command and export_params) or role_assignment
 falsepositives:
     - Unlikely
 level: critical

--- a/rules/windows/builtin/system/microsoft_windows_kernel_general/win_system_susp_sam_dump.yml
+++ b/rules/windows/builtin/system/microsoft_windows_kernel_general/win_system_susp_sam_dump.yml
@@ -4,7 +4,7 @@ status: test
 description: Detects suspicious SAM dump activity as cause by QuarksPwDump and other password dumpers
 author: Florian Roth (Nextron Systems)
 date: 2018/01/27
-modified: 2022/04/14
+modified: 2023/04/30
 tags:
     - attack.credential_access
     - attack.t1003.002
@@ -17,9 +17,10 @@ detection:
         Provider_Name: Microsoft-Windows-Kernel-General
         EventID: 16
     keywords:
-        - '\AppData\Local\Temp\SAM-'
-        - '.dmp'
-    condition: selection and all of keywords
+        '|all':
+            - '\AppData\Local\Temp\SAM-'
+            - '.dmp'
+    condition: selection and keywords
 falsepositives:
     - Unknown
 level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request
Changed to use `'|all'` instead of `all of kewords` to make rules more maintainable

<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->

### Detailed Description of the Pull Request / Additional Comments
The related issue and discussion are below.
- https://github.com/SigmaHQ/sigma-specification/discussions/53
- https://github.com/SigmaHQ/sigma/pull/3952
<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

### Example Log Event
N/A
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues
N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)

Thanks for maintaining the rules :)
Regards.