### PR TITLE
Add Rule Covering New Persistence Technique Using RegisterAppRestart AppCompat Layer

### DIFF
--- a/deprecated/windows/image_load_side_load_svchost_dlls.yml
+++ b/deprecated/windows/image_load_side_load_svchost_dlls.yml
@@ -10,7 +10,7 @@ references:
     - https://posts.specterops.io/lateral-movement-scm-and-dll-hijacking-primer-d2f61e8ab992
 author: SBousseaden
 date: 2019/10/28
-modified: 2021/11/27
+modified: 2024/01/10
 tags:
     - attack.persistence
     - attack.defense_evasion

--- a/deprecated/windows/image_load_side_load_svchost_dlls.yml
+++ b/deprecated/windows/image_load_side_load_svchost_dlls.yml
@@ -1,6 +1,6 @@
 title: Svchost DLL Search Order Hijack
 id: 602a1f13-c640-4d73-b053-be9a2fa58b77
-status: test
+status: deprecated
 description: |
     Detects DLL sideloading of DLLs that are loaded by the SCM for some services (IKE, IKEEXT, SessionEnv) which do not exists on a typical modern system
     IKEEXT and SessionEnv service, as they call LoadLibrary on files that do not exist within C:\Windows\System32\ by default.

--- a/rules/windows/file/file_event/file_event_win_create_non_existent_dlls.yml
+++ b/rules/windows/file/file_event/file_event_win_create_non_existent_dlls.yml
@@ -4,7 +4,9 @@ related:
     - id: 6b98b92b-4f00-4f62-b4fe-4d1920215771 # ImageLoad rule
       type: similar
 status: test
-description: Detects the creation of system dlls that are not present on the system. Usually to achieve dll hijacking
+description: |
+    Detects the creation of system dlls that are usually not present on the system (or at least not in system directories).
+    Usually this technique is used to achieve dll hijacking.
 references:
     - https://decoded.avast.io/martinchlumecky/png-steganography/
     - https://posts.specterops.io/lateral-movement-scm-and-dll-hijacking-primer-d2f61e8ab992
@@ -14,7 +16,7 @@ references:
     - https://github.com/blackarrowsec/redteam-research/tree/26e6fc0c0d30d364758fa11c2922064a9a7fd309/LPE%20via%20StorSvc
 author: Nasreddine Bencherchali (Nextron Systems), fornotes
 date: 2022/12/01
-modified: 2023/02/15
+modified: 2024/01/10
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -26,17 +28,15 @@ logsource:
     category: file_event
 detection:
     selection:
-        - TargetFilename:
-              - 'C:\Windows\System32\WLBSCTRL.dll'
-              - 'C:\Windows\System32\TSMSISrv.dll'
-              - 'C:\Windows\System32\TSVIPSrv.dll'
-              - 'C:\Windows\System32\wow64log.dll'
-              - 'C:\Windows\System32\WptsExtensions.dll'
-              - 'C:\Windows\System32\wbem\wbemcomn.dll'
-        - TargetFilename|endswith: '\SprintCSP.dll'
-    filter:
-        Image|startswith: 'C:\Windows\System32\'
-    condition: selection and not filter
+        TargetFilename|endswith:
+            - ':\Windows\System32\TSMSISrv.dll'
+            - ':\Windows\System32\TSVIPSrv.dll'
+            - ':\Windows\System32\wbem\wbemcomn.dll'
+            - ':\Windows\System32\WLBSCTRL.dll'
+            - ':\Windows\System32\wow64log.dll'
+            - ':\Windows\System32\WptsExtensions.dll'
+            - '\SprintCSP.dll'
+    condition: selection
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/file/file_event/file_event_win_create_non_existent_dlls.yml
+++ b/rules/windows/file/file_event/file_event_win_create_non_existent_dlls.yml
@@ -5,8 +5,8 @@ related:
       type: similar
 status: test
 description: |
-    Detects the creation of system dlls that are usually not present on the system (or at least not in system directories).
-    Usually this technique is used to achieve dll hijacking.
+    Detects the creation of system DLLs that are usually not present on the system (or at least not in system directories).
+    Usually this technique is used to achieve DLL hijacking.
 references:
     - https://decoded.avast.io/martinchlumecky/png-steganography/
     - https://posts.specterops.io/lateral-movement-scm-and-dll-hijacking-primer-d2f61e8ab992

--- a/rules/windows/image_load/image_load_side_load_from_non_system_location.yml
+++ b/rules/windows/image_load/image_load_side_load_from_non_system_location.yml
@@ -1,7 +1,7 @@
 title: Potential System DLL Sideloading From Non System Locations
 id: 4fc0deee-0057-4998-ab31-d24e46e0aba4
 status: experimental
