### PR TITLE
New rule: Failed DNS Zone Transfer

### DIFF
--- a/rules-placeholder/windows/win_failed_dns_zone_transfer.yml
+++ b/rules-placeholder/windows/win_failed_dns_zone_transfer.yml
@@ -1,0 +1,22 @@
+title: Failed DNS Zone Transfer
+id: e2b5163d-7deb-4566-9af3-40afea6858c3
+status: experimental
+description: Detects when there is a failed DNS zone transfer.
+references:
+author: Zach Mathis
+date: 2023/05/14
+modified: 2023/05/14
+tags:
+    - attack.reconnaissance
+    - attack.t1590.002
+logsource:
+    product: windows
+    service: dns-server
+detection:
+    selection:
+        EventID: 6004
+    selection_bad_zone_transfer:
+        - 'DNS_EVENT_BAD_ZONE_TRANSFER_REQUEST'
+    condition: all of selection*
+falsepositives: 
+level: medium

--- a/rules/windows/builtin/dns_server/win_dns_server_failed_dns_zone_transfer.yml
+++ b/rules/windows/builtin/dns_server/win_dns_server_failed_dns_zone_transfer.yml
@@ -3,9 +3,9 @@ id: e2b5163d-7deb-4566-9af3-40afea6858c3
 status: experimental
 description: Detects when there is a failed DNS zone transfer.
 references:
+    - https://kb.eventtracker.com/evtpass/evtpages/EventId_6004_Microsoft-Windows-DNS-Server-Service_65410.asp
 author: Zach Mathis
-date: 2023/05/14
-modified: 2023/05/14
+date: 2023/05/24
 tags:
     - attack.reconnaissance
     - attack.t1590.002
@@ -14,9 +14,8 @@ logsource:
     service: dns-server
 detection:
     selection:
-        EventID: 6004
-    selection_bad_zone_transfer:
-        - 'DNS_EVENT_BAD_ZONE_TRANSFER_REQUEST'
-    condition: all of selection*
-falsepositives: 
+        EventID: 6004 # The DNS server received a zone transfer request from %1 for a non-existent or non-authoritative zone %2.
+    condition: selection
+falsepositives:
+    - Unlikely
 level: medium

--- a/rules/windows/builtin/dns_server/win_dns_server_failed_dns_zone_transfer.yml
+++ b/rules/windows/builtin/dns_server/win_dns_server_failed_dns_zone_transfer.yml
@@ -1,5 +1,5 @@
 title: Failed DNS Zone Transfer
-id: e2b5163d-7deb-4566-9af3-40afea6858c3
+id: 6d444368-6da1-43fe-b2fc-44202430480e
 status: experimental
 description: Detects when there is a failed DNS zone transfer.
 references:

--- a/rules/windows/builtin/dns_server/win_dns_server_failed_dns_zone_transfer.yml
+++ b/rules/windows/builtin/dns_server/win_dns_server_failed_dns_zone_transfer.yml
@@ -1,7 +1,7 @@
 title: Failed DNS Zone Transfer
 id: 6d444368-6da1-43fe-b2fc-44202430480e
 status: experimental
-description: Detects when there is a failed DNS zone transfer.
+description: Detects when a DNS zone transfer failed.
 references:
     - https://kb.eventtracker.com/evtpass/evtpages/EventId_6004_Microsoft-Windows-DNS-Server-Service_65410.asp
 author: Zach Mathis


### PR DESCRIPTION
### Summary of the Pull Request

New Windows rule to detect failed DNS zone transfer.

### Detailed Description of the Pull Request / Additional Comments

no further comments.

### Example Log Event

```
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
<System>
  <Provider Name="Microsoft-Windows-DNS-Server-Service" Guid="{71a551f5-c893-4849-886b-b5ec8502641e}" /> 
  <EventID>6004</EventID> 
  <Version>0</Version> 
  <Level>3</Level> 
  <Task>0</Task> 
  <Opcode>0</Opcode> 
  <Keywords>0x8000000000080000</Keywords> 
  <TimeCreated SystemTime="2020-07-11T12:58:57.4510620Z" /> 
  <EventRecordID>343</EventRecordID> 
  <Correlation /> 
  <Execution ProcessID="1764" ThreadID="2284" /> 
  <Channel>DNS Server</Channel> 
  <Computer>rootdc1.offsec.lan</Computer> 
  <Security UserID="S-1-5-18" /> 
  </System>
<EventData Name="DNS_EVENT_BAD_ZONE_TRANSFER_REQUEST">
  <Data Name="param1">10.23.23.9</Data> 
  <Data Name="param2">hacking-zone.lan.</Data> 
  <Binary /> 
  </EventData>
</Event>
```

### Fixed Issues

no fixes.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
