### PR TITLE
update: use original `Data` field instead of specific PowerShell Classic log's extracted field

### DIFF
--- a/rules/windows/powershell/powershell_classic/posh_pc_abuse_nslookup_with_dns_records.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_abuse_nslookup_with_dns_records.yml
@@ -4,7 +4,7 @@ related:
     - id: 1b3b01c7-84e9-4072-86e5-fc285a41ff23
       type: similar
 status: test
-description: Detects suspicious powershell download cradle using nslookup. This cradle uses nslookup to extract payloads from DNS records
+description: Detects a powershell download cradle using nslookup. This cradle uses nslookup to extract payloads from DNS records.
 references:
     - https://twitter.com/Alh4zr3d/status/1566489367232651264
 author: Sai Prashanth Pulisetti @pulisettis, Aishwarya Singam
@@ -17,13 +17,15 @@ logsource:
     product: windows
     category: ps_classic_start
 detection:
-    selection_ps:
-        Data: '*HostApplication=*powershell*nslookup*'
-    selection_param:
+    selection:
+        Data|contains|all:
+            - 'powershell'
+            - 'nslookup'
+            - '[1]'
         Data|contains:
-            - '-q=txt'
-            - '-querytype=txt'
-    condition: selection_ps or selection_param
+            - '-q=txt http'
+            - '-querytype=txt http'
+    condition: selection
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_classic/posh_pc_abuse_nslookup_with_dns_records.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_abuse_nslookup_with_dns_records.yml
@@ -9,23 +9,22 @@ references:
     - https://twitter.com/Alh4zr3d/status/1566489367232651264
 author: Sai Prashanth Pulisetti @pulisettis, Aishwarya Singam
 date: 2022/12/10
-modified: 2022/12/19
+modified: 2023/10/27
 tags:
     - attack.execution
     - attack.t1059.001
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
-    selection:
-        HostApplication|contains|all:
-            - 'powershell'
-            - 'nslookup'
-        HostApplication|contains:
+    selection_ps:
+        Data: '*HostApplication=*powershell*nslookup*'
+    selection_param:
+        Data|contains:
             - '-q=txt'
             - '-querytype=txt'
-    condition: selection
+    condition: selection_ps or selection_param
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_classic/posh_pc_abuse_nslookup_with_dns_records.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_abuse_nslookup_with_dns_records.yml
@@ -16,7 +16,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection_ps:
         Data: '*HostApplication=*powershell*nslookup*'

--- a/rules/windows/powershell/powershell_classic/posh_pc_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_alternate_powershell_hosts.yml
@@ -1,4 +1,4 @@
-title: Alternate PowerShell Hosts
+title: Uncommon PowerShell Hosts
 id: d7326048-328b-4d5e-98af-86e84b17c765
 related:
     - id: 64e8e417-c19a-475a-8d19-98ea705394cc
@@ -19,14 +19,18 @@ logsource:
 detection:
     selection:
         Data|contains: 'HostApplication='
-    # Use the filter list described in 64e8e417-c19a-475a-8d19-98ea705394cc to filter FPs
-    filter_ps:
+    # Note: Powershell Logging Data is localized. Meaning that "HostApplication" field will be translated to a different field on a non english layout. This rule doesn't take this into account due to the sheer ammount of possibilities. It's up to the user to add these cases.
+    filter_main_ps:
         Data|contains:
             - 'HostApplication=powershell'
-            - 'HostApplication=C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe'
-    filter_citrix:
-        Data: '*Context Information:*Citrix\ConfigSync\ConfigSync.ps1*'
-    condition: selection and not 1 of filter_*
+            - 'HostApplication=C:\Windows\System32\WindowsPowerShell\v1.0\powershell'
+            - 'HostApplication=C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell'
+            # In some cases powershell was invoked with inverted slashes
+            - 'HostApplication=C:/Windows/System32/WindowsPowerShell/v1.0/powershell'
+            - 'HostApplication=C:/Windows/SysWOW64/WindowsPowerShell/v1.0/powershell'
+    filter_optional_citrix:
+        Data|contains: 'Citrix\ConfigSync\ConfigSync.ps1*'
+    condition: selection and not 1 of filter_main_* and not 1 of filter_optional_*
 falsepositives:
     - Programs using PowerShell directly without invocation of a dedicated interpreter
     - MSP Detection Searcher

