### PR TITLE
Corrected the detection condition/logic for registry persistence technique

### DIFF
--- a/rules/windows/registry/registry_set/registry_set_persistence_globalflags.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_globalflags.yml
@@ -8,9 +8,9 @@ description: Detects registry persistence technique using the GlobalFlags and Si
 references:
     - https://oddvar.moe/2018/04/10/persistence-using-globalflags-in-image-file-execution-options-hidden-from-autoruns-exe/
     - https://www.deepinstinct.com/2021/02/16/lsass-memory-dumps-are-stealthier-than-ever-before-part-2/
-author: Karneades, Jonhnathan Ribeiro, Florian Roth
+author: Karneades, Jonhnathan Ribeiro, Florian Roth, Swachchhanda Shrawan Poudel
 date: 2018/04/11
-modified: 2023/01/10
+modified: 2023/06/05
 tags:
     - attack.privilege_escalation
     - attack.persistence
@@ -33,7 +33,7 @@ detection:
         TargetObject|contains:
             - '\ReportingMode'
             - '\MonitorProcess'
-    condition: all of selection_*
+    condition: 1 of selection_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/registry/registry_set/registry_set_persistence_globalflags.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_globalflags.yml
@@ -8,7 +8,7 @@ description: Detects registry persistence technique using the GlobalFlags and Si
 references:
     - https://oddvar.moe/2018/04/10/persistence-using-globalflags-in-image-file-execution-options-hidden-from-autoruns-exe/
     - https://www.deepinstinct.com/2021/02/16/lsass-memory-dumps-are-stealthier-than-ever-before-part-2/
-author: Karneades, Jonhnathan Ribeiro, Florian Roth, Swachchhanda Shrawan Poudel
+author: Karneades, Jonhnathan Ribeiro, Florian Roth
 date: 2018/04/11
 modified: 2023/06/05
 tags:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->
Corrected the detection condition/logic for registry persistence technique using the GlobalFlags and SilentProcessExit Keys

### Detailed Description of the Pull Request / Additional Comments
reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\notepad.exe" /v GlobalFlag /t REG_DWORD /d 512
reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\notepad.exe" /v ReportingMode /t REG_DWORD /d 1
reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\SilentProcessExit\notepad.exe" /v MonitorProcess /d "C:\temp\evil.exe"

The pre-existing rule is wrong because it cannot detect these commands due to logical flaw in the condition. 

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
N/A

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
