### PR TITLE
Updated to exclude false positives from common CLI searches like "fin…

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_jwt_token_search.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_jwt_token_search.yml
@@ -3,12 +3,13 @@ id: 6d3a3952-6530-44a3-8554-cf17c116c615
 status: test
 description: |
     Detects possible search for JWT tokens via CLI by looking for the string "eyJ0eX" or "eyJhbG".
-    This string is used as an anchor to look for the start of the JWT token used by microsoft office and similar apps.
+    This string is used as an anchor to look for the start of the JWT token used by Microsoft Office and similar apps.
+    Updated to exclude false positives from common CLI searches like "findstr /i eyJ0eX".
 references:
     - https://mrd0x.com/stealing-tokens-from-office-applications/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022-10-25
-modified: 2024-10-06
+modified: 2025-02-24
 tags:
     - attack.credential-access
     - attack.t1528
@@ -17,15 +18,9 @@ logsource:
     product: windows
 detection:
     selection:
-        CommandLine|contains:
-            - 'eyJ0eXAiOi' # {"typ":
-            - 'eyJhbGciOi' # {"alg":
-            - ' eyJ0eX'
-            - ' "eyJ0eX"'
-            - " 'eyJ0eX'"
-            - ' eyJhbG'
-            - ' "eyJhbG"'
-            - " 'eyJhbG'"
+        CommandLine|regex:
+            - '(?i)findstr.*(?i)eyJhbG[a-zA-Z0-9]*'
+            - '(?i)findstr.*(?i)eyJ0eX[a-zA-Z0-9]*'
     condition: selection
 falsepositives:
     - Unknown


### PR DESCRIPTION
…dstr /i eyJ0eX".

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

The original rule generated too many false positives because it simply looked for the presence of JWT tokens (eyJ0eX or eyJhbG) anywhere in the command line. This caused benign processes—especially those involving legitimate use of JWTs—to be flagged unnecessarily.

For instance, in the example provided, the token is used as a query parameter in a legitimate process (such as opening a link in a browser), and there is no indication of malicious activity. Attackers often use tools like findstr to search for tokens within process memory dumps (e.g., strings64.exe WINWORD.EXE.dmp | findstr /i eyJ0eX). Consequently, just seeing a JWT in the command line is insufficient to consider it malicious or suspicious.

By requiring the presence of findstr together with the JWT token pattern (e.g., eyJ0eX), the new rule focuses on the actual technique attackers typically use:

Dumping process memory (using tools such as strings64.exe),
Searching for JWT tokens with findstr.
This approach reduces false positives while still detecting malicious behavior. In other words, the updated rule is more precise because it only triggers when a suspect JWT search command (findstr) occurs rather than every instance of JWT usage.

I don't want to just edit this rule, it really produces a lot of false positives.
I would appreciate it if you could write my nickname (kagebunsher) somewhere in the rule.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

**update:** description - Edited according to the new code.
**delete:** new: detection:selection:CommandLine|contains - It increases the false positive rate.
**new:** detection:selection:CommandLine|regex - The regex containing findstr was written to include all jwt starts already in the code.

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

I can't provide the event log.  The following log would normally be found, but will not be detected due to the enhancement, which is now FP-reduced.

Processes.parent_process="C:\\Program Files\\Microsoft Office\\root\\Office16\\OUTLOOK.EXE", 
Processes.parent_process_name="OUTLOOK.EXE", 
Processes.process="\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\" --single-argument <url-here>?tk=<jwt-token-here>&amp;languageId=1", 
Processes.process_exec="msedge.exe", 
Processes.process_name="msedge.exe", 
Processes.user="<user-here>", 


### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

6d3a3952-6530-44a3-8554-cf17c116c615

### SigmaHQ Rule Creation Conventions

- My PR don't adds new rules.