### PR TITLE
Reg.exe Detections added

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
@@ -1,0 +1,28 @@
+title: OS Build Number Discovery via reg.exe
+id: 9c349345-6844-4628-843f-2c8ad5967978
+status: test
+description: This Sigma rule detects the use of reg.exe to query the Windows registry for the operating system's build number. 
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1082/T1082.md#atomic-test-40---discover-os-build-number-via-registry
+author: lazarg
+date: 2024-12-19
+tags:
+    - attack.discovery
+    - attack.T1082
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\reg.exe'
+        - OriginalFileName: 'reg.exe'
+    selection_command_line:
+        CommandLine|contains|all:
+            - 'query'
+            - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion' 
+            - '/v'
+            - 'CurrentBuildNumber'
+    condition: selection_img and selection_command_line
+falsepositives:
+    - Unlikely
+level: high

--- a/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
@@ -26,4 +26,4 @@ detection:
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely
-level: high
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
@@ -1,7 +1,7 @@
 title: OS Build Number Discovery via reg.exe
 id: 9c349345-6844-4628-843f-2c8ad5967978
 status: test
-description: This Sigma rule detects the use of reg.exe to query the Windows registry for the operating system's build number. 
+description: This Sigma rule detects the use of reg.exe to query the Windows registry for the operating system's build number.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1082/T1082.md#atomic-test-40---discover-os-build-number-via-registry
 author: lazarg
@@ -19,7 +19,7 @@ detection:
     selection_command_line:
         CommandLine|contains|all:
             - 'query'
-            - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion' 
+            - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
             - 'CurrentBuildNumber'
         CommandLine|windash|contains:
             - '-v'

--- a/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
@@ -20,8 +20,9 @@ detection:
         CommandLine|contains|all:
             - 'query'
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion' 
-            - '/v'
             - 'CurrentBuildNumber'
+        CommandLine|windash|contains:
+        - '-v'
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely

--- a/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
@@ -22,7 +22,7 @@ detection:
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion' 
             - 'CurrentBuildNumber'
         CommandLine|windash|contains:
-        - '-v'
+            - '-v'
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely

--- a/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
@@ -21,8 +21,7 @@ detection:
             - 'query'
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
             - 'CurrentBuildNumber'
-        CommandLine|windash|contains:
-            - '-v'
+        CommandLine|windash|contains: '-v'
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely

--- a/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_build_number_discovery.yml
@@ -8,7 +8,7 @@ author: lazarg
 date: 2024-12-19
 tags:
     - attack.discovery
-    - attack.T1082
+    - attack.t1082
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
@@ -1,0 +1,28 @@
+title: OS Product Name Discovery via reg.exe
+id: 6c13d616-13ff-41ca-b94f-35fc294feb48
+status: test
+description: This Sigma rule identifies the use of reg.exe to query the Windows registry for the operating system's product name.
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1082/T1082.md#atomic-test-39---discover-os-product-name-via-registry
+author: lazarg
+date: 2024-12-19
+tags:
+    - attack.discovery
+    - attack.T1082
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\reg.exe'
+        - OriginalFileName: 'reg.exe'
+    selection_command_line:
+        CommandLine|contains|all:
+            - 'query'
+            - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion' 
+            - '/v'
+            - 'ProductName'
+    condition: selection_img and selection_command_line
+falsepositives:
+    - Unlikely
+level: high

--- a/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
@@ -26,4 +26,4 @@ detection:
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely
-level: high
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
@@ -19,7 +19,7 @@ detection:
     selection_command_line:
         CommandLine|contains|all:
             - 'query'
-            - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion' 
+            - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
             - 'ProductName'
         CommandLine|windash|contains:
             - '-v'

--- a/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
@@ -8,7 +8,7 @@ author: lazarg
 date: 2024-12-19
 tags:
     - attack.discovery
-    - attack.T1082
+    - attack.t1082
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
@@ -22,7 +22,7 @@ detection:
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion' 
             - 'ProductName'
         CommandLine|windash|contains:
-             - '-v'
+            - '-v'
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely

--- a/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
@@ -20,8 +20,9 @@ detection:
         CommandLine|contains|all:
             - 'query'
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion' 
-            - '/v'
             - 'ProductName'
+        CommandLine|windash|contains:
+             - '-v'
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely

