### PR TITLE
Fix Linux Buffer Overflow Attempts detection to correctly use regexes

### DIFF
--- a/rules/linux/builtin/lnx_buffer_overflows.yml
+++ b/rules/linux/builtin/lnx_buffer_overflows.yml
@@ -15,10 +15,10 @@ logsource:
 detection:
     keywords:
         '|re':
-          - 'attempt to execute code on stack by'
-          - 'FTP LOGIN FROM .* 0bin0sh'
-          - 'rpc.statd[\d+]: gethostbyname error for'
-          - 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+            - 'attempt to execute code on stack by'
+            - 'FTP LOGIN FROM .* 0bin0sh'
+            - 'rpc.statd[\d+]: gethostbyname error for'
+            - 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
     condition: keywords
 falsepositives:
     - Unknown

--- a/rules/linux/builtin/lnx_buffer_overflows.yml
+++ b/rules/linux/builtin/lnx_buffer_overflows.yml
@@ -6,6 +6,7 @@ references:
     - https://github.com/ossec/ossec-hids/blob/1ecffb1b884607cb12e619f9ab3c04f530801083/etc/rules/attack_rules.xml
 author: Florian Roth (Nextron Systems)
 date: 2017-03-01
+modified: 2024-12-18
 tags:
     - attack.t1068
     - attack.privilege-escalation
@@ -13,10 +14,11 @@ logsource:
     product: linux
 detection:
     keywords:
-        - 'attempt to execute code on stack by'
-        - 'FTP LOGIN FROM .* 0bin0sh'
-        - 'rpc.statd[\d+]: gethostbyname error for'
-        - 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+        '|re':
+          - 'attempt to execute code on stack by'
+          - 'FTP LOGIN FROM .* 0bin0sh'
+          - 'rpc.statd[\d+]: gethostbyname error for'
+          - 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
     condition: keywords
 falsepositives:
     - Unknown


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Fixes the Buffer Overflow Attempts rule to correctly use the regular expressions specified in the detection items. Error spotted by flabitron in the [Sigma Discord](https://discord.com/channels/1176230866515669072/1186682164163649667/1318723415846289428).

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

update:	Buffer Overflow Attempts - correct detection to utilize regexes

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
