### PR TITLE
Refractor registry_set  rules

### DIFF
--- a/deprecated/windows/registry_set_abusing_windows_telemetry_for_persistence.yml
+++ b/deprecated/windows/registry_set_abusing_windows_telemetry_for_persistence.yml
@@ -9,7 +9,7 @@ references:
     - https://www.trustedsec.com/blog/abusing-windows-telemetry-for-persistence/
 author: Sreeman
 date: 2020/09/29
-modified: 2022/12/19
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -20,7 +20,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\TelemetryController\'
         Details|endswith:
             - '.sh'

--- a/deprecated/windows/registry_set_add_hidden_user.yml
+++ b/deprecated/windows/registry_set_add_hidden_user.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/40b77d63808dd4f4eafb83949805636735a1fd15/atomics/T1564.002/T1564.002.md
 author: frack113
 date: 2022/08/20
-modified: 2023/01/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1564.002
@@ -15,7 +15,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\Userlist\'
         TargetObject|endswith: '$'
         Details: DWORD (0x00000000)

--- a/deprecated/windows/registry_set_disable_microsoft_office_security_features.yml
+++ b/deprecated/windows/registry_set_disable_microsoft_office_security_features.yml
@@ -8,7 +8,7 @@ references:
     - https://yoroi.company/research/cyber-criminal-espionage-operation-insists-on-italian-manufacturing/
 author: frack113
 date: 2021/06/08
-modified: 2023/06/21
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -23,7 +23,6 @@ logsource:
     # <TargetObject name="T1562,office" condition="end with">\DisableAttachementsInPV</TargetObject>
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Office\'
         TargetObject|endswith:
             - VBAWarnings

--- a/deprecated/windows/registry_set_office_security.yml
+++ b/deprecated/windows/registry_set_office_security.yml
@@ -8,7 +8,7 @@ references:
     - https://securelist.com/scarcruft-surveilling-north-korean-defectors-and-human-rights-activists/105074/
 author: Trent Liffick (@tliffick)
 date: 2020/05/22
-modified: 2023/06/21
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|endswith:
             - '\Security\Trusted Documents\TrustRecords'
             - '\Security\AccessVBOM'

--- a/deprecated/windows/registry_set_silentprocessexit.yml
+++ b/deprecated/windows/registry_set_silentprocessexit.yml
@@ -7,7 +7,7 @@ references:
     - https://www.deepinstinct.com/2021/02/16/lsass-memory-dumps-are-stealthier-than-ever-before-part-2/
 author: Florian Roth (Nextron Systems)
 date: 2021/02/26
-modified: 2022/12/19
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.012
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: 'Microsoft\Windows NT\CurrentVersion\SilentProcessExit'
         Details|contains: 'MonitorProcess'
     condition: selection

--- a/rules-emerging-threats/2021/Exploits/registry_set_cve_2021_31979_cve_2021_33771_exploits.yml
+++ b/rules-emerging-threats/2021/Exploits/registry_set_cve_2021_31979_cve_2021_33771_exploits.yml
@@ -7,7 +7,7 @@ references:
     - https://citizenlab.ca/2021/07/hooking-candiru-another-mercenary-spyware-vendor-comes-into-focus/
 author: Sittikorn S, frack113
 date: 2021/07/16
-modified: 2022/08/23
+modified: 2023/08/17
 tags:
     - attack.credential_access
     - attack.t1566
@@ -21,7 +21,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith:
             - CLSID\{CF4CC405-E2C5-4DDD-B3CE-5E7582D8C9FA}\InprocServer32\(Default)
             - CLSID\{7C857801-7381-11CF-884D-00AA004B2E24}\InProcServer32\(Default)

--- a/rules-emerging-threats/2021/Malware/Small-Sieve/registry_set_malware_small_sieve_evasion_typo.yml
+++ b/rules-emerging-threats/2021/Malware/Small-Sieve/registry_set_malware_small_sieve_evasion_typo.yml
@@ -6,6 +6,7 @@ references:
     - https://www.ncsc.gov.uk/static-assets/documents/malware-analysis-reports/small-sieve/NCSC-MAR-Small-Sieve.pdf
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/19
+modified: 2023/08/17
 tags:
     - attack.persistence
     - detection.emerging_threats
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection_path:
-        EventType: SetValue
         TargetObject|contains: '\Microsoft\Windows\CurrentVersion\Run\'
     selection_value:
         - TargetObject|contains: 'Microsift'

--- a/rules-emerging-threats/2023/Exploits/CVE-2023-23397/registry_set_exploit_cve_2023_23397_outlook_reminder_trigger.yml
+++ b/rules-emerging-threats/2023/Exploits/CVE-2023-23397/registry_set_exploit_cve_2023_23397_outlook_reminder_trigger.yml
@@ -6,6 +6,7 @@ references:
     - https://www.microsoft.com/en-us/security/blog/2023/03/24/guidance-for-investigating-attacks-using-cve-2023-23397/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/04/05
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1137
@@ -22,7 +23,6 @@ detection:
         TargetObject|contains:
             - '\Tasks\'
             - '\Notes\'
-        EventType: SetValue
     condition: selection
 falsepositives:
     - Legitimate reminders received for a task or a note will also trigger this rule.

--- a/rules-emerging-threats/2023/Malware/COLDSTEEL/registry_set_malware_coldsteel_created_users.yml
+++ b/rules-emerging-threats/2023/Malware/COLDSTEEL/registry_set_malware_coldsteel_created_users.yml
@@ -6,6 +6,7 @@ references:
     - https://www.ncsc.gov.uk/static-assets/documents/malware-analysis-reports/cold-steel/NCSC-MAR-Cold-Steel.pdf
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/02
+modified: 2023/08/17
 tags:
     - attack.persistence
     - detection.emerging_threats
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains|all:
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\ProfileList\S-1-5-21-'
             - '\ProfileImagePath'

--- a/rules-emerging-threats/2023/Malware/SNAKE/registry_set_malware_snake_encrypted_key.yml
+++ b/rules-emerging-threats/2023/Malware/SNAKE/registry_set_malware_snake_encrypted_key.yml
@@ -6,6 +6,7 @@ references:
     - https://media.defense.gov/2023/May/09/2003218554/-1/-1/0/JOINT_CSA_HUNTING_RU_INTEL_SNAKE_MALWARE_20230509.PDF
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/10
+modified: 2023/08/17
 tags:
     - attack.persistence
     - detection.emerging_threats
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Classes\.wav\OpenWithProgIds\'
     filter_main_wav:
         - TargetObject|endswith: '.AssocFile.WAV'

--- a/rules-threat-hunting/windows/registry/registry_set/registry_set_office_trusted_location.yml
+++ b/rules-threat-hunting/windows/registry/registry_set/registry_set_office_trusted_location.yml
@@ -9,6 +9,7 @@ references:
     - https://admx.help/?Category=Office2016&Policy=excel16.Office.Microsoft.Policies.Windows::L_TrustedLoc01
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/06/21
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -18,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|contains: 'Security\Trusted Locations\Location'
         TargetObject|endswith: '\Path'
     condition: selection

--- a/rules/windows/registry/registry_event/registry_event_hybridconnectionmgr_svc_installation.yml
+++ b/rules/windows/registry/registry_event/registry_event_hybridconnectionmgr_svc_installation.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/Cyb3rWard0g/status/1381642789369286662
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 date: 2021/04/12
-modified: 2022/11/27
+modified: 2023/08/17
 tags:
     - attack.resource_development
     - attack.t1608
@@ -17,7 +17,6 @@ detection:
     selection1:
         TargetObject|contains: '\Services\HybridConnectionManager'
     selection2:
-        EventType: SetValue
         Details|contains: 'Microsoft.HybridConnectionManager.Listener.exe'
     condition: selection1 or selection2
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_add_load_service_in_safe_mode.yml
+++ b/rules/windows/registry/registry_set/registry_set_add_load_service_in_safe_mode.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1112/T1112.md#atomic-test-34---windows-add-registry-value-to-load-service-in-safe-mode-with-network
 author: frack113
 date: 2022/04/04
-modified: 2022/06/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1564.001
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|startswith:
             - 'HKLM\SYSTEM\CurrentControlSet\Control\SafeBoot\Minimal\'
             - 'HKLM\SYSTEM\CurrentControlSet\Control\SafeBoot\Network\'

--- a/rules/windows/registry/registry_set/registry_set_add_port_monitor.yml
+++ b/rules/windows/registry/registry_set/registry_set_add_port_monitor.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1547.010/T1547.010.md
 author: frack113
 date: 2021/12/30
-modified: 2022/09/18
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.010
@@ -19,7 +19,6 @@ detection:
     selection:
         TargetObject|startswith: 'HKLM\System\CurrentControlSet\Control\Print\Monitors\'
         Details|endswith: '.dll'
-        EventType: SetValue
     filter_cutepdf:
         Image: 'C:\Windows\System32\spoolsv.exe'
         TargetObject|contains: '\System\CurrentControlSet\Control\Print\Monitors\CutePDF Writer Monitor v4.0\Driver'

--- a/rules/windows/registry/registry_set/registry_set_aedebug_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_aedebug_persistence.yml
@@ -7,6 +7,7 @@ references:
     - https://docs.microsoft.com/en-us/windows/win32/debug/configuring-automatic-debugging
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug\Debugger'
         Details|endswith: '.dll'
     filter:

--- a/rules/windows/registry/registry_set/registry_set_allow_rdp_remote_assistance_feature.yml
+++ b/rules/windows/registry/registry_set/registry_set_allow_rdp_remote_assistance_feature.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/40b77d63808dd4f4eafb83949805636735a1fd15/atomics/T1112/T1112.md
 author: frack113
 date: 2022/08/19
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'System\CurrentControlSet\Control\Terminal Server\fAllowToGetHelp'
         Details: DWORD (0x00000001)
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_amsi_com_hijack.yml
+++ b/rules/windows/registry/registry_set/registry_set_amsi_com_hijack.yml
@@ -7,6 +7,7 @@ references:
     - https://github.com/r00t-3xp10it/hacking-material-books/blob/43cb1e1932c16ff1f58b755bc9ab6b096046853f/obfuscation/simple_obfuscation.md#amsi-comreg-bypass
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/01/04
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -15,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\CLSID\{fdb00e52-a214-4aa1-8fba-4357bb0072ec}\InProcServer32\(Default)'
     filter:
         Details: '%windir%\system32\amsi.dll'

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_classes.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_classes.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2023/01/18
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     selection_classes_base:
-        EventType: SetValue
         TargetObject|contains: '\Software\Classes'
     selection_classes_target:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_common.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_common.yml
@@ -12,7 +12,7 @@ references:
     - https://persistence-info.github.io/Data/userinitmprlogonscript.html # UserInitMprLogonScript
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split), wagga (name)
 date: 2019/10/25
-modified: 2023/03/24
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -21,7 +21,6 @@ logsource:
     product: windows
 detection:
     main_selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\SOFTWARE\Wow6432Node\Microsoft\Windows CE Services\AutoStart'
             - '\Software\Wow6432Node\Microsoft\Command Processor\Autorun'

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentcontrolset.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentcontrolset.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2022/09/20
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     system_control_base:
-        EventType: SetValue
         TargetObject|contains: '\SYSTEM\CurrentControlSet\Control'
     system_control_keys:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion.yml