--- a/rules/windows/powershell/powershell_classic/posh_pc_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_alternate_powershell_hosts.yml
@@ -16,7 +16,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection:
         Data|contains: 'HostApplication='

--- a/rules/windows/powershell/powershell_classic/posh_pc_alternate_powershell_hosts.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_alternate_powershell_hosts.yml
@@ -9,24 +9,25 @@ references:
     - https://threathunterplaybook.com/hunts/windows/190815-RemoteServiceInstallation/notebook.html
 author: Roberto Rodriguez @Cyb3rWard0g
 date: 2019/08/11
-modified: 2023/04/12
+modified: 2023/10/27
 tags:
     - attack.execution
     - attack.t1059.001
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
     selection:
-        HostApplication|contains: '*'
-    filter:
-        # If you extracted the fields from this event. Use the filter list described in 64e8e417-c19a-475a-8d19-98ea705394cc to filter FPs
-        - HostApplication|startswith:
-              - 'powershell'
-              - 'C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe'
-        - ContextInfo|contains: 'Citrix\ConfigSync\ConfigSync.ps1'
-    condition: selection and not filter
+        Data|contains: 'HostApplication='
+    # Use the filter list described in 64e8e417-c19a-475a-8d19-98ea705394cc to filter FPs
+    filter_ps:
+        Data|contains:
+            - 'HostApplication=powershell'
+            - 'HostApplication=C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe'
+    filter_citrix:
+        Data: '*Context Information:*Citrix\ConfigSync\ConfigSync.ps1*'
+    condition: selection and not 1 of filter_*
 falsepositives:
     - Programs using PowerShell directly without invocation of a dedicated interpreter
     - MSP Detection Searcher

--- a/rules/windows/powershell/powershell_classic/posh_pc_delete_volume_shadow_copies.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_delete_volume_shadow_copies.yml
@@ -14,7 +14,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection_wmi:
         Data: '*HostApplication=*Get-WmiObject*Win32_Shadowcopy*'

--- a/rules/windows/powershell/powershell_classic/posh_pc_delete_volume_shadow_copies.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_delete_volume_shadow_copies.yml
@@ -7,23 +7,22 @@ references:
     - https://www.fortinet.com/blog/threat-research/stomping-shadow-copies-a-second-look-into-deletion-methods
 author: frack113
 date: 2021/06/03
-modified: 2021/10/16
+modified: 2023/10/27
 tags:
     - attack.impact
     - attack.t1490
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
-    selection:
-        HostApplication|contains|all:
-            - 'Get-WmiObject'
-            - ' Win32_Shadowcopy'
-        HostApplication|contains:
-            - 'Delete()'
+    selection_wmi:
+        Data: '*HostApplication=*Get-WmiObject*Win32_Shadowcopy*'
+    selection_cmd:
+        Data|contains:
             - 'Remove-WmiObject'
-    condition: selection
+            - 'Delete()'
+    condition: selection_wmi and selection_cmd
 fields:
     - HostApplication
 falsepositives:

--- a/rules/windows/powershell/powershell_classic/posh_pc_delete_volume_shadow_copies.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_delete_volume_shadow_copies.yml
@@ -15,15 +15,14 @@ logsource:
     product: windows
     category: ps_classic_start
 detection:
-    selection_wmi:
-        Data: '*HostApplication=*Get-WmiObject*Win32_Shadowcopy*'
-    selection_cmd:
+    selection:
+        Data|contains|all:
+            - 'Get-WmiObject'
+            - 'Win32_Shadowcopy'
         Data|contains:
-            - 'Remove-WmiObject'
             - 'Delete()'
-    condition: selection_wmi and selection_cmd
-fields:
-    - HostApplication
+            - 'Remove-WmiObject'
+    condition: selection
 falsepositives:
     - Legitimate Administrator deletes Shadow Copies using operating systems utilities for legitimate reason
 level: high

--- a/rules/windows/powershell/powershell_classic/posh_pc_downgrade_attack.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_downgrade_attack.yml
@@ -6,7 +6,7 @@ references:
     - http://www.leeholmes.com/blog/2017/03/17/detecting-and-preventing-powershell-downgrade-attacks/
 author: Florian Roth (Nextron Systems), Lee Holmes (idea), Harish Segar (improvements)
 date: 2017/03/22
-modified: 2022/12/02
+modified: 2023/10/27
 tags:
     - attack.defense_evasion
     - attack.execution
