### PR TITLE
Rule parse error fix: remove extra asterisk

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_webshell_susp_process_spawned_from_webserver.yml
+++ b/rules/windows/process_creation/proc_creation_win_webshell_susp_process_spawned_from_webserver.yml
@@ -7,7 +7,7 @@ references:
     - https://media.defense.gov/2020/Jun/09/2002313081/-1/-1/0/CSI-DETECT-AND-PREVENT-WEB-SHELL-MALWARE-20200422.PDF
 author: Thomas Patzke, Florian Roth (Nextron Systems), Zach Stanford @svch0st, Tim Shelton, Nasreddine Bencherchali (Nextron Systems)
 date: 2019/01/16
-modified: 2023/11/09
+modified: 2023/11/11
 tags:
     - attack.persistence
     - attack.t1505.003

--- a/rules/windows/process_creation/proc_creation_win_webshell_susp_process_spawned_from_webserver.yml
+++ b/rules/windows/process_creation/proc_creation_win_webshell_susp_process_spawned_from_webserver.yml
@@ -81,7 +81,7 @@ detection:
         CommandLine|contains|all:
             - 'sc query'
             - 'ADManager Plus'
-    condition: 1 of selection_webserver_* and selection_anomaly_children and not 1 of filter_main_**
+    condition: 1 of selection_webserver_* and selection_anomaly_children and not 1 of filter_main_*
 falsepositives:
     - Particular web applications may spawn a shell process legitimately
 level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Fixes rule parsing error.

### Fixed Issues

Hayabusa and probably other backends cannot parse this rule because it has an extra unneeded asterisk in the condition so I changed it to a single asterisk.