### PR TITLE
fix: `Renamed Plink Execution` rule selection logical condition

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_renamed_plink.yml
+++ b/rules/windows/process_creation/proc_creation_win_renamed_plink.yml
@@ -7,7 +7,7 @@ references:
     - https://the.earth.li/~sgtatham/putty/0.58/htmldoc/Chapter7.html
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/06/06
-modified: 2023/02/03
+modified: 2023/07/01
 tags:
     - attack.defense_evasion
     - attack.t1036
@@ -16,8 +16,8 @@ logsource:
     product: windows
 detection:
     selection:
-        - OriginalFileName: 'Plink'
-        - CommandLine|contains|all:
+        OriginalFileName: 'Plink'
+        CommandLine|contains|all:
             - ' -l forward'
             - ' -P '
             - ' -R '


### PR DESCRIPTION
Hello, Thanks for the development :)

### Summary of the Pull Request

Fixed an issue in the selection **logical condition** of `Renamed Plink Execution` rule.

### Detailed Description of the Pull Request / Additional Comments
The current `Renamed Plink Execution` rule has an **OR condition** as follows.
https://github.com/SigmaHQ/sigma/blob/c0332a9d96f6c7804fcc85dd706caed889446a62/rules/windows/process_creation/proc_creation_win_renamed_plink.yml#L17-L26

However, it seems correct to be an **AND condition**, so I changed it.
(I'm sorry if the above is my misunderstanding.)

### Example Log Event
N/A

### Fixed Issues
N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
