### PR TITLE
Update lnx_auditd_masquerading_crond.yml

### DIFF
--- a/rules/linux/auditd/lnx_auditd_masquerading_crond.yml
+++ b/rules/linux/auditd/lnx_auditd_masquerading_crond.yml
@@ -19,8 +19,7 @@ detection:
     selection:
         type: 'execve'
         a0: 'cp'
-        a1: '-i'
-        a2: '/bin/sh'
-        a3|endswith: '/crond'
+        a1: '/bin/sh'
+        a2|endswith: '/crond'
     condition: selection
 level: medium

--- a/rules/linux/auditd/lnx_auditd_masquerading_crond.yml
+++ b/rules/linux/auditd/lnx_auditd_masquerading_crond.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/8a82e9b66a5b4f4bc5b91089e9f24e0544f20ad7/atomics/T1036.003/T1036.003.md#atomic-test-2---masquerading-as-linux-crond-process
 author: Timur Zinniatullin, oscd.community
 date: 2019/10/21
-modified: 2021/11/27
+modified: 2023/08/22
 tags:
     - attack.defense_evasion
     - attack.t1036.003


### PR DESCRIPTION

### Summary of the Pull Request

Adapting the rule so it corresponds to the linked atomic red scenario [1].


### Detailed Description of the Pull Request / Additional Comments

Removing the argument `-i` (interactive) from the execve argument list.
The atomic red team scenario does not contain this arguemnt and my opinion is that an adversery would not care if the destination file will be overwritten.

### Example Log Event

No false positives.

### Fixed Issues

`cp /bin/sh /home/alice/crond` will be matched

### SigmaHQ Rule Creation Conventions

[1] https://github.com/redcanaryco/atomic-red-team/blob/8a82e9b66a5b4f4bc5b91089e9f24e0544f20ad7/atomics/T1036.003/T1036.003.md#atomic-test-2---masquerading-as-linux-crond-process