### PR TITLE
Implement logsource product filter

### DIFF
--- a/tests/sigma-package-release.py
+++ b/tests/sigma-package-release.py
@@ -139,7 +139,7 @@ def select_rules(args: dict) -> list:
             # Filter rules if filtering for logsource products are used.
             # Either we filter for a specific logsource product or we filter that the product is not defined in a rule.
             logsource = rule["logsource"]
-            if len(args.logsource_products) >= 1 and args.logsource_products == ["None"]:
+            if len(args.logsource_products) == 1 and args.logsource_products == ["None"]:
                 # Include if product is missing in logsource
                 include = include and ("product" not in logsource)
             else:

--- a/tests/sigma-package-release.py
+++ b/tests/sigma-package-release.py
@@ -66,6 +66,9 @@ def init_arguments(arguments: list) -> list:
     parser.add_argument(
         "-r", "--rule-types", choices=RULES, nargs="*", help="Select type of rules"
     )
+    parser.add_argument(
+        "-p", "--logsource-products", nargs="*", help="Select logsource product(s) of rules"
+    )
     args = parser.parse_args(arguments)
 
     if not args.outfile.endswith(".zip"):
@@ -82,6 +85,10 @@ def init_arguments(arguments: list) -> list:
     if args.rule_types == None:
         args.rule_types = ["generic"]
         print('[I] -r/--rule-types not defined: Using "generic" by default')
+
+    if args.logsource_products == None:
+        args.logsource_products = []
+        print("[I] -p/--logsource-products not defined: Using all by default")
 
     if args.min_level != None:
         i = LEVEL.index(args.min_level)
@@ -126,7 +133,9 @@ def select_rules(args: dict) -> list:
 
             rule = rule_yaml[0]
             if rule["level"] in args.levels and rule["status"] in args.statuses:
-                selected_rules.append(file)
+                logsource = rule["logsource"]
+                if len(args.logsource_products) == 0 or (("product" in logsource) and logsource["product"] in args.logsource_products):
+                    selected_rules.append(file)
 
     return selected_rules
 

--- a/tests/sigma-package-release.py
+++ b/tests/sigma-package-release.py
@@ -132,10 +132,22 @@ def select_rules(args: dict) -> list:
                 continue
 
             rule = rule_yaml[0]
-            if rule["level"] in args.levels and rule["status"] in args.statuses:
-                logsource = rule["logsource"]
-                if len(args.logsource_products) == 0 or (("product" in logsource) and logsource["product"] in args.logsource_products):
-                    selected_rules.append(file)
+
+            # Base filter: Include rule if level and status matches.
+            include = rule["level"] in args.levels and rule["status"] in args.statuses
+
+            # Filter rules if filtering for logsource products are used.
+            # Either we filter for a specific logsource product or we filter that the product is not defined in a rule.
+            logsource = rule["logsource"]
+            if len(args.logsource_products) >= 1 and args.logsource_products == ["None"]:
+                # Include if product is missing in logsource
+                include = include and ("product" not in logsource)
+            else:
+                # Include if product is present in logsource
+                include = include and ("product" in logsource) and logsource["product"] in args.logsource_products
+
+            if include:
+                selected_rules.append(file)
 
     return selected_rules
 


### PR DESCRIPTION
### Summary of the Pull Request
This commit extends `sigma-package-release.py` and implements a `--logsource-products` or `-p` command line argument to filter rules to given products.

### Changelog
new: --logsource-products filter

### Example Log Event

n/a

### Fixed Issues

n/a

### SigmaHQ Rule Creation Conventions

n/a

### Example Usage

Filter stable rules having a `high` level but limit it to `windows` logsource product.
```
python ".\tests\sigma-package-release.py" --min-status stable --levels high -p windows --rule-types core --outfile sigma-high-windows.zip
```
