### PR TITLE
Permiso p0-LUCR-1 (aka GUI-vil)

### DIFF
--- a/rules/cloud/aws/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
+++ b/rules/cloud/aws/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
@@ -1,7 +1,7 @@
 title: AWS IAM S3Browser Templated S3 Bucket Policy Creation
 id: db014773-7375-4f4e-b83b-133337c0ffee
 status: experimental
-description: Detects S3 Browser utility creating Inline IAM Policy containing default S3 bucket name placeholder value of "<YOUR-BUCKET-NAME>".
+description: Detects S3 browser utility creating Inline IAM policy containing default S3 bucket name placeholder value of "<YOUR-BUCKET-NAME>".
 references:
     - https://permiso.io/blog/s/unmasking-guivil-new-cloud-threat-actor
 author: daniel.bohannon@permiso.io (@danielhbohannon)
@@ -26,5 +26,5 @@ detection:
             - '"Allow"'
     condition: selection
 falsepositives:
-    - Valid usage of S3 Browser with accidental creation of default Inline IAM Policy without changing default S3 bucket name placeholder value
+    - Valid usage of S3 browser with accidental creation of default Inline IAM policy without changing default S3 bucket name placeholder value
 level: high

--- a/rules/cloud/aws/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
+++ b/rules/cloud/aws/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
@@ -1,0 +1,33 @@
+title: AWS IAM S3Browser Templated S3 Bucket Policy Creation
+id: db014773-7375-4f4e-b83b-133337c0ffee
+status: experimental
+description: Detects S3 Browser utility creating Inline IAM Policy containing default S3 bucket name placeholder value of <YOUR-BUCKET-NAME>.
+references:
+    - https://permiso.io/blog/s/unmasking-guivil-new-cloud-threat-actor
+author: daniel.bohannon@permiso.io (@danielhbohannon)
+date: 2023/05/17
+modified: 2023/05/17
+tags:
+    - attack.execution
+    - attack.t1059.009
+    - attack.persistence
+    - attack.t1078.004
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection_source:
+        eventSource: iam.amazonaws.com
+        eventName: PutUserPolicy
+    filter_tooling:
+        userAgent|contains: 'S3 Browser'
+    filter_policy_resource:
+        requestParameters|contains: '"arn:aws:s3:::<YOUR-BUCKET-NAME>/*"'
+    filter_policy_action:
+        requestParameters|contains: '"s3:GetObject"'
+    filter_policy_effect:
+        requestParameters|contains: '"Allow"'
+    condition: selection_source and filter_tooling and filter_policy_resource and filter_policy_action and filter_policy_effect
+falsepositives:
+    - Valid usage of S3 Browser with accidental creation of default Inline IAM Policy without changing default S3 bucket name placeholder value
+level: high

--- a/rules/cloud/aws/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
+++ b/rules/cloud/aws/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
@@ -1,7 +1,7 @@
 title: AWS IAM S3Browser Templated S3 Bucket Policy Creation
 id: db014773-7375-4f4e-b83b-133337c0ffee
 status: experimental
-description: Detects S3 Browser utility creating Inline IAM Policy containing default S3 bucket name placeholder value of <YOUR-BUCKET-NAME>.
+description: Detects S3 Browser utility creating Inline IAM Policy containing default S3 bucket name placeholder value of "<YOUR-BUCKET-NAME>".
 references:
     - https://permiso.io/blog/s/unmasking-guivil-new-cloud-threat-actor
 author: daniel.bohannon@permiso.io (@danielhbohannon)
@@ -16,18 +16,15 @@ logsource:
     product: aws
     service: cloudtrail
 detection:
-    selection_source:
+    selection:
         eventSource: iam.amazonaws.com
         eventName: PutUserPolicy
-    filter_tooling:
         userAgent|contains: 'S3 Browser'
-    filter_policy_resource:
-        requestParameters|contains: '"arn:aws:s3:::<YOUR-BUCKET-NAME>/*"'
-    filter_policy_action:
-        requestParameters|contains: '"s3:GetObject"'
-    filter_policy_effect:
-        requestParameters|contains: '"Allow"'
-    condition: selection_source and filter_tooling and filter_policy_resource and filter_policy_action and filter_policy_effect
+        requestParameters|contains|all:
+            - '"arn:aws:s3:::<YOUR-BUCKET-NAME>/*"'
+            - '"s3:GetObject"'
+            - '"Allow"'
+    condition: selection
 falsepositives:
     - Valid usage of S3 Browser with accidental creation of default Inline IAM Policy without changing default S3 bucket name placeholder value
 level: high


### PR DESCRIPTION
### Summary of the Pull Request

Adding Sigma rules outlined in the following blog post associated with named cloud-focused threat actor p0-LUCR-1 (aka GUI-vil): https://permiso.io/blog/s/unmasking-guivil-new-cloud-threat-actor

### Detailed Description of the Pull Request / Additional Comments

Detects S3 Browser utility creating Inline IAM Policy containing default S3 bucket name placeholder value of <YOUR-BUCKET-NAME>.

### Example Log Event

Example requestParameters value from iam:PutUserPolicy event in CloudTrail logs:

{
	"userName": "FileBackupAccount",
	"policyName": "dq",
	"policyDocument": "{\\r\\n  \\"Statement\\": [\\r\\n    {\\r\\n      \\"Effect\\": \\"Allow\\",\\r\\n      \\"Action\\": \\"s3:GetObject\\",\\r\\n      \\"Resource\\": \\"arn:aws:s3:::<YOUR-BUCKET-NAME>/*\\",\\r\\n      \\"Condition\\": {}\\r\\n    }\\r\\n  ]\\r\\n}"
}

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
