### PR TITLE
Update lnx_auditd_network_service_scanning.yml

### DIFF
--- a/rules/linux/auditd/lnx_auditd_network_service_scanning.yml
+++ b/rules/linux/auditd/lnx_auditd_network_service_scanning.yml
@@ -25,6 +25,7 @@ detection:
             - '/nmap'
             - '/netcat'
             - '/nc'
+            - '/nc.openbsd'
         key: 'network_connect_4'
     condition: selection
 falsepositives:

--- a/rules/linux/auditd/lnx_auditd_network_service_scanning.yml
+++ b/rules/linux/auditd/lnx_auditd_network_service_scanning.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1046/T1046.md
 author: Alejandro Ortuno, oscd.community
 date: 2020/10/21
-modified: 2022/11/26
+modified: 2023/09/26
 tags:
     - attack.discovery
     - attack.t1046
@@ -25,6 +25,7 @@ detection:
             - '/nmap'
             - '/netcat'
             - '/nc'
+            - '/ncat'
             - '/nc.openbsd'
         key: 'network_connect_4'
     condition: selection


### PR DESCRIPTION
### Summary of the Pull Request

On modern OSs the binaries of `netcat` and `nc` point to `ns.openbsd`. This change expand the rule to catch these binaries as well.

### Changelog

update:	Network Service Scanning - incorporates modern binary names

### Example Log Event

Two example Auditd records from calls of `netcat` and `nc` from Ubuntu 22.04
```
type=SYSCALL msg=audit(1695734795.486:1434733): arch=c000003e syscall=9 success=yes exit=140647583555584 a0=0 a1=1 a2=3 a3=2 items=0 ppid=10964 pid=10974 auid=1001 uid=1001 gid=1001 euid=1001 suid=1001 fsuid=1001 egid=1001 sgid=1001 fsgid=1001 tty=pts1 ses=244 comm="nc" exe="/usr/bin/nc.openbsd" subj=unconfined key=(null)ARCH=x86_64 SYSCALL=mmap AUID="alice" UID="alice" GID="alice" EUID="alice" SUID="alice" FSUID="alice" EGID="alice" SGID="alice" FSGID="alice"
```

```
type=SYSCALL msg=audit(1695734795.514:1434860): arch=c000003e syscall=59 success=yes exit=0 a0=55b30bbe1838 a1=55b30b2c8808 a2=55b30bbe17a8 a3=7ffd4dcb6e46 items=2 ppid=10964 pid=10975 auid=1001 uid=1001 gid=1001 euid=1001 suid=1001 fsuid=1001 egid=1001 sgid=1001 fsgid=1001 tty=pts1 ses=244 comm="netcat" exe="/usr/bin/nc.openbsd" subj=unconfined key=(null)ARCH=x86_64 SYSCALL=execve AUID="alice" UID="alice" GID="alice" EUID="alice" SUID="alice" FSUID="alice" EGID="alice" SGID="alice" FSGID="alice"
```

### Fixed Issues

This rule will not catch calls of `nc` and `netcat` on Ubuntu 22.04