### PR TITLE
Regex improvement on Powershell rules

### DIFF
--- a/rules/windows/dns_query/dns_query_win_remote_access_software_domains_non_browsers.yml
+++ b/rules/windows/dns_query/dns_query_win_remote_access_software_domains_non_browsers.yml
@@ -23,7 +23,7 @@ references:
     - https://learn.microsoft.com/en-us/windows/client-management/client-tools/quick-assist#disable-quick-assist-within-your-organization
 author: frack113, Connor Martin
 date: 2022-07-11
-modified: 2024-09-13
+modified: 2024-12-17
 tags:
     - attack.command-and-control
     - attack.t1219
@@ -51,6 +51,7 @@ detection:
             - 'dwservice.net'
             - 'express.gotoassist.com'
             - 'getgo.com'
+            - 'getscreen.me'  # https://x.com/malmoeb/status/1868757130624614860?s=12&t=C0_T_re0wRP_NfKa27Xw9w
             - 'integratedchat.teamviewer.com'
             - 'join.zoho.com'
             - 'kickstart.jumpcloud.com'

--- a/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
@@ -7,7 +7,7 @@ references:
     - https://speakerdeck.com/heirhabarov/hunting-for-powershell-abuse
 author: Harish Segar, frack113
 date: 2020-06-29
-modified: 2024-10-08
+modified: 2024-12-27
 tags:
     - attack.execution
     - attack.t1059.001

--- a/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_renamed_powershell.yml
@@ -30,7 +30,7 @@ detection:
     filter_main_host_application_null:
         # Note: Since we're using the raw data field to match. There is no easy way to filter out cases where the "HostApplication" field is null (i.e doesn't exist). We're practically forced to use a regex.
         # If you're already mapping and extracting the field, then obviously use that directly.
-        Data|re: 'HostId=[a-zA-Z0-9-]{36} EngineVersion='
+        Data|re: 'HostId=[a-zA-Z0-9-]{36}\r\n\tEngineVersion='
     condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown

--- a/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/bohops/WSMan-WinRM
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 date: 2020-06-24
-modified: 2024-10-08
+modified: 2024-12-27
 tags:
     - attack.execution
     - attack.t1059.001

--- a/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
+++ b/rules/windows/powershell/powershell_classic/posh_pc_wsman_com_provider_no_powershell.yml
@@ -31,7 +31,7 @@ detection:
     filter_main_host_application_null:
         # Note: Since we're using the raw data field to match. There is no easy way to filter out cases where the "HostApplication" field is null (i.e doesn't exist). We're practically forced to use a regex.
         # If you're already mapping and extracting the field, then obviously use that directly.
-        Data|re: 'HostId=[a-zA-Z0-9-]{36} EngineVersion='
+        Data|re: 'HostId=[a-zA-Z0-9-]{36}\r\n\tEngineVersion='
     condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Hi,

Proposing a regex fix for following rules:

1. 30a8cb77-8eb3-4cfb-8e79-ad457c5a4592
2. df9a0e0e-fedb-4d6c-8668-d765dfc92aa7

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

Regex condition update for following rules:

- Suspicious Non PowerShell WSMAN COM Provider
- Renamed Powershell Under Powershell Channel


### Example Log Event

<!--
Fill this in case of false positive fixes
-->

```
- <Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
- <System>
  <Provider Name="PowerShell" /> 
  <EventID Qualifiers="0">400</EventID> 
  <Level>4</Level> 
  <Task>4</Task> 
  <Keywords>0x80000000000000</Keywords> 
  <TimeCreated SystemTime="2024-12-01T14:26:10.0000000Z" /> 
  <EventRecordID>3079110</EventRecordID> 
  <Channel>Windows PowerShell</Channel> 
  <Computer>McServer.mcdermott.local</Computer> 
  <Security /> 
  </System>
- <EventData>
  <Data>Available</Data> 
  <Data>None</Data> 
  <Data>NewEngineState=Available PreviousEngineState=None SequenceNumber=37 HostName=RunspaceHost HostVersion=15.0.0.0 HostId=9d15ca57-8227-4b5f-a365-fed71ccb085b EngineVersion=3.0 RunspaceId=5e473451-e6ff-4eba-b8d8-c96c5fe84509 PipelineId= CommandName= CommandType= ScriptName= CommandPath= CommandLine=</Data> 
  </EventData>
  </Event>
```

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

Above Example of Log Event is beautified view from Event Viewer.

![Screenshot 2024-12-27 122655](https://github.com/user-attachments/assets/6ad96e60-9ece-4d10-af31-0bd21f367602)

However after **HostId=9d15ca57-8227-4b5f-a365-fed71ccb085b** there is no **whitespace** but **\r\n\t**. I checked this in many EVTX parsers to be sure and all of them have **\r\n\t**.

**Windows Powershell.evtx** in HxD shows the same.
![Screenshot 2024-12-27 122853](https://github.com/user-attachments/assets/d69d27d5-a319-4025-9c08-9254b2b0da45)




### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
