### PR TITLE
Use `expand` modifier to tranform placeholders

### DIFF
--- a/rules-placeholder/cloud/azure/azure_ad_account_created_deleted_nonapproved_user.yml
+++ b/rules-placeholder/cloud/azure/azure_ad_account_created_deleted_nonapproved_user.yml
@@ -19,7 +19,7 @@ detection:
             - Delete user
         Status: Sucess
     valid_admin:
-        Initiatied.By: '%ApprovedUserUpn%'
+        Initiatied.By|expand: '%ApprovedUserUpn%'
     condition: selection and not valid_admin
 falsepositives:
     - Legit administrative action

--- a/rules-placeholder/cloud/azure/azure_ad_account_created_deleted_nonapproved_user.yml
+++ b/rules-placeholder/cloud/azure/azure_ad_account_created_deleted_nonapproved_user.yml
@@ -6,6 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/security-operations-user-accounts#short-lived-accounts
 author: Mark Morowczynski '@markmorow', MikeDuddington, '@dudders1'
 date: 2022/08/11
+modified: 2023/12/15
 tags:
     - attack.defense_evasion
     - attack.t1078

--- a/rules-placeholder/cloud/azure/azure_ad_account_signin_outside_hours.yml
+++ b/rules-placeholder/cloud/azure/azure_ad_account_signin_outside_hours.yml
@@ -6,6 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/security-operations-user-accounts#monitoring-for-failed-unusual-sign-ins
 author: Mark Morowczynski '@markmorow', MikeDuddington, '@dudders1'
 date: 2022/08/11
+modified: 2023/12/15
 tags:
     - attack.persistence
     - attack.t1078

--- a/rules-placeholder/cloud/azure/azure_ad_account_signin_outside_hours.yml
+++ b/rules-placeholder/cloud/azure/azure_ad_account_signin_outside_hours.yml
@@ -16,9 +16,9 @@ detection:
     selection:
         Status: Sucess
         # Countries you DO operate out of e,g GB, use list for mulitple
-        Location: '%LegitCountries%'
+        Location|expand: '%LegitCountries%'
         # outside normal working hours
-        Date: '%ClosingTime%'
+        Date|expand: '%ClosingTime%'
     condition: selection
 falsepositives:
     - User doing actual work outside of normal business hours.

--- a/rules-placeholder/cloud/azure/azure_privileged_account_no_saw_paw.yml
+++ b/rules-placeholder/cloud/azure/azure_privileged_account_no_saw_paw.yml
@@ -6,6 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/security-operations-privileged-accounts#things-to-monitor
 author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
 date: 2022/08/11
+modified: 2023/12/15
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation

--- a/rules-placeholder/cloud/azure/azure_privileged_account_no_saw_paw.yml
+++ b/rules-placeholder/cloud/azure/azure_privileged_account_no_saw_paw.yml
@@ -18,10 +18,10 @@ detection:
     selection:
         properties.message|contains: Add memmber to role completed (PIM aciviation)
         # Countries you DO operate out of e,g GB, use list for mulitple
-        Location: '%LegitCountries%'
-        IPaddress: '%UnApprovedIp%'
+        Location|expand: '%LegitCountries%'
+        IPaddress|expand: '%UnApprovedIp%'
         # unapproved browser, operating system
-        DeviceInfo: '%UnApprovedDevice%'
+        DeviceInfo|expand: '%UnApprovedDevice%'
         DeviceDetail.isCompliant: 'false'
         Status:
             - Sucess

--- a/rules-placeholder/cloud/azure/azure_privileged_account_sigin_expected_controls.yml
+++ b/rules-placeholder/cloud/azure/azure_privileged_account_sigin_expected_controls.yml
@@ -6,6 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/security-operations-privileged-accounts#things-to-monitor
 author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
 date: 2022/08/11
+modified: 2023/12/15
 tags:
     - attack.defense_evasion
     - attack.t1078

--- a/rules-placeholder/cloud/azure/azure_privileged_account_sigin_expected_controls.yml
+++ b/rules-placeholder/cloud/azure/azure_privileged_account_sigin_expected_controls.yml
@@ -17,10 +17,10 @@ detection:
     selection:
         Status: failure
         # Countries you do NOT operate out of e,g GB, use list for mulitple