@@ -14,12 +14,12 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
     selection:
-        EngineVersion|startswith: '2.'
+        Data|contains: 'EngineVersion=2.'
     filter:
-        HostVersion|startswith: '2.'
+        Data|contains: 'HostVersion=2.'
     condition: selection and not filter
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_downgrade_attack.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_downgrade_attack.yml
@@ -14,7 +14,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection:
         Data|contains: 'EngineVersion=2.'

--- a/rules/windows/powershell/powershell_classic/posh_pc_downgrade_attack.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_downgrade_attack.yml
@@ -17,9 +17,9 @@ logsource:
 detection:
     selection:
         Data|contains: 'EngineVersion=2.'
-    filter:
+    filter_main:
         Data|contains: 'HostVersion=2.'
-    condition: selection and not filter
+    condition: selection and not filter_main
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_classic/posh_pc_exe_calling_ps.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_exe_calling_ps.yml
@@ -14,7 +14,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection_engine:
         Data|contains:

--- a/rules/windows/powershell/powershell_classic/posh_pc_exe_calling_ps.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_exe_calling_ps.yml
@@ -6,7 +6,7 @@ references:
     - https://adsecurity.org/?p=2921
 author: Sean Metcalf (source), Florian Roth (Nextron Systems)
 date: 2017/03/05
-modified: 2022/12/25
+modified: 2023/10/27
 tags:
     - attack.defense_evasion
     - attack.execution
@@ -14,15 +14,16 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
-    selection1:
-        EngineVersion|startswith:
-            - '2.'
-            - '4.'
-            - '5.'
-        HostVersion|startswith: '3.'
-    condition: selection1
+    selection_engine:
+        Data|contains:
+            - 'EngineVersion=2.'
+            - 'EngineVersion=4.'
+            - 'EngineVersion=5.'
+    selection_host:
+        Data|contains: 'HostVersion=3.'
+    condition: selection_engine and selection_host
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/powershell/powershell_classic/posh_pc_exe_calling_ps.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_exe_calling_ps.yml
@@ -22,7 +22,7 @@ detection:
             - 'EngineVersion=5.'
     selection_host:
         Data|contains: 'HostVersion=3.'
-    condition: selection_engine and selection_host
+    condition: all of selection_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/powershell/powershell_classic/posh_pc_powercat.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_powercat.yml
@@ -11,19 +11,19 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1095/T1095.md
 author: frack113
 date: 2021/07/21
-modified: 2022/12/25
+modified: 2023/10/27
 tags:
     - attack.command_and_control
     - attack.t1095
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
     selection:
-        HostApplication|contains:
-            - 'powercat '
-            - 'powercat.ps1'
+        Data:
+            - '*HostApplication=*powercat *'
+            - '*HostApplication=*powercat.ps1*'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_powercat.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_powercat.yml
@@ -18,7 +18,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection:
         Data:

--- a/rules/windows/powershell/powershell_classic/posh_pc_powercat.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_powercat.yml
@@ -20,9 +20,9 @@ logsource:
     category: ps_classic_start
 detection:
     selection:
-        Data:
-            - '*HostApplication=*powercat *'
-            - '*HostApplication=*powercat.ps1*'
+        Data|contains:
+            - 'powercat '
+            - 'powercat.ps1'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_remote_powershell_session.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_remote_powershell_session.yml
@@ -9,7 +9,7 @@ references:
     - https://threathunterplaybook.com/hunts/windows/190511-RemotePwshExecution/notebook.html
 author: Roberto Rodriguez @Cyb3rWard0g
 date: 2019/08/10
-modified: 2022/06/20
+modified: 2023/10/27
 tags:
     - attack.execution
     - attack.t1059.001
@@ -18,12 +18,13 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
-    selection:
-        HostName: 'ServerRemoteHost'
-        HostApplication|contains: 'wsmprovhost.exe'
-    condition: selection
+    selection_host:
+        Data|contains: 'HostName=ServerRemoteHost'
+    selection_app:
+        Data: '*HostApplication=*wsmprovhost.exe*'
+    condition: selection_host and selection_app
 falsepositives:
     - Legitimate use remote PowerShell sessions
 level: high

--- a/rules/windows/powershell/powershell_classic/posh_pc_remote_powershell_session.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_remote_powershell_session.yml
@@ -18,7 +18,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection_host:
         Data|contains: 'HostName=ServerRemoteHost'

