### PR TITLE
Add ATT&CK Group Tag For Some Emerging Threats Rules

### DIFF
--- a/rules-emerging-threats/2021/TA/HAFNIUM/proc_creation_win_apt_hafnium.yml
+++ b/rules-emerging-threats/2021/TA/HAFNIUM/proc_creation_win_apt_hafnium.yml
@@ -15,6 +15,7 @@ tags:
     - attack.persistence
     - attack.t1546
     - attack.t1053
+    - attack.g0125
     - detection.emerging_threats
 logsource:
     category: process_creation

--- a/rules-emerging-threats/2021/TA/HAFNIUM/web_exchange_exploitation_hafnium.yml
+++ b/rules-emerging-threats/2021/TA/HAFNIUM/web_exchange_exploitation_hafnium.yml
@@ -11,6 +11,7 @@ modified: 2023/01/02
 tags:
     - attack.initial_access
     - attack.t1190
+    - attack.g0125
     - detection.emerging_threats
 logsource:
     category: webserver

--- a/rules-emerging-threats/2023/TA/EquationGroup/net_dns_apt_equation_group_triangulation_c2_coms.yml
+++ b/rules-emerging-threats/2023/TA/EquationGroup/net_dns_apt_equation_group_triangulation_c2_coms.yml
@@ -12,6 +12,7 @@ author: Florian Roth (Nextron Systems)
 date: 2023/06/01
 tags:
     - attack.command_and_control
+    - attack.g0020
     - detection.emerging_threats
 logsource:
     category: dns

--- a/rules-emerging-threats/2023/TA/EquationGroup/proxy_apt_equation_group_triangulation_c2_coms.yml
+++ b/rules-emerging-threats/2023/TA/EquationGroup/proxy_apt_equation_group_triangulation_c2_coms.yml
@@ -12,6 +12,7 @@ author: Florian Roth (Nextron Systems)
 date: 2023/06/01
 tags:
     - attack.command_and_control
+    - attack.g0020
     - detection.emerging_threats
 logsource:
     category: proxy

--- a/rules-emerging-threats/2023/TA/FIN7/file_event_win_apt_fin7_powershell_scripts_naming_convention.yml
+++ b/rules-emerging-threats/2023/TA/FIN7/file_event_win_apt_fin7_powershell_scripts_naming_convention.yml
@@ -8,6 +8,7 @@ author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/04
 tags:
     - attack.execution
+    - attack.g0046
     - detection.emerging_threats
 logsource:
     category: file_event

--- a/rules-emerging-threats/2023/TA/FIN7/posh_ps_apt_fin7_powerhold.yml
+++ b/rules-emerging-threats/2023/TA/FIN7/posh_ps_apt_fin7_powerhold.yml
@@ -9,6 +9,7 @@ date: 2023/05/04
 tags:
     - attack.execution
     - attack.t1059.001
+    - attack.g0046
     - detection.emerging_threats
 logsource:
     product: windows

--- a/rules-emerging-threats/2023/TA/FIN7/posh_ps_apt_fin7_powertrash_execution.yml
+++ b/rules-emerging-threats/2023/TA/FIN7/posh_ps_apt_fin7_powertrash_execution.yml
@@ -9,6 +9,7 @@ date: 2023/05/04
 tags:
     - attack.execution
     - attack.t1059.001
+    - attack.g0046
     - detection.emerging_threats
 logsource:
     product: windows

--- a/rules-emerging-threats/2023/TA/FIN7/proc_creation_win_apt_fin7_powertrash_lateral_movement.yml
+++ b/rules-emerging-threats/2023/TA/FIN7/proc_creation_win_apt_fin7_powertrash_lateral_movement.yml
@@ -10,6 +10,7 @@ author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/04
 tags:
     - attack.execution
+    - attack.g0046
     - detection.emerging_threats
 logsource:
     category: process_creation

--- a/rules-emerging-threats/2023/TA/Lazarus/image_load_apt_lazarus_side_load_activity.yml
+++ b/rules-emerging-threats/2023/TA/Lazarus/image_load_apt_lazarus_side_load_activity.yml
@@ -12,6 +12,7 @@ tags:
     - attack.privilege_escalation
     - attack.t1574.001
     - attack.t1574.002
+    - attack.g0032
     - detection.emerging_threats
 logsource:
     product: windows

--- a/rules-emerging-threats/2023/TA/Mustang-Panda-Australia-Campaign/proc_creation_win_apt_mustang_panda_indicators.yml
+++ b/rules-emerging-threats/2023/TA/Mustang-Panda-Australia-Campaign/proc_creation_win_apt_mustang_panda_indicators.yml
@@ -8,6 +8,7 @@ author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/05/15
 tags:
     - attack.execution
+    - attack.g0129
     - detection.emerging_threats
 logsource:
     category: process_creation


### PR DESCRIPTION
### Summary of the Pull Request

Add ATT&CK group tags to some of the emerging threats rules

### Changelog

update: Exchange Exploitation Used by HAFNIUM - Add related ATT&CK group tag
update: Potential Operation Triangulation C2 Beaconing Activity - DNS - Add related ATT&CK group tag
update : Potential Operation Triangulation C2 Beaconing Activity - Proxy - Add related ATT&CK group tag
update : Potential POWERTRASH Script Execution - Add related ATT&CK group tag
update : Potential APT FIN7 Related PowerShell Script Created - Add related ATT&CK group tag
update : Potential APT FIN7 POWERHOLD Execution - Add related ATT&CK group tag
update : Potential APT Mustang Panda Activity Against Australian Gov - Add related ATT&CK group tag
update : Potential APT FIN7 Reconnaissance/POWERTRASH Related Activity - Add related ATT&CK group tag

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:


-->

### Example Log Event

N/A
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
