### PR TITLE
Changed to not use `Lookahead` regex

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
@@ -29,7 +29,7 @@ detection:
         #   ${e`Nv:pATh}
         - ScriptBlockText|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
     filter_envpath:
-        ScriptBlockText|contains: '${env:path}'
+        ScriptBlockText|contains: '${env:path}' # TODO: Fix this. See https://github.com/SigmaHQ/sigma/pull/4964
     filter_chocolatey:
         ScriptBlockText|contains:
             - 'it will return true or false instead'  # Chocolatey install script https://github.com/chocolatey/chocolatey

--- a/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
@@ -23,13 +23,14 @@ detection:
         #   IN`V`o`Ke-eXp`ResSIOn (Ne`W-ob`ject Net.WebClient).DownloadString
         #   &('In'+'voke-Expressi'+'o'+'n') (.('New-Ob'+'jec'+'t') Net.WebClient).DownloadString
         #   &("{2}{3}{0}{4}{1}"-f 'e','Expression','I','nvok','-') (&("{0}{1}{2}"-f'N','ew-O','bject') Net.WebClient).DownloadString
-        #   ${e`Nv:pATh}
         - ScriptBlockText|re: '\w+`(\w+|-|.)`[\w+|\s]'
         # - ScriptBlockText|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
         - ScriptBlockText|re: '"(\{\d\}){2,}"\s*-f'  # trigger on at least two placeholders. One might be used for legitimate string formatting
     selection_2:
-        ScriptBlockText|contains: '`'
+        #   ${e`Nv:pATh}
         ScriptBlockText|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
+    filter_envpath:
+        ScriptBlockText|contains: '${env:path}'
     filter_chocolatey:
         ScriptBlockText|contains:
             - 'it will return true or false instead'  # Chocolatey install script https://github.com/chocolatey/chocolatey

--- a/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
@@ -18,7 +18,7 @@ logsource:
     category: ps_script
     definition: 'Requirements: Script Block Logging must be enabled'
 detection:
-    selection_1:
+    selection:
         # Examples:
         #   IN`V`o`Ke-eXp`ResSIOn (Ne`W-ob`ject Net.WebClient).DownloadString
         #   &('In'+'voke-Expressi'+'o'+'n') (.('New-Ob'+'jec'+'t') Net.WebClient).DownloadString
@@ -26,9 +26,8 @@ detection:
         - ScriptBlockText|re: '\w+`(\w+|-|.)`[\w+|\s]'
         # - ScriptBlockText|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
         - ScriptBlockText|re: '"(\{\d\}){2,}"\s*-f'  # trigger on at least two placeholders. One might be used for legitimate string formatting
-    selection_2:
         #   ${e`Nv:pATh}
-        ScriptBlockText|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
+        - ScriptBlockText|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
     filter_envpath:
         ScriptBlockText|contains: '${env:path}'
     filter_chocolatey:
@@ -39,7 +38,7 @@ detection:
         Path|startswith: 'C:\Program Files\Microsoft\Exchange Server\'
         Path|endswith: '\bin\servicecontrol.ps1'
         ScriptBlockText|contains: '`r`n'
-    condition: 1 of selection_* and not 1 of filter_*
+    condition: selection and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
@@ -28,7 +28,7 @@ detection:
         # - ScriptBlockText|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
         - ScriptBlockText|re: '"(\{\d\}){2,}"\s*-f'  # trigger on at least two placeholders. One might be used for legitimate string formatting
     selection_2:
-        ScriptBlockText|contains: `
+        ScriptBlockText|contains: '`'
         ScriptBlockText|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
     filter_chocolatey:
         ScriptBlockText|contains:

--- a/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_token_obfuscation.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/danielbohannon/Invoke-Obfuscation
 author: frack113
 date: 2022/12/27
-modified: 2024/08/10
+modified: 2024/08/11
 tags:
     - attack.defense_evasion
     - attack.t1027.009
@@ -18,7 +18,7 @@ logsource:
     category: ps_script
     definition: 'Requirements: Script Block Logging must be enabled'
 detection:
-    selection:
+    selection_1:
         # Examples:
         #   IN`V`o`Ke-eXp`ResSIOn (Ne`W-ob`ject Net.WebClient).DownloadString
         #   &('In'+'voke-Expressi'+'o'+'n') (.('New-Ob'+'jec'+'t') Net.WebClient).DownloadString
@@ -27,7 +27,9 @@ detection:
         - ScriptBlockText|re: '\w+`(\w+|-|.)`[\w+|\s]'
         # - ScriptBlockText|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
         - ScriptBlockText|re: '"(\{\d\}){2,}"\s*-f'  # trigger on at least two placeholders. One might be used for legitimate string formatting