--- a/rules/windows/powershell/powershell_classic/posh_pc_remote_powershell_session.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_remote_powershell_session.yml
@@ -19,11 +19,11 @@ logsource:
     product: windows
     category: ps_classic_start
 detection:
-    selection_host:
-        Data|contains: 'HostName=ServerRemoteHost'
-    selection_app:
-        Data: '*HostApplication=*wsmprovhost.exe*'
-    condition: selection_host and selection_app
+    selection:
+        Data|contains|all:
+            - 'HostName=ServerRemoteHost'
+            - 'wsmprovhost.exe'
+    condition: selection
 falsepositives:
     - Legitimate use remote PowerShell sessions
 level: high

--- a/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
@@ -16,11 +16,16 @@ logsource:
 detection:
     selection:
         Data|contains: 'HostName=ConsoleHost'
-    filter:
+    # Note: Powershell Logging Data is localized. Meaning that "HostApplication" field will be translated to a different field on a non english layout. This rule doesn't take this into account due to the sheer ammount of possibilities. It's up to the user to add these cases.
+    filter_main_ps:
         Data|contains:
-            - 'HostApplication=powershell.exe'
-            - 'HostApplication=C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe'
-    condition: selection and not filter
+            - 'HostApplication=powershell'
+            - 'HostApplication=C:\Windows\System32\WindowsPowerShell\v1.0\powershell'
+            - 'HostApplication=C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell'
+            # In some cases powershell was invoked with inverted slashes
+            - 'HostApplication=C:/Windows/System32/WindowsPowerShell/v1.0/powershell'
+            - 'HostApplication=C:/Windows/SysWOW64/WindowsPowerShell/v1.0/powershell'
+    condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown
 level: low

--- a/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
@@ -13,7 +13,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection:
         Data|contains: 'HostName=ConsoleHost'

--- a/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
@@ -6,21 +6,21 @@ references:
     - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse
 author: Harish Segar, frack113
 date: 2020/06/29
-modified: 2021/10/16
+modified: 2023/10/27
 tags:
     - attack.execution
     - attack.t1059.001
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
     selection:
-        HostName: ConsoleHost
+        Data|contains: 'HostName=ConsoleHost'
     filter:
-        HostApplication|startswith:
-            - powershell.exe
-            - C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe
+        Data|contains:
+            - 'HostApplication=powershell.exe'
+            - 'HostApplication=C:\WINDOWS\System32\WindowsPowerShell\v1.0\powershell.exe'
     condition: selection and not filter
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_download.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_download.yml
@@ -16,7 +16,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection_webclient:
         Data: '*HostApplication=*Net.WebClient*'

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_download.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_download.yml
@@ -18,11 +18,11 @@ logsource:
     category: ps_classic_start
 detection:
     selection_webclient:
-        Data: '*HostApplication=*Net.WebClient*'
+        Data|contains: 'Net.WebClient'
     selection_download:
-        Data:
-            - '*HostApplication=*.DownloadFile(*'
-            - '*HostApplication=*.DownloadString(*'
+        Data|contains:
+            - '.DownloadFile('
+            - '.DownloadString('
     condition: all of selection_*
 falsepositives:
     - PowerShell scripts that download content from the Internet

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_download.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_download.yml
@@ -9,21 +9,21 @@ references:
     - https://www.trendmicro.com/en_us/research/22/j/lv-ransomware-exploits-proxyshell-in-attack.html
 author: Florian Roth (Nextron Systems)
 date: 2017/03/05
-modified: 2022/11/09
+modified: 2023/10/27
 tags:
     - attack.execution
     - attack.t1059.001
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
     selection_webclient:
-        HostApplication|contains: 'Net.WebClient'
+        Data: '*HostApplication=*Net.WebClient*'
     selection_download:
-        HostApplication|contains:
-            - '.DownloadFile('
-            - '.DownloadString('
+        Data:
+            - '*HostApplication=*.DownloadFile(*'
+            - '*HostApplication=*.DownloadString(*'
     condition: all of selection_*
 falsepositives:
     - PowerShell scripts that download content from the Internet

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_get_nettcpconnection.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_get_nettcpconnection.yml
@@ -6,17 +6,17 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1049/T1049.md#atomic-test-2---system-network-connections-discovery-with-powershell
 author: frack113
 date: 2021/12/10
