### PR TITLE
Github New Rules for Secret Scanning and Push Protection Features

### DIFF
--- a/rules/cloud/github/github_push_protection_bypass_detected.yml
+++ b/rules/cloud/github/github_push_protection_bypass_detected.yml
@@ -1,0 +1,23 @@
+title: Github Push Protection Bypass Detected
+id: 02cf536a-cf21-4876-8842-4159c8aee3cc
+status: experimental
+description: Detects when a user bypasses the push protection on a secret detected by secret scanning.
+references:
+    - https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/push-protection-for-repositories-and-organizations
+    - https://thehackernews.com/2024/03/github-rolls-out-default-secret.html
+author: Muhammad Faisal (@faisalusuf)
+date: 2024/03/01
+tags:
+    - attack.defense_evasion
+    - attack.t1562.001
+logsource:
+    product: github
+    service: audit
+    definition: 'Requirements: The audit log streaming feature must be enabled to be able to receive such logs. You can enable following the documentation here: https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/streaming-the-audit-log-for-your-enterprise#setting-up-audit-log-streaming'
+detection:
+    selection:
+        action|contains: 'secret_scanning_push_protection.bypass'
+    condition: selection
+falsepositives:
+    - Allowed administrative activities.
+level: low

--- a/rules/cloud/github/github_push_protection_bypass_detected.yml
+++ b/rules/cloud/github/github_push_protection_bypass_detected.yml
@@ -6,7 +6,7 @@ references:
     - https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/push-protection-for-repositories-and-organizations
     - https://thehackernews.com/2024/03/github-rolls-out-default-secret.html
 author: Muhammad Faisal (@faisalusuf)
-date: 2024/03/01
+date: 2024/03/07
 tags:
     - attack.defense_evasion
     - attack.t1562.001

--- a/rules/cloud/github/github_push_protection_disabled.yml
+++ b/rules/cloud/github/github_push_protection_disabled.yml
@@ -1,12 +1,12 @@
 title: Github Push Protection Disabled
 id: ccd55945-badd-4bae-936b-823a735d37dd
 status: experimental
-description: Detects push protection feature if disabled for organization, enterprise, repositories or custom pattern rules.
+description: Detects if the push protection feature is disabled for an organization, enterprise, repositories or custom pattern rules.
 references:
     - https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/push-protection-for-repositories-and-organizations
     - https://thehackernews.com/2024/03/github-rolls-out-default-secret.html
 author: Muhammad Faisal (@faisalusuf)
-date: 2024/03/01
+date: 2024/03/07
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -17,13 +17,13 @@ logsource:
 detection:
     selection:
         action:
-            - 'repository_secret_scanning_custom_pattern_push_protection.disabled'
-            - 'org.secret_scanning_push_protection_new_repos_disable'
-            - 'org.secret_scanning_push_protection_disable'
-            - 'org.secret_scanning_custom_pattern_push_protection_disabled'
+            - 'business_secret_scanning_custom_pattern_push_protection.disabled'
             - 'business_secret_scanning_push_protection.disable'
             - 'business_secret_scanning_push_protection.disabled_for_new_repos'
-            - 'business_secret_scanning_custom_pattern_push_protection.disabled'
+            - 'org.secret_scanning_custom_pattern_push_protection_disabled'
+            - 'org.secret_scanning_push_protection_disable'
+            - 'org.secret_scanning_push_protection_new_repos_disable'
+            - 'repository_secret_scanning_custom_pattern_push_protection.disabled'
     condition: selection
 falsepositives:
     - Allowed administrative activities.