-        Location: '%UnLegitCountries%'
-        IPaddress: '%UnApprovedIp%'
+        Location|expand: '%UnLegitCountries%'
+        IPaddress|expand: '%UnApprovedIp%'
         # unapproved browser, operating system
-        DeviceInfo: '%UnApprovedDevice%'
+        DeviceInfo|expand: '%UnApprovedDevice%'
     condition: selection
 falsepositives:
     - A legit admin not following proper processes

--- a/rules-placeholder/cloud/azure/azure_privileged_account_signin_outside_hours.yml
+++ b/rules-placeholder/cloud/azure/azure_privileged_account_signin_outside_hours.yml
@@ -17,10 +17,10 @@ detection:
     selection:
         Status: Sucess
         # Countries you DO operate out of e,g GB, use list for mulitple
-        Location: '%LegitCountries%'
+        Location|expand: '%LegitCountries%'
         # outside normal working hours
-        Date: '%ClosingTime%'
-        Initiatied.By: '%ApprovedUserUpn%'
+        Date|expand: '%ClosingTime%'
+        Initiatied.By|expand: '%ApprovedUserUpn%'
     condition: selection
 falsepositives:
     - An admin doing actual work outside of normal business hours

--- a/rules-placeholder/cloud/azure/azure_privileged_account_signin_outside_hours.yml
+++ b/rules-placeholder/cloud/azure/azure_privileged_account_signin_outside_hours.yml
@@ -6,6 +6,7 @@ references:
     - https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/security-operations-privileged-accounts#things-to-monitor
 author: Mark Morowczynski '@markmorow', Yochana Henderson, '@Yochana-H'
 date: 2022/08/11
+modified: 2023/12/15
 tags:
     - attack.persistence
     - attack.t1078

--- a/rules-placeholder/windows/builtin/security/win_security_exploit_cve_2020_1472.yml
+++ b/rules-placeholder/windows/builtin/security/win_security_exploit_cve_2020_1472.yml
@@ -7,7 +7,7 @@ references:
     - https://www.logpoint.com/en/blog/detecting-zerologon-vulnerability-in-logpoint/
 author: Aleksandr Akhremchik, @aleqs4ndr, ocsd.community
 date: 2020/10/15
-modified: 2023/04/25
+modified: 2023/12/15
 tags:
     - attack.privilege_escalation
     - attack.t1068

--- a/rules-placeholder/windows/builtin/security/win_security_exploit_cve_2020_1472.yml
+++ b/rules-placeholder/windows/builtin/security/win_security_exploit_cve_2020_1472.yml
@@ -19,7 +19,7 @@ detection:
     selection:
         EventID: 4742
         SubjectUserName: 'ANONYMOUS LOGON'
-        TargetUserName: '%DC-MACHINE-NAME%' # DC machine account name that ends with '$'
+        TargetUserName|expand: '%DC-MACHINE-NAME%' # DC machine account name that ends with '$'
     filter_main:
         PasswordLastSet: '-'
     condition: selection and not filter_main

--- a/rules-placeholder/windows/builtin/security/win_security_potential_pass_the_hash.yml
+++ b/rules-placeholder/windows/builtin/security/win_security_potential_pass_the_hash.yml
@@ -22,8 +22,8 @@ detection:
             - 4625
         LogonType: 3
         LogonProcessName: 'NtLmSsp'
-        WorkstationName: '%Workstations%'
-        ComputerName: '%Workstations%'
+        WorkstationName|expand: '%Workstations%'
+        ComputerName|expand: '%Workstations%'
     filter:
         TargetUserName: 'ANONYMOUS LOGON'
     condition: selection and not filter

--- a/rules-placeholder/windows/builtin/security/win_security_potential_pass_the_hash.yml
+++ b/rules-placeholder/windows/builtin/security/win_security_potential_pass_the_hash.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/nsacyber/Event-Forwarding-Guidance/tree/6e92d622fa33da911f79e7633da4263d632f9624/Events
 author: Ilias el Matani (rule), The Information Assurance Directorate at the NSA (method)
 date: 2017/03/08
-modified: 2023/04/25
+modified: 2023/12/15
 tags:
     - attack.lateral_movement
     - attack.t1550.002

