### PR TITLE
update "Suspicious Export-PfxCertificate" rule

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_export_certificate.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_export_certificate.yml
@@ -1,14 +1,17 @@
-title: Certificate Exported via PowerShell
+title: Certificate Exported Via PowerShell - ScriptBlock
 id: aa7a3fce-bef5-4311-9cc1-5f04bb8c308c
+related:
+    - id: 9e716b33-63b2-46da-86a4-bd3c3b9b5dfb
+      type: similar
 status: test
-description: Detects commandlets that are used to export certificates from the local certificate store which are sometimes used by threat actors to steal private keys from compromised machines.
+description: Detects calls to cmdlets inside of PowerShell scripts that are used to export certificates from the local certificate store. Threat actors were seen abusing this to steal private keys from compromised machines.
 references:
     - https://us-cert.cisa.gov/ncas/analysis-reports/ar21-112a
     - https://docs.microsoft.com/en-us/powershell/module/pki/export-pfxcertificate
     - https://www.splunk.com/en_us/blog/security/breaking-the-chain-defending-against-certificate-services-abuse.html
 author: Florian Roth (Nextron Systems)
 date: 2021/04/23
-modified: 2023/05/15
+modified: 2023/05/18
 tags:
     - attack.credential_access
     - attack.t1552.004
@@ -18,12 +21,12 @@ logsource:
     definition: 'Requirements: Script Block Logging must be enabled'
 detection:
     selection:
-        ScriptBlockText|contains: 
+        ScriptBlockText|contains:
             - 'Export-PfxCertificate'
             - 'Export-Certificate'
-    filter_moduleexport:
+    filter_optional_module_export:
         ScriptBlockText|contains: 'CmdletsToExport = @('
-    condition: selection and not filter_moduleexport
+    condition: selection and not 1 of filter_optional_*
 falsepositives:
-    - Legitimate certificate exports invoked by administrators or users (depends on processes in the environment - filter if unusable)
-level: high
+    - Legitimate certificate exports by administrators. Additional filters might be required.
+level: medium

--- a/rules/windows/powershell/powershell_script/posh_ps_susp_export_pfxcertificate.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_susp_export_pfxcertificate.yml
@@ -1,13 +1,14 @@
-title: Suspicious Export-PfxCertificate
+title: Certificate Exported via PowerShell
 id: aa7a3fce-bef5-4311-9cc1-5f04bb8c308c
 status: test
-description: Detects Commandlet that is used to export certificates from the local certificate store and sometimes used by threat actors to steal private keys from compromised machines
+description: Detects commandlets that are used to export certificates from the local certificate store which are sometimes used by threat actors to steal private keys from compromised machines.
 references:
     - https://us-cert.cisa.gov/ncas/analysis-reports/ar21-112a
     - https://docs.microsoft.com/en-us/powershell/module/pki/export-pfxcertificate
+    - https://www.splunk.com/en_us/blog/security/breaking-the-chain-defending-against-certificate-services-abuse.html
 author: Florian Roth (Nextron Systems)
 date: 2021/04/23
-modified: 2023/01/24
+modified: 2023/05/15
 tags:
     - attack.credential_access
     - attack.t1552.004
@@ -17,10 +18,12 @@ logsource:
     definition: 'Requirements: Script Block Logging must be enabled'
 detection:
     selection:
-        ScriptBlockText|contains: 'Export-PfxCertificate'
+        ScriptBlockText|contains: 
+            - 'Export-PfxCertificate'
+            - 'Export-Certificate'
     filter_moduleexport:
         ScriptBlockText|contains: 'CmdletsToExport = @('
-    condition: selection and not 1 of filter*
+    condition: selection and not filter_moduleexport
 falsepositives:
     - Legitimate certificate exports invoked by administrators or users (depends on processes in the environment - filter if unusable)
 level: high

--- a/rules/windows/process_creation/proc_creation_win_powershell_export_certificate.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_export_certificate.yml
@@ -1,0 +1,25 @@
+title: Certificate Exported Via PowerShell
+id: 9e716b33-63b2-46da-86a4-bd3c3b9b5dfb
+related:
+    - id: aa7a3fce-bef5-4311-9cc1-5f04bb8c308c
+      type: similar
+status: experimental
+description: Detects calls to cmdlets that are used to export certificates from the local certificate store. Threat actors were seen abusing this to steal private keys from compromised machines.
+references:
+    - https://us-cert.cisa.gov/ncas/analysis-reports/ar21-112a
+    - https://docs.microsoft.com/en-us/powershell/module/pki/export-pfxcertificate
+    - https://www.splunk.com/en_us/blog/security/breaking-the-chain-defending-against-certificate-services-abuse.html
+author: Nasreddine Bencherchali (Nextron Systems)
+date: 2023/05/18
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection:
+        CommandLine|contains:
+            - 'Export-PfxCertificate '
+            - 'Export-Certificate '
+    condition: selection
+falsepositives:
+    - Legitimate certificate exports by administrators. Additional filters might be required.
+level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

This PR updates the "Suspicious Export-PfxCertificate" based on Splunks research here: https://www.splunk.com/en_us/blog/security/breaking-the-chain-defending-against-certificate-services-abuse.html

### Detailed Description of the Pull Request / Additional Comments

I updated the rule to also look for the keyword `Export-Certificate`
I changed the rule title as the rule just seems to look match on when certificates are being exported and is not checking for any keywords that would make it inherently suspicious but feel free to change back.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
