### PR TITLE
Detect RTLO extension spoofing, MITRE T1036.002 in File-Events

### DIFF
--- a/rules/windows/file/file_event/file_event_win_susp_right_to_left_override_extension_spoofing.yml
+++ b/rules/windows/file/file_event/file_event_win_susp_right_to_left_override_extension_spoofing.yml
@@ -1,15 +1,16 @@
-title: Potential File Extension Spoofing Right-to-Left Override
+title: Potential File Extension Spoofing Using Right-to-Left Override
 id: 979baf41-ca44-4540-9d0c-4fcef3b5a3a4
 related:
     - id: ad691d92-15f2-4181-9aa4-723c74f9ddc3
       type: derived
 status: experimental
-description: Detects suspicious filenames that contain right-to-left override characters and potentially spoofed file extensions
+description: |
+    Detects suspicious filenames that contain a right-to-left override character and a potentially spoofed file extensions.
 references:
     - https://redcanary.com/blog/right-to-left-override/
     - https://www.malwarebytes.com/blog/news/2014/01/the-rtlo-method
-author: Jonathan Peters (NextronSystems), Florian Roth (NextronSystems)
-date: 2024-10-25
+author: Jonathan Peters (Nextron Systems), Florian Roth (Nextron Systems)
+date: 2024-11-17
 tags:
     - attack.execution
     - attack.defense-evasion
@@ -18,15 +19,16 @@ logsource:
     category: file_event
     product: windows
 detection:
-    selection:
-        - TargetFilename|contains:
-            - 'nls..'
+    selection_rtlo_unicode:
+        TargetFilename|contains: '\u202e'
+    selection_extensions:
+        TargetFilename|contains:
             - 'fpd..'
+            - 'nls..'
+            - 'vsc..'
             - 'xcod.'
             - 'xslx.'
-            - 'vsc..'
-        - TargetFilename|contains: '\u202e'
-    condition: selection
+    condition: all of selection_*
 falsepositives:
     - Filenames that contains scriptures such as arabic or hebrew might make use of this character
 level: high

--- a/rules/windows/file/file_event/file_event_win_susp_rtlo_extension_spoofing.yml
+++ b/rules/windows/file/file_event/file_event_win_susp_rtlo_extension_spoofing.yml
@@ -8,11 +8,12 @@ description: Detects suspicious filenames that contain right-to-left override ch
 references:
     - https://redcanary.com/blog/right-to-left-override/
     - https://www.malwarebytes.com/blog/news/2014/01/the-rtlo-method
-    - https://attack.mitre.org/techniques/T1036/002/
 author: Jonathan Peters (NextronSystems), Florian Roth (NextronSystems)
 date: 2024-10-25
 tags:
     - attack.execution
+    - attack.defense-evasion
+    - attack.t1036.002
 logsource:
     category: file_event
     product: windows

--- a/rules/windows/file/file_event/file_event_win_susp_rtlo_extension_spoofing.yml
+++ b/rules/windows/file/file_event/file_event_win_susp_rtlo_extension_spoofing.yml
@@ -1,0 +1,31 @@
+title: Potential File Extension Spoofing Right-to-Left Override
+id: 979baf41-ca44-4540-9d0c-4fcef3b5a3a4
+related:
+    - id: ad691d92-15f2-4181-9aa4-723c74f9ddc3
+      type: derived
+status: experimental
+description: Detects suspicious filenames that contain right-to-left override characters and potentially spoofed file extensions
+references:
+    - https://redcanary.com/blog/right-to-left-override/
+    - https://www.malwarebytes.com/blog/news/2014/01/the-rtlo-method
+    - https://attack.mitre.org/techniques/T1036/002/
+author: Jonathan Peters (NextronSystems), Florian Roth (NextronSystems)
+date: 2024-10-25
+tags:
+    - attack.execution
+logsource:
+    category: file_event
+    product: windows
+detection:
+    selection:
+        - TargetFilename|contains:
+            - 'nls..'
+            - 'fpd..'
+            - 'xcod.'
+            - 'xslx.'
+            - 'vsc..'
+        - TargetFilename|contains: '\u202e'
+    condition: selection
+falsepositives:
+    - Filenames that contains scriptures such as arabic or hebrew might make use of this character
+level: high


### PR DESCRIPTION
Add rule for RTLO extension spoofing, MITRE T1036.002

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

Detect interactions with files abusing the Right-To-Left Unicode extension spoofing technique.
The rule uses patterns of commonly spoofed extensions.

Example of a spoofed extension:
`Pandora%20Resou%E2%80%AEnls..scr`

The typical structure includes two dots (..) after the reversed extension, followed by the spoofed extension.

For shorter more common patterns we use two dots in front of the reversed extension to avoid potential false positivies.

### Changelog
new: Potential File Extension Spoofing Using Right-to-Left Override
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
