### PR TITLE
Fixes #4666 - sigma-logsource-checker tries to parse non-yml files

### DIFF
--- a/documentation/tools/sigma-logsource-checker.py
+++ b/documentation/tools/sigma-logsource-checker.py
@@ -161,19 +161,23 @@ def test_invalid_logsource_attributes(path_to_rules):
     ]
 
     for file in yield_next_rule_file_path(path_to_rules):
-        logsource = get_rule_part(file_path=file, part_name="logsource")
-        if not logsource:
-            print("Rule {} has no 'logsource'.".format(file))
-            faulty_rules.append(file)
-            continue
-        valid = True
-        for key in logsource:
-            if key.lower() not in valid_logsource:
-                print("Rule {} has a logsource with an invalid field ({})".format(file, key))
-                valid = False
-            elif not isinstance(logsource[key], str):
-                print("Rule {} has a logsource with an invalid field type ({})".format(file, key))
-                valid = False
+        if not file.endswith(".yml") and not file.endswith(".yaml") :
+            print("File {} is not a YAML file.".format(file))
+            valid = False
+        else:
+            logsource = get_rule_part(file_path=file, part_name="logsource")
+            if not logsource:
+                print("Rule {} has no 'logsource'.".format(file))
+                faulty_rules.append(file)
+                continue
+            valid = True
+            for key in logsource:
+                if key.lower() not in valid_logsource:
+                    print("Rule {} has a logsource with an invalid field ({})".format(file, key))
+                    valid = False
+                elif not isinstance(logsource[key], str):
+                    print("Rule {} has a logsource with an invalid field type ({})".format(file, key))
+                    valid = False
         if not valid:
             faulty_rules.append(file)
 

--- a/documentation/tools/sigma-logsource-checker.py
+++ b/documentation/tools/sigma-logsource-checker.py
@@ -111,7 +111,8 @@ WINDOWS_SECURITY_SPECIAL_PROCESS_CREATION_FIELDS = ["SubjectUserSid", "SubjectUs
 def yield_next_rule_file_path(path_to_rules: str) -> str:
     for root, _, files in os.walk(path_to_rules):
         for file in files:
-            yield os.path.join(root, file)
+            if file.endswith(".yml"):
+                yield os.path.join(root, file)
 
 def get_rule_part(file_path: str, part_name: str):
     yaml_dicts = get_rule_yaml(file_path)
@@ -161,23 +162,19 @@ def test_invalid_logsource_attributes(path_to_rules):
     ]
 
     for file in yield_next_rule_file_path(path_to_rules):
-        if not file.endswith(".yml") and not file.endswith(".yaml") :
-            print("File {} is not a YAML file.".format(file))
-            valid = False
-        else:
-            logsource = get_rule_part(file_path=file, part_name="logsource")
-            if not logsource:
-                print("Rule {} has no 'logsource'.".format(file))
-                faulty_rules.append(file)
-                continue
-            valid = True
-            for key in logsource:
-                if key.lower() not in valid_logsource:
-                    print("Rule {} has a logsource with an invalid field ({})".format(file, key))
-                    valid = False
-                elif not isinstance(logsource[key], str):
-                    print("Rule {} has a logsource with an invalid field type ({})".format(file, key))
-                    valid = False
+        logsource = get_rule_part(file_path=file, part_name="logsource")
+        if not logsource:
+            print("Rule {} has no 'logsource'.".format(file))
+            faulty_rules.append(file)
+            continue
+        valid = True
+        for key in logsource:
+            if key.lower() not in valid_logsource:
+                print("Rule {} has a logsource with an invalid field ({})".format(file, key))
+                valid = False
+            elif not isinstance(logsource[key], str):
+                print("Rule {} has a logsource with an invalid field type ({})".format(file, key))
+                valid = False
         if not valid:
             faulty_rules.append(file)
 


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

This PR fixes issue #4666 -`documentations/tools/sugma-logsource-checker.py` tries to read in non-yaml files and breaks.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

chore: add additional checks to the `sigma-logsource-checker.py` so that it only cares about yaml files

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

N/A

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

Fixes #4666 

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
