### PR TITLE
Add Rule: proc_creation_macos_susp_hdiutil_mount.yml

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_hdiutil_create.yml
+++ b/rules/macos/process_creation/proc_creation_macos_hdiutil_create.yml
@@ -1,0 +1,23 @@
+title: Disk Image Creation Via Hdiutil - MacOS
+id: 1cf98dc2-fcb0-47c9-8aea-654c9284d1ae
+status: experimental
+description: Detects the execution of the hdiutil utility in order to create a disk image.
+references:
+    - https://www.loobins.io/binaries/hdiutil/
+    - https://www.sentinelone.com/blog/from-the-front-linesunsigned-macos-orat-malware-gambles-for-the-win/
+    - https://ss64.com/mac/hdiutil.html
+author: Omar Khaled (@beacon_exe)
+date: 2024/08/10
+tags:
+    - attack.exfiltration
+logsource:
+    product: macos
+    category: process_creation
+detection:
+    selection:
+        Image|endswith: /hdiutil
+        CommandLine|contains: 'create'
+    condition: selection
+falsepositives:
+    - Legitimate usage of hdiutil by administrators and users.
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_hdiutil_mount.yml
+++ b/rules/macos/process_creation/proc_creation_macos_hdiutil_mount.yml
@@ -1,12 +1,13 @@
-title: File Mounting Via hdiutil - MacOS
+title: Disk Image Mounting Via Hdiutil - MacOS
 id: bf241472-f014-4f01-a869-96f99330ca8c
 status: experimental
-description: Detects the execution of the hdiutil utility in order to mount files or exfiltrate data
+description: Detects the execution of the hdiutil utility in order to mount disk images.
 references:
     - https://www.loobins.io/binaries/hdiutil/
-    - https://www.sentinelone.com/blog/from-the-front-lines-unsigned-macos-orat-malware-gambles-for-the-win/
+    - https://www.sentinelone.com/blog/from-the-front-linesunsigned-macos-orat-malware-gambles-for-the-win/
+    - https://ss64.com/mac/hdiutil.html
 author: Omar Khaled (@beacon_exe)
-date: 2024/08/04
+date: 2024/08/10
 tags:
     - attack.initial_access
     - attack.t1566.001
@@ -20,8 +21,7 @@ detection:
         CommandLine|contains:
             - 'attach '
             - 'mount '
-            - 'create '
     condition: selection
 falsepositives:
-    - Legitimate usage of hdiutil by administrators and users
+    - Legitimate usage of hdiutil by administrators and users.
 level: medium

--- a/rules/macos/process_creation/proc_creation_macos_susp_hdiutil_mount.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_hdiutil_mount.yml
@@ -1,0 +1,27 @@
+title: File Mounting Via hdiutil - MacOS
+id: bf241472-f014-4f01-a869-96f99330ca8c
+status: experimental
+description: Detects the execution of the hdiutil utility in order to mount files or exfiltrate data
+references:
+    - https://www.loobins.io/binaries/hdiutil/
+    - https://www.sentinelone.com/blog/from-the-front-lines-unsigned-macos-orat-malware-gambles-for-the-win/
+author: Omar Khaled (@beacon_exe)
+date: 2024/08/04
+tags:
+    - attack.initial_access
+    - attack.t1566.001
+    - attack.t1560.001
+logsource:
+    product: macos
+    category: process_creation
+detection:
+    selection:
+        Image|endswith: /hdiutil
+        CommandLine|contains:
+            - 'attach '
+            - 'mount '
+            - 'create '
+    condition: selection
+falsepositives:
+    - Legitimate usage of hdiutil by administrators and users
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Thie PR adds the detection of `hdiutil` on macOS, which is used for mounting DMG files and creating DMG files to store exfiltrated data.  For example, the command /usr/bin/hdiutil attach `/tmp/bitget-0.0.7 (1).dmg` will mount to `/Volumes/bitget-0.0.7/`. Notably referenced in the  [Sentinelone IoC Section](https://www.sentinelone.com/blog/from-the-front-lines-unsigned-macos-orat-malware-gambles-for-the-win/) and the [loobins](https://www.loobins.io/binaries/hdiutil/) project.


### Changelog

new:	Disk Image Mounting Via Hdiutil - MacOS
new: Disk Image Creation Via Hdiutil - MacOS

### Example Log Event

N/A
### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)
