### PR TITLE
Update proc_creation_win_taskkill_execution.yml

### DIFF
--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_taskkill_execution.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_taskkill_execution.yml
@@ -32,7 +32,7 @@ detection:
             - '\AppData\Local\Temp\'
             - ':\Windows\Temp'
         ParentImage|endswith: '.tmp'
-    condition: selection_img and (selection_1_cli or selection_2_cli) and not 1 of filter_main_*
+    condition: all of selection_* and not 1 of filter_main_*
 falsepositives:
     - Expected FP with some processes using this techniques to terminate one of their processes during installations and updates
 level: low

--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_taskkill_execution.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_taskkill_execution.yml
@@ -6,9 +6,10 @@ description: |
     Attackers might leverage this in order to conduct data destruction or data encrypted for impact on the data stores of services like Exchange and SQL Server.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1489/T1489.md#atomic-test-3---windows---stop-service-by-killing-process
-author: frack113
+    - https://unit42.paloaltonetworks.com/snipbot-romcom-malware-variant/
+author: frack113, MalGamy (Nextron Systems)
 date: 2021-12-26
-modified: 2023-11-06
+modified: 2024-10-03
 tags:
     - attack.impact
     - attack.t1489
@@ -20,16 +21,18 @@ detection:
     selection_img:
         - Image|endswith: '\taskkill.exe'
         - OriginalFileName: 'taskkill.exe'
-    selection_cli:
-        CommandLine|contains|all:
-            - ' /f'
+    selection_1_cli:
+        CommandLine|contains: ' /f'
+    selection_2_cli:
+        CommandLine|contains:
             - ' /im '
+            - ' /pid '
     filter_main_installers:
         ParentImage|contains:
             - '\AppData\Local\Temp\'
             - ':\Windows\Temp'
         ParentImage|endswith: '.tmp'
-    condition: all of selection_* and not 1 of filter_main_*
+    condition: selection_img and (selection_1_cli or selection_2_cli) and not 1 of filter_main_*
 falsepositives:
     - Expected FP with some processes using this techniques to terminate one of their processes during installations and updates
 level: low

--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_taskkill_execution.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_taskkill_execution.yml
@@ -7,9 +7,9 @@ description: |
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1489/T1489.md#atomic-test-3---windows---stop-service-by-killing-process
     - https://unit42.paloaltonetworks.com/snipbot-romcom-malware-variant/
-author: frack113, MalGamy (Nextron Systems)
+author: frack113, MalGamy (Nextron Systems), Nasreddine Bencherchali
 date: 2021-12-26
-modified: 2024-10-03
+modified: 2024-10-06
 tags:
     - attack.impact
     - attack.t1489
@@ -21,10 +21,11 @@ detection:
     selection_img:
         - Image|endswith: '\taskkill.exe'
         - OriginalFileName: 'taskkill.exe'
-    selection_1_cli:
-        CommandLine|contains: ' /f'
-    selection_2_cli:
-        CommandLine|contains:
+    selection_cli_force:
+        - CommandLine|contains|windash: ' /f '
+        - CommandLine|endswith|windash: ' /f'
+    selection_cli_filter_process:
+        CommandLine|contains|windash:
             - ' /im '
             - ' /pid '
     filter_main_installers:


### PR DESCRIPTION
### Summary of the Pull Request
Add command line argument flags used with taskkill by the attacker to terminate a process by its PID
### Changelog
update: Process Terminated Via Taskkill - Add `/pid` flag and windash support
### Example Log Event

``` Process Create:
RuleName: -
UtcTime: 2024-10-02 21:02:05.228
ProcessGuid: {6e6be129-b4cd-66fd-cb01-000000001900}
ProcessId: 4568
Image: C:\Windows\System32\taskkill.exe
FileVersion: 10.0.19041.1 (WinBuild.160101.0800)
Description: Terminates Processes
Product: Microsoft® Windows® Operating System
Company: Microsoft Corporation
OriginalFileName: taskkill.exe
CommandLine: taskkill  /pid 380 /f
CurrentDirectory: C:\Users\MalGamy\
User: DESKTOP-0TOC207\MalGamy
LogonGuid: {6e6be129-ae65-66fd-58dc-0d0000000000}
LogonId: 0xDDC58
TerminalSessionId: 1
IntegrityLevel: Medium
Hashes: SHA256=56F8CC2C1790C389394733B84C3FB55E10977E9F0FE0C08110AC11F0FE47F05E
ParentProcessGuid: {6e6be129-b4b0-66fd-c901-000000001900}
ParentProcessId: 1416
ParentImage: C:\Windows\System32\cmd.exe
ParentCommandLine: "C:\Windows\system32\cmd.exe" 
ParentUser: DESKTOP-0TOC207\MalGamy 
```