-modified: 2022/12/25
+modified: 2023/10/27
 tags:
     - attack.discovery
     - attack.t1049
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
     selection:
-        HostApplication|contains: Get-NetTCPConnection
+        Data: '*HostApplication=*Get-NetTCPConnection*'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_get_nettcpconnection.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_get_nettcpconnection.yml
@@ -15,7 +15,7 @@ logsource:
     category: ps_classic_start
 detection:
     selection:
-        Data: '*HostApplication=*Get-NetTCPConnection*'
+        Data|contains: 'Get-NetTCPConnection'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_get_nettcpconnection.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_get_nettcpconnection.yml
@@ -13,7 +13,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection:
         Data: '*HostApplication=*Get-NetTCPConnection*'

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
@@ -9,22 +9,23 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1074.001/T1074.001.md
 author: frack113
 date: 2021/07/20
-modified: 2022/12/02
+modified: 2023/10/27
 tags:
     - attack.collection
     - attack.t1074.001
 logsource:
     product: windows
     service: powershell-classic
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
-    selection:
-        HostApplication|contains|all:
-            - 'Compress-Archive '
-            - ' -Path '
-            - ' -DestinationPath '
-            - '$env:TEMP\'
-    condition: selection
+     selection_cmd:
+         Data: '*HostApplication=*Compress-Archive*'
+     selection_params:
+         Data|contains|all:
+             - ' -Path '
+             - ' -DestinationPath '
+             - '$env:TEMP\'
+     condition: selection_cmd and selection_params
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
@@ -18,14 +18,14 @@ logsource:
     service: powershell-classic
     definition: No need to extract fields from the event
 detection:
-     selection_cmd:
-         Data: '*HostApplication=*Compress-Archive*'
-     selection_params:
-         Data|contains|all:
-             - ' -Path '
-             - ' -DestinationPath '
-             - '$env:TEMP\'
-     condition: selection_cmd and selection_params
+    selection_cmd:
+        Data: '*HostApplication=*Compress-Archive*'
+    selection_params:
+        Data|contains|all:
+           - ' -Path '
+           - ' -DestinationPath '
+           - '$env:TEMP\'
+    condition: selection_cmd and selection_params
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
@@ -16,7 +16,6 @@ tags:
 logsource:
     product: windows
     service: powershell-classic
-    definition: No need to extract fields from the event
 detection:
     selection_cmd:
         Data: '*HostApplication=*Compress-Archive*'

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
@@ -17,14 +17,13 @@ logsource:
     product: windows
     service: powershell-classic
 detection:
-    selection_cmd:
-        Data: '*HostApplication=*Compress-Archive*'
-    selection_params:
+    selection:
         Data|contains|all:
+            - 'Compress-Archive'
             - ' -Path '
             - ' -DestinationPath '
             - '$env:TEMP\'
-    condition: selection_cmd and selection_params
+    condition: selection
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_susp_zip_compress.yml
@@ -22,9 +22,9 @@ detection:
         Data: '*HostApplication=*Compress-Archive*'
     selection_params:
         Data|contains|all:
-           - ' -Path '
-           - ' -DestinationPath '
-           - '$env:TEMP\'
+            - ' -Path '
+            - ' -DestinationPath '
+            - '$env:TEMP\'
     condition: selection_cmd and selection_params
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_tamper_windows_defender_set_mp.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_tamper_windows_defender_set_mp.yml
@@ -16,7 +16,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_provider_start
-    definition: No need to extract fields from the event
 detection:
     selection_options_disabling_preference:
         Data: '*HostApplication=*Set-MpPreference*'

--- a/rules/windows/powershell/powershell_classic/posh_pc_tamper_windows_defender_set_mp.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_tamper_windows_defender_set_mp.yml
@@ -9,19 +9,19 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1562.001/T1562.001.md
 author: frack113, Nasreddine Bencherchali (Nextron Systems)
 date: 2021/06/07
-modified: 2023/07/13
+modified: 2023/10/27
 tags:
     - attack.defense_evasion
     - attack.t1562.001
 logsource:
     product: windows
     category: ps_classic_provider_start
-    definition: fields have to be extracted from the event
+    definition: No need to extract fields from the event
 detection:
     selection_options_disabling_preference:
-        HostApplication|contains: 'Set-MpPreference'
+        Data: '*HostApplication=*Set-MpPreference*'
     selection_options_disabling_function:
