### PR TITLE
Fix hashes

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_hktl_coercedpotato.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_coercedpotato.yml
@@ -7,7 +7,7 @@ references:
     - https://blog.hackvens.fr/articles/CoercedPotato.html
 author: Florian Roth (Nextron Systems)
 date: 2023/10/11
-modified: 2024/04/04
+modified: 2024/04/15
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation

--- a/rules/windows/process_creation/proc_creation_win_hktl_coercedpotato.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_coercedpotato.yml
@@ -7,6 +7,7 @@ references:
     - https://blog.hackvens.fr/articles/CoercedPotato.html
 author: Florian Roth (Nextron Systems)
 date: 2023/10/11
+modified: 2024/04/04
 tags:
     - attack.defense_evasion
     - attack.privilege_escalation

--- a/rules/windows/process_creation/proc_creation_win_hktl_coercedpotato.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_coercedpotato.yml
@@ -24,7 +24,7 @@ detection:
               - 'a75d7669db6b2e107a44c4057ff7f7d6'
               - 'f91624350e2c678c5dcbe5e1f24e22c9'
               - '14c81850a079a87e83d50ca41c709a15'
-        - Hashes:
+        - Hashes|contains:
               - 'IMPHASH=A75D7669DB6B2E107A44C4057FF7F7D6'
               - 'IMPHASH=F91624350E2C678C5DCBE5E1F24E22C9'
               - 'IMPHASH=14C81850A079A87E83D50CA41C709A15'

--- a/rules/windows/process_creation/proc_creation_win_hktl_handlekatz.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_handlekatz.yml
@@ -21,7 +21,7 @@ detection:
         - Imphash:
               - '38d9e015591bbfd4929e0d0f47fa0055'
               - '0e2216679ca6e1094d63322e3412d650'
-        - Hashes:
+        - Hashes|contains:
               - 'IMPHASH=38D9E015591BBFD4929E0D0F47FA0055'
               - 'IMPHASH=0E2216679CA6E1094D63322E3412D650'
     selection_flags:

--- a/rules/windows/process_creation/proc_creation_win_hktl_handlekatz.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_handlekatz.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/codewhitesec/HandleKatz
 author: Florian Roth (Nextron Systems)
 date: 2022/08/18
-modified: 2024/04/04
+modified: 2024/04/15
 tags:
     - attack.credential_access
     - attack.t1003.001

--- a/rules/windows/process_creation/proc_creation_win_hktl_handlekatz.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_handlekatz.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/codewhitesec/HandleKatz
 author: Florian Roth (Nextron Systems)
 date: 2022/08/18
-modified: 2023/02/04
+modified: 2024/04/04
 tags:
     - attack.credential_access
     - attack.t1003.001

--- a/rules/windows/process_creation/proc_creation_win_hktl_sysmoneop.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_sysmoneop.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Wh04m1001/SysmonEoP
 author: Florian Roth (Nextron Systems)
 date: 2022/12/04
-modified: 2024/04/04
+modified: 2024/04/15
 tags:
     - cve.2022.41120
     - attack.t1068

--- a/rules/windows/process_creation/proc_creation_win_hktl_sysmoneop.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_sysmoneop.yml
@@ -18,7 +18,7 @@ detection:
     selection_img:
         Image|endswith: '\SysmonEOP.exe'
     selection_hash:
-        - Hashes:
+        - Hashes|contains:
               - 'IMPHASH=22F4089EB8ABA31E1BB162C6D9BF72E5'
               - 'IMPHASH=5123FA4C4384D431CD0D893EEB49BBEC'
         - Imphash:

--- a/rules/windows/process_creation/proc_creation_win_hktl_sysmoneop.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_sysmoneop.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/Wh04m1001/SysmonEoP
 author: Florian Roth (Nextron Systems)
 date: 2022/12/04
-modified: 2023/02/04
+modified: 2024/04/04
 tags:
     - cve.2022.41120
     - attack.t1068


### PR DESCRIPTION
Since `Hashes` contains several hashes, it is necessary to use the `contains` modifier.

### Changelog

update: HackTool - CoercedPotato Execution - Update `Hashes` field to use `contains` modifier
update: HackTool - HandleKatz LSASS Dumper Execution - Update `Hashes` field to use `contains` modifier
update: HackTool - SysmonEOP Execution - Update `Hashes` field to use `contains` modifier