### PR TITLE
Update two rules involving loading of DLLs with Windows utilities

### DIFF
--- a/rules/windows/image_load/image_load_susp_unsigned_dll.yml
+++ b/rules/windows/image_load/image_load_susp_unsigned_dll.yml
@@ -9,7 +9,7 @@ references:
     - https://akhere.hashnode.dev/hunting-unsigned-dlls-using-kql
     - https://unit42.paloaltonetworks.com/unsigned-dlls/?web_view=true
 author: Swachchhanda Shrawan Poudel
-date: 2024/01/22
+date: 2024/02/28
 tags:
     - attack.t1218.011
     - attack.t1218.010

--- a/rules/windows/image_load/image_load_susp_unsigned_dll.yml
+++ b/rules/windows/image_load/image_load_susp_unsigned_dll.yml
@@ -21,6 +21,9 @@ detection:
     selection:
         Image|endswith:
             # Note: Add additional utilities that allow the loading of DLLs
+            - '\InstallUtil.exe'
+            - '\regasm.exe'
+            - '\regsvcs.exe'
             - '\regsvr32.exe'
             - '\rundll32.exe'
     filter_main_signed:

--- a/rules/windows/image_load/image_load_susp_unsigned_dll.yml
+++ b/rules/windows/image_load/image_load_susp_unsigned_dll.yml
@@ -1,4 +1,4 @@
-title: Unsigned DLL Loaded by Windows Utilities
+title: Unsigned DLL Loaded by Windows Utility
 id: b5de0c9a-6f19-43e0-af4e-55ad01f550af
 status: experimental
 description: |
@@ -10,6 +10,7 @@ references:
     - https://unit42.paloaltonetworks.com/unsigned-dlls/?web_view=true
 author: Swachchhanda Shrawan Poudel
 date: 2024/02/28
+modified: 2024/03/07
 tags:
     - attack.t1218.011
     - attack.t1218.010
@@ -22,17 +23,30 @@ detection:
         Image|endswith:
             # Note: Add additional utilities that allow the loading of DLLs
             - '\InstallUtil.exe'
-            - '\regasm.exe'
-            - '\regsvcs.exe'
+            - '\RegAsm.exe'
+            - '\RegSvcs.exe'
             - '\regsvr32.exe'
             - '\rundll32.exe'
     filter_main_signed:
-        - Signed: 'true'
-        - SignatureStatus:
-              - 'errorChaining'
-              - 'errorCode_endpoint'
-              - 'errorExpired'
-              - 'trusted'
+        Signed: 'true'
+    filter_main_sig_status:
+        SignatureStatus:
+            - 'errorChaining'
+            - 'errorCode_endpoint'
+            - 'errorExpired'
+            - 'trusted'
+    filter_main_signed_null:
+        Signed: null
+    filter_main_signed_empty:
+        Signed:
+            - ''
+            - '-'
+    filter_main_sig_status_null:
+        SignatureStatus: null
+    filter_main_sig_status_empty:
+        SignatureStatus:
+            - ''
+            - '-'
     condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown

--- a/rules/windows/image_load/image_load_susp_unsigned_dll.yml
+++ b/rules/windows/image_load/image_load_susp_unsigned_dll.yml
@@ -1,8 +1,8 @@
-title: Unsigned DLL Loaded by RunDLL32/RegSvr32
+title: Unsigned DLL Loaded by windows utilities
 id: b5de0c9a-6f19-43e0-af4e-55ad01f550af
 status: experimental
 description: |
-    Detects RunDLL32/RegSvr32 loading an unsigned or untrusted DLL.
+    Detects windows utilities loading an unsigned or untrusted DLL.
     Adversaries often abuse those programs to proxy execution of malicious code.
 references:
     - https://www.elastic.co/security-labs/Hunting-for-Suspicious-Windows-Libraries-for-Execution-and-Evasion

--- a/rules/windows/image_load/image_load_susp_unsigned_dll.yml
+++ b/rules/windows/image_load/image_load_susp_unsigned_dll.yml
@@ -1,4 +1,4 @@
-title: Unsigned DLL Loaded by windows utilities
+title: Unsigned DLL Loaded by Windows Utilities
 id: b5de0c9a-6f19-43e0-af4e-55ad01f550af
 status: experimental
 description: |

