### PR TITLE
New Analytics: LocaltoNet tunneling

### DIFF
--- a/rules/linux/network_connection/net_connection_lnx_domain_localtonet_tunnel.yml
+++ b/rules/linux/network_connection/net_connection_lnx_domain_localtonet_tunnel.yml
@@ -1,4 +1,4 @@
-title: Communication To LocaltoNet Tunneling Service Initiated
+title: Communication To LocaltoNet Tunneling Service Initiated - Linux
 id: c4568f5d-131f-4e78-83d4-45b2da0ec4f1
 status: experimental
 description: |
@@ -10,7 +10,6 @@ references:
     - https://cloud.google.com/blog/topics/threat-intelligence/unc3944-targets-saas-applications
 author: Andreas Braathen (mnemonic.io)
 date: 2024/06/17
-modified: 2024/06/17
 tags:
     - attack.command_and_control
     - attack.t1572

--- a/rules/linux/network_connection/net_connection_lnx_localtonet_tunnel.yml
+++ b/rules/linux/network_connection/net_connection_lnx_localtonet_tunnel.yml
@@ -24,7 +24,7 @@ detection:
         DestinationHostname|endswith:
             - '.localto.net'
             - '.localtonet.com'
-		Initiated: 'true'
+        Initiated: 'true'
     condition: selection
 falsepositives:
     - Legitimate use of the LocaltoNet service.

--- a/rules/linux/network_connection/net_connection_lnx_localtonet_tunnel.yml
+++ b/rules/linux/network_connection/net_connection_lnx_localtonet_tunnel.yml
@@ -1,0 +1,31 @@
+title: Communication To LocaltoNet Tunneling Service Initiated
+id: c4568f5d-131f-4e78-83d4-45b2da0ec4f1
+status: experimental
+description: |
+    Detects an executable initiating a network connection to "LocaltoNet" tunneling sub-domains.
+    LocaltoNet is a reverse proxy that enables localhost services to be exposed to the Internet.
+    Attackers have been seen to use this service for command-and-control activities to bypass MFA and perimeter controls.
+references:
+    - https://localtonet.com/documents/supported-tunnels
+    - https://cloud.google.com/blog/topics/threat-intelligence/unc3944-targets-saas-applications
+author: Andreas Braathen (mnemonic.io)
+date: 2024/06/17
+modified: 2024/06/17
+tags:
+    - attack.command_and_control
+    - attack.t1572
+    - attack.t1090
+    - attack.t1102
+logsource:
+    category: network_connection
+    product: linux
+detection:
+    selection:
+        DestinationHostname|endswith:
+            - '.localto.net'
+            - '.localtonet.com'
+		Initiated: 'true'
+    condition: selection
+falsepositives:
+    - Legitimate use of the LocaltoNet service.
+level: high

--- a/rules/windows/network_connection/net_connection_win_domain_localtonet_tunnel.yml
+++ b/rules/windows/network_connection/net_connection_win_domain_localtonet_tunnel.yml
@@ -24,7 +24,7 @@ detection:
         DestinationHostname|endswith:
             - '.localto.net'
             - '.localtonet.com'
-		Initiated: 'true'
+        Initiated: 'true'
     condition: selection
 falsepositives:
     - Legitimate use of the LocaltoNet service.

--- a/rules/windows/network_connection/net_connection_win_domain_localtonet_tunnel.yml
+++ b/rules/windows/network_connection/net_connection_win_domain_localtonet_tunnel.yml
@@ -1,0 +1,31 @@
+title: Communication To LocaltoNet Tunneling Service Initiated
+id: 3ab65069-d82a-4d44-a759-466661a082d1
+status: experimental
+description: |
+    Detects an executable initiating a network connection to "LocaltoNet" tunneling sub-domains.
+    LocaltoNet is a reverse proxy that enables localhost services to be exposed to the Internet.
+    Attackers have been seen to use this service for command-and-control activities to bypass MFA and perimeter controls.
+references:
+    - https://localtonet.com/documents/supported-tunnels
+    - https://cloud.google.com/blog/topics/threat-intelligence/unc3944-targets-saas-applications
+author: Andreas Braathen (mnemonic.io)
+date: 2024/06/17
+modified: 2024/06/17
+tags:
+    - attack.command_and_control
+    - attack.t1572
+    - attack.t1090
+    - attack.t1102
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    selection:
+        DestinationHostname|endswith:
+            - '.localto.net'
+            - '.localtonet.com'
+		Initiated: 'true'
+    condition: selection
+falsepositives:
+    - Legitimate use of the LocaltoNet service.
+level: high

--- a/rules/windows/network_connection/net_connection_win_domain_localtonet_tunnel.yml
+++ b/rules/windows/network_connection/net_connection_win_domain_localtonet_tunnel.yml
@@ -10,7 +10,6 @@ references:
     - https://cloud.google.com/blog/topics/threat-intelligence/unc3944-targets-saas-applications
 author: Andreas Braathen (mnemonic.io)
 date: 2024/06/17
-modified: 2024/06/17
 tags:
     - attack.command_and_control
     - attack.t1572


### PR DESCRIPTION
### Summary of the Pull Request

Adds analytics to detect tunneling through the [LocaltoNet](https://localtonet.com/documents) service.

LocaltoNet is a legitimate reverse proxy application that _may_ enable threat actors to perform tactics incl. enabling command-and-control and exfil. Similar to Ngrok. 

A recent campaign includes https://cloud.google.com/blog/topics/threat-intelligence/unc3944-targets-saas-applications

### Changelog

- new: Communication To LocaltoNet Tunneling Service Initiated
- new: Communication To LocaltoNet Tunneling Service Initiated - Linux

### Example Log Event

Install locally via https://localtonet.com/documents. Generates network event id (Sysmon 3 / 5156). Can alternative be captured by DNS-lookup or Proxy logs (http tunneling, not all protocols).
