### PR TITLE
Expand ESXi Detections with ESXCli & VIM-CMD Detections

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
@@ -1,9 +1,9 @@
 title: ESXi Firewall Default Action Set to Pass
 id: e0f2e697-0352-49a3-b488-11b3dcf1c9fd
 status: experimental
-description: Detects when the ESXi firewall default action is set to PASS instead of DROP
+description: Detects when the ESXi firewall default action is set to PASS instead of DROP.
 references:
-    - 
+    - https://developer.broadcom.com/xapis/esxcli-command-reference/7.0.0/namespace/esxcli_network.html
 author: Nathan Burns
 date: 2024-11-20
 tags:
@@ -12,9 +12,19 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection:
-        
-    condition: selection
+    selection_img:
+        Image|endswith: '/esxcli'
+    selection_cli:
+        CommandLine|contains|all:
+            - 'network'
+            - 'firewall'
+            - 'set'
+            - 'false'
+    selection_default_action_switch:
+        CommandLine|contains:
+            - '--default-action'
+            - '-d'
+    condition: 1 of selection_default* and selection_img and selection_cli
 falsepositives:
-    - Unknown
-level: critical
+    - Legitimate system administration actions
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
@@ -15,7 +15,6 @@ logsource:
 detection:
     selection_img:
         Image|endswith: '/esxcli'
-    selection_cli:
         CommandLine|contains|all:
             - 'network'
             - 'firewall'
@@ -25,7 +24,7 @@ detection:
         CommandLine|contains:
             - '--default-action'
             - '-d'
-    condition: 1 of selection_default* and selection_img and selection_cli
+    condition: all of selection_*
 falsepositives:
     - Legitimate system administration actions
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
@@ -1,0 +1,20 @@
+title: ESXi Firewall Default Action Set to Pass
+id: e0f2e697-0352-49a3-b488-11b3dcf1c9fd
+status: experimental
+description: Detects when the ESXi firewall default action is set to PASS instead of DROP
+references:
+    - 
+author: Nathan Burns
+date: 2024-11-20
+tags:
+    - attack.t1562.004
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection:
+        
+    condition: selection
+falsepositives:
+    - Unknown
+level: critical

--- a/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
@@ -19,7 +19,7 @@ detection:
             - 'network'
             - 'firewall'
             - 'set'
-            - 'false'
+            - 'true'
     selection_default_action_switch:
         CommandLine|contains:
             - '--default-action'

--- a/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_default_action_changed.yml
@@ -4,6 +4,7 @@ status: experimental
 description: Detects when the ESXi firewall default action is set to PASS instead of DROP.
 references:
     - https://developer.broadcom.com/xapis/esxcli-command-reference/7.0.0/namespace/esxcli_network.html
+    - https://lolesxi-project.github.io/LOLESXi/lolesxi/Binaries/esxcli/
 author: Nathan Burns
 date: 2024-11-20
 tags:

--- a/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_disable.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_disable.yml
@@ -15,7 +15,6 @@ logsource:
 detection:
     selection_img:
         Image|endswith: '/esxcli'
-    selection_cli:
         CommandLine|contains|all:
             - 'network'
             - 'firewall'
@@ -24,7 +23,7 @@ detection:
         CommandLine|contains:
             - '-e false'
             - '--enabled false'
-    condition: selection_enable_switch and selection_img and selection_cli
+    condition: all of selection_*
 falsepositives:
     - Legitimate system administration actions
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_disable.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_disable.yml
@@ -24,7 +24,7 @@ detection:
         CommandLine|contains:
             - '-e false'
             - '--enabled false'
