### PR TITLE
add winlog-channel to win_codeintegrity_revoked

### DIFF
--- a/rules/windows/builtin/code_integrity/win_codeintegrity_revoked_driver_loaded.yml
+++ b/rules/windows/builtin/code_integrity/win_codeintegrity_revoked_driver_loaded.yml
@@ -18,6 +18,7 @@ detection:
         EventID:
             - 3021 # Code Integrity determined a revoked kernel module %2 is loaded into the system.  Check with the publisher to see if a new signed version of the kernel module is available.
             - 3022 # Code Integrity determined a revoked kernel module %2 is loaded into the system. The image is allowed to load because kernel mode debugger is attached.
+            winlog.channel: Microsoft-Windows-Code Integrity/Operational
     condition: selection
 falsepositives:
     - Unlikely


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
-->
Hi, I am getting false positives in security-onion with this rule. Problem is that, the winlog.channel is not checked and therefore this rule gets triggerd also for other channels that are not the correct one.
Therefore I suggest to add the winlog.channel to this rule to avoid false positives.
Greetings
security-companion

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
-->
rules/windows/builtin/code_integrity/win_codeintegrity_revoked_driver_loaded.yml
update:	CodeIntegrity - Revoked Kernel Driver Loaded

### Example Log Event

<!--
-->
event_data.winlog.api | wineventlog
event_data.winlog.channel | Application

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
