### PR TITLE
Update registry_set_persistence_com_hijacking_builtin.yml

### DIFF
--- a/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
@@ -12,9 +12,10 @@ references:
     - https://unit42.paloaltonetworks.com/snipbot-romcom-malware-variant/
     - https://blog.talosintelligence.com/uat-5647-romcom/
     - https://global.ptsecurity.com/analytics/pt-esc-threat-intelligence/darkhotel-a-cluster-of-groups-united-by-common-techniques
+    - https://threatbook.io/blog/Analysis-of-APT-C-60-Attack-on-South-Korea
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2024-07-16
-modified: 2024-11-19
+modified: 2024-12-14
 tags:
     - attack.persistence
     - attack.t1546.015

--- a/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
@@ -39,6 +39,7 @@ detection:
             - '\{F82B4EF1-93A9-4DDE-8015-F7950A1A6E31}\'
             - '\{7849596a-48ea-486e-8937-a2a3009f31a9}\'
             - '\{0b91a74b-ad7c-4a9d-b563-29eef9167172}\'
+            - '\{603D3801-BD81-11d0-A3A5-00C04FD706EC}\'
     selection_susp_location_1:
         Details|contains:
             # Note: Add more suspicious paths and locations


### PR DESCRIPTION
Summary of the Pull Request
Update Rule: Detection of COM Object Hijacking via CLSID Default Value Modification

Changelog
Update registry_set_persistence_com_hijacking_builtin.yml

Example Log Event
Add legitimate CLSID to the rule based on this report: https://threatbook.io/blog/Analysis-of-APT-C-60-Attack-on-South-Korea

Fixed Issues
SigmaHQ Rule Creation Conventions
If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)