-    condition: 1 of selection_enable_switch and selection_img and selection_cli
+    condition: selection_enable_switch and selection_img and selection_cli
 falsepositives:
     - Legitimate system administration actions
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_disable.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_disable.yml
@@ -1,0 +1,30 @@
+title: ESXi Firewall Disabled via ESXCLI
+id: 18fba7a0-8f63-49d3-9fc4-6192fe34793c
+status: experimental
+description: Detects when the ESXi firewall is disabled via esxcli.
+references:
+    - https://developer.broadcom.com/xapis/esxcli-command-reference/7.0.0/namespace/esxcli_network.html
+    - https://lolesxi-project.github.io/LOLESXi/lolesxi/Binaries/esxcli/
+author: Nathan Burns
+date: 2024-11-20
+tags:
+    - attack.t1562.004
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        Image|endswith: '/esxcli'
+    selection_cli:
+        CommandLine|contains|all:
+            - 'network'
+            - 'firewall'
+            - 'set'
+    selection_enable_switch:
+        CommandLine|contains:
+            - '-e false'
+            - '--enabled false'
+    condition: 1 of selection_enable_switch and selection_img and selection_cli
+falsepositives:
+    - Legitimate system administration actions
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_disable.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_esxcli_firewall_disable.yml
@@ -19,10 +19,11 @@ detection:
             - 'network'
             - 'firewall'
             - 'set'
+            - 'false'
     selection_enable_switch:
         CommandLine|contains:
-            - '-e false'
-            - '--enabled false'
+            - '--enabled'
+            - '-e'
     condition: all of selection_*
 falsepositives:
     - Legitimate system administration actions

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_delete_snapshots.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_delete_snapshots.yml
@@ -1,0 +1,23 @@
+title: ESXi VM Snapshots Deleted via VIM-CMD
+id: c50a1afa-ce52-4ea2-9697-1b6d89e83c9a
+status: experimental
+description: Detects when vim-cmd is used to delete snapshots for an ESXi virtual machine.
+references:
+    - https://lolesxi-project.github.io/LOLESXi/lolesxi/Binaries/vim-cmd/
+author: Nathan Burns
+date: 2024-11-21
+tags:
+    - attack.t1485
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        Image|endswith: '/vim-cmd'
+    selection_cli:
+        CommandLine|contains:
+            - 'vmsvc/snapshot.removeall'
+    condition: selection_img and selection_cli
+falsepositives:
+    - Legitimate system administration actions
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_delete_snapshots.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_delete_snapshots.yml
@@ -15,8 +15,7 @@ detection:
     selection_img:
         Image|endswith: '/vim-cmd'
     selection_cli:
-        CommandLine|contains:
-            - 'vmsvc/snapshot.removeall'
+        CommandLine|contains: 'vmsvc/snapshot.removeall'
     condition: selection_img and selection_cli
 falsepositives:
     - Legitimate system administration actions

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_delete_snapshots.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_delete_snapshots.yml
@@ -12,11 +12,10 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection_img:
+    selection:
         Image|endswith: '/vim-cmd'
-    selection_cli:
         CommandLine|contains: 'vmsvc/snapshot.removeall'
-    condition: selection_img and selection_cli
+    condition: selection
 falsepositives:
     - Legitimate system administration actions
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_disable_autostart.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_disable_autostart.yml
@@ -14,7 +14,6 @@ logsource:
 detection:
     selection_img:
         Image|endswith: '/vim-cmd'
-    selection_cli:
         CommandLine|contains: 'hostsvc/autostartmanager/enable_autostart'
     selection_check:
         CommandLine|contains:

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_disable_autostart.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_disable_autostart.yml
@@ -20,7 +20,7 @@ detection:
         CommandLine|contains:
             - '0'
             - 'false'
-    condition: selection_img and 1 of selection_cli and 1 of selection_check
+    condition: all of selection_*
 falsepositives:
     - Legitimate system administration actions.
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_disable_autostart.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_disable_autostart.yml
@@ -15,8 +15,7 @@ detection:
     selection_img:
         Image|endswith: '/vim-cmd'
     selection_cli:
