### PR TITLE
remove the dual use tool nmap from "Linux HackTool Execution"

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_susp_hktl_execution.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_susp_hktl_execution.yml
@@ -14,7 +14,7 @@ references:
     - https://github.com/Pennyw0rth/NetExec/
 author: Nasreddine Bencherchali (Nextron Systems), Georg Lauenstein (sure[secure])
 date: 2023-01-03
-modified: 2023-10-25
+modified: 2024-09-19
 tags:
     - attack.execution
     - attack.resource-development
@@ -47,10 +47,8 @@ detection:
             - '/legion'
             - '/naabu'
             - '/netdiscover'
-            - '/nmap'
             - '/nuclei'
             - '/recon-ng'
-            - '/zenmap'
     selection_scanners_sniper:
         Image|contains: '/sniper'
     selection_web_enum:

--- a/rules/linux/process_creation/proc_creation_lnx_susp_network_utilities_execution.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_susp_network_utilities_execution.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/Tib3rius/AutoRecon
 author: Alejandro Ortuno, oscd.community, Georg Lauenstein (sure[secure])
 date: 2020-10-21
-modified: 2023-10-25
+modified: 2024-09-19
 tags:
     - attack.discovery
     - attack.t1046
@@ -32,6 +32,7 @@ detection:
             - '/nmap'
             - '/nping'
             - '/telnet' # could be wget, curl, ssh, many things. basically everything that is able to do network connection. consider fine tuning
+            - '/zenmap'
     filter_main_netcat_listen_flag:
         CommandLine|contains:
             - ' --listen '


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

Remove the dual use tool nmap from "Linux HackTool Execution". It's also already covered in "Linux Network Service Scanning Tools Execution" which has the right level for it. Just adding the missing `zenmap` there.

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

Remove the dual use tool nmap from "Linux HackTool Execution". It's also already covered in "Linux Network Service Scanning Tools Execution" which has the right level for it. Just adding the missing `zenmap` there.


<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

update: Linux HackTool Execution - Remove "zenmap" and "nmap" as they are already covered by 3e102cd9-a70d-4a7a-9508-403963092f31
update: Linux Network Service Scanning Tools Execution - Add "zenmap" utility


<!--
Fill this in case of false positive fixes
-->

### Fixed Issues
N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