@@ -12,7 +12,7 @@ references:
     - https://oddvar.moe/2018/03/21/persistence-using-runonceex-hidden-from-autoruns-exe/
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2022/10/20
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -21,7 +21,6 @@ logsource:
     product: windows
 detection:
     current_version_base:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion'
     current_version_keys:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion_nt.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_currentversion_nt.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2022/07/05
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     nt_current_version_base:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
     nt_current_version:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_internet_explorer.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_internet_explorer.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     ie:
-        EventType: SetValue
         TargetObject|contains:
             - '\Software\Wow6432Node\Microsoft\Internet Explorer'
             - '\Software\Microsoft\Internet Explorer'

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_office.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_office.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2023/02/17
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     office:
-        EventType: SetValue
         TargetObject|contains:
             - '\Software\Wow6432Node\Microsoft\Office'
             - '\Software\Microsoft\Office'

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_session_manager.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_session_manager.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -21,7 +21,6 @@ logsource:
     product: windows
 detection:
     session_manager_base:
-        EventType: SetValue
         TargetObject|contains: '\System\CurrentControlSet\Control\Session Manager'
     session_manager:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_system_scripts.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_system_scripts.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     scripts_base:
-        EventType: SetValue
         TargetObject|contains: '\Software\Policies\Microsoft\Windows\System\Scripts'
     scripts:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_winsock2.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_winsock2.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     winsock_parameters_base:
-        EventType: SetValue
         TargetObject|contains: '\System\CurrentControlSet\Services\WinSock2\Parameters'
     winsock_parameters:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_wow6432node.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_wow6432node.yml
@@ -12,7 +12,7 @@ references:
     - https://oddvar.moe/2018/03/21/persistence-using-runonceex-hidden-from-autoruns-exe/
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2023/01/19
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -21,7 +21,6 @@ logsource:
     product: windows
 detection:
     selection_wow_current_version_base:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion'
     selection_wow_current_version_keys:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_wow6432node_classes.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_wow6432node_classes.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     wow_classes_base:
-        EventType: SetValue
         TargetObject|contains: '\Software\Wow6432Node\Classes'
     wow_classes:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_wow6432node_currentversion.yml
+++ b/rules/windows/registry/registry_set/registry_set_asep_reg_keys_modification_wow6432node_currentversion.yml
@@ -11,7 +11,7 @@ references:
     - https://gist.github.com/GlebSukhodolskiy/0fc5fa5f482903064b448890db1eaf9d # a list with registry keys
 author: Victor Sergeev, Daniil Yugoslavskiy, Gleb Sukhodolskiy, Timur Zinniatullin, oscd.community, Tim Shelton, frack113 (split)
 date: 2019/10/25
-modified: 2022/11/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     wow_nt_current_version_base:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Wow6432Node\Microsoft\Windows NT\CurrentVersion'
     wow_nt_current_version:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_blackbyte_ransomware.yml
+++ b/rules/windows/registry/registry_set/registry_set_blackbyte_ransomware.yml
@@ -7,7 +7,7 @@ references:
     - https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/blackbyte-ransomware-pt-1-in-depth-analysis/
 author: frack113
 date: 2022/01/24
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject:
             - HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LocalAccountTokenFilterPolicy
             - HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\EnableLinkedConnections

--- a/rules/windows/registry/registry_set/registry_set_bypass_uac_using_delegateexecute.yml
+++ b/rules/windows/registry/registry_set/registry_set_bypass_uac_using_delegateexecute.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1548.002/T1548.002.md#atomic-test-7---bypass-uac-using-sdclt-delegateexecute
 author: frack113
 date: 2022/01/05
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.privilege_escalation
     - attack.defense_evasion
@@ -18,7 +18,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\open\command\DelegateExecute'
         Details: (Empty)
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_bypass_uac_using_eventviewer.yml
+++ b/rules/windows/registry/registry_set/registry_set_bypass_uac_using_eventviewer.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1548.002/T1548.002.md#atomic-test-1---bypass-uac-using-event-viewer-cmd
 author: frack113
 date: 2022/01/05
-modified: 2022/10/05
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.010
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '_Classes\mscfile\shell\open\command\(Default)'
     filter:
         Details|startswith: '%SystemRoot%\system32\mmc.exe "%1" %'

--- a/rules/windows/registry/registry_set/registry_set_bypass_uac_using_silentcleanup_task.yml
+++ b/rules/windows/registry/registry_set/registry_set_bypass_uac_using_silentcleanup_task.yml
@@ -7,7 +7,7 @@ references:
     - https://www.reddit.com/r/hacking/comments/ajtrws/bypassing_highest_uac_level_windows_810/
 author: frack113
 date: 2022/01/06
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.privilege_escalation
     - attack.defense_evasion
@@ -19,7 +19,6 @@ detection:
     selection:
         TargetObject|endswith: '\Environment\windir'
         Details|contains: '&REM'
-        EventType: SetValue
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/registry/registry_set/registry_set_change_rdp_port.yml
+++ b/rules/windows/registry/registry_set/registry_set_change_rdp_port.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1021.001/T1021.001.md#atomic-test-1---rdp-to-domaincontroller
 author: frack113
 date: 2022/01/01
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.010
@@ -18,7 +18,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject: HKLM\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp\PortNumber
     filter:
         Details: DWORD (0x00000d3d)

--- a/rules/windows/registry/registry_set/registry_set_change_security_zones.yml
+++ b/rules/windows/registry/registry_set/registry_set_change_security_zones.yml
@@ -10,7 +10,7 @@ references:
     - https://docs.microsoft.com/en-us/troubleshoot/developer/browsers/security-privacy/ie-security-zones-registry-entries
 author: frack113
 date: 2022/01/22
-modified: 2022/04/04
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1137
@@ -19,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection_domains:
-        EventType: SetValue
         TargetObject|contains: \SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap\Domains\
     filter:
         Details:

--- a/rules/windows/registry/registry_set/registry_set_change_sysmon_driver_altitude.yml
+++ b/rules/windows/registry/registry_set/registry_set_change_sysmon_driver_altitude.yml
@@ -7,6 +7,7 @@ references:
     - https://youtu.be/zSihR3lTf7g
 author: B.Talebi
 date: 2022/07/28
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -15,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\SYSTEM\CurrentControlSet\'
         TargetObject|endswith: '\Instances\Sysmon Instance\Altitude'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_change_winevt_channelaccess.yml
+++ b/rules/windows/registry/registry_set/registry_set_change_winevt_channelaccess.yml
@@ -8,7 +8,7 @@ references:
     - https://itconnect.uw.edu/tools-services-support/it-systems-infrastructure/msinf/other-help/understanding-sddl-syntax/
 author: frack113
 date: 2022/09/17
-modified: 2022/09/29
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.002
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WINEVT\Channels\'
         TargetObject|endswith: '\ChannelAccess'
         # Add more interesting combinations if you found them

--- a/rules/windows/registry/registry_set/registry_set_chrome_extension.yml
+++ b/rules/windows/registry/registry_set/registry_set_chrome_extension.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1133/T1133.md#atomic-test-1---running-chrome-vpn-extensions-via-the-registry-2-vpn-extension
 author: frack113
 date: 2021/12/28
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1133
@@ -17,7 +17,6 @@ detection:
     chrome_ext:
         TargetObject|contains: 'Software\Wow6432Node\Google\Chrome\Extensions'
         TargetObject|endswith: 'update_url'
-        EventType: SetValue
     chrome_vpn:
         TargetObject|contains:
             - fdcgdnkidjaadafnichfpabhfomcebme # ZenMate VPN

--- a/rules/windows/registry/registry_set/registry_set_clickonce_trust_prompt.yml
+++ b/rules/windows/registry/registry_set/registry_set_clickonce_trust_prompt.yml
@@ -7,6 +7,7 @@ references:
     - https://learn.microsoft.com/en-us/visualstudio/deployment/how-to-configure-the-clickonce-trust-prompt-behavior
 author: '@SerkinValery, Nasreddine Bencherchali (Nextron Systems)'
 date: 2023/06/12
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -15,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\MICROSOFT\.NETFramework\Security\TrustManager\PromptingLevel\'
         TargetObject|endswith:
             - '\Internet'

--- a/rules/windows/registry/registry_set/registry_set_cobaltstrike_service_installs.yml
+++ b/rules/windows/registry/registry_set/registry_set_cobaltstrike_service_installs.yml
@@ -9,7 +9,7 @@ references:
     - https://www.sans.org/webcasts/tech-tuesday-workshop-cobalt-strike-detection-log-analysis-119395
 author: Wojciech Lesicki
 date: 2021/06/29
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.execution
     - attack.privilege_escalation
@@ -22,7 +22,6 @@ logsource:
     product: windows
 detection:
     main:
-        EventType: SetValue
         TargetObject|contains: 'HKLM\System\CurrentControlSet\Services'
     selection_1:
         Details|contains|all:

--- a/rules/windows/registry/registry_set/registry_set_comhijack_sdclt.yml
+++ b/rules/windows/registry/registry_set/registry_set_comhijack_sdclt.yml
@@ -7,7 +7,7 @@ references:
     - https://www.exploit-db.com/exploits/47696
 author: Omkar Gudhate
 date: 2020/09/27
-modified: 2022/06/26
+modified: 2023/08/17
 tags:
     - attack.privilege_escalation
     - attack.t1546
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject: 'HKCU\Software\Classes\Folder\shell\open\command\DelegateExecute'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_crashdump_disabled.yml
+++ b/rules/windows/registry/registry_set/registry_set_crashdump_disabled.yml
@@ -6,7 +6,7 @@ references:
     - https://www.sentinelone.com/labs/hermetic-wiper-ukraine-under-attack/
 author: Tobias Michalski (Nextron Systems)
 date: 2022/02/24
-modified: 2022/08/23
+modified: 2023/08/17
 tags:
     - attack.t1564
     - attack.t1112
@@ -15,7 +15,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: 'SYSTEM\CurrentControlSet\Control\CrashControl'
         Details: 'DWORD (0x00000000)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_creation_service_susp_folder.yml
+++ b/rules/windows/registry/registry_set/registry_set_creation_service_susp_folder.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1562.001/T1562.001.md
 author: Florian Roth (Nextron Systems), frack113
 date: 2022/05/02
-modified: 2022/12/02
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -18,7 +18,6 @@ logsource:
     product: windows
 detection:
     selection_1:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\System\CurrentControlSet\Services\'
         TargetObject|endswith: '\Start'
         Image|contains:
@@ -32,7 +31,6 @@ detection:
             - 'DWORD (0x00000002)'  # Automatic
             # 3 - Manual , 4 - Disabled
     selection_2:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\System\CurrentControlSet\Services\'
         TargetObject|endswith: '\ImagePath'
         Details|contains:

--- a/rules/windows/registry/registry_set/registry_set_creation_service_uncommon_folder.yml
+++ b/rules/windows/registry/registry_set/registry_set_creation_service_uncommon_folder.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1562.001/T1562.001.md
 author: Florian Roth (Nextron Systems)
 date: 2022/05/02
-modified: 2022/05/04
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection_1:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\System\CurrentControlSet\Services\'
         TargetObject|endswith: '\Start'
         Image|contains:
@@ -27,7 +26,6 @@ detection:
             - 'DWORD (0x00000002)'  # Automatic
             # 3 - Manual , 4 - Disabled
     selection_2:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\System\CurrentControlSet\Services\'
         TargetObject|endswith: '\ImagePath'
         Details|contains:

--- a/rules/windows/registry/registry_set/registry_set_custom_file_open_handler_powershell_execution.yml
+++ b/rules/windows/registry/registry_set/registry_set_custom_file_open_handler_powershell_execution.yml
@@ -6,6 +6,7 @@ references:
     - https://news.sophos.com/en-us/2022/02/01/solarmarker-campaign-used-novel-registry-changes-to-establish-persistence/?cmp=30728
 author: CD_R0M_
 date: 2022/06/11
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1202
@@ -18,7 +19,6 @@ detection:
         Details|contains|all:
             - 'powershell'
             - '-command'
-        EventType: SetValue
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/registry/registry_set/registry_set_cve_2020_1048_new_printer_port.yml
+++ b/rules/windows/registry/registry_set/registry_set_cve_2020_1048_new_printer_port.yml
@@ -6,7 +6,7 @@ references:
     - https://windows-internals.com/printdemon-cve-2020-1048/
 author: EagleEye Team, Florian Roth (Nextron Systems), NVISO
 date: 2020/05/13
-modified: 2022/01/13
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.execution
@@ -17,7 +17,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Ports'
         Details|contains:
             - '.dll'

--- a/rules/windows/registry/registry_set/registry_set_cve_2022_30190_msdt_follina.yml
+++ b/rules/windows/registry/registry_set/registry_set_cve_2022_30190_msdt_follina.yml
@@ -7,7 +7,7 @@ references:
     - https://msrc-blog.microsoft.com/2022/05/30/guidance-for-cve-2022-30190-microsoft-support-diagnostic-tool-vulnerability/
 author: Sittikorn S
 date: 2020/05/31
-modified: 2022/10/09
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1221
@@ -16,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith: 'HKCR\ms-msdt\'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_dbgmanageddebugger_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_dbgmanageddebugger_persistence.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/last-byte/PersistenceSniper
 author: frack113
 date: 2022/08/07
-modified: 2022/12/19
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1574
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Microsoft\.NETFramework\DbgManagedDebugger'
     filter:
         Details: '"C:\Windows\system32\vsjitdebugger.exe" PID %d APPDOM %d EXTEXT "%s" EVTHDL %d'

--- a/rules/windows/registry/registry_set/registry_set_defender_exclusions.yml
+++ b/rules/windows/registry/registry_set/registry_set_defender_exclusions.yml
@@ -9,7 +9,7 @@ references:
     - https://twitter.com/_nullbind/status/1204923340810543109
 author: Christian Burkard (Nextron Systems)
 date: 2021/07/06
-modified: 2022/11/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -18,8 +18,6 @@ logsource:
     category: registry_set
 detection:
     selection2:
-        #EventID: 13
-        EventType: SetValue
         TargetObject|contains: '\Microsoft\Windows Defender\Exclusions'
     condition: selection2
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_dhcp_calloutdll.yml
+++ b/rules/windows/registry/registry_set/registry_set_dhcp_calloutdll.yml
@@ -8,7 +8,7 @@ references:
     - https://msdn.microsoft.com/de-de/library/windows/desktop/aa363389(v=vs.85).aspx
 author: Dimitrios Slamaris
 date: 2017/05/15
-modified: 2022/06/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1574.002
@@ -18,7 +18,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|endswith:
             - '\Services\DHCPServer\Parameters\CalloutDlls'
             - '\Services\DHCPServer\Parameters\CalloutEnabled'

--- a/rules/windows/registry/registry_set/registry_set_disable_administrative_share.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_administrative_share.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1070.005/T1070.005.md#atomic-test-4---disable-administrative-share-creation-at-startup
 author: frack113
 date: 2022/01/16
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1070.005
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\System\CurrentControlSet\Services\LanmanServer\Parameters\'
         TargetObject|endswith:
             - 'AutoShareWks'

--- a/rules/windows/registry/registry_set/registry_set_disable_autologger_sessions.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_autologger_sessions.yml
@@ -8,7 +8,7 @@ references:
     - https://i.blackhat.com/EU-21/Wednesday/EU-21-Teodorescu-Veni-No-Vidi-No-Vici-Attacks-On-ETW-Blind-EDRs.pdf
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/01
-modified: 2023/01/18
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
 logsource:
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection_main:
-        EventType: SetValue
         TargetObject|contains: '\System\CurrentControlSet\Control\WMI\Autologger\'
     selection_values:
         TargetObject|contains: # We only care about some autologger to avoid FP. Add more if you need

--- a/rules/windows/registry/registry_set/registry_set_disable_defender_firewall.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_defender_firewall.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1562.004/T1562.004.md#atomic-test-2---disable-microsoft-defender-firewall-via-registry
 author: frack113
 date: 2022/01/09
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.004
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         #HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\DomainProfile\EnableFirewall
         #HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\PublicProfile\EnableFirewall
         #HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy\StandardProfile\EnableFirewall

--- a/rules/windows/registry/registry_set/registry_set_disable_function_user.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_function_user.yml
@@ -8,7 +8,7 @@ references:
     - https://blogs.vmware.com/security/2022/11/batloader-the-evasive-downloader-malware.html
 author: frack113, Nasreddine Bencherchali
 date: 2022/03/18
-modified: 2022/11/17
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection_set_1:
-        EventType: SetValue
         TargetObject|endswith:
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\DisableRegistryTools'
             - 'SOFTWARE\Policies\Microsoft\Windows\System\DisableCMD'
@@ -28,7 +27,6 @@ detection:
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\StartMenuLogOff'
         Details: 'DWORD (0x00000001)'
     selection_set_0:
-        EventType: SetValue
         TargetObject|endswith:
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\shutdownwithoutlogon'
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\ConsentPromptBehaviorAdmin'

--- a/rules/windows/registry/registry_set/registry_set_disable_macroruntimescanscope.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_macroruntimescanscope.yml
@@ -3,6 +3,7 @@ id: ab871450-37dc-4a3a-997f-6662aa8ae0f1
 description: Detects tampering with the MacroRuntimeScanScope registry key to disable runtime scanning of enabled macros
 status: experimental
 date: 2022/10/25
+modified: 2023/08/17
 author: Nasreddine Bencherchali (Nextron Systems)
 references:
     - https://www.microsoft.com/en-us/security/blog/2018/09/12/office-vba-amsi-parting-the-veil-on-malicious-macros/
@@ -15,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains|all:
             - '\SOFTWARE\'
             - '\Microsoft\Office\'

--- a/rules/windows/registry/registry_set/registry_set_disable_privacy_settings_experience.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_privacy_settings_experience.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/9e5b12c4912c07562aec7500447b11fa3e17e254/atomics/T1562.001/T1562.001.md
 author: frack113
 date: 2022/10/02
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\SOFTWARE\Policies\Microsoft\Windows\OOBE\DisablePrivacyExperience'
         Details: 'DWORD (0x00000000)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_disable_security_center_notifications.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_security_center_notifications.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/40b77d63808dd4f4eafb83949805636735a1fd15/atomics/T1112/T1112.md
 author: frack113
 date: 2022/08/19
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'Windows\CurrentVersion\ImmersiveShell\UseActionCenterExperience'
         Details: 'DWORD (0x00000000)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_disable_system_restore.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_system_restore.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1490/T1490.md#atomic-test-9---disable-system-restore-through-registry
 author: frack113
 date: 2022/04/04
-modified: 2022/09/09
+modified: 2023/08/17
 tags:
     - attack.impact
     - attack.t1490
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|contains:
             - '\Policies\Microsoft\Windows NT\SystemRestore'
             - '\Microsoft\Windows NT\CurrentVersion\SystemRestore'

--- a/rules/windows/registry/registry_set/registry_set_disable_uac_registry.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_uac_registry.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1548.002/T1548.002.md#atomic-test-8---disable-uac-using-regexe
 author: frack113
 date: 2022/01/05
-modified: 2022/08/06
+modified: 2023/08/17
 tags:
     - attack.privilege_escalation
     - attack.defense_evasion
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\EnableLUA
         Details: DWORD (0x00000000)
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_disable_windows_defender_service.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_windows_defender_service.yml
@@ -7,6 +7,7 @@ references:
     - https://gist.github.com/anadr/7465a9fde63d41341136949f14c21105
 author: Ján Trenčanský, frack113, AlertIQ, Nasreddine Bencherchali
 date: 2022/08/01
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -15,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject: 'HKLM\SYSTEM\CurrentControlSet\Services\WinDefend\Start'
         Details: 'DWORD (0x00000004)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_disable_windows_firewall.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_windows_firewall.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/40b77d63808dd4f4eafb83949805636735a1fd15/atomics/T1562.004/T1562.004.md
 author: frack113
 date: 2022/08/19
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.004
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith:
             - \SOFTWARE\Policies\Microsoft\WindowsFirewall\StandardProfile\EnableFirewall
             - \SOFTWARE\Policies\Microsoft\WindowsFirewall\DomainProfile\EnableFirewall

--- a/rules/windows/registry/registry_set/registry_set_disable_winevt_logging.yml
+++ b/rules/windows/registry/registry_set/registry_set_disable_winevt_logging.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/DebugPrivilege/CPP/blob/c39d365617dbfbcb01fffad200d52b6239b2918c/Windows%20Defender/RestoreDefenderConfig.cpp
 author: frack113, Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/04
-modified: 2023/04/05
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.002
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WINEVT\Channels\'
         TargetObject|endswith: '\Enabled'
         Details: 'DWORD (0x00000000)'

--- a/rules/windows/registry/registry_set/registry_set_disabled_exploit_guard_net_protection_on_ms_defender.yml
+++ b/rules/windows/registry/registry_set/registry_set_disabled_exploit_guard_net_protection_on_ms_defender.yml
@@ -6,7 +6,7 @@ references:
     - https://www.tenforums.com/tutorials/105533-enable-disable-windows-defender-exploit-protection-settings.html
 author: Austin Songer @austinsonger
 date: 2021/08/04
-modified: 2022/08/05
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: 'SOFTWARE\Policies\Microsoft\Windows Defender Security Center\App and Browser protection\DisallowExploitProtectionOverride'
         Details: 'DWORD (00000001)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_disabled_microsoft_defender_eventlog.yml
+++ b/rules/windows/registry/registry_set/registry_set_disabled_microsoft_defender_eventlog.yml
@@ -6,6 +6,7 @@ references:
     - https://twitter.com/WhichbufferArda/status/1543900539280293889/photo/2
 author: Florian Roth (Nextron Systems)
 date: 2022/07/04
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\Microsoft\Windows\CurrentVersion\WINEVT\Channels\Microsoft-Windows-Windows Defender/Operational\Enabled'
         Details: 'DWORD (0x00000000)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_disabled_pua_protection_on_microsoft_defender.yml
+++ b/rules/windows/registry/registry_set/registry_set_disabled_pua_protection_on_microsoft_defender.yml
@@ -6,7 +6,7 @@ references:
     - https://www.tenforums.com/tutorials/32236-enable-disable-microsoft-defender-pua-protection-windows-10-a.html
 author: Austin Songer @austinsonger
 date: 2021/08/04