--- a/rules/cloud/github/github_push_protection_disabled.yml
+++ b/rules/cloud/github/github_push_protection_disabled.yml
@@ -1,0 +1,30 @@
+title: Github Push Protection Disabled
+id: ccd55945-badd-4bae-936b-823a735d37dd
+status: experimental
+description: Detects push protection feature if disabled for organization, enterprise, repositories or custom pattern rules.
+references:
+    - https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/push-protection-for-repositories-and-organizations
+    - https://thehackernews.com/2024/03/github-rolls-out-default-secret.html
+author: Muhammad Faisal (@faisalusuf)
+date: 2024/03/01
+tags:
+    - attack.defense_evasion
+    - attack.t1562.001
+logsource:
+    product: github
+    service: audit
+    definition: 'Requirements: The audit log streaming feature must be enabled to be able to receive such logs. You can enable following the documentation here: https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/streaming-the-audit-log-for-your-enterprise#setting-up-audit-log-streaming'
+detection:
+    selection:
+        action:
+            - 'repository_secret_scanning_custom_pattern_push_protection.disabled'
+            - 'org.secret_scanning_push_protection_new_repos_disable'
+            - 'org.secret_scanning_push_protection_disable'
+            - 'org.secret_scanning_custom_pattern_push_protection_disabled'
+            - 'business_secret_scanning_push_protection.disable'
+            - 'business_secret_scanning_push_protection.disabled_for_new_repos'
+            - 'business_secret_scanning_custom_pattern_push_protection.disabled'
+    condition: selection
+falsepositives:
+    - Allowed administrative activities.
+level: high

--- a/rules/cloud/github/github_secret_scanning_feature_disabled.yml
+++ b/rules/cloud/github/github_secret_scanning_feature_disabled.yml
@@ -1,11 +1,11 @@
 title: Github Secret Scanning Feature Disabled
 id: 3883d9a0-fd0f-440f-afbb-445a2a799bb8
 status: experimental
-description: Detects the secret scanning feature if disabled for an enterprise or repositories.
+description: Detects if the secret scanning feature is disabled for an enterprise or repository.
 references:
     - https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/about-secret-scanning
 author: Muhammad Faisal (@faisalusuf)
-date: 2024/03/01
+date: 2024/03/07
 tags:
     - attack.defense_evasion
     - attack.t1562.001
@@ -16,10 +16,10 @@ logsource:
 detection:
     selection:
         action:
-            - 'repository_secret_scanning.disable'
-            - 'secret_scanning.disable'
             - 'business_secret_scanning.disable'
             - 'business_secret_scanning.disabled_for_new_repos'
+            - 'repository_secret_scanning.disable'
+            - 'secret_scanning.disable'
     condition: selection
 falsepositives:
     - Allowed administrative activities.

--- a/rules/cloud/github/github_secret_scanning_feature_disabled.yml
+++ b/rules/cloud/github/github_secret_scanning_feature_disabled.yml
@@ -1,0 +1,26 @@
+title: Github Secret Scanning Feature Disabled
+id: 3883d9a0-fd0f-440f-afbb-445a2a799bb8
+status: experimental
+description: Detects the secret scanning feature if disabled for an enterprise or repositories.
+references:
+    - https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/about-secret-scanning
+author: Muhammad Faisal (@faisalusuf)
+date: 2024/03/01
+tags:
+    - attack.defense_evasion
+    - attack.t1562.001
+logsource:
+    product: github
+    service: audit
+    definition: 'Requirements: The audit log streaming feature must be enabled to be able to receive such logs. You can enable following the documentation here: https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/streaming-the-audit-log-for-your-enterprise#setting-up-audit-log-streaming'
+detection:
+    selection:
+        action:
+            - 'repository_secret_scanning.disable'
+            - 'secret_scanning.disable'
+            - 'business_secret_scanning.disable'
+            - 'business_secret_scanning.disabled_for_new_repos'
+    condition: selection
+falsepositives:
+    - Allowed administrative activities.
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
The Github enterprise keeps on releasing new security features targeting sensitive information (secrets) and now the push protection feature is turned on by default for all public repositories. This pull includes detection rules around these security features.
Ref: 

1. https://thehackernews.com/2024/03/github-rolls-out-default-secret.html
2. https://docs.github.com/en/code-security/secret-scanning/push-protection-for-repositories-and-organizations
3. https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning

### Changelog

new: Github Push Protection Bypass Detected
new: Github Push Protection Disabled
new: Github Secret Scanning Feature Disabled

### Example Log Event

N/A
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