--- a/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_product_name_discovery.yml
@@ -21,8 +21,7 @@ detection:
             - 'query'
             - '\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
             - 'ProductName'
-        CommandLine|windash|contains:
-            - '-v'
+        CommandLine|windash|contains: '-v'
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely

--- a/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
@@ -1,0 +1,28 @@
+title: Time Zone Discovery via reg.exe
+id: 9090d3ad-df87-47f7-b47a-63e34e29b035
+status: test
+description: This Sigma rule detects the use of reg.exe to query the system's time zone information from the Windows registry. 
+references:
+    - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1124/T1124.md#atomic-test-6---discover-system-time-zone-via-registry
+author: lazarg
+date: 2024-12-19
+tags:
+    - attack.discovery
+    - attack.T1124
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\reg.exe'
+        - OriginalFileName: 'reg.exe'
+    selection_command_line:
+        CommandLine|contains|all:
+            - 'query'
+            - '\SYSTEM\CurrentControlSet\Control\TimeZoneInformation' 
+            - '/v'
+            - 'TimeZoneKeyName'
+    condition: selection_img and selection_command_line
+falsepositives:
+    - Unlikely
+level: high

--- a/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
@@ -26,4 +26,4 @@ detection:
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely
-level: high
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
@@ -21,8 +21,7 @@ detection:
             - 'query'
             - '\SYSTEM\CurrentControlSet\Control\TimeZoneInformation'
             - 'TimeZoneKeyName'
-        CommandLine|windash|contains:
-            - '-v'
+        CommandLine|windash|contains: '-v'
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely

--- a/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
@@ -1,7 +1,7 @@
 title: Time Zone Discovery via reg.exe
 id: 9090d3ad-df87-47f7-b47a-63e34e29b035
 status: test
-description: This Sigma rule detects the use of reg.exe to query the system's time zone information from the Windows registry. 
+description: This Sigma rule detects the use of reg.exe to query the system's time zone information from the Windows registry.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1124/T1124.md#atomic-test-6---discover-system-time-zone-via-registry
 author: lazarg
@@ -19,7 +19,7 @@ detection:
     selection_command_line:
         CommandLine|contains|all:
             - 'query'
-            - '\SYSTEM\CurrentControlSet\Control\TimeZoneInformation' 
+            - '\SYSTEM\CurrentControlSet\Control\TimeZoneInformation'
             - 'TimeZoneKeyName'
         CommandLine|windash|contains:
             - '-v'

--- a/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
@@ -8,7 +8,7 @@ author: lazarg
 date: 2024-12-19
 tags:
     - attack.discovery
-    - attack.T1124
+    - attack.t1124
 logsource:
     category: process_creation
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
+++ b/rules/windows/process_creation/proc_creation_win_reg_time_zone_discovery.yml
@@ -20,8 +20,9 @@ detection:
         CommandLine|contains|all:
             - 'query'
             - '\SYSTEM\CurrentControlSet\Control\TimeZoneInformation' 
-            - '/v'
             - 'TimeZoneKeyName'
+        CommandLine|windash|contains:
+            - '-v'
     condition: selection_img and selection_command_line
 falsepositives:
     - Unlikely


### PR DESCRIPTION
### Summary of the Pull Request

Added rules to detect the use of reg.exe to query registry about OS/Time Zone information

### Changelog

new: OS Product Name Discovery via reg.exe
new: OS Build Number Discovery via reg.exe
new: Time Zone Discovery via reg.exe

### Example Log Event:

OS Product Name Discovery via reg.exe:
Event ID 4688
![image](https://github.com/user-attachments/assets/cb8ad585-ab79-4323-b921-16f8e8ddfb06)


OS Build Number Discovery via reg.exe:
 Event ID 4688
![image](https://github.com/user-attachments/assets/17f3bbac-6740-4259-b448-c510a014e7e2)


Time Zone Discovery via reg.exe:
 Event ID 4688
![image](https://github.com/user-attachments/assets/fe9bd603-ac48-47c6-aed1-0fbbcea078a9)


### Relevant Links :

-https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1082/T1082.md#atomic-test-40---discover-os-build-number-via-registry
-https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1082/T1082.md#atomic-test-39---discover-os-product-name-via-registry
-https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1124/T1124.md#atomic-test-6---discover-system-time-zone-via-registry

### Fixed Issues

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/sigmahq_conventions.md)