### PR TITLE
added expand modifier to placeholder rule

### DIFF
--- a/rules-placeholder/windows/process_creation/proc_creation_win_userdomain_variable_enumeration.yml
+++ b/rules-placeholder/windows/process_creation/proc_creation_win_userdomain_variable_enumeration.yml
@@ -15,9 +15,8 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains|all:
-            - 'echo '
-            - '%userdomain%'
+        CommandLine|contains: 'echo '
+        CommandLine|contains|expand: '%userdomain%'
     condition: selection
 falsepositives:
     - Certain scripts or applications may leverage this.

--- a/rules-placeholder/windows/process_creation/proc_creation_win_userdomain_variable_enumeration.yml
+++ b/rules-placeholder/windows/process_creation/proc_creation_win_userdomain_variable_enumeration.yml
@@ -7,6 +7,7 @@ references:
     - https://thedfirreport.com/2022/11/14/bumblebee-zeros-in-on-meterpreter/
 author: 'Christopher Peacock @SecurePeacock, SCYTHE @scythe_io'
 date: 2023/02/09
+modified: 2024/08/01
 tags:
     - attack.discovery
     - attack.t1016


### PR DESCRIPTION
All of the other placeholder rules use the `|expand` modifier except this one so I figured it was overlooked and added it.

fix: Userdomain Variable Enumeration