-        CommandLine|contains:
-            - 'hostsvc/autostartmanager/enable_autostart'
+        CommandLine|contains: 'hostsvc/autostartmanager/enable_autostart'
     selection_check:
         CommandLine|contains:
             - '0'

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_disable_autostart.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_disable_autostart.yml
@@ -1,0 +1,27 @@
+title: ESXi VM Autostart Disabled via VIM-CMD
+id: 28f12744-6c57-4498-bfdc-aa727fbece49
+status: experimental
+description: Detects when vim-cmd is used to disable the autostart of an ESXi virtual machine.
+references:
+    - https://lolesxi-project.github.io/LOLESXi/lolesxi/Binaries/vim-cmd/
+author: Nathan Burns
+date: 2024-11-22
+tags:
+    - attack.t1529
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        Image|endswith: '/vim-cmd'
+    selection_cli:
+        CommandLine|contains:
+            - 'hostsvc/autostartmanager/enable_autostart'
+    selection_check:
+        CommandLine|contains:
+            - '0'
+            - 'false'
+    condition: selection_img and 1 of selection_cli and 1 of selection_check
+falsepositives:
+    - Legitimate system administration actions.
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_enable_ssh.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_enable_ssh.yml
@@ -1,0 +1,23 @@
+title: SSH Enable on ESXi Host via VIM-CMD
+id: fefed8a8-1cc0-46b1-9e62-5b5b32df9bb7
+status: experimental
+description: Detects when vim-cmd is used to enable SSH on an ESXi host.
+references:
+    - https://lolesxi-project.github.io/LOLESXi/lolesxi/Binaries/vim-cmd/
+author: Nathan Burns
+date: 2024-11-22
+tags:
+    - attack.t1021.004
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        Image|endswith: '/vim-cmd'
+    selection_cli:
+        CommandLine|contains:
+            - 'hostsvc/enable_ssh'
+    condition: selection_*
+falsepositives:
+    - Legitimate system administration actions
+level: medium

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_enable_ssh.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_enable_ssh.yml
@@ -16,7 +16,7 @@ detection:
         Image|endswith: '/vim-cmd'
     selection_cli:
         CommandLine|contains: 'hostsvc/enable_ssh'
-    condition: selection_*
+    condition: selection_img and selection_cli
 falsepositives:
     - Legitimate system administration actions
 level: medium

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_enable_ssh.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_enable_ssh.yml
@@ -15,8 +15,7 @@ detection:
     selection_img:
         Image|endswith: '/vim-cmd'
     selection_cli:
-        CommandLine|contains:
-            - 'hostsvc/enable_ssh'
+        CommandLine|contains: 'hostsvc/enable_ssh'
     condition: selection_*
 falsepositives:
     - Legitimate system administration actions

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_enable_ssh.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_enable_ssh.yml
@@ -12,11 +12,10 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection_img:
+    selection:
         Image|endswith: '/vim-cmd'
-    selection_cli:
         CommandLine|contains: 'hostsvc/enable_ssh'
-    condition: selection_img and selection_cli
+    condition: selection
 falsepositives:
     - Legitimate system administration actions
 level: medium

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_power_off_vm.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_power_off_vm.yml
@@ -12,11 +12,10 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection_img:
+    selection:
         Image|endswith: '/vim-cmd'
-    selection_cli:
         CommandLine|contains: 'vmsvc/power.off'
-    condition: selection_img and selection_cli
+    condition: selection
 falsepositives:
     - Legitimate system administration actions.
 level: medium

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_power_off_vm.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_power_off_vm.yml
@@ -15,8 +15,7 @@ detection:
     selection_img:
         Image|endswith: '/vim-cmd'
     selection_cli:
-        CommandLine|contains:
-            - 'vmsvc/power.off'
+        CommandLine|contains: 'vmsvc/power.off'
     condition: selection_img and selection_cli
 falsepositives:
     - Legitimate system administration actions.

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_power_off_vm.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_power_off_vm.yml
@@ -1,0 +1,23 @@
+title: ESXi VM Powered Off via VIM-CMD
+id: 7e38eb5c-10b6-4853-bb8f-11163776401d
+status: experimental
+description: Detects when vim-cmd is used to power off an ESXi virtual machine.
+references:
+    - https://lolesxi-project.github.io/LOLESXi/lolesxi/Binaries/vim-cmd/
+author: Nathan Burns
+date: 2024-11-22
+tags:
+    - attack.t1529
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        Image|endswith: '/vim-cmd'
+    selection_cli:
+        CommandLine|contains:
+            - 'vmsvc/power.off'
+    condition: selection_img and selection_cli
+falsepositives:
+    - Legitimate system administration actions.
+level: medium

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_system_discovery.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_system_discovery.yml
@@ -12,13 +12,12 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection_img:
+    selection:
         Image|endswith: '/vim-cmd'