-modified: 2022/07/04
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\Policies\Microsoft\Windows Defender\PUAProtection'
         Details: 'DWORD (0x00000000)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_disabled_tamper_protection_on_microsoft_defender.yml
+++ b/rules/windows/registry/registry_set/registry_set_disabled_tamper_protection_on_microsoft_defender.yml
@@ -6,7 +6,7 @@ references:
     - https://www.tenforums.com/tutorials/123792-turn-off-tamper-protection-microsoft-defender-antivirus.html
 author: Austin Songer @austinsonger
 date: 2021/08/04
-modified: 2022/04/21
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\Microsoft\Windows Defender\Features\TamperProtection'
         Details: DWORD (0x00000000)
     filter_msmpeng_client: # only disabled temporarily during updates

--- a/rules/windows/registry/registry_set/registry_set_disallowrun_execution.yml
+++ b/rules/windows/registry/registry_set/registry_set_disallowrun_execution.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/40b77d63808dd4f4eafb83949805636735a1fd15/atomics/T1112/T1112.md
 author: frack113
 date: 2022/08/19
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\DisallowRun'
         Details: 'DWORD (0x00000001)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_disk_cleanup_handler_autorun_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_disk_cleanup_handler_autorun_persistence.yml
@@ -13,7 +13,7 @@ references:
     - https://www.hexacorn.com/blog/2018/09/02/beyond-good-ol-run-key-part-86/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
-modified: 2022/10/21
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -21,7 +21,6 @@ logsource:
     product: windows
 detection:
     root:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches\'
     selection_autorun:
         # Launching PreCleanupString / CleanupString programs w/o gui, i.e. while using e.g. /autoclean

--- a/rules/windows/registry/registry_set/registry_set_dns_over_https_enabled.yml
+++ b/rules/windows/registry/registry_set/registry_set_dns_over_https_enabled.yml
@@ -12,7 +12,7 @@ references:
     - https://admx.help/HKLM/Software/Policies/Mozilla/Firefox/DNSOverHTTPS
 author: Austin Songer
 date: 2021/07/22
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1140
@@ -22,15 +22,12 @@ logsource:
     category: registry_set
 detection:
     selection_edge:
-        EventType: SetValue
         TargetObject|endswith: '\SOFTWARE\Policies\Microsoft\Edge\BuiltInDnsClientEnabled'
         Details: DWORD (0x00000001)
     selection_chrome:
-        EventType: SetValue
         TargetObject|endswith: '\SOFTWARE\Google\Chrome\DnsOverHttpsMode'
         Details: 'secure'
     selection_firefox:
-        EventType: SetValue
         TargetObject|endswith: '\SOFTWARE\Policies\Mozilla\Firefox\DNSOverHTTPS\Enabled'
         Details: DWORD (0x00000001)
     condition: 1 of selection_*

--- a/rules/windows/registry/registry_set/registry_set_dns_server_level_plugin_dll.yml
+++ b/rules/windows/registry/registry_set/registry_set_dns_server_level_plugin_dll.yml
@@ -12,7 +12,7 @@ references:
     - https://blog.3or.de/hunting-dns-server-level-plugin-dll-injection.html
 author: Florian Roth (Nextron Systems)
 date: 2017/05/08
-modified: 2023/02/05
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1574.002
@@ -22,7 +22,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\services\DNS\Parameters\ServerLevelPluginDll'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_dot_net_etw_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_dot_net_etw_tamper.yml
@@ -19,7 +19,7 @@ references:
     - https://i.blackhat.com/EU-21/Wednesday/EU-21-Teodorescu-Veni-No-Vidi-No-Vici-Attacks-On-ETW-Blind-EDRs.pdf
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 date: 2020/06/05
-modified: 2022/12/09
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -29,11 +29,9 @@ logsource:
     category: registry_set
 detection:
     selection_etw_enabled:
-        EventType: SetValue
         TargetObject|endswith: 'SOFTWARE\Microsoft\.NETFramework\ETWEnabled'
         Details: 'DWORD (0x00000000)'
     selection_complus:
-        EventType: SetValue
         TargetObject|endswith:
             - '\COMPlus_ETWEnabled'
             - '\COMPlus_ETWFlags'

--- a/rules/windows/registry/registry_set/registry_set_enabling_cor_profiler_env_variables.yml
+++ b/rules/windows/registry/registry_set/registry_set_enabling_cor_profiler_env_variables.yml
@@ -8,7 +8,7 @@ references:
     - https://www.sans.org/cyber-security-summit/archives
 author: Jose Rodriguez (@Cyb3rPandaH), OTR (Open Threat Research)
 date: 2020/09/10
-modified: 2022/06/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.privilege_escalation
@@ -19,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|endswith:
             - '\COR_ENABLE_PROFILING'
             - '\COR_PROFILER'

--- a/rules/windows/registry/registry_set/registry_set_enabling_turnoffcheck.yml
+++ b/rules/windows/registry/registry_set/registry_set_enabling_turnoffcheck.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/wdormann/status/1537075968568877057?s=20&t=0lr18OAnmAGoGpma6grLUw
 author: 'Christopher Peacock @securepeacock, SCYTHE @scythe_io'
 date: 2022/06/15
-modified: 2022/09/09
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -15,7 +15,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Policies\Microsoft\Windows\ScriptedDiagnostics\TurnOffCheck'
         Details: 'DWORD (0x00000001)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_evtx_file_key_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_evtx_file_key_tamper.yml
@@ -6,6 +6,7 @@ references:
     - https://learn.microsoft.com/en-us/windows/win32/eventlog/eventlog-key
 author: D3F7A5105
 date: 2023/01/02
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.002
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SYSTEM\CurrentControlSet\Services\EventLog\'
         TargetObject|endswith: '\File'
     filter:

--- a/rules/windows/registry/registry_set/registry_set_exploit_guard_susp_allowed_apps.yml
+++ b/rules/windows/registry/registry_set/registry_set_exploit_guard_susp_allowed_apps.yml
@@ -6,6 +6,7 @@ references:
     - https://www.microsoft.com/security/blog/2017/10/23/windows-defender-exploit-guard-reduce-the-attack-surface-against-next-generation-malware/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/05
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection_key:
-        EventType: SetValue
         TargetObject|contains: 'SOFTWARE\Microsoft\Windows Defender\Windows Defender Exploit Guard\Controlled Folder Access\AllowedApplications'
     selection_paths:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_file_association_exefile.yml
+++ b/rules/windows/registry/registry_set/registry_set_file_association_exefile.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/mrd0x/status/1461041276514623491
 author: Andreas Hunkeler (@Karneades)
 date: 2021/11/19
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
 logsource:
@@ -16,7 +16,6 @@ detection:
     selection:
         TargetObject|contains: 'Classes\.'
         Details: 'exefile'
-        EventType: SetValue
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/registry/registry_set/registry_set_hangs_debugger_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_hangs_debugger_persistence.yml
@@ -7,6 +7,7 @@ references:
     - https://www.hexacorn.com/blog/2019/09/20/beyond-good-ol-run-key-part-116/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\Windows Error Reporting\Hangs\Debugger'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_hhctrl_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_hhctrl_persistence.yml
@@ -7,6 +7,7 @@ references:
     - https://www.hexacorn.com/blog/2018/04/23/beyond-good-ol-run-key-part-77/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\CLSID\{52A2AAAE-085D-4187-97EA-8C30DB990436}\InprocServer32\(Default)'
     filter:
         Details: 'C:\Windows\System32\hhctrl.ocx'

--- a/rules/windows/registry/registry_set/registry_set_hidden_extention.yml
+++ b/rules/windows/registry/registry_set/registry_set_hidden_extention.yml
@@ -8,7 +8,7 @@ references:
     - https://www.microsoft.com/en-us/wdsi/threats/malware-encyclopedia-description?name=TrojanSpy%3aMSIL%2fHakey.A
 author: frack113
 date: 2022/01/22
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1137
@@ -17,11 +17,9 @@ logsource:
     product: windows
 detection:
     selection_HideFileExt:
-        EventType: SetValue
         TargetObject|endswith: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\HideFileExt'
         Details: 'DWORD (0x00000001)'
     selection_Hidden:
-        EventType: SetValue
         TargetObject|endswith: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\Hidden'
         Details: 'DWORD (0x00000002)'
     condition: 1 of selection_*

--- a/rules/windows/registry/registry_set/registry_set_hide_file.yml
+++ b/rules/windows/registry/registry_set/registry_set_hide_file.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1564.001/T1564.001.md#atomic-test-8---hide-files-through-registry
 author: frack113
 date: 2022/04/02
-modified: 2022/06/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1564.001
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject:
             - HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ShowSuperHidden
             - HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\Hidden

--- a/rules/windows/registry/registry_set/registry_set_hide_function_user.yml
+++ b/rules/windows/registry/registry_set/registry_set_hide_function_user.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1564.001/T1564.001.md
 author: frack113
 date: 2022/03/18
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection_set_1:
-        EventType: SetValue
         TargetObject|endswith:
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\HideClock'
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\HideSCAHealth'
@@ -24,7 +23,6 @@ detection:
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\HideSCAVolume'
         Details: 'DWORD (0x00000001)'
     selection_set_0:
-        EventType: SetValue
         TargetObject|endswith:
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ShowInfoTip'
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ShowCompColor'

--- a/rules/windows/registry/registry_set/registry_set_hide_scheduled_task_via_index_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_hide_scheduled_task_via_index_tamper.yml
@@ -13,6 +13,7 @@ references:
     - https://blog.qualys.com/vulnerabilities-threat-research/2022/06/20/defending-against-scheduled-task-attacks-in-windows-environments
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562
@@ -21,7 +22,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains|all:
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\Tree\'
             - 'Index'

--- a/rules/windows/registry/registry_set/registry_set_install_root_or_ca_certificat.yml
+++ b/rules/windows/registry/registry_set/registry_set_install_root_or_ca_certificat.yml
@@ -7,7 +7,7 @@ references:
     - https://posts.specterops.io/code-signing-certificate-cloning-attacks-and-defenses-6f98657fc6ec
 author: frack113
 date: 2022/04/04
-modified: 2022/06/26
+modified: 2023/08/17
 tags:
     - attack.impact
     - attack.t1490
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|contains:
             - '\SOFTWARE\Microsoft\SystemCertificates\Root\Certificates\'
             - '\SOFTWARE\Policies\Microsoft\SystemCertificates\Root\Certificates\'

--- a/rules/windows/registry/registry_set/registry_set_internet_explorer_disable_first_run_customize.yml
+++ b/rules/windows/registry/registry_set/registry_set_internet_explorer_disable_first_run_customize.yml
@@ -9,6 +9,7 @@ references:
     - https://admx.help/?Category=InternetExplorer&Policy=Microsoft.Policies.InternetExplorer::NoFirstRunCustomise
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/16
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
 logsource:
@@ -16,7 +17,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Microsoft\Internet Explorer\Main\DisableFirstRunCustomize'
         Details:
             - 'DWORD (0x00000001)' # Home Page

--- a/rules/windows/registry/registry_set/registry_set_legalnotice_susp_message.yml
+++ b/rules/windows/registry/registry_set/registry_set_legalnotice_susp_message.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/5c1e6f1b4fafd01c8d1ece85f510160fc1275fbf/atomics/T1491.001/T1491.001.md
 author: frack113
 date: 2022/12/11
