### PR TITLE
BTunnels Detection for Data Exfiltration

### DIFF
--- a/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
+++ b/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
@@ -1,5 +1,5 @@
 title: Network Connection Initiated To BTunnels  Domains
-id: 7cd1dcdc-6edf-4896-86dc-d1f19ad64903
+id: 9e02c8ec-02b9-43e8-81eb-34a475ba7965
 related:
     - id: a1d9eec5-33b2-4177-8d24-27fe754d0812
       type: derived

--- a/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
+++ b/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
@@ -14,7 +14,6 @@ author: Kamran Saifullah
 date: 2024-09-08
 tags:
     - attack.exfiltration
-    - attack.command_and_control
     - attack.t1567.001
 logsource:
     category: network_connection

--- a/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
+++ b/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
@@ -22,8 +22,7 @@ logsource:
 detection:
     selection:
         Initiated: 'true'
-        DestinationHostname|endswith:
-            - '*.btunnel.co.in'
+        DestinationHostname|endswith: '.btunnel.co.in'
     condition: selection
 falsepositives:
     - Legitimate use of BTunnels will also trigger this.

--- a/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
+++ b/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
@@ -1,0 +1,30 @@
+title: Network Connection Initiated To Cloudflared Tunnels Domains
+id: 7cd1dcdc-6edf-4896-86dc-d1f19ad64903
+related:
+    - id: a1d9eec5-33b2-4177-8d24-27fe754d0812
+      type: derived
+status: experimental
+description: |
+    Detects network connections to BTunnels domains initiated by a process on the system.
+    Attackers can abuse that feature to establish a reverse shell or persistence on a machine.
+references:
+    - https://defr0ggy.github.io/research/Utilizing-BTunnel-For-Data-Exfiltration/
+    - Internal Research
+author: Kamran Saifullah
+date: 2024/09/08
+tags:
+    - attack.exfiltration
+    - attack.command_and_control
+    - attack.t1567.001
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    selection:
+        Initiated: 'true'
+        DestinationHostname|endswith:
+            - '*.btunnel.co.in'
+    condition: selection
+falsepositives:
+    - Legitimate use of BTunnels will also trigger this.
+level: medium

--- a/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
+++ b/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
@@ -1,4 +1,4 @@
-title: Network Connection Initiated To Cloudflared Tunnels Domains
+title: Network Connection Initiated To BTunnels  Domains
 id: 7cd1dcdc-6edf-4896-86dc-d1f19ad64903
 related:
     - id: a1d9eec5-33b2-4177-8d24-27fe754d0812

--- a/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
+++ b/rules/windows/network_connection/net_connection_win_btunnels_communication.yml
@@ -11,7 +11,7 @@ references:
     - https://defr0ggy.github.io/research/Utilizing-BTunnel-For-Data-Exfiltration/
     - Internal Research
 author: Kamran Saifullah
-date: 2024/09/08
+date: 2024-09-08
 tags:
     - attack.exfiltration
     - attack.command_and_control

--- a/rules/windows/network_connection/net_connection_win_domain_btunnels.yml
+++ b/rules/windows/network_connection/net_connection_win_domain_btunnels.yml
@@ -1,17 +1,13 @@
-title: Network Connection Initiated To BTunnels  Domains
+title: Network Connection Initiated To BTunnels Domains
 id: 9e02c8ec-02b9-43e8-81eb-34a475ba7965
-related:
-    - id: a1d9eec5-33b2-4177-8d24-27fe754d0812
-      type: derived
 status: experimental
 description: |
     Detects network connections to BTunnels domains initiated by a process on the system.
     Attackers can abuse that feature to establish a reverse shell or persistence on a machine.
 references:
     - https://defr0ggy.github.io/research/Utilizing-BTunnel-For-Data-Exfiltration/
-    - Internal Research
 author: Kamran Saifullah
-date: 2024-09-08
+date: 2024-09-13
 tags:
     - attack.exfiltration
     - attack.t1567.001


### PR DESCRIPTION
Similar to DevTunnels and CloudFlared, this tool can also be used for Data Exfiltration and for downloading malicious binaries as well as for C2 communications. 

I have written a research article on the same and adding detection rule into the Sigma repo. 

https://defr0ggy.github.io/research/Utilizing-BTunnel-For-Data-Exfiltration/