### PR TITLE
Update rule Powershell Exfiltration Over SMTP considering the attachm…

### DIFF
--- a/rules-threat-hunting/windows/powershell/powershell_script/posh_ps_send_mailmessage.yml
+++ b/rules-threat-hunting/windows/powershell/powershell_script/posh_ps_send_mailmessage.yml
@@ -1,31 +1,28 @@
-title: Powershell Exfiltration Over SMTP
+title: Potential Data Exfiltration Over SMTP Via Send-MailMessage Cmdlet
 id: 9a7afa56-4762-43eb-807d-c3dc9ffe211b
 status: test
 description: |
-    Adversaries may steal data by exfiltrating it over an un-encrypted network protocol other than that of the existing command and control channel.
-    The data may also be sent to an alternate network location from the main command and control server.
+    Detects the execution of a PowerShell script with a call to the "Send-MailMessage" cmdlet along with the "-Attachments" flag. This could be a potential sign of data exfiltration via Email.
+    Adversaries may steal data by exfiltrating it over an un-encrypted network protocol other than that of the existing command and control channel. The data may also be sent to an alternate network location from the main command and control server.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1048.003/T1048.003.md#atomic-test-5---exfiltration-over-alternative-protocol---smtp
     - https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/send-mailmessage?view=powershell-7.4
     - https://www.ietf.org/rfc/rfc2821.txt
 author: frack113
 date: 2022-09-26
-modified: 2024-10-15
+modified: 2024-11-01
 tags:
     - attack.exfiltration
     - attack.t1048.003
+    - detection.threat-hunting
 logsource:
     product: windows
     category: ps_script
     definition: 'Requirements: Script Block Logging must be enabled'
 detection:
     selection:
-        ScriptBlockText|contains|all:
-        - 'Send-MailMessage'
-        - '-Attachments'
-    filter:
-        ScriptBlockText|contains: 'CmdletsToExport'
-    condition: selection and not filter
+        ScriptBlockText|contains: 'Send-MailMessage*-Attachments'
+    condition: selection
 falsepositives:
-    - Legitimate script
+    - Unknown
 level: medium

--- a/rules/windows/powershell/powershell_script/posh_ps_send_mailmessage.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_send_mailmessage.yml
@@ -9,7 +9,8 @@ references:
     - https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/send-mailmessage?view=powershell-7.4
     - https://www.ietf.org/rfc/rfc2821.txt
 author: frack113
-date: 2024-10-15
+date: 2022-09-26
+modified: 2024-10-15
 tags:
     - attack.exfiltration
     - attack.t1048.003

--- a/rules/windows/powershell/powershell_script/posh_ps_send_mailmessage.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_send_mailmessage.yml
@@ -9,7 +9,7 @@ references:
     - https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/send-mailmessage?view=powershell-7.4
     - https://www.ietf.org/rfc/rfc2821.txt
 author: frack113
-date: 2022-09-26
+date: 2024-10-15
 tags:
     - attack.exfiltration
     - attack.t1048.003
@@ -19,7 +19,9 @@ logsource:
     definition: 'Requirements: Script Block Logging must be enabled'
 detection:
     selection:
-        ScriptBlockText|contains: 'Send-MailMessage'
+        ScriptBlockText|contains|all:
+        - 'Send-MailMessage'
+        - '-Attachments'
     filter:
         ScriptBlockText|contains: 'CmdletsToExport'
     condition: selection and not filter


### PR DESCRIPTION
…ent flag

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Updating the `posh_ps_send_mailmessage` rule by considering the `Attachments` flag according to the documentation. 
The rule wants to detect exfiltration, so I suggest considering the -Attachments parameter. 

In my case, this avoids a lot of FP.

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

update: Potential Data Exfiltration Over SMTP Via Send-MailMessage Cmdlet - Add the "-Attachments" flag to the logic in order to reduce false positives.
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event
N/A
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues
N/A
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