--- a/rules-placeholder/windows/builtin/security/win_security_remote_registry_management_via_reg.yml
+++ b/rules-placeholder/windows/builtin/security/win_security_remote_registry_management_via_reg.yml
@@ -6,7 +6,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 author: Teymur Kheirkhabarov, oscd.community
 date: 2019/10/22
-modified: 2023/04/25
+modified: 2023/12/15
 tags:
     - attack.credential_access
     - attack.defense_evasion

--- a/rules-placeholder/windows/builtin/security/win_security_remote_registry_management_via_reg.yml
+++ b/rules-placeholder/windows/builtin/security/win_security_remote_registry_management_via_reg.yml
@@ -23,7 +23,7 @@ detection:
         EventID: 5145
         RelativeTargetName|contains: '\winreg'
     filter_main:
-        IpAddress: '%Admins_Workstations%'
+        IpAddress|expand: '%Admins_Workstations%'
     condition: selection and not filter_main
 falsepositives:
     - Legitimate usage of remote registry management by administrator

--- a/rules-placeholder/windows/builtin/security/win_security_susp_interactive_logons.yml
+++ b/rules-placeholder/windows/builtin/security/win_security_susp_interactive_logons.yml
@@ -4,7 +4,7 @@ status: test
 description: Detects interactive console logons to Server Systems
 author: Florian Roth (Nextron Systems)
 date: 2017/03/17
-modified: 2023/04/25
+modified: 2023/12/15
 tags:
     - attack.lateral_movement
     - attack.t1078

--- a/rules-placeholder/windows/builtin/security/win_security_susp_interactive_logons.yml
+++ b/rules-placeholder/windows/builtin/security/win_security_susp_interactive_logons.yml
@@ -19,12 +19,12 @@ detection:
             - 4624
             - 4625
         LogonType: 2
-        ComputerName:
+        ComputerName|expand:
             - '%ServerSystems%'
             - '%DomainControllers%'
     filter_main:
         LogonProcessName: 'Advapi'
-        ComputerName: '%Workstations%'
+        ComputerName|expand: '%Workstations%'
     condition: selection and not filter_main
 falsepositives:
     - Administrative activity via KVM or ILO board


### PR DESCRIPTION
### Summary of the Pull Request

The rules in `rules-placeholder` directory do not contain the `expand` modifier.

### Changelog

The `expand` modifier is added to the fields that has a placeholder string value, for example `'%ServerSystems%'`. The only exception is [this one](https://github.com/SigmaHQ/sigma/blob/426ff8c4126cd7ada94b00724dc5517f9b179da5/rules-placeholder/windows/process_creation/proc_creation_win_userdomain_variable_enumeration.yml#L18-L20), where it is actually a Windows env-var, not a Sigma placeholder per se.

update: Account Created And Deleted By Non Approved Users - Add missing `expand` modifier
update: Authentication Occuring Outside Normal Business Hours - Add missing `expand` modifier
update: Privilege Role Elevation Not Occuring on SAW or PAW - Add missing `expand` modifier
update: Privilege Role Sign-In Outside Expected Controls - Add missing `expand` modifier
update: Privilege Role Sign-In Outside Of Normal Hours - Add missing `expand` modifier
update: Potential Zerologon (CVE-2020-1472) Exploitation - Add missing `expand` modifier
update: Potential Pass the Hash Activity - Add missing `expand` modifier
update: Interactive Logon to Server Systems - Add missing `expand` modifier
update: Remote Registry Management Using Reg Utility - Add missing `expand` modifier


### Details

@kelnage and I were discussing this the other day and were trying to find a way to detect whether a placeholder is applied or not, given that there is no existing pipeline (with a transformation) to expand the placeholder using the `expand` modifier. While doing so, we found that there are no `expand` modifier in this repository for testing, and digging a little deeper we found that the rules I just fixed in this PR contain placeholders, but the fields themselves do not have `|expand` modifier, which is why I propose this fix.

Another thing is that the result of the modifiers are not verified, hence if there is no pipeline (with a transformation) that can replace the placeholder, it'll just spit out the placeholder (sigma)string as is. I have a working solution and would be happy to propose a fix to pySigma if you want. Although the solution only applies to the placeholders, but with some work it can be expanded to include others. (sorry if this is not the right place to mention this, and I think this was a better fit for pySigma discussions)