-description: Detects DLL sideloading of DLLs usually located in system locations (System32, SysWOW64, etc.)
+description: Detects DLL sideloading of DLLs usually located in system locations (System32, SysWOW64, etc.).
 references:
     - https://hijacklibs.net/ # For list of DLLs that could be sideloaded (search for dlls mentioned here in there). Wietze Beukema (project and research)
     - https://blog.cyble.com/2022/07/21/qakbot-resurfaces-with-new-playbook/ # WindowsCodecs.dll
@@ -9,7 +9,7 @@ references:
     - https://github.com/XForceIR/SideLoadHunter/blob/cc7ef2e5d8908279b0c4cee4e8b6f85f7b8eed52/SideLoads/README.md # XForceIR (SideLoadHunter Project), Chris Spehn (research WFH Dridex)
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022/08/14
-modified: 2023/12/15
+modified: 2024/01/10
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -442,13 +442,13 @@ detection:
             - '\wbemcomn.dll'
     filter_main_generic:
         # Note: this filter is generic on purpose to avoid insane amount of FP from legitimate third party applications. A better approach would be to baseline everything and add specific filters to avoid blind spots
-        ImageLoaded|startswith:
-            - 'C:\Windows\System32\'
-            - 'C:\Windows\SysWOW64\'
-            - 'C:\Windows\WinSxS\'
-            - 'C:\Windows\SoftwareDistribution\'
-            - 'C:\Windows\SystemTemp\'
-            - 'C:\$WINDOWS.~BT\'
+        ImageLoaded|contains:
+            - ':\Windows\System32\'
+            - ':\Windows\SysWOW64\'
+            - ':\Windows\WinSxS\'
+            - ':\Windows\SoftwareDistribution\'
+            - ':\Windows\SystemTemp\'
+            - ':\$WINDOWS.~BT\'
     filter_main_defender:
         Image|contains: ':\ProgramData\Microsoft\Windows Defender\Platform\'
         Image|endswith: '\version.dll'

--- a/rules/windows/image_load/image_load_side_load_non_existent_dlls.yml
+++ b/rules/windows/image_load/image_load_side_load_non_existent_dlls.yml
@@ -7,7 +7,7 @@ related:
       type: obsoletes
 status: test
 description: |
-    Detects DLL sideloading of system dlls that are not present on the system by default (at least not in system directories).
+    Detects DLL sideloading of system DLLs that are not present on the system by default (at least not in system directories).
     Usually this technique is used to achieve UAC bypass or privilege escalation.
 references:
     - https://decoded.avast.io/martinchlumecky/png-steganography/

--- a/rules/windows/image_load/image_load_side_load_non_existent_dlls.yml
+++ b/rules/windows/image_load/image_load_side_load_non_existent_dlls.yml
@@ -3,8 +3,12 @@ id: 6b98b92b-4f00-4f62-b4fe-4d1920215771
 related:
     - id: df6ecb8b-7822-4f4b-b412-08f524b4576c # FileEvent rule
       type: similar
+    - id: 602a1f13-c640-4d73-b053-be9a2fa58b77
+      type: obsoletes
 status: test
-description: Detects DLL sideloading of system dlls that are not present on the system by default. Usually to achieve techniques such as UAC bypass and privilege escalation
+description: |
+    Detects DLL sideloading of system dlls that are not present on the system by default (at least not in system directories).
+    Usually this technique is used to achieve UAC bypass or privilege escalation.
 references:
     - https://decoded.avast.io/martinchlumecky/png-steganography/
     - https://posts.specterops.io/lateral-movement-scm-and-dll-hijacking-primer-d2f61e8ab992
@@ -12,9 +16,9 @@ references:
     - https://github.com/Wh04m1001/SysmonEoP
     - https://www.hexacorn.com/blog/2013/12/08/beyond-good-ol-run-key-part-5/
     - http://remoteawesomethoughts.blogspot.com/2019/05/windows-10-task-schedulerservice.html
-author: Nasreddine Bencherchali (Nextron Systems)
+author: Nasreddine Bencherchali (Nextron Systems), SBousseaden
 date: 2022/12/09
-modified: 2023/01/30
+modified: 2024/01/10
 tags:
     - attack.defense_evasion
     - attack.persistence
@@ -26,19 +30,20 @@ logsource:
     product: windows
 detection:
     selection:
-        ImageLoaded:
+        ImageLoaded|endswith:
             # Add other DLLs
