### PR TITLE
Update AWS Rule to use fieldref modifier instead of contains

### DIFF
--- a/rules/cloud/aws/cloudtrail/aws_update_login_profile.yml
+++ b/rules/cloud/aws/cloudtrail/aws_update_login_profile.yml
@@ -20,7 +20,7 @@ detection:
         eventSource: iam.amazonaws.com
         eventName: UpdateLoginProfile
     filter:
-        userIdentity.arn|contains: requestParameters.userName
+        userIdentity.arn|fieldref: requestParameters.userName
     condition: selection_source and not filter
 fields:
     - userIdentity.arn

--- a/rules/cloud/aws/cloudtrail/aws_update_login_profile.yml
+++ b/rules/cloud/aws/cloudtrail/aws_update_login_profile.yml
@@ -2,8 +2,8 @@ title: AWS User Login Profile Was Modified
 id: 055fb148-60f8-462d-ad16-26926ce050f1
 status: test
 description: |
-    An attacker with the iam:UpdateLoginProfile permission on other users can change the password used to login to the AWS console on any user that already has a login profile setup.
-    With this alert, it is used to detect anyone is changing password on behalf of other users.
+    Detects activity when someone is changing passwords on behalf of other users.
+    An attacker with the "iam:UpdateLoginProfile" permission on other users can change the password used to login to the AWS console on any user that already has a login profile setup.
 references:
     - https://github.com/RhinoSecurityLabs/AWS-IAM-Privilege-Escalation
 author: toffeebr33k
@@ -16,17 +16,12 @@ logsource:
     product: aws
     service: cloudtrail
 detection:
-    selection_source:
-        eventSource: iam.amazonaws.com
-        eventName: UpdateLoginProfile
-    filter:
+    selection:
+        eventSource: 'iam.amazonaws.com'
+        eventName: 'UpdateLoginProfile'
+    filter_main_user_identity:
         userIdentity.arn|fieldref: requestParameters.userName
-    condition: selection_source and not filter
-fields:
-    - userIdentity.arn
-    - requestParameters.userName
-    - errorCode
-    - errorMessage
+    condition: selection and not 1 of filter_main_*
 falsepositives:
-    - Legit User Account Administration
+    - Legitimate user account administration
 level: high

--- a/rules/cloud/aws/cloudtrail/aws_update_login_profile.yml
+++ b/rules/cloud/aws/cloudtrail/aws_update_login_profile.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/RhinoSecurityLabs/AWS-IAM-Privilege-Escalation
 author: toffeebr33k
 date: 2021/08/09
-modified: 2022/10/09
+modified: 2024/04/26
 tags:
     - attack.persistence
     - attack.t1098


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

In deploying [this rule](https://github.com/SigmaHQ/sigma/blob/master/rules/cloud/aws/cloudtrail/aws_update_login_profile.yml), the Grafana SecOps team discovered that the `contains` modifier does not reference the field that this rule is trying to reference. Instead, we discovered that there is another modifier in `pySigma` that will enable field referencing which is called [`fieldref`](https://github.com/SigmaHQ/pySigma/blob/main/sigma/modifiers.py#L358) which enables us to update [pySigma-backend-loki](https://github.com/grafana/pySigma-backend-loki/pull/137) to reflect this modifier.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

update: AWS User Login Profile Was Modified - use `fieldref` instead of `contains` modifier

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
An (abridged) event we want to match on:

```json
{"eventName": "UpdateLoginProfile", "userIdentity": {"arn": "arn:aws:iam::123456789012:user/OrgAdmin"}, "requestParameters": {"userName": "arn:aws:iam::123456789012:user/Alice"}}
```

Whereas something we don't want to detect on:

```json
{"eventName": "UpdateLoginProfile", "userIdentity": {"arn": "arn:aws:iam::123456789012:user/Alice"}, "requestParameters": {"userName": "arn:aws:iam::123456789012:user/Alice"}}
```
### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