+modified: 2023/08/17
 tags:
     - attack.impact
     - attack.t1491.001
@@ -14,7 +15,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LegalNoticeCaption'
             - '\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\LegalNoticeText'

--- a/rules/windows/registry/registry_set/registry_set_lolbin_onedrivestandaloneupdater.yml
+++ b/rules/windows/registry/registry_set/registry_set_lolbin_onedrivestandaloneupdater.yml
@@ -8,6 +8,7 @@ references:
     - https://lolbas-project.github.io/lolbas/Binaries/OneDriveStandaloneUpdater/
 author: frack113
 date: 2022/05/28
+modified: 2023/08/17
 tags:
     - attack.command_and_control
     - attack.t1105
@@ -16,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\OneDrive\UpdateOfficeConfig\UpdateRingSettingURLFromOC'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_lsa_disablerestrictedadmin.yml
+++ b/rules/windows/registry/registry_set/registry_set_lsa_disablerestrictedadmin.yml
@@ -13,6 +13,7 @@ references:
     - https://social.technet.microsoft.com/wiki/contents/articles/32905.remote-desktop-services-enable-restricted-admin-mode.aspx
 author: frack113
 date: 2023/01/13
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -21,7 +22,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'System\CurrentControlSet\Control\Lsa\DisableRestrictedAdmin'
         Details: 'DWORD (0x00000001)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_lsass_usermode_dumping.yml
+++ b/rules/windows/registry/registry_set/registry_set_lsass_usermode_dumping.yml
@@ -8,6 +8,7 @@ references:
     - https://media.defcon.org/DEF%20CON%2030/DEF%20CON%2030%20presentations/Asaf%20Gilboa%20-%20LSASS%20Shtinkering%20Abusing%20Windows%20Error%20Reporting%20to%20Dump%20LSASS.pdf
 author: '@pbssubhash'
 date: 2022/12/08
+modified: 2023/08/17
 tags:
     - attack.credential_access
     - attack.t1003.001
@@ -16,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\DumpType'
             - '\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\lsass.exe\DumpType'

--- a/rules/windows/registry/registry_set/registry_set_mal_adwind.yml
+++ b/rules/windows/registry/registry_set/registry_set_mal_adwind.yml
@@ -10,7 +10,7 @@ references:
     - https://www.first.org/resources/papers/conf2017/Advanced-Incident-Detection-and-Threat-Hunting-using-Sysmon-and-Splunk.pdf
 author: Florian Roth (Nextron Systems), Tom Ueltschi, Jonhnathan Ribeiro, oscd.community
 date: 2017/11/10
-modified: 2022/11/26
+modified: 2023/08/17
 tags:
     - attack.execution
     - attack.t1059.005
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run'
         Details|startswith: '%AppData%\Roaming\Oracle\bin\'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_mal_blue_mockingbird.yml
+++ b/rules/windows/registry/registry_set/registry_set_mal_blue_mockingbird.yml
@@ -9,7 +9,7 @@ references:
     - https://redcanary.com/blog/blue-mockingbird-cryptominer/
 author: Trent Liffick (@tliffick)
 date: 2020/05/14
-modified: 2022/11/26
+modified: 2023/08/17
 tags:
     - attack.execution
     - attack.t1112
@@ -19,7 +19,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|endswith: '\CurrentControlSet\Services\wercplsupport\Parameters\ServiceDll'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_net_cli_ngenassemblyusagelog.yml
+++ b/rules/windows/registry/registry_set/registry_set_net_cli_ngenassemblyusagelog.yml
@@ -9,6 +9,7 @@ references:
     - https://bohops.com/2021/03/16/investigating-net-clr-usage-log-tampering-techniques-for-edr-evasion/
 author: frack113
 date: 2022/11/18
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -17,7 +18,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'SOFTWARE\Microsoft\.NETFramework\NGenAssemblyUsageLog'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_new_application_appcompat.yml
+++ b/rules/windows/registry/registry_set/registry_set_new_application_appcompat.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/OTRF/ThreatHunter-Playbook/blob/2d4257f630f4c9770f78d0c1df059f891ffc3fec/docs/evals/apt29/detections/1.A.1_DFD6A782-9BDB-4550-AB6B-525E825B095E.md
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 date: 2020/05/02
-modified: 2022/06/26
+modified: 2023/08/17
 tags:
     - attack.execution
     - attack.t1204.002
@@ -16,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|contains: '\AppCompatFlags\Compatibility Assistant\Store\'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_new_network_provider.yml
+++ b/rules/windows/registry/registry_set/registry_set_new_network_provider.yml
@@ -10,7 +10,7 @@ references:
     - https://github.com/gtworek/PSBits/tree/master/PasswordStealing/NPPSpy
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/23
-modified: 2023/02/02
+modified: 2023/08/17
 tags:
     - attack.credential_access
     - attack.t1003
@@ -19,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains|all:
             - '\System\CurrentControlSet\Services\'
             - '\NetworkProvider'

--- a/rules/windows/registry/registry_set/registry_set_odbc_driver_registered.yml
+++ b/rules/windows/registry/registry_set/registry_set_odbc_driver_registered.yml
@@ -6,6 +6,7 @@ references:
     - https://www.hexacorn.com/blog/2020/08/23/odbcconf-lolbin-trifecta/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/23
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -13,7 +14,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\ODBC\ODBCINST.INI\'
         TargetObject|endswith: '\Driver'
     filter_main_sqlserver:

--- a/rules/windows/registry/registry_set/registry_set_odbc_driver_registered_susp.yml
+++ b/rules/windows/registry/registry_set/registry_set_odbc_driver_registered_susp.yml
@@ -6,7 +6,7 @@ references:
     - https://www.hexacorn.com/blog/2020/08/23/odbcconf-lolbin-trifecta/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/23
-modified: 2023/05/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1003
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\ODBC\ODBCINST.INI\'
         TargetObject|endswith:
             - '\Driver'

--- a/rules/windows/registry/registry_set/registry_set_office_access_vbom_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_access_vbom_tamper.yml
@@ -11,7 +11,7 @@ references:
     - https://securelist.com/scarcruft-surveilling-north-korean-defectors-and-human-rights-activists/105074/
 author: Trent Liffick (@tliffick), Nasreddine Bencherchali (Nextron Systems)
 date: 2020/05/22
-modified: 2023/06/21
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|endswith: '\Security\AccessVBOM'
         Details: 'DWORD (0x00000001)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_office_disable_protected_view_features.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_disable_protected_view_features.yml
@@ -12,7 +12,7 @@ references:
     - https://admx.help/HKCU/software/policies/microsoft/office/16.0/excel/security/protectedview
 author: frack113, Nasreddine Bencherchali (Nextron Systems)
 date: 2021/06/08
-modified: 2023/06/21
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -21,7 +21,6 @@ logsource:
     category: registry_set
 detection:
     selection_path:
-        EventType: SetValue
         TargetObject|contains|all:
             - '\SOFTWARE\Microsoft\Office\'
             - '\Security\ProtectedView\'

--- a/rules/windows/registry/registry_set/registry_set_office_enable_dde.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_enable_dde.yml
@@ -6,7 +6,7 @@ references:
     - https://msrc.microsoft.com/update-guide/vulnerability/ADV170021
 author: frack113
 date: 2022/02/26
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.execution
     - attack.t1559.002
@@ -15,13 +15,11 @@ logsource:
     product: windows
 detection:
     selection_word:
-        EventType: SetValue
         TargetObject|endswith: '\Word\Security\AllowDDE'
         Details:
             - 'DWORD (0x00000001)'
             - 'DWORD (0x00000002)'
     selection_excel:
-        EventType: SetValue
         TargetObject|endswith:
             - '\Excel\Security\DisableDDEServerLaunch'
             - '\Excel\Security\DisableDDEServerLookup'

--- a/rules/windows/registry/registry_set/registry_set_office_outlook_enable_load_macro_provider_on_boot.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_outlook_enable_load_macro_provider_on_boot.yml
@@ -7,7 +7,7 @@ references:
     - https://www.linkedin.com/pulse/outlook-backdoor-using-vba-samir-b-/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2021/04/05
-modified: 2023/02/08
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.command_and_control
@@ -19,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Outlook\LoadMacroProviderOnBoot'
         Details|contains: '0x00000001'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_office_outlook_enable_macro_execution.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_outlook_enable_macro_execution.yml
@@ -7,7 +7,7 @@ references:
     - https://speakerdeck.com/heirhabarov/hunting-for-persistence-via-microsoft-exchange-server-or-outlook?slide=53
 author: '@ScoubiMtl'
 date: 2021/04/05
-modified: 2023/02/08
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.command_and_control
@@ -19,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Outlook\Security\Level'
         Details|contains: '0x00000001' # Enable all Macros
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_office_outlook_enable_unsafe_client_mail_rules.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_outlook_enable_unsafe_client_mail_rules.yml
@@ -12,7 +12,7 @@ references:
     - https://speakerdeck.com/heirhabarov/hunting-for-persistence-via-microsoft-exchange-server-or-outlook?slide=44
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/02/08
-modified: 2023/02/09
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -21,7 +21,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Outlook\Security\EnableUnsafeClientMailRules'
         Details: 'DWORD (0x00000001)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_office_outlook_security_settings.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_outlook_security_settings.yml
@@ -10,7 +10,7 @@ references:
     - https://docs.microsoft.com/en-us/outlook/troubleshoot/security/information-about-email-security-settings
 author: frack113
 date: 2021/12/28
-modified: 2023/02/08
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1137
@@ -22,7 +22,6 @@ detection:
         TargetObject|contains|all:
             - '\SOFTWARE\Microsoft\Office\'
             - '\Outlook\Security\'
-        EventType: SetValue
     condition: selection
 falsepositives:
     - Administrative activity

--- a/rules/windows/registry/registry_set/registry_set_office_trust_record_susp_location.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_trust_record_susp_location.yml
@@ -10,6 +10,7 @@ references:
     - Internal Research
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/06/21
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -18,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection_value:
-        EventType: Setvalue
         TargetObject|contains: '\Security\Trusted Documents\TrustRecords'
     selection_paths:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_office_trusted_location_uncommon.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_trusted_location_uncommon.yml
@@ -10,6 +10,7 @@ references:
     - https://admx.help/?Category=Office2016&Policy=excel16.Office.Microsoft.Policies.Windows::L_TrustedLoc01
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/06/21
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -18,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|contains: 'Security\Trusted Locations\Location'
         TargetObject|endswith: '\Path'
     filter_exclude_known_paths:

--- a/rules/windows/registry/registry_set/registry_set_office_vba_warnings_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_office_vba_warnings_tamper.yml
@@ -11,7 +11,7 @@ references:
     - https://securelist.com/scarcruft-surveilling-north-korean-defectors-and-human-rights-activists/105074/
 author: Trent Liffick (@tliffick), Nasreddine Bencherchali (Nextron Systems)
 date: 2020/05/22
-modified: 2023/06/21
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: Setvalue
         TargetObject|endswith: '\Security\VBAWarnings'
         Details: 'DWORD (0x00000001)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_persistence_app_paths.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_app_paths.yml