-        HostApplication|contains:
+        Data|contains:
             - '-dbaf $true'
             - '-dbaf 1'
             - '-dbm $true'
@@ -61,9 +61,9 @@ detection:
             - '-dss $true'
             - '-dss 1'
     selection_other_default_actions_allow:
-        HostApplication|contains: 'Set-MpPreference'
+        Data: '*HostApplication=*Set-MpPreference*'
     selection_other_default_actions_func:
-        HostApplication|contains:
+        Data|contains:
             - 'HighThreatDefaultAction Allow'
             - 'htdefac Allow'
             - 'LowThreatDefaultAction Allow'

--- a/rules/windows/powershell/powershell_classic/posh_pc_tamper_windows_defender_set_mp.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_tamper_windows_defender_set_mp.yml
@@ -1,7 +1,7 @@
 title: Tamper Windows Defender - PSClassic
 id: ec19ebab-72dc-40e1-9728-4c0b805d722c
 related:
-    - id: ec19ebab-72dc-40e1-9728-4c0b805d722c
+    - id: 14c71865-6cd3-44ae-adaa-1db923fae5f2
       type: similar
 status: experimental
 description: Attempting to disable scheduled scanning and other parts of Windows Defender ATP or set default actions to allow.
@@ -17,9 +17,9 @@ logsource:
     product: windows
     category: ps_classic_provider_start
 detection:
-    selection_options_disabling_preference:
-        Data: '*HostApplication=*Set-MpPreference*'
-    selection_options_disabling_function:
+    selection_set_mppreference:
+        Data|contains: 'Set-MpPreference'
+    selection_options_bool_allow:
         Data|contains:
             - '-dbaf $true'
             - '-dbaf 1'
@@ -59,9 +59,7 @@ detection:
             - '-dsnf 1'
             - '-dss $true'
             - '-dss 1'
-    selection_other_default_actions_allow:
-        Data: '*HostApplication=*Set-MpPreference*'
-    selection_other_default_actions_func:
+    selection_options_actions_func:
         Data|contains:
             - 'HighThreatDefaultAction Allow'
             - 'htdefac Allow'
@@ -71,7 +69,7 @@ detection:
             - 'mtdefac Allow'
             - 'SevereThreatDefaultAction Allow'
             - 'stdefac Allow'
-    condition: all of selection_options_disabling_* or 1 of selection_other_*
+    condition: selection_set_mppreference and 1 of selection_options_*
 falsepositives:
     - Legitimate PowerShell scripts that disable Windows Defender for troubleshooting purposes. Must be investigated.
 level: high

--- a/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
@@ -20,9 +20,15 @@ logsource:
 detection:
     selection:
         Data|contains: 'ProviderName=WSMan'
-    filter:
-        Data: '*HostApplication=*powershell*'
-    condition: selection and not filter
+    filter_main_ps:
+        Data|contains:
+            - 'HostApplication=powershell'
+            - 'HostApplication=C:\Windows\System32\WindowsPowerShell\v1.0\powershell'
+            - 'HostApplication=C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell'
+            # In some cases powershell was invoked with inverted slashes
+            - 'HostApplication=C:/Windows/System32/WindowsPowerShell/v1.0/powershell'
+            - 'HostApplication=C:/Windows/SysWOW64/WindowsPowerShell/v1.0/powershell'
+    condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
@@ -17,7 +17,6 @@ tags:
 logsource:
     product: windows
     service: powershell-classic
-    definition: No need to extract fields from the event
 detection:
     selection:
         Data|contains: 'ProviderName=WSMan'

--- a/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/bohops/WSMan-WinRM
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 date: 2020/06/24
-modified: 2022/10/09
+modified: 2023/10/27
 tags:
     - attack.execution
     - attack.t1059.001
@@ -17,12 +17,12 @@ tags:
 logsource:
     product: windows
     service: powershell-classic
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
     selection:
-        ProviderName: WSMan
+        Data|contains: 'ProviderName=WSMan'
     filter:
-        HostApplication|contains: powershell
+        Data: '*HostApplication=*powershell*'
     condition: selection and not filter
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_xor_commandline.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_xor_commandline.yml
@@ -6,22 +6,22 @@ references:
     - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse?slide=46
 author: Teymur Kheirkhabarov, Harish Segar (rule)
 date: 2020/06/29