-        - ScriptBlockText|re: '(?i)\$\{(?=.*`)+?`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
+    selection_2:
+        ScriptBlockText|contains: `
+        ScriptBlockText|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
     filter_chocolatey:
         ScriptBlockText|contains:
             - 'it will return true or false instead'  # Chocolatey install script https://github.com/chocolatey/chocolatey
@@ -36,7 +38,7 @@ detection:
         Path|startswith: 'C:\Program Files\Microsoft\Exchange Server\'
         Path|endswith: '\bin\servicecontrol.ps1'
         ScriptBlockText|contains: '`r`n'
-    condition: selection and not 1 of filter_*
+    condition: 1 of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/danielbohannon/Invoke-Obfuscation
 author: frack113
 date: 2022/12/27
-modified: 2024/08/09
+modified: 2024/08/11
 tags:
     - attack.defense_evasion
     - attack.t1027.009
@@ -17,7 +17,7 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
+    selection_1:
         # Examples:
         #   IN`V`o`Ke-eXp`ResSIOn (Ne`W-ob`ject Net.WebClient).DownloadString
         #   &('In'+'voke-Expressi'+'o'+'n') (.('New-Ob'+'jec'+'t') Net.WebClient).DownloadString
@@ -26,8 +26,10 @@ detection:
         - CommandLine|re: '\w+`(\w+|-|.)`[\w+|\s]'
         # - CommandLine|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
         - CommandLine|re: '"(\{\d\})+"\s*-f'
-        - CommandLine|re: '(?i)\$\{(?=.*`)+?`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
-    condition: selection
+    selection_2:
+        CommandLine|contains: `
+        CommandLine|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
+    condition: 1 of selection_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
@@ -22,14 +22,15 @@ detection:
         #   IN`V`o`Ke-eXp`ResSIOn (Ne`W-ob`ject Net.WebClient).DownloadString
         #   &('In'+'voke-Expressi'+'o'+'n') (.('New-Ob'+'jec'+'t') Net.WebClient).DownloadString
         #   &("{2}{3}{0}{4}{1}"-f 'e','Expression','I','nvok','-') (&("{0}{1}{2}"-f'N','ew-O','bject') Net.WebClient).DownloadString
-        #   ${e`Nv:pATh}
         - CommandLine|re: '\w+`(\w+|-|.)`[\w+|\s]'
         # - CommandLine|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
         - CommandLine|re: '"(\{\d\})+"\s*-f'
     selection_2:
-        CommandLine|contains: '`'
+        #   ${e`Nv:pATh}
         CommandLine|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
-    condition: 1 of selection_*
+    filter_envpath:
+        CommandLine|contains: '${env:path}'
+    condition: 1 of selection_* and not filter_envpath
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
@@ -17,7 +17,7 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection_1:
+    selection:
         # Examples:
         #   IN`V`o`Ke-eXp`ResSIOn (Ne`W-ob`ject Net.WebClient).DownloadString
         #   &('In'+'voke-Expressi'+'o'+'n') (.('New-Ob'+'jec'+'t') Net.WebClient).DownloadString
@@ -25,12 +25,11 @@ detection:
         - CommandLine|re: '\w+`(\w+|-|.)`[\w+|\s]'
         # - CommandLine|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
         - CommandLine|re: '"(\{\d\})+"\s*-f'
-    selection_2:
         #   ${e`Nv:pATh}
-        CommandLine|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
-    filter_envpath:
+        - CommandLine|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
+    filter_main_envpath:
         CommandLine|contains: '${env:path}'
-    condition: 1 of selection_* and not filter_envpath
+    condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_token_obfuscation.yml
@@ -27,7 +27,7 @@ detection:
         # - CommandLine|re: '\((\'(\w|-|\.)+\'\+)+\'(\w|-|\.)+\'\)' TODO: fixme
         - CommandLine|re: '"(\{\d\})+"\s*-f'
     selection_2:
-        CommandLine|contains: `
+        CommandLine|contains: '`'
         CommandLine|re: '(?i)\$\{`?e`?n`?v`?:`?p`?a`?t`?h`?\}'
     condition: 1 of selection_*
 falsepositives:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request
Since lookahead(and lookbehind) regex are not supported in Golang or Rust,
I replaced the lookahead regex with simple `contains` logic as follows.
- before(lookahead regex): <code>(?=.*`)</code>
- after(contains logic):  <code>|contains: '`'</code>

FYI: https://github.com/SigmaHQ/sigma/pull/4526

I think it's difficult to support regex for all languages...,
but I think it might be better to use more supported regex as much as possible.

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog
fix: Powershell Token Obfuscation - Powershell - Changed to not use Lookahead regex
fix: Powershell Token Obfuscation - Process Creation - Changed to not use Lookahead regex
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event
N/A
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues
#### Golang
https://go.dev/play/p/YjkmggquHlV
<img width="1080" alt="スクリーンショット 2024-08-11 9 28 44" src="https://github.com/user-attachments/assets/22cb83e8-66cc-407c-8df2-81e3db4f1fb0">


#### Rust
<img width="1080" alt="スクリーンショット 2024-08-11 8 45 32" src="https://github.com/user-attachments/assets/cd6e8eb2-c009-46d3-8f94-8921572c1c60">


<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