@@ -11,7 +11,7 @@ references:
     - https://docs.microsoft.com/en-us/windows/win32/shell/app-registration?redirectedfrom=MSDN
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/10
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.012
@@ -20,7 +20,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths'
         TargetObject|endswith:
             - '(Default)'

--- a/rules/windows/registry/registry_set/registry_set_persistence_appx_debugger.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_appx_debugger.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/rootm0s/WinPwnage
 author: frack113
 date: 2022/07/27
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.015
@@ -16,11 +16,9 @@ logsource:
     product: windows
 detection:
     selection_debug:
-        EventType: SetValue
         TargetObject|contains: 'Classes\ActivatableClasses\Package\Microsoft.'
         TargetObject|endswith: '\DebugPath'
     selection_default:
-        EventType: SetValue
         TargetObject|contains: '\Software\Microsoft\Windows\CurrentVersion\PackagedAppXDebug\Microsoft.'
         TargetObject|endswith: '\(Default)'
     condition: 1 of selection_*

--- a/rules/windows/registry/registry_set/registry_set_persistence_autodial_dll.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_autodial_dll.yml
@@ -7,7 +7,7 @@ references:
     - https://persistence-info.github.io/Data/autodialdll.html
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/10
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\Services\WinSock2\Parameters\AutodialDLL'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_persistence_chm.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_chm.yml
@@ -7,7 +7,7 @@ references:
     - https://www.hexacorn.com/blog/2018/04/22/beyond-good-ol-run-key-part-76/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\Software\Microsoft\HtmlHelp Author\Location'
             - '\Software\WOW6432Node\Microsoft\HtmlHelp Author\Location'

--- a/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_susp_locations.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_susp_locations.yml
@@ -6,7 +6,7 @@ references:
     - https://www.microsoft.com/security/blog/2022/07/27/untangling-knotweed-european-private-sector-offensive-actor-using-0-day-exploits/ (idea)
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/28
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.015
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith:
             - 'HKCR\CLSID\'
             - 'HKEY_CLASSES_ROOT\CLSID\'

--- a/rules/windows/registry/registry_set/registry_set_persistence_comhijack_psfactorybuffer.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_comhijack_psfactorybuffer.yml
@@ -9,6 +9,7 @@ references:
     - https://www.trendmicro.com/en_us/research/23/e/void-rabisu-s-use-of-romcom-backdoor-shows-a-growing-shift-in-th.html
 author: BlackBerry Threat Research and Intelligence Team - @Joseliyo_Jstnk
 date: 2023/06/07
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.015
@@ -17,7 +18,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\CLSID\{c90250f3-4d7d-4991-9b69-a5c5bc1c2ae6}\InProcServer32\(Default)'
     filter_main:
         Details:

--- a/rules/windows/registry/registry_set/registry_set_persistence_ie.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_ie.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1112/T1112.md#atomic-test-5---javascript-in-registry
 author: frack113
 date: 2022/01/22
-modified: 2023/01/06
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection_domains:
-        EventType: SetValue
         TargetObject|contains: '\Software\Microsoft\Windows\CurrentVersion\Internet Settings'
     filter_dword:
         Details|startswith: 'DWORD'

--- a/rules/windows/registry/registry_set/registry_set_persistence_ifilter.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_ifilter.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/gtworek/PSBits/blob/8d767892f3b17eefa4d0668f5d2df78e844f01d8/IFilter/Dll.cpp#L281-L308
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -17,13 +17,11 @@ logsource:
     product: windows
 detection:
     selection_ext:
-        EventType: SetValue
         TargetObject|startswith:
             - 'HKLM\SOFTWARE\Classes\.'
             - 'HKEY_LOCAL_MACHINE\SOFTWARE\Classes\.'
         TargetObject|contains: '\PersistentHandler'
     selection_clsid:
-        EventType: SetValue
         TargetObject|startswith:
             - 'HKLM\SOFTWARE\Classes\CLSID'
             - 'HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID'

--- a/rules/windows/registry/registry_set/registry_set_persistence_lsa_extension.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_lsa_extension.yml
@@ -9,7 +9,7 @@ references:
     - https://twitter.com/0gtweet/status/1476286368385019906
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SYSTEM\CurrentControlSet\Control\LsaExtensionConfig\LsaSrv\Extensions'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_persistence_mpnotify.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_mpnotify.yml
@@ -7,7 +7,7 @@ references:
     - https://www.youtube.com/watch?v=ggY3srD9dYs&ab_channel=GrzegorzTworek
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\mpnotify'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_persistence_mycomputer.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_mycomputer.yml
@@ -6,7 +6,7 @@ references:
     - https://www.hexacorn.com/blog/2017/01/18/beyond-good-ol-run-key-part-55/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/09
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -14,7 +14,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MyComputer'
         TargetObject|endswith: '(Default)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_persistence_natural_language.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_natural_language.yml
@@ -7,7 +7,7 @@ references:
     - https://www.hexacorn.com/blog/2018/12/30/beyond-good-ol-run-key-part-98/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection_root:
-        EventType: SetValue
         # The path can be for multiple languages
         # Example:  HKLM\System\CurrentControlSet\Control\ContentIndex\Language\English_UK
         #           HKLM\System\CurrentControlSet\Control\ContentIndex\Language\English_US

--- a/rules/windows/registry/registry_set/registry_set_persistence_office_vsto.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_office_vsto.yml
@@ -7,7 +7,7 @@ references:
     - https://vanmieghem.io/stealth-outlook-persistence/
 author: Bhabesh Raj
 date: 2021/01/10
-modified: 2023/08/11
+modified: 2023/08/17
 tags:
     - attack.t1137.006
     - attack.persistence
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\Software\Microsoft\Office\Outlook\Addins\'
             - '\Software\Microsoft\Office\Word\Addins\'

--- a/rules/windows/registry/registry_set/registry_set_persistence_outlook_homepage.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_outlook_homepage.yml
@@ -7,7 +7,7 @@ references:
     - https://support.microsoft.com/en-us/topic/outlook-home-page-feature-is-missing-in-folder-properties-d207edb7-aa02-46c5-b608-5d9dbed9bd04?ui=en-us&rs=en-us&ad=us
 author: Tobias Michalski (Nextron Systems)
 date: 2021/06/09
-modified: 2023/02/09
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1112
@@ -16,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection_1:
-        EventType: SetValue
         TargetObject|contains:
             - '\Software\Microsoft\Office\'
             - '\Outlook\WebView\'

--- a/rules/windows/registry/registry_set/registry_set_persistence_outlook_todaypage.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_outlook_todaypage.yml
@@ -6,7 +6,7 @@ references:
     - https://speakerdeck.com/heirhabarov/hunting-for-persistence-via-microsoft-exchange-server-or-outlook?slide=74
 author: Tobias Michalski (Nextron Systems)
 date: 2021/06/10
-modified: 2023/02/08
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1112
@@ -15,7 +15,6 @@ logsource:
     category: registry_set
 detection:
     selection_main:
-        EventType: SetValue
         TargetObject|contains|all:
             - 'Software\Microsoft\Office\'
             - '\Outlook\Today\'

--- a/rules/windows/registry/registry_set/registry_set_persistence_scrobj_dll.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_scrobj_dll.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/40b77d63808dd4f4eafb83949805636735a1fd15/atomics/T1546.015/T1546.015.md
 author: frack113
 date: 2022/08/20
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.015
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'InprocServer32\(Default)'
         Details: 'C:\WINDOWS\system32\scrobj.dll'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_persistence_search_order.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_search_order.yml
@@ -6,7 +6,7 @@ references:
     - https://www.cyberbit.com/blog/endpoint-security/com-hijacking-windows-overlooked-security-vulnerability/
 author: Maxime Thiebaut (@0xThiebaut), oscd.community, Cédric Hien
 date: 2020/04/14
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.015
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection: # Detect new COM servers in the user hive
-        EventType: SetValue
         TargetObject|startswith:
             - 'HKCR\CLSID\'
             - 'HKCU\Software\Classes\CLSID\'

--- a/rules/windows/registry/registry_set/registry_set_persistence_shim_database.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_shim_database.yml
@@ -10,7 +10,7 @@ references:
     - https://andreafortuna.org/2018/11/12/process-injection-and-persistence-using-application-shimming/
 author: frack113
 date: 2021/12/30
-modified: 2023/08/01
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.011
@@ -19,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\InstalledSDB\'
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Custom\'

--- a/rules/windows/registry/registry_set/registry_set_persistence_shim_database_susp_application.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_shim_database_susp_application.yml
@@ -7,6 +7,7 @@ references:
     - https://www.fireeye.com/blog/threat-research/2017/05/fin7-shim-databases-persistence.html
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/08/01
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.011
@@ -15,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Custom\'
         TargetObject|endswith:
             # Note: add other application to increase coverage

--- a/rules/windows/registry/registry_set/registry_set_persistence_shim_database_uncommon_location.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_shim_database_uncommon_location.yml
@@ -8,6 +8,7 @@ references:
     - https://www.blackhat.com/docs/asia-14/materials/Erickson/Asia-14-Erickson-Persist-It-Using-And-Abusing-Microsofts-Fix-It-Patches.pdf
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/08/01
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.011
@@ -16,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains|all:
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\InstalledSDB\'
             - '\DatabasePath'

--- a/rules/windows/registry/registry_set/registry_set_persistence_typed_paths.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_typed_paths.yml
@@ -7,7 +7,7 @@ references:
     - https://forensafe.com/blogs/typedpaths.html
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/22
-modified: 2023/01/11
+modified: 2023/08/17
 tags:
     - attack.persistence
 logsource:
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\Software\Microsoft\Windows\CurrentVersion\Explorer\TypedPaths\'
     filter:
         Image:

--- a/rules/windows/registry/registry_set/registry_set_persistence_xll.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_xll.yml
@@ -7,6 +7,7 @@ references:
     - https://labs.withsecure.com/publications/add-in-opportunities-for-office-persistence
 author: frack113
 date: 2023/01/15
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1137.006
@@ -15,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: 'Software\Microsoft\Office\'
         TargetObject|endswith: '\Excel\Options'
         Details|startswith: '/R '

--- a/rules/windows/registry/registry_set/registry_set_policies_associations_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_policies_associations_tamper.yml
@@ -7,7 +7,7 @@ references:
     - https://www.virustotal.com/gui/file/2bcd5702a7565952c44075ac6fb946c7780526640d1264f692c7664c02c68465
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/01
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
 logsource:
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection_main:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Associations\'
     selection_value_default_file_type_rsik:
         TargetObject|endswith: '\DefaultFileTypeRisk'

--- a/rules/windows/registry/registry_set/registry_set_policies_attachments_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_policies_attachments_tamper.yml
@@ -7,7 +7,7 @@ references:
     - https://www.virustotal.com/gui/file/2bcd5702a7565952c44075ac6fb946c7780526640d1264f692c7664c02c68465
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/01
-modified: 2023/01/10
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
 logsource:
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection_main:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Attachments\'
     selection_value_hide_zone_info:
         TargetObject|endswith: '\HideZoneInfoOnProperties'