-            - 'C:\Windows\System32\WLBSCTRL.dll'
-            - 'C:\Windows\System32\TSMSISrv.dll'
-            - 'C:\Windows\System32\TSVIPSrv.dll'
-            - 'C:\Windows\System32\wow64log.dll'
-            - 'C:\Windows\System32\WptsExtensions.dll'
-            - 'C:\Windows\System32\wbem\wbemcomn.dll'
-    filter_ms_signed:
+            - ':\Windows\System32\TSMSISrv.dll'
+            - ':\Windows\System32\TSVIPSrv.dll'
+            - ':\Windows\System32\wbem\wbemcomn.dll'
+            - ':\Windows\System32\WLBSCTRL.dll'
+            - ':\Windows\System32\wow64log.dll'
+            - ':\Windows\System32\WptsExtensions.dll'
+    filter_main_ms_signed:
         Signed: 'true'
+        SignatureStatus: 'Valid'
         # There could be other signatures (please add when found)
         Signature: 'Microsoft Windows'
-    condition: selection and not 1 of filter_*
+    condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/powershell/powershell_classic/posh_pc_remote_powershell_session.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_remote_powershell_session.yml
@@ -9,7 +9,7 @@ references:
     - https://threathunterplaybook.com/hunts/windows/190511-RemotePwshExecution/notebook.html
 author: Roberto Rodriguez @Cyb3rWard0g
 date: 2019/08/10
-modified: 2023/10/27
+modified: 2024/01/03
 tags:
     - attack.execution
     - attack.t1059.001
@@ -26,4 +26,5 @@ detection:
     condition: selection
 falsepositives:
     - Legitimate use remote PowerShell sessions
-level: high
+# Note: Increase the level to "medium" in environments that do not leverage PowerShell remoting
+level: low

--- a/rules/windows/process_creation/proc_creation_win_sdbinst_susp_extension.yml
+++ b/rules/windows/process_creation/proc_creation_win_sdbinst_susp_extension.yml
@@ -29,10 +29,10 @@ detection:
     filter_main_svchost:
         # ParentImage|endswith: ':\Windows\System32\svchost.exe'
         - CommandLine|endswith:
-            - ' -c'
-            - ' -f'
-            - ' -mm'
-            - ' -t'
+              - ' -c'
+              - ' -f'
+              - ' -mm'
+              - ' -t'
         - CommandLine|contains: ' -m -bg'
     filter_main_null:
         CommandLine: null

--- a/rules/windows/process_creation/proc_creation_win_sdbinst_susp_extension.yml
+++ b/rules/windows/process_creation/proc_creation_win_sdbinst_susp_extension.yml
@@ -9,9 +9,10 @@ description: |
     Adversaries may establish persistence and/or elevate privileges by executing malicious content triggered by application shims
 references:
     - https://www.fireeye.com/blog/threat-research/2017/05/fin7-shim-databases-persistence.html
+    - https://github.com/nasbench/Misc-Research/blob/8ee690e43a379cbce8c9d61107442c36bd9be3d3/Other/Undocumented-Flags-Sdbinst.md
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023/08/01
-modified: 2023/12/13
+modified: 2024/01/10
 tags:
     - attack.persistence
     - attack.privilege_escalation
@@ -27,7 +28,11 @@ detection:
         CommandLine|contains: '.sdb'
     filter_main_svchost:
         # ParentImage|endswith: ':\Windows\System32\svchost.exe'
-        - CommandLine|endswith: ' -mm'
+        - CommandLine|endswith:
+            - ' -c'
+            - ' -f'
+            - ' -mm'
+            - ' -t'
         - CommandLine|contains: ' -m -bg'
     filter_main_null:
         CommandLine: null

--- a/rules/windows/registry/registry_set/registry_set_deviceguard_hypervisorenforcedcodeintegrity_disabled.yml
+++ b/rules/windows/registry/registry_set/registry_set_deviceguard_hypervisorenforcedcodeintegrity_disabled.yml
@@ -18,7 +18,7 @@ detection:
     selection:
         EventType: SetValue
         TargetObject|endswith:
-            - '\Control\DeviceGuard\HypervisorEnforcedCodeIntegrity'
+            - '\Microsoft\Windows\DeviceGuard\HypervisorEnforcedCodeIntegrity'
             - '\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity\Enabled'
         Details: 'DWORD (0x00000000)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_deviceguard_hypervisorenforcedcodeintegrity_disabled.yml
+++ b/rules/windows/registry/registry_set/registry_set_deviceguard_hypervisorenforcedcodeintegrity_disabled.yml
@@ -7,6 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/04e487c1828d76df3e834621f4f893ea756d5232/atomics/T1562.001/T1562.001.md#atomic-test-43---disable-hypervisor-enforced-code-integrity-hvci
 author: Nasreddine Bencherchali (Nextron Systems), Anish Bogati
 date: 2023/03/14
