### PR TITLE
Filtering FP in pipe_created_hktl_efspotato.yml

### DIFF
--- a/rules/windows/pipe_created/pipe_created_hktl_efspotato.yml
+++ b/rules/windows/pipe_created/pipe_created_hktl_efspotato.yml
@@ -23,7 +23,9 @@ detection:
             - '\pipe\srvsvc'  # more specific version (use only this one if the other causes too many false positives)
     filter_optional_ctx:
         PipeName|contains: '\CtxShare'
+    filter_optional_default:
+        PipeName|startswith: '\pipe\' # excludes pipes that start with \pipe\*
     condition: selection and not 1 of filter_optional_*
 falsepositives:
-    - Unknown
+    - \pipe\LOCAL\Monitorian # https://github.com/emoacht/Monitorian
 level: high

--- a/rules/windows/pipe_created/pipe_created_hktl_efspotato.yml
+++ b/rules/windows/pipe_created/pipe_created_hktl_efspotato.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/zcgonvh/EfsPotato
 author: Florian Roth (Nextron Systems)
 date: 2021/08/23
-modified: 2023/08/07
+modified: 2023/12/21
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Added exclusion for pipe naming that starts with \pipe\*, an example of FP https://github.com/emoacht/Monitorian where the pipe name is \pipe\LOCAL\Monitorian. We keep detection of *\pipe\*, but excluding ^\pipe\*
<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

fix: HackTool - EfsPotato Named Pipe Creation - Add exclusion for pipe names starting with `\pipe\`
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event
```
Pipe Created:
RuleName: -
EventType: CreatePipe
UtcTime: 2023-12-19 02:59:29.816
ProcessGuid: {773bac78-0711-6581-6e19-000000000600}
ProcessId: 17972
PipeName: \pipe\LOCAL\Monitorian
Image: C:\Program Files\WindowsApps\10186emoacht.Monitorian_4.6.0.0_neutral__0q7myvhtpbc7w\MonitorianPlus\MonitorianPlus.exe
User: LAB\user1"
```
### Fixed Issues

N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