--- a/rules/windows/process_creation/proc_creation_win_powershell_dll_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_dll_execution.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/p3nt4/PowerShdll/blob/62cfa172fb4e1f7f4ac00ca942685baeb88ff356/README.md
 author: Markus Neis, Nasreddine Bencherchali
 date: 2018/08/25
-modified: 2023/01/26
+modified: 2024/02/28
 tags:
     - attack.defense_evasion
     - attack.t1218.011

--- a/rules/windows/process_creation/proc_creation_win_powershell_dll_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_dll_execution.yml
@@ -20,11 +20,13 @@ detection:
               - '\regsvcs.exe'
               - '\InstallUtil.exe'
               - '\regasm.exe'
+              - '\regsvr32.exe'
         - OriginalFileName:
               - 'RUNDLL32.EXE'
               - 'RegSvcs.exe'
               - 'InstallUtil.exe'
               - 'RegAsm.exe'
+              - 'REGSVR32.EXE'
     selection_cli:
         CommandLine|contains:
             - 'Default.GetString'

--- a/rules/windows/process_creation/proc_creation_win_susp_powershell_execution_via_dll.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_powershell_execution_via_dll.yml
@@ -1,12 +1,14 @@
 title: Potential PowerShell Execution Via DLL
 id: 6812a10b-60ea-420c-832f-dfcc33b646ba
 status: test
-description: Detects potential PowerShell execution from a DLL instead of the usual PowerShell process as seen used in PowerShdll
+description: |
+    Detects potential PowerShell execution from a DLL instead of the usual PowerShell process as seen used in PowerShdll.
+    This detection assumes that PowerShell commands are passed via the CommandLine.
 references:
     - https://github.com/p3nt4/PowerShdll/blob/62cfa172fb4e1f7f4ac00ca942685baeb88ff356/README.md
-author: Markus Neis, Nasreddine Bencherchali
+author: Markus Neis, Nasreddine Bencherchali (Nextron Systems)
 date: 2018/08/25
-modified: 2024/02/28
+modified: 2024/03/07
 tags:
     - attack.defense_evasion
     - attack.t1218.011
@@ -16,26 +18,26 @@ logsource:
 detection:
     selection_img:
         - Image|endswith:
-              - '\rundll32.exe'
-              - '\regsvcs.exe'
               - '\InstallUtil.exe'
-              - '\regasm.exe'
+              - '\RegAsm.exe'
+              - '\RegSvcs.exe'
               - '\regsvr32.exe'
+              - '\rundll32.exe'
         - OriginalFileName:
-              - 'RUNDLL32.EXE'
-              - 'RegSvcs.exe'
               - 'InstallUtil.exe'
               - 'RegAsm.exe'
+              - 'RegSvcs.exe'
               - 'REGSVR32.EXE'
+              - 'RUNDLL32.EXE'
     selection_cli:
         CommandLine|contains:
             - 'Default.GetString'
+            - 'DownloadString'
             - 'FromBase64String'
-            - 'Invoke-Expression'
+            - 'ICM '
             - 'IEX '
             - 'Invoke-Command'
-            - 'ICM '
-            - 'DownloadString'
+            - 'Invoke-Expression'
     condition: all of selection_*
 falsepositives:
     - Unknown


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

This PR aims to add a few images to two rules that involve loading DLLs with relevant images:

LOLBAS references related to "Unsigned DLL Loaded by windows utilities":
- https://lolbas-project.github.io/lolbas/Binaries/Installutil/
- https://lolbas-project.github.io/lolbas/Binaries/Regasm/
- https://lolbas-project.github.io/lolbas/Binaries/Regsvcs/

Reference for update: Potential PowerShell Execution Via DLL - add regsvr32.exe:
- https://github.com/p3nt4/PowerShdll

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

update: Unsigned DLL Loaded by Windows Utility - Add InstallUtil, RegAsm and RegSvcs as additional process and add additional "null" and "empty" filters to cover for non available fields.
update: Potential PowerShell Execution Via DLL - Add regsvr32 to increase coverage.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
N/A

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
