### PR TITLE
Update proxy_ua_bitsadmin_susp_tld.yml to use proxy field

### DIFF
--- a/rules-emerging-threats/2023/TA/3CX-Supply-Chain/proxy_malware_3cx_compromise_c2_beacon_activity.yml
+++ b/rules-emerging-threats/2023/TA/3CX-Supply-Chain/proxy_malware_3cx_compromise_c2_beacon_activity.yml
@@ -21,14 +21,14 @@ references:
     - https://www.reddit.com/r/crowdstrike/comments/125r3uu/20230329_situational_awareness_crowdstrike/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/03/29
-modified: 2023/03/31
+modified: 2023/05/18
 tags:
     - attack.command_and_control
 logsource:
     category: proxy
 detection:
     selection:
-        r-dns|contains:
+        cs-host|contains:
             - 'akamaicontainer.com'
             - 'akamaitechcloudservices.com'
             - 'azuredeploystore.com'

--- a/rules/web/proxy_generic/proxy_apt40.yml
+++ b/rules/web/proxy_generic/proxy_apt40.yml
@@ -6,7 +6,7 @@ references:
     - Internal research from Florian Roth
 author: Thomas Patzke
 date: 2019/11/12
-modified: 2021/11/27
+modified: 2023/05/18
 tags:
     - attack.command_and_control
     - attack.t1071.001
@@ -17,7 +17,7 @@ logsource:
 detection:
     selection:
         c-useragent: 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36'
-        r-dns: 'api.dropbox.com'
+        cs-host: 'api.dropbox.com'
     condition: selection
 fields:
     - c-ip

--- a/rules/web/proxy_generic/proxy_download_susp_dyndns.yml
+++ b/rules/web/proxy_generic/proxy_download_susp_dyndns.yml
@@ -6,7 +6,7 @@ references:
     - https://www.alienvault.com/blogs/security-essentials/dynamic-dns-security-and-potential-threats
 author: Florian Roth (Nextron Systems)
 date: 2017/11/08
-modified: 2021/11/27
+modified: 2023/05/18
 tags:
     - attack.defense_evasion
     - attack.command_and_control
@@ -35,7 +35,7 @@ detection:
             - 'sct'
             - 'zip'
             # If you want to add more extensions - see https://docs.google.com/spreadsheets/d/1TWS238xacAto-fLKh1n5uTsdijWdCEsGIM0Y0Hvmc5g/
-        r-dns|endswith:
+        cs-host|endswith:
             - '.hopto.org'
             - '.no-ip.org'
             - '.no-ip.info'

--- a/rules/web/proxy_generic/proxy_download_susp_tlds_blacklist.yml
+++ b/rules/web/proxy_generic/proxy_download_susp_tlds_blacklist.yml
@@ -12,7 +12,7 @@ references:
     - https://krebsonsecurity.com/2018/06/bad-men-at-work-please-dont-click/
 author: Florian Roth (Nextron Systems)
 date: 2017/11/07
-modified: 2023/01/09
+modified: 2023/05/18
 tags:
     - attack.initial_access
     - attack.t1566
@@ -42,7 +42,7 @@ detection:
             - 'sct'
             - 'zip'
             # If you want to add more extensions - see https://docs.google.com/spreadsheets/d/1TWS238xacAto-fLKh1n5uTsdijWdCEsGIM0Y0Hvmc5g/
-        r-dns|endswith:
+        cs-host|endswith:
             # Symantec / Chris Larsen analysis
             - '.country'
             - '.stream'

--- a/rules/web/proxy_generic/proxy_download_susp_tlds_whitelist.yml
+++ b/rules/web/proxy_generic/proxy_download_susp_tlds_whitelist.yml
@@ -7,7 +7,7 @@ status: test
 description: Detects executable downloads from suspicious remote systems
 author: Florian Roth (Nextron Systems)
 date: 2017/03/13
-modified: 2023/01/09
+modified: 2023/05/18
 tags:
     - attack.initial_access
     - attack.t1566
@@ -38,7 +38,7 @@ detection:
             - 'zip'
             # If you want to add more extensions - see https://docs.google.com/spreadsheets/d/1TWS238xacAto-fLKh1n5uTsdijWdCEsGIM0Y0Hvmc5g/
     filter:
-        r-dns|endswith:
+        cs-host|endswith:
             - '.com'
             - '.org'
             - '.net'

--- a/rules/web/proxy_generic/proxy_telegram_api.yml
+++ b/rules/web/proxy_generic/proxy_telegram_api.yml
@@ -8,7 +8,7 @@ references:
     - https://www.welivesecurity.com/2016/12/13/rise-telebots-analyzing-disruptive-killdisk-attacks/
 author: Florian Roth (Nextron Systems)
 date: 2018/06/05
-modified: 2021/11/27
+modified: 2023/05/18
 tags:
     - attack.defense_evasion
     - attack.command_and_control
@@ -18,7 +18,7 @@ logsource:
     category: proxy
 detection:
     selection:
-        r-dns: 'api.telegram.org' # Often used by Bots
+        cs-host: 'api.telegram.org' # Often used by Bots
     filter:
         c-useragent|contains:
             # Used https://core.telegram.org/bots/samples for this list

--- a/rules/web/proxy_generic/proxy_ua_bitsadmin_susp_tld.yml
+++ b/rules/web/proxy_generic/proxy_ua_bitsadmin_susp_tld.yml
@@ -7,7 +7,7 @@ references:
     - https://isc.sans.edu/forums/diary/Investigating+Microsoft+BITS+Activity/23281/
 author: Florian Roth (Nextron Systems), Tim Shelton
 date: 2019/03/07
-modified: 2022/08/16
+modified: 2023/05/17
 tags:
     - attack.command_and_control
     - attack.t1071.001
@@ -21,7 +21,7 @@ detection:
     selection:
         c-useragent|startswith: 'Microsoft BITS/'
     falsepositives:
-        r-dns|endswith:
+        cs-host|endswith:
             - '.com'
             - '.net'
             - '.org'


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

Current rule filters on r-dns which is not suitable for proxy logs where cs-host is standard.

In current production environment I'm in we map r-dns and cs-host do different fields which causes false positives as r-dns is empty for all our proxy logs

### Detailed Description of the Pull Request / Additional Comments

Nothing to add.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
