### PR TITLE
Fix Zero Networks Blog 404s

### DIFF
--- a/rules/application/rpc_firewall/rpc_firewall_atsvc_lateral_movement.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_atsvc_lateral_movement.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/d1058a28-7e02-4948-8b8d-4a347fa64931
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-TSCH.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_atsvc_recon.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_atsvc_recon.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/d1058a28-7e02-4948-8b8d-4a347fa64931
     - https://github.com/zeronetworks/rpcfirewall
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-TSCH.md
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_dcsync_attack.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_dcsync_attack.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-drsr/f977faaa-673e-4f66-b9bf-48c640241d47?redirectedfrom=MSDN
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-DRSR.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_efs_abuse.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_efs_abuse.yml
@@ -6,7 +6,7 @@ references:
     - https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-36942
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-EFSR.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_eventlog_recon.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_eventlog_recon.yml
@@ -4,7 +4,7 @@ status: test
 description: Detects remote RPC calls to get event log information via EVEN or EVEN6
 references:
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_itaskschedulerservice_lateral_movement.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_itaskschedulerservice_lateral_movement.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/d1058a28-7e02-4948-8b8d-4a347fa64931
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-TSCH.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_itaskschedulerservice_recon.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_itaskschedulerservice_recon.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/d1058a28-7e02-4948-8b8d-4a347fa64931
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-TSCH.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_printing_lateral_movement.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_printing_lateral_movement.yml
@@ -8,7 +8,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-pan/e44d984c-07d3-414c-8ffc-f8c8ad8512a8
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-RPRN-PAR.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_remote_dcom_or_wmi.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_remote_dcom_or_wmi.yml
@@ -5,7 +5,7 @@ description: Detects remote RPC calls that performs remote DCOM operations. Thes
 references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-srvs/accf23b0-0f57-441c-9185-43041f1b0ee9
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_remote_registry_lateral_movement.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_remote_registry_lateral_movement.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/0fa3191d-bb79-490a-81bd-54c2601b7a78
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-RRP.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_remote_registry_recon.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_remote_registry_recon.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rrp/0fa3191d-bb79-490a-81bd-54c2601b7a78
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-RRP.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_remote_server_service_abuse.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_remote_server_service_abuse.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-srvs/accf23b0-0f57-441c-9185-43041f1b0ee9
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-SRVS.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_remote_service_lateral_movement.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_remote_service_lateral_movement.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-srvs/accf23b0-0f57-441c-9185-43041f1b0ee9
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-SCMR.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_sasec_lateral_movement.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_sasec_lateral_movement.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/d1058a28-7e02-4948-8b8d-4a347fa64931
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-TSCH.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_sasec_recon.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_sasec_recon.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/d1058a28-7e02-4948-8b8d-4a347fa64931
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-TSCH.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/11/17

--- a/rules/application/rpc_firewall/rpc_firewall_sharphound_recon_account.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_sharphound_recon_account.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wkst/55118c55-2122-4ef9-8664-0c1ff9e168f3
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-WKST.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01

--- a/rules/application/rpc_firewall/rpc_firewall_sharphound_recon_sessions.yml
+++ b/rules/application/rpc_firewall/rpc_firewall_sharphound_recon_sessions.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-srvs/02b1f559-fda2-4ba3-94c2-806eb2777183
     - https://github.com/jsecurity101/MSRPC-to-ATTACK/blob/ddd4608fe8684fcf2fcf9b48c5f0b3c28097f8a3/documents/MS-SRVS.md
     - https://github.com/zeronetworks/rpcfirewall
-    - https://zeronetworks.com/blog/stopping_lateral_movement_via_the_rpc_firewall/
+    - https://zeronetworks.com/blog/stopping-lateral-movement-via-the-rpc-firewall/
 author: Sagie Dulce, Dekel Paz
 date: 2022/01/01
 modified: 2022/01/01


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->

Fixes Zero Networks Blog 404s

### Detailed Description of the Pull Request / Additional Comments

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->

It appears that the Zero Networks blog switched from using underscores to dashes in their URLs. This PR updates the blog links so they are no longer 404s.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

N/A

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
