### PR TITLE
Update registry_set_persistence_com_hijacking_builtin.yml

### DIFF
--- a/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
@@ -13,7 +13,7 @@ references:
     - https://blog.talosintelligence.com/uat-5647-romcom/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2024-07-16
-modified: 2024-10-18
+modified: 2024-11-19
 tags:
     - attack.persistence
     - attack.t1546.015
@@ -36,6 +36,7 @@ detection:
             - '\{ddc05a5a-351a-4e06-8eaf-54ec1bc2dcea}\'
             - '\{F56F6FDD-AA9D-4618-A949-C1B91AF43B1A}\'
             - '\{F82B4EF1-93A9-4DDE-8015-F7950A1A6E31}\'
+            - '\{7849596a-48ea-486e-8937-a2a3009f31a9}\'
     selection_susp_location_1:
         Details|contains:
             # Note: Add more suspicious paths and locations

--- a/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
@@ -11,6 +11,7 @@ references:
     - https://www.microsoft.com/security/blog/2022/07/27/untangling-knotweed-european-private-sector-offensive-actor-using-0-day-exploits/ (idea)
     - https://unit42.paloaltonetworks.com/snipbot-romcom-malware-variant/
     - https://blog.talosintelligence.com/uat-5647-romcom/
+    - https://global.ptsecurity.com/analytics/pt-esc-threat-intelligence/darkhotel-a-cluster-of-groups-united-by-common-techniques
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2024-07-16
 modified: 2024-11-19

--- a/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
@@ -37,6 +37,7 @@ detection:
             - '\{F56F6FDD-AA9D-4618-A949-C1B91AF43B1A}\'
             - '\{F82B4EF1-93A9-4DDE-8015-F7950A1A6E31}\'
             - '\{7849596a-48ea-486e-8937-a2a3009f31a9}\'
+            - '\{0b91a74b-ad7c-4a9d-b563-29eef9167172}\'
     selection_susp_location_1:
         Details|contains:
             # Note: Add more suspicious paths and locations


### PR DESCRIPTION
### Summary of the Pull Request

Update Rule: Detection of COM Object Hijacking via CLSID Default Value Modification


### Changelog
Update registry_set_persistence_com_hijacking_builtin.yml


### Example Log Event

Add legitimate CLSID to the rule based on this report: https://global.ptsecurity.com/analytics/pt-esc-threat-intelligence/darkhotel-a-cluster-of-groups-united-by-common-techniques

### Fixed Issues



### SigmaHQ Rule Creation Conventions
If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