-modified: 2022/12/02
+modified: 2023/10/27
 tags:
     - attack.execution
     - attack.t1059.001
 logsource:
     product: windows
     category: ps_classic_start
-    definition: fields have to be extract from event
+    definition: No need to extract fields from the event
 detection:
     selection:
-        HostName: 'ConsoleHost'
+        Data|contains: 'HostName=ConsoleHost'
     filter:
-        HostApplication|contains:
-            - 'bxor'
-            - 'join'
-            - 'char'
+        Data:
+            - '*HostApplication=*bxor*'
+            - '*HostApplication=*join*'
+            - '*HostApplication=*char*'
     condition: selection and filter
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_xor_commandline.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_xor_commandline.yml
@@ -17,10 +17,10 @@ detection:
     selection:
         Data|contains: 'HostName=ConsoleHost'
     filter:
-        Data:
-            - '*HostApplication=*bxor*'
-            - '*HostApplication=*join*'
-            - '*HostApplication=*char*'
+        Data|contains:
+            - 'bxor'
+            - 'char'
+            - 'join'
     condition: selection and filter
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_xor_commandline.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_xor_commandline.yml
@@ -13,7 +13,6 @@ tags:
 logsource:
     product: windows
     category: ps_classic_start
-    definition: No need to extract fields from the event
 detection:
     selection:
         Data|contains: 'HostName=ConsoleHost'


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request
Changed detection rules in `PowerShell Classic` to refer original `Data` fields instead of extracted specific fields. 
Please see the discussion below for more information on the background behind this PR.
https://github.com/SigmaHQ/sigma/discussions/4510

~~If there are no problems with the changes in this PR, I will also modify the `Task Scheduler` detection rules in another PR.~~
(↑Sorry, the Task scheduler event log fields was defined in XML.)

I would appreciate it if you could review.

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request. 
-->

### Changelog
update: Suspicious XOR Encoded PowerShell Command Line - PowerShell
update: Uncommon PowerShell Hosts
update: Delete Volume Shadow Copies Via WMI With PowerShell
update: PowerShell Downgrade Attack - PowerShell
update: PowerShell Called from an Executable Version Mismatch
update: Netcat The Powershell Version
update: Remote PowerShell Session (PS Classic)
update: Renamed Powershell Under Powershell Channel
update: Suspicious PowerShell Download
update: Use Get-NetTCPConnection
update: Zip A Folder With PowerShell For Staging In Temp - PowerShell
update: Tamper Windows Defender - PSClassic
update: Suspicious Non PowerShell WSMAN COM Provider
update: Suspicious XOR Encoded PowerShell Command Line - PowerShell


<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
-->

### Example Log Event
The EID:400 log sample for `Windows PowerShell.evtx` is as follows: 
(It's not malicious one. But I'm pasting it so you can see the evtx format specification)
```xml
<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
  <System>
    <Provider Name="PowerShell" /> 
    <EventID Qualifiers="0">400</EventID> 
    <Version>0</Version> 
    <Level>4</Level> 
    <Task>4</Task> 
    <Opcode>0</Opcode> 
    <Keywords>0x80000000000000</Keywords> 
    <TimeCreated SystemTime="2023-10-09T13:24:55.2952147Z" /> 
    <EventRecordID>1643</EventRecordID> 
    <Correlation /> 
    <Execution ProcessID="4684" ThreadID="0" /> 
    <Channel>Windows PowerShell</Channel> 
    <Computer>HOSTA</Computer> 
    <Security /> 
  </System>
  <EventData>
    <Data>Available</Data> 
    <Data>None</Data> 
    <Data>NewEngineState=Available PreviousEngineState=None SequenceNumber=13 HostName=ConsoleHost HostVersion=5.1.22621.963 HostId=e2a4b19b-92ef-407b-9fe0-b646489b66c5 HostApplication=C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -Command Get-WmiObject Win32_Process | Where-Object { $_.ExecutablePath -eq 'C:\Users\alice\AppData\Local\Programs\Microsoft VS Code\bin\code-tunnel.exe' } | Select @{Name='Id'; Expression={$_.ProcessId}} | Stop-Process -Force EngineVersion=5.1.22621.963 RunspaceId=e1518a29-e3b8-41d3-931a-ff4db039a628 PipelineId= CommandName= CommandType= ScriptName= CommandPath= CommandLine=</Data> 
  </EventData>
</Event>
```
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues
N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
