### PR TITLE
Add alterix to Projects or Products that use Sigma

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Windows 'Security' Eventlog: Suspicious Number of Failed Logons from a Single So
 * [Aurora Agent](https://www.nextron-systems.com/2021/11/13/aurora-sigma-based-edr-agent-preview/)
 * [Confluent Sigma](https://github.com/confluentinc/cyber/tree/master/confluent-sigma)
 * [SEKOIA.IO](https://www.sekoia.io) - XDR supporting Sigma and Sigma Correlation rules languages
+* [alterix](https://github.com/mtnmunuklu/alterix) - Converts sigma rules to query language of the crypttech next generation siem product.
 
 Sigma is available in some Linux distribution repositories:
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Windows 'Security' Eventlog: Suspicious Number of Failed Logons from a Single So
 * [Aurora Agent](https://www.nextron-systems.com/2021/11/13/aurora-sigma-based-edr-agent-preview/)
 * [Confluent Sigma](https://github.com/confluentinc/cyber/tree/master/confluent-sigma)
 * [SEKOIA.IO](https://www.sekoia.io) - XDR supporting Sigma and Sigma Correlation rules languages
-* [alterix](https://github.com/mtnmunuklu/alterix) - Converts sigma rules to query language of the crypttech next generation siem product.
+* [alterix](https://github.com/mtnmunuklu/alterix) - Converts Sigma rules to the query language of CRYPTTECH's SIEM.
 
 Sigma is available in some Linux distribution repositories:
 


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

Add [alterix](https://github.com/mtnmunuklu/alterix) to Projects or Products that use Sigma

### Detailed Description of the Pull Request / Additional Comments

This pull request adds [alterix](https://github.com/mtnmunuklu/alterix) to the list of projects or products that use Sigma. `alterix` is a tool that converts sigma rules to the query format of the crypttech next generation siem product.

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

N/A