-    selection_cli:
         CommandLine|contains:
             - 'hostsvc/hostsummary'
             - 'vmsvc/getallvms'
-    condition: selection_img and selection_cli
+    condition: selection
 falsepositives:
     - Legitimate system administration actions
 level: medium

--- a/rules/linux/process_creation/proc_creation_lnx_vim_cmd_system_discovery.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_vim_cmd_system_discovery.yml
@@ -1,0 +1,24 @@
+title: ESXi System Information Discovery via VIM-CMD
+id: d1270942-f26a-476c-a391-0fa1d25315a8
+status: experimental
+description: Detects when vim-cmd is used to discover information of an ESXi host.
+references:
+    - https://lolesxi-project.github.io/LOLESXi/lolesxi/Binaries/vim-cmd/
+author: Nathan Burns
+date: 2024-11-22
+tags:
+    - attack.t1082
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        Image|endswith: '/vim-cmd'
+    selection_cli:
+        CommandLine|contains:
+            - 'hostsvc/hostsummary'
+            - 'vmsvc/getallvms'
+    condition: selection_img and selection_cli
+falsepositives:
+    - Legitimate system administration actions
+level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

This PR adds 7 new process creation detections focused on the the usage of built-in administrative tools in an ESXi system. These detections were developed and tested using ESXi v7.0 and log artifacts were collected from the built-in ESXi `/var/log/shell.log` file.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: ESXi VM Snapshots Deleted via VIM-CMD
new: SSH Enable on ESXi Host via VIM-CMD
new: ESXi VM Autostart Disabled via VIM-CMD
new: ESXi VM Powered Off via VIM-CMD
new: ESXi System Information Discovery via VIM-CMD
new: ESXi Firewall Default Action Set to Pass
new: ESXi Firewall Disabled via ESXCLI

### Example Log Event
#### ESXi VM Snapshots Deleted via VIM-CMD
Note: Any number of spaces can be present between `snapshot.removeall` and the VM id.
```
2024-11-22T05:48:06.700Z shell[69457]: [root]: vim-cmd vmsvc/snapshot.removeall 1
```
#### SSH Enable on ESXi Host via VIM-CMD
```
2024-11-23T00:19:04.876Z shell[69977]: [root]: vim-cmd hostsvc/enable_ssh
```
#### ESXi VM Autostart Disabled via VIM-CMD
Note: There can be any number of spaces between `enable_autostart` and either `0` or `false`
```
2024-11-23T00:26:48.206Z shell[69977]: [root]: vim-cmd hostsvc/autostartmanager/enable_autostart false
```
```
2024-11-23T00:26:40.941Z shell[69977]: [root]: vim-cmd hostsvc/autostartmanager/enable_autostart 0
```
#### ESXi VM Powered Off via VIM-CMD
Note: There can be any number of spaces between `power.off` and the VM ID.
```
2024-11-23T00:40:14.531Z shell[69977]: [root]: vim-cmd vmsvc/power.off 1
```
#### ESXi System Information Discovery via VIM-CMD
```
2024-11-23T00:47:58.783Z shell[69977]: [root]: vim-cmd vmsvc/getallvms
```
#### ESXi Firewall Default Action Set to Pass
Note: `--default-action=false` and `--default-action false` are valid.  
Note: Any number of spaces can be present between `-d|--default-action` and `false` and the command will still be valid.
```
2024-11-22T05:37:34.333Z shell[69457]: [root]: esxcli network firewall set --default-action false
```
```
2024-11-22T05:38:00.966Z shell[69457]: [root]: esxcli network firewall set -d false
```
#### ESXi Firewall Disabled via ESXCLI
Note: Any number of spaces can be present between `-e|--enable` and `false`
```
2024-11-23T04:29:55.507Z shell[70843]: [root]: esxcli network firewall set -e false
```
```
2024-11-23T04:31:26.003Z shell[70843]: [root]: esxcli network firewall set --enabled false
```
<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)