### PR TITLE
update proc_creation_win_findstr_lnk.yml

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_findstr_lnk.yml
+++ b/rules/windows/process_creation/proc_creation_win_findstr_lnk.yml
@@ -24,7 +24,8 @@ detection:
               - 'FIND.EXE'
               - 'FINDSTR.EXE'
     selection_cli:
-        CommandLine|endswith: '.lnk'
+        - CommandLine|endswith: '.lnk'
+        - CommandLine|endswith: '.lnk"'
     condition: all of selection_*
 falsepositives:
     - Unknown


### PR DESCRIPTION
The value of commandline maybe end with double quotes

For example:
CommandLine: C:\\Users\\admin\\tool.exe \"a link with space.lnk\"