--- a/rules/windows/registry/registry_set/registry_set_powershell_as_service.yml
+++ b/rules/windows/registry/registry_set/registry_set_powershell_as_service.yml
@@ -6,7 +6,7 @@ references:
     - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse
 author: oscd.community, Natalia Shornikova
 date: 2020/10/06
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.execution
     - attack.t1569.002
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\Services\'
         TargetObject|endswith: '\ImagePath'
         Details|contains:

--- a/rules/windows/registry/registry_set/registry_set_powershell_execution_policy.yml
+++ b/rules/windows/registry/registry_set/registry_set_powershell_execution_policy.yml
@@ -13,6 +13,7 @@ references:
     - https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy?view=powershell-7.3
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/01/11
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
 logsource:
@@ -20,7 +21,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith:
             # Note for future readers: For PowerShell 7+ the ExecutionPolicy is handled via a setting file due to the fact that PWSH7 is available for mac and linux
             # Attackers can create a per-user setting file (powershell.config.json) and set the execution policy there

--- a/rules/windows/registry/registry_set/registry_set_powershell_in_run_keys.yml
+++ b/rules/windows/registry/registry_set/registry_set_powershell_in_run_keys.yml
@@ -7,7 +7,7 @@ references:
     - https://www.trendmicro.com/en_us/research/22/j/lv-ransomware-exploits-proxyshell-in-attack.html
 author: frack113, Florian Roth (Nextron Systems)
 date: 2022/03/17
-modified: 2023/01/19
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\Software\Microsoft\Windows\CurrentVersion\Run' # Also covers "RunOnce" and "RunOnceEx"
         Details|contains:
             - 'powershell'

--- a/rules/windows/registry/registry_set/registry_set_powershell_logging_disabled.yml
+++ b/rules/windows/registry/registry_set/registry_set_powershell_logging_disabled.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1112/T1112.md#atomic-test-32---windows-powershell-logging-disabled
 author: frack113
 date: 2022/04/02
-modified: 2023/01/20
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1564.001
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\Microsoft\Windows\PowerShell\' # PowerShell 5
             - '\Microsoft\PowerShellCore\' # PowerShell 7

--- a/rules/windows/registry/registry_set/registry_set_provisioning_command_abuse.yml
+++ b/rules/windows/registry/registry_set/registry_set_provisioning_command_abuse.yml
@@ -14,6 +14,7 @@ references:
     - https://twitter.com/0gtweet/status/1674399582162153472
 author: Swachchhanda Shrawan Poudel
 date: 2023/08/02
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1218
@@ -23,7 +24,6 @@ logsource:
     definition: 'Requirements: The registry key "\SOFTWARE\Microsoft\Provisioning\Commands\" and its subkey must be monitored'
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Provisioning\Commands\'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_renamed_sysinternals_eula_accepted.yml
+++ b/rules/windows/registry/registry_set/registry_set_renamed_sysinternals_eula_accepted.yml
@@ -11,7 +11,7 @@ references:
     - Internal Research
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/24
-modified: 2023/05/16
+modified: 2023/08/17
 tags:
     - attack.resource_development
     - attack.t1588.002
@@ -20,7 +20,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\PsExec'
             - '\ProcDump'

--- a/rules/windows/registry/registry_set/registry_set_rpcrt4_etw_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_rpcrt4_etw_tamper.yml
@@ -6,6 +6,7 @@ references:
     - http://redplait.blogspot.com/2020/07/whats-wrong-with-etw.html
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/12/09
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -15,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Microsoft\Windows NT\Rpc\ExtErrorInformation'
         Details:
             # This is disabled by default for some reason

--- a/rules/windows/registry/registry_set/registry_set_scr_file_executed_by_rundll32.yml
+++ b/rules/windows/registry/registry_set/registry_set_scr_file_executed_by_rundll32.yml
@@ -8,7 +8,7 @@ references:
     - https://jstnk9.github.io/jstnk9/research/InstallScreenSaver-SCR-files
 author: Jose Luis Sanchez Martinez (@Joseliyo_Jstnk)
 date: 2022/05/04
-modified: 2022/05/04
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1218.011
@@ -17,7 +17,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         Image|endswith: '\rundll32.exe'
     registry:
         TargetObject|contains: '\Control Panel\Desktop\SCRNSAVE.EXE'

--- a/rules/windows/registry/registry_set/registry_set_servicedll_hijack.yml
+++ b/rules/windows/registry/registry_set/registry_set_servicedll_hijack.yml
@@ -7,7 +7,7 @@ references:
     - https://www.hexacorn.com/blog/2013/09/19/beyond-good-ol-run-key-part-4/
 author: frack113
 date: 2022/02/04
-modified: 2022/09/20
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.privilege_escalation
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\System\CurrentControlSet\Services\'
         TargetObject|endswith: '\Parameters\ServiceDll'
     filter_printextensionmanger:

--- a/rules/windows/registry/registry_set/registry_set_services_etw_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_services_etw_tamper.yml
@@ -6,6 +6,7 @@ references:
     - http://redplait.blogspot.com/2020/07/whats-wrong-with-etw.html
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/12/09
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -15,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'Software\Microsoft\Windows NT\CurrentVersion\Tracing\SCM\Regular\TracingDisabled'
         Details: 'DWORD (0x00000001)' # Funny (sad) enough, this value is by default 1.
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_set_nopolicies_user.yml
+++ b/rules/windows/registry/registry_set/registry_set_set_nopolicies_user.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1112/T1112.md
 author: frack113
 date: 2022/03/18
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection_set_1:
-        EventType: SetValue
         TargetObject|endswith:
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoLogOff'
             - 'SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer\NoDesktop'

--- a/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_sip_persistence.yml
@@ -8,7 +8,7 @@ references:
     - https://specterops.io/assets/resources/SpecterOps_Subverting_Trust_in_Windows.pdf
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/07/21
-modified: 2022/09/21
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.defense_evasion
@@ -18,7 +18,6 @@ logsource:
     product: windows
 detection:
     selection_root:
-        EventType: SetValue
         TargetObject|contains:
             - '\SOFTWARE\Microsoft\Cryptography\Providers\'
             - '\SOFTWARE\Microsoft\Cryptography\OID\EncodingType'

--- a/rules/windows/registry/registry_set/registry_set_sophos_av_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_sophos_av_tamper.yml
@@ -6,6 +6,7 @@ references:
     - https://redacted.com/blog/bianlian-ransomware-gang-gives-it-a-go/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/09/02
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -14,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\Sophos Endpoint Defense\TamperProtection\Config\SAVEnabled'
             - '\Sophos Endpoint Defense\TamperProtection\Config\SEDEnabled'

--- a/rules/windows/registry/registry_set/registry_set_suppress_defender_notifications.yml
+++ b/rules/windows/registry/registry_set/registry_set_suppress_defender_notifications.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/40b77d63808dd4f4eafb83949805636735a1fd15/atomics/T1112/T1112.md
 author: frack113
 date: 2022/08/19
-modified: 2022/11/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'SOFTWARE\Policies\Microsoft\Windows Defender\UX Configuration\Notification_Suppress'
         Details: DWORD (0x00000001)
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_susp_keyboard_layout_load.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_keyboard_layout_load.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/SwiftOnSecurity/sysmon-config/pull/92/files
 author: Florian Roth (Nextron Systems)
 date: 2019/10/12
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.resource_development
     - attack.t1588.002
@@ -17,7 +17,6 @@ logsource:
     definition: 'Requirements: Sysmon config that monitors \Keyboard Layout\Preload subkey of the HKLU hives - see https://github.com/SwiftOnSecurity/sysmon-config/pull/92/files'
 detection:
     selection_registry:
-        EventType: SetValue
         TargetObject|contains:
             - '\Keyboard Layout\Preload\'
             - '\Keyboard Layout\Substitutes\'

--- a/rules/windows/registry/registry_set/registry_set_susp_printer_driver.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_printer_driver.yml
@@ -6,7 +6,7 @@ references:
     - https://twitter.com/SBousseaden/status/1410545674773467140
 author: Florian Roth (Nextron Systems)
 date: 2020/07/01
-modified: 2023/03/14
+modified: 2023/08/17
 tags:
     - attack.privilege_escalation
     - attack.t1574
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains|all:
             - '\Control\Print\Environments\Windows x64\Drivers'
             - '\Manufacturer'

--- a/rules/windows/registry/registry_set/registry_set_susp_reg_persist_explorer_run.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_reg_persist_explorer_run.yml
@@ -6,7 +6,7 @@ references:
     - https://researchcenter.paloaltonetworks.com/2018/07/unit42-upatre-continues-evolve-new-anti-analysis-techniques/
 author: Florian Roth (Nextron Systems), oscd.community
 date: 2018/07/18
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run'
     selection2:
         - Details|startswith:

--- a/rules/windows/registry/registry_set/registry_set_susp_run_key_img_folder.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_run_key_img_folder.yml
@@ -6,7 +6,7 @@ references:
     - https://www.fireeye.com/blog/threat-research/2018/08/fin7-pursuing-an-enigmatic-and-evasive-global-criminal-operation.html
 author: Florian Roth (Nextron Systems), Markus Neis, Sander Wiebing
 date: 2018/08/25
-modified: 2022/09/13
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection_target:
-        EventType: SetValue
         TargetObject|contains:
             - '\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\'
             - '\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce\'

--- a/rules/windows/registry/registry_set/registry_set_susp_service_installed.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_service_installed.yml
@@ -9,6 +9,7 @@ references:
 author: xknow (@xknow_infosec), xorxes (@xor_xes)
 date: 2019/04/08
 modified: 2022/12/07
+modified: 2023/08/17
 tags:
     - attack.t1562.001
     - attack.defense_evasion
@@ -17,7 +18,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject:
             - 'HKLM\System\CurrentControlSet\Services\NalDrv\ImagePath'
             - 'HKLM\System\CurrentControlSet\Services\PROCEXP152\ImagePath'

--- a/rules/windows/registry/registry_set/registry_set_susp_service_installed.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_service_installed.yml
@@ -8,7 +8,6 @@ references:
     - https://web.archive.org/web/20200419024230/https://blog.dylan.codes/evading-sysmon-and-windows-event-logging/
 author: xknow (@xknow_infosec), xorxes (@xor_xes)
 date: 2019/04/08
-modified: 2022/12/07
 modified: 2023/08/17
 tags:
     - attack.t1562.001

--- a/rules/windows/registry/registry_set/registry_set_susp_user_shell_folders.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_user_shell_folders.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/9e5b12c4912c07562aec7500447b11fa3e17e254/atomics/T1547.001/T1547.001.md
 author: frack113
 date: 2022/10/01
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.privilege_escalation
@@ -15,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: 'SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders'
         TargetObject|endswith: 'Startup' # cover Common Startup and Startup
         # can use Details|contains: path if get too many FP

--- a/rules/windows/registry/registry_set/registry_set_suspicious_env_variables.yml
+++ b/rules/windows/registry/registry_set/registry_set_suspicious_env_variables.yml
@@ -6,6 +6,7 @@ references:
     - https://infosec.exchange/@sbousseaden/109542254124022664
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/12/20
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -14,7 +15,6 @@ logsource:
     category: registry_set
 detection:
     selection_main:
-        EventType: SetValue
         TargetObject|contains: '\Environment\'
     selection_details:
         - Details:

--- a/rules/windows/registry/registry_set/registry_set_taskcache_entry.yml
+++ b/rules/windows/registry/registry_set/registry_set_taskcache_entry.yml
@@ -7,7 +7,7 @@ references:
     - https://labs.f-secure.com/blog/scheduled-task-tampering/
 author: Syed Hasan (@syedhasan009)
 date: 2021/06/18
-modified: 2022/10/21
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1053
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: 'SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\TaskCache\'
     filter:
         TargetObject|contains:

--- a/rules/windows/registry/registry_set/registry_set_telemetry_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_telemetry_persistence.yml
@@ -13,7 +13,7 @@ references:
     - https://www.trustedsec.com/blog/abusing-windows-telemetry-for-persistence/
 author: Lednyov Alexey, oscd.community, Sreeman
 date: 2020/10/16
-modified: 2023/08/01
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1053.005
@@ -23,7 +23,6 @@ logsource:
     definition: 'Requirements: Sysmon config that monitors \SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\TelemetryController subkey of the HKLM hives'
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\TelemetryController\'
         TargetObject|endswith: '\Command'
         Details|contains:

--- a/rules/windows/registry/registry_set/registry_set_terminal_server_tampering.yml
+++ b/rules/windows/registry/registry_set/registry_set_terminal_server_tampering.yml
@@ -21,7 +21,7 @@ references:
     - https://admx.help/HKLM/SOFTWARE/Policies/Microsoft/Windows%20NT/Terminal%20Services # Contain description for most of the keys mentioned here (check it out if you want more information)
 author: Samir Bousseaden, David ANDRE, Roberto Rodriguez @Cyb3rWard0g, Nasreddine Bencherchali
 date: 2022/08/06
-modified: 2022/09/29
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -31,7 +31,6 @@ logsource:
     product: windows
 detection:
     selection_shadow:
-        EventType: SetValue
         TargetObject|contains:
             - 'SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\'
             - '\Control\Terminal Server\'
@@ -42,7 +41,6 @@ detection:
             - 'DWORD (0x00000003)' # View Session with user’s permission
             - 'DWORD (0x00000004)' # View Session without user’s permission
     selection_terminal_services_key:
-        EventType: SetValue
         TargetObject|contains:
             - '\Control\Terminal Server\'
             - 'SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services\'
@@ -53,7 +51,6 @@ detection:
         Details: 'DWORD (0x00000001)'
     selection_tamper_only:
         # Any changes to these keys should be suspicious and looked at
-        EventType: SetValue
         TargetObject|contains:
             - '\services\TermService\Parameters\ServiceDll' # RDP hijacking
             - '\Control\Terminal Server\WinStations\RDP-Tcp\InitialProgram' # This value can be set to pecify a program to run automatically when a user logs on to a remote computer.

--- a/rules/windows/registry/registry_set/registry_set_timeproviders_dllname.yml
+++ b/rules/windows/registry/registry_set/registry_set_timeproviders_dllname.yml
@@ -9,6 +9,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1547.003/T1547.003.md
 author: frack113
 date: 2022/06/19
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.privilege_escalation
@@ -18,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|startswith: 'HKLM\System\CurrentControlSet\Services\W32Time\TimeProviders'
         TargetObject|endswith: 'DllName'
     filter:

--- a/rules/windows/registry/registry_set/registry_set_treatas_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_treatas_persistence.yml
@@ -7,7 +7,7 @@ references:
     - https://www.youtube.com/watch?v=3gz1QmiMhss&t=1251s
 author: frack113
 date: 2022/08/28
-modified: 2023/01/06
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1546.015
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'TreatAs\(Default)'
     filter_office:
         Image|startswith: 'C:\Program Files\Common Files\Microsoft Shared\ClickToRun\'

--- a/rules/windows/registry/registry_set/registry_set_turn_on_dev_features.yml
+++ b/rules/windows/registry/registry_set/registry_set_turn_on_dev_features.yml
@@ -10,6 +10,7 @@ references:
     - https://www.sentinelone.com/labs/inside-malicious-windows-apps-for-malware-deployment/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/01/12
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
 logsource:
@@ -17,7 +18,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains:
             - '\Microsoft\Windows\CurrentVersion\AppModelUnlock'
             - '\Policies\Microsoft\Windows\Appx\'

--- a/rules/windows/registry/registry_set/registry_set_uac_bypass_sdclt.yml
+++ b/rules/windows/registry/registry_set/registry_set_uac_bypass_sdclt.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/hfiref0x/UACME
 author: Omer Yampel, Christian Burkard (Nextron Systems)
 date: 2017/03/17
-modified: 2022/12/01
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
@@ -18,10 +18,8 @@ logsource:
     product: windows
 detection:
     selection1:
-        EventType: SetValue
         TargetObject|endswith: 'Software\Classes\exefile\shell\runas\command\isolatedCommand'
     selection2:
-        EventType: SetValue
         TargetObject|endswith: 'Software\Classes\Folder\shell\open\command\SymbolicLinkValue'
         Details|re: '-1[0-9]{3}\\Software\\Classes\\'
     condition: 1 of selection*

--- a/rules/windows/registry/registry_set/registry_set_uac_bypass_winsat.yml
+++ b/rules/windows/registry/registry_set/registry_set_uac_bypass_winsat.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/hfiref0x/UACME
 author: Christian Burkard (Nextron Systems)
 date: 2021/08/30
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: '\Root\InventoryApplicationFile\winsat.exe|'
         TargetObject|endswith: '\LowerCaseLongPath'
         Details|startswith: 'c:\users\'

--- a/rules/windows/registry/registry_set/registry_set_uac_bypass_wmp.yml
+++ b/rules/windows/registry/registry_set/registry_set_uac_bypass_wmp.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/hfiref0x/UACME
 author: Christian Burkard (Nextron Systems)
 date: 2021/08/23
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation
@@ -16,7 +16,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Compatibility Assistant\Store\C:\Program Files\Windows Media Player\osk.exe'
         Details: 'Binary Data'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_vbs_payload_stored.yml
+++ b/rules/windows/registry/registry_set/registry_set_vbs_payload_stored.yml
@@ -6,7 +6,7 @@ references:
     - https://www.microsoft.com/security/blog/2021/03/04/goldmax-goldfinder-sibot-analyzing-nobelium-malware/
 author: Florian Roth (Nextron Systems)
 date: 2021/03/05
-modified: 2022/09/19
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.001
@@ -15,7 +15,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|contains: 'Software\Microsoft\Windows\CurrentVersion'
         Details|contains:
             - 'vbscript:'

--- a/rules/windows/registry/registry_set/registry_set_wab_dllpath_reg_change.yml
+++ b/rules/windows/registry/registry_set/registry_set_wab_dllpath_reg_change.yml
@@ -8,7 +8,7 @@ references:
     - http://www.hexacorn.com/blog/2018/05/01/wab-exe-as-a-lolbin/
 author: oscd.community, Natalia Shornikova
 date: 2020/10/13
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1218
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Software\Microsoft\WAB\DLLPath'
     filter:
         Details: '%CommonProgramFiles%\System\wab32.dll'

--- a/rules/windows/registry/registry_set/registry_set_wdigest_enable_uselogoncredential.yml
+++ b/rules/windows/registry/registry_set/registry_set_wdigest_enable_uselogoncredential.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/73fcfa1d4863f6a4e17f90e54401de6e30a312bb/atomics/T1112/T1112.md#atomic-test-3---modify-registry-to-store-logon-credentials 
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 date: 2019/09/12
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1112
@@ -17,7 +17,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: 'WDigest\UseLogonCredential'
         Details: DWORD (0x00000001)
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_windows_defender_tamper.yml
+++ b/rules/windows/registry/registry_set/registry_set_windows_defender_tamper.yml
@@ -17,7 +17,7 @@ references:
     - https://www.tenforums.com/tutorials/123792-turn-off-tamper-protection-microsoft-defender-antivirus.html
 author: AlertIQ, Ján Trenčanský, frack113, Nasreddine Bencherchali, Swachchhanda Shrawan Poudel
 date: 2022/08/01
-modified: 2023/05/10
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -26,7 +26,6 @@ logsource:
     category: registry_set
 detection:
     selection_main:
-        EventType: SetValue
         TargetObject|contains:
             - '\SOFTWARE\Microsoft\Windows Defender\'
             - '\SOFTWARE\Policies\Microsoft\Windows Defender Security Center\'

--- a/rules/windows/registry/registry_set/registry_set_winget_admin_settings_tampering.yml
+++ b/rules/windows/registry/registry_set/registry_set_winget_admin_settings_tampering.yml
@@ -7,6 +7,7 @@ references:
     - https://github.com/microsoft/winget-cli/blob/02d2f93807c9851d73eaacb4d8811a76b64b7b01/src/AppInstallerCommonCore/Public/winget/AdminSettings.h#L13
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/04/17
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -15,7 +16,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         Image|endswith: '\winget.exe'
         TargetObject|startswith: '\REGISTRY\A\'
         TargetObject|endswith: '\LocalState\admin_settings'

--- a/rules/windows/registry/registry_set/registry_set_winget_enable_local_manifest.yml
+++ b/rules/windows/registry/registry_set/registry_set_winget_enable_local_manifest.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/nasbench/Misc-Research/tree/b9596e8109dcdb16ec353f316678927e507a5b8d/LOLBINs/Winget
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/04/17
+modified: 2023/08/17
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -14,7 +15,6 @@ logsource:
     category: registry_set
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\AppInstaller\EnableLocalManifestFiles'
         Details: 'DWORD (0x00000001)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_winlogon_allow_multiple_tssessions.yml
+++ b/rules/windows/registry/registry_set/registry_set_winlogon_allow_multiple_tssessions.yml
@@ -9,6 +9,7 @@ references:
     - http://blog.talosintelligence.com/2022/09/lazarus-three-rats.html
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/09/09
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.defense_evasion
@@ -18,7 +19,6 @@ logsource:
     product: windows
 detection:
     selection:
-        EventType: SetValue
         TargetObject|endswith: '\Microsoft\Windows NT\CurrentVersion\Winlogon\AllowMultipleTSSessions'
         Details|endswith: DWORD (0x00000001)
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_winlogon_notify_key.yml
+++ b/rules/windows/registry/registry_set/registry_set_winlogon_notify_key.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1547.004/T1547.004.md#atomic-test-3---winlogon-notify-key-logon-persistence---powershell
 author: frack113
 date: 2021/12/30
-modified: 2022/03/26
+modified: 2023/08/17
 tags:
     - attack.persistence
     - attack.t1547.004
@@ -19,7 +19,6 @@ detection:
     selection:
         TargetObject|endswith: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\Notify\logon'
         Details|endswith: '.dll'
-        EventType: SetValue
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process. PLEASE DO NOT DELETE ANY SECTION OR THE CONTENT OF THE TEMPLATE.
-->

### Summary of the Pull Request

<!--
**Please note that this Section is required and must be filled**
A short summary of your pull request. 
-->
Refractor registry_set  rules

### Detailed Description of the Pull Request / Additional Comments

<!--
**Please note that this Section is required and must be filled**
A detailed description of the pull request and any additional comments or context.
-->
With the logsource `registry_set`,  `EventType` will allways set to `SetValue`

when I split up the registry_event rules wiith the new logsource , I did not remove it on purpose.
I didn't want to disrupt detection until the logsource had been implemented.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
