### PR TITLE
Fix typos: tag -> tags

### DIFF
--- a/rules-emerging-threats/2022/Exploits/CVE-2022-21554/proc_creation_win_exploit_cve_2023_21554_queuejumper.yml
+++ b/rules-emerging-threats/2022/Exploits/CVE-2022-21554/proc_creation_win_exploit_cve_2023_21554_queuejumper.yml
@@ -6,7 +6,7 @@ references:
     - https://research.checkpoint.com/2023/queuejumper-critical-unauthorized-rce-vulnerability-in-msmq-service/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/04/12
-tag:
+tags:
     - attack.privilege_escalation
     - attack.execution
     - cve.2023.21554

--- a/rules-emerging-threats/2022/Exploits/CVE-2022-41120/proc_creation_win_exploit_cve_2022_41120_sysmon_eop.yml
+++ b/rules-emerging-threats/2022/Exploits/CVE-2022-41120/proc_creation_win_exploit_cve_2022_41120_sysmon_eop.yml
@@ -9,7 +9,7 @@ references:
 author: Florian Roth (Nextron Systems), Tim Shelton (fp werfault)
 date: 2022/11/10
 modified: 2022/12/30
-tag:
+tags:
     - attack.privilege_escalation
     - attack.t1068
     - cve.2022.41120


### PR DESCRIPTION
### Summary of the Pull Request

fix 2 rules that used 'tag' instead of 'tags'

### Detailed Description of the Pull Request / Additional Comments

change tag -> tags in the following rules:
- rules-emerging-threats/2022/Exploits/CVE-2022-21554/proc_creation_win_exploit_cve_2023_21554_queuejumper.yml
- rules-emerging-threats/2022/Exploits/CVE-2022-41120/proc_creation_win_exploit_cve_2022_41120_sysmon_eop.yml

### Example Log Event

n/a

### Fixed Issues

n/a

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
