### PR TITLE
Fix: add `status` field for goofy guineapig rules

### DIFF
--- a/rules-emerging-threats/2021/Malware/Goofy-Guineapig/proc_creation_win_malware_goofy_guineapig_broken_cmd.yml
+++ b/rules-emerging-threats/2021/Malware/Goofy-Guineapig/proc_creation_win_malware_goofy_guineapig_broken_cmd.yml
@@ -1,10 +1,12 @@
 title: Potential Goofy Guineapig Backdoor Activity
 id: 477a5ed3-a374-4282-9f3b-ed94e159a108
+status: experimental
 description: Detects a specific broken command that was used by Goofy-Guineapig as described by the NCSC report.
 references:
     - https://www.ncsc.gov.uk/static-assets/documents/malware-analysis-reports/goofy-guineapig/NCSC-MAR-Goofy-Guineapig.pdf
 author: X__Junior (Nextron Systems)
 date: 2023/05/14
+modified: 2023/05/31
 tags:
     - attack.execution
 logsource:

--- a/rules-emerging-threats/2021/Malware/Goofy-Guineapig/proc_creation_win_malware_goofy_guineapig_googleupdate_uncommon_child_instance.yml
+++ b/rules-emerging-threats/2021/Malware/Goofy-Guineapig/proc_creation_win_malware_goofy_guineapig_googleupdate_uncommon_child_instance.yml
@@ -1,10 +1,12 @@
 title: Potential Goofy Guineapig GoolgeUpdate Process Anomaly
 id: bdbab15a-3826-48fa-a1b7-723cd8f32fcc
+status: experimental
 description: Detects "GoogleUpdate.exe" spawning a new instance of itself in an uncommon location as seen used by the Goofy Guineapig backdoor
 references:
     - https://www.ncsc.gov.uk/static-assets/documents/malware-analysis-reports/goofy-guineapig/NCSC-MAR-Goofy-Guineapig.pdf
 author: X__Junior (Nextron Systems), Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/15
+modified: 2023/05/31
 tags:
     - attack.defense_evasion
 logsource:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->
Thank you for maintaining rules :)

### Summary of the Pull Request
Added a `status` field because there was a rule without a `status` field.
(I understand that the `status` field is optional, but I'd prefer to have one, so I've added it.)

<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->

### Detailed Description of the Pull Request 

As far as I can confirm, all the following rules were created at the same time with reference to the same article, so I think the status is the same. (I'm sorry if I misunderstood)
https://github.com/SigmaHQ/sigma/tree/f885b3bc39c66ee68f0260c338774da3b90d1e5c/rules-emerging-threats/2021/Malware/Goofy-Guineapig

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

### Example Log Event
N/A
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues
N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)


I would appreciate it if you could review it.
Regards,
