### PR TITLE
add: RustiveDump, NativeDump pattern, fix: NanoDump pattern

### DIFF
--- a/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
+++ b/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
@@ -28,32 +28,29 @@ logsource:
 detection:
     selection_1:
         TargetFilename|endswith:
-            - '\lsass.dmp'
-            - '\lsass.zip'
-            - '\lsass.rar'
             - '\Andrew.dmp'
             - '\Coredump.dmp'
+            - '\lsass.dmp'
+            - '\lsass.rar'
+            - '\lsass.zip'
             - '\NotLSASS.zip'  # https://github.com/CCob/MirrorDump
             - '\PPLBlade.dmp'  # https://github.com/tastypepperoni/PPLBlade
             - '\rustive.dmp' # https://github.com/safedv/RustiveDump/blob/main/src/main.rs#L35
     selection_2:
         TargetFilename|contains:
             - '\lsass_2'  # default format of procdump v9.0 is lsass_YYMMDD_HHmmss.dmp
-            - '\lsassdump'
             - '\lsassdmp'
+            - '\lsassdump'
     selection_3:
         TargetFilename|contains|all:
             - '\lsass'
             - '.dmp'
     selection_4:
-        TargetFilename|contains: 'SQLDmpr'
+        TargetFilename|contains:
+            - 'SQLDmpr'
+            - '\nanodump'
+            - '\proc_' # NativeDump pattern https://github.com/ricardojoserf/NativeDump/blob/01d8cd17f31f51f5955a38e85cd3c83a17596175/NativeDump/Program.cs#L258
         TargetFilename|endswith: '.mdmp'
-    selection_5:
-        TargetFilename|contains: '\nanodump'
-        TargetFilename|endswith: '.dmp'
-    selection_6: # NativeDump pattern https://github.com/ricardojoserf/NativeDump/blob/01d8cd17f31f51f5955a38e85cd3c83a17596175/NativeDump/Program.cs#L258
-        TargetFilename|contains: '\proc_'
-        TargetFilename|endswith: '.dmp'
     condition: 1 of selection_*
 falsepositives:
     - Unknown

--- a/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
+++ b/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
@@ -14,6 +14,8 @@ references:
     - https://www.whiteoaksecurity.com/blog/attacks-defenses-dumping-lsass-no-mimikatz/
     - https://github.com/helpsystems/nanodump
     - https://github.com/CCob/MirrorDump
+    - https://github.com/safedv/RustiveDump/blob/main/src/main.rs#L35
+    - https://github.com/ricardojoserf/NativeDump/blob/01d8cd17f31f51f5955a38e85cd3c83a17596175/NativeDump/Program.cs#L258
 author: Florian Roth (Nextron Systems)
 date: 2021-11-15
 modified: 2024-10-08
@@ -47,7 +49,10 @@ detection:
         TargetFilename|contains: 'SQLDmpr'
         TargetFilename|endswith: '.mdmp'
     selection_5:
-        TargetFilename|startswith: 'nanodump'
+        TargetFilename|contains: '\nanodump'
+        TargetFilename|endswith: '.dmp'
+    selection_6: # NativeDump pattern https://github.com/ricardojoserf/NativeDump/blob/01d8cd17f31f51f5955a38e85cd3c83a17596175/NativeDump/Program.cs#L258
+        TargetFilename|contains: '\proc_'
         TargetFilename|endswith: '.dmp'
     condition: 1 of selection_*
 falsepositives:

--- a/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
+++ b/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
@@ -16,7 +16,7 @@ references:
     - https://github.com/CCob/MirrorDump
 author: Florian Roth (Nextron Systems)
 date: 2021-11-15
-modified: 2023-09-05
+modified: 2024-10-08
 tags:
     - attack.credential-access
     - attack.t1003.001
@@ -33,6 +33,7 @@ detection:
             - '\Coredump.dmp'
             - '\NotLSASS.zip'  # https://github.com/CCob/MirrorDump
             - '\PPLBlade.dmp'  # https://github.com/tastypepperoni/PPLBlade
+            - '\rustive.dmp' # https://github.com/safedv/RustiveDump/blob/main/src/main.rs#L35
     selection_2:
         TargetFilename|contains:
             - '\lsass_2'  # default format of procdump v9.0 is lsass_YYMMDD_HHmmss.dmp

--- a/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
+++ b/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
@@ -46,11 +46,13 @@ detection:
             - '\lsass'
             - '.dmp'
     selection_4:
+        TargetFilename|contains: 'SQLDmpr'
+        TargetFilename|endswith: '.mdmp'
+    selection_5:
         TargetFilename|contains:
-            - 'SQLDmpr'
             - '\nanodump'
             - '\proc_' # NativeDump pattern https://github.com/ricardojoserf/NativeDump/blob/01d8cd17f31f51f5955a38e85cd3c83a17596175/NativeDump/Program.cs#L258
-        TargetFilename|endswith: '.mdmp'
+        TargetFilename|endswith: '.dmp'
     condition: 1 of selection_*
 falsepositives:
     - Unknown

--- a/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
+++ b/rules/windows/file/file_event/file_event_win_lsass_default_dump_file_names.yml
@@ -14,7 +14,7 @@ references:
     - https://www.whiteoaksecurity.com/blog/attacks-defenses-dumping-lsass-no-mimikatz/
     - https://github.com/helpsystems/nanodump
     - https://github.com/CCob/MirrorDump
-    - https://github.com/safedv/RustiveDump/blob/main/src/main.rs#L35
+    - https://github.com/safedv/RustiveDump/blob/1a9b026b477587becfb62df9677cede619d42030/src/main.rs#L35
     - https://github.com/ricardojoserf/NativeDump/blob/01d8cd17f31f51f5955a38e85cd3c83a17596175/NativeDump/Program.cs#L258
 author: Florian Roth (Nextron Systems)
 date: 2021-11-15


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

Add new patterns for RustiveDump and NativeDump to an old rule. (and a bug fix in the nanodump pattern selection)

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

update: LSASS Process Memory Dump Files - add new dump pattern for RustiveDump and NativeDump, and exchanged "startswith" with "contains" modifier for better coverage


### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

I exchanged the "startswith" modifier with the "contains" modifier, because the "TargetFileName" field usually contains the full path and not just the filename. 
Therefore "startswith: nanodump" would always be wrong. 

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