+modified: 2024/01/10
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -16,7 +17,9 @@ logsource:
 detection:
     selection:
         EventType: SetValue
-        TargetObject|endswith: '\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity\Enabled'
+        TargetObject|endswith:
+            - '\Control\DeviceGuard\HypervisorEnforcedCodeIntegrity'
+            - '\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity\Enabled'
         Details: 'DWORD (0x00000000)'
     condition: selection
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_deviceguard_hypervisorenforcedcodeintegrity_disabled.yml
+++ b/rules/windows/registry/registry_set/registry_set_deviceguard_hypervisorenforcedcodeintegrity_disabled.yml
@@ -19,6 +19,7 @@ detection:
         EventType: SetValue
         TargetObject|endswith:
             - '\Microsoft\Windows\DeviceGuard\HypervisorEnforcedCodeIntegrity'
+            - '\Control\DeviceGuard\HypervisorEnforcedCodeIntegrity'
             - '\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity\Enabled'
         Details: 'DWORD (0x00000000)'
     condition: selection

--- a/rules/windows/registry/registry_set/registry_set_persistence_app_cpmpat_layer_registerapprestart.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_app_cpmpat_layer_registerapprestart.yml
@@ -1,0 +1,22 @@
+title: Potential Persistence Via AppCompat RegisterAppRestart Layer
+id: b86852fb-4c77-48f9-8519-eb1b2c308b59
+status: experimental
+description: Detects the installation of a new shim database where the file is located in a non-default location
+references:
+    - https://github.com/nasbench/Misc-Research/blob/d114d6a5e0a437d3818e492ef9864367152543e7/Other/Persistence-Via-RegisterAppRestart-Shim.md
+author: Nasreddine Bencherchali (Nextron Systems)
+date: 2024/01/01
+tags:
+    - attack.persistence
+    - attack.t1546.011
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        TargetObject|contains: '\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers\'
+        Details|contains: 'REGISTERAPPRESTART'
+    condition: selection
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/registry/registry_set/registry_set_persistence_app_cpmpat_layer_registerapprestart.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_app_cpmpat_layer_registerapprestart.yml
@@ -1,7 +1,10 @@
 title: Potential Persistence Via AppCompat RegisterAppRestart Layer
 id: b86852fb-4c77-48f9-8519-eb1b2c308b59
 status: experimental
-description: Detects the installation of a new shim database where the file is located in a non-default location
+description: |
+    Detects the setting of the REGISTERAPPRESTART compatibility layer on an application.
+    This compatibility layer allows an application to register for restart using the "RegisterApplicationRestart" API.
+    This can be potentially abused as a persistence mechanism.
 references:
     - https://github.com/nasbench/Misc-Research/blob/d114d6a5e0a437d3818e492ef9864367152543e7/Other/Persistence-Via-RegisterAppRestart-Shim.md
 author: Nasreddine Bencherchali (Nextron Systems)

--- a/rules/windows/registry/registry_set/registry_set_persistence_app_cpmpat_layer_registerapprestart.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_app_cpmpat_layer_registerapprestart.yml
@@ -18,5 +18,5 @@ detection:
         Details|contains: 'REGISTERAPPRESTART'
     condition: selection
 falsepositives:
-    - Unknown
+    - Legitimate applications making use of this feature for compatibility reasons
 level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

This PR adds a new rule covering a new persistence technique using the `RegisterAppRestart` AppCompat layer
<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

new: Potential Persistence Via AppCompat RegisterAppRestart Layer
update:  Uncommon Extension Shim Database Installation Via Sdbinst.EXE - Add additional commandline flag that might trigger FPs
update: Hypervisor Enforced Code Integrity Disabled - Add additional path for the HVCI config
update: Creation Of Non-Existent System DLL - Remove driver anchor and the `System32` filter. The reason behind this is that an attacker can copy the file elsewhere and then use a system utility such as copy or xcopy located in the system32 folder to create it again. Which will bypass the rule.
update: Potential System DLL Sideloading From Non System Locations - Remove the driver anchor from the filter to catch cases where the system is installed on non default `C:` driver
update: Potential DLL Sideloading Of Non-Existent DLLs From System Folders - Add `SignatureStatus` in the filter to exclude only `valid` signatures and decrease bypass.
remove: Svchost DLL Search Order Hijack - Deprecated in favor of the rule 6b98b92b-4f00-4f62-b4fe-4d1920215771. The reason is that for legit cases where the DLL is still present we can't filter out anything. We assume that the loading is done by a non valid/signed DLLs which will catch most cases. In cas the attacker had the option to sign the DLL with a valid signature he can bypass the rule.

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

N/A
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
