### PR TITLE
Analytic for Signal Desktop sensitive data access

### DIFF
--- a/rules/windows/file/file_event/file_event_win_susp_signal_data_access.yml
+++ b/rules/windows/file/file_event/file_event_win_susp_signal_data_access.yml
@@ -1,0 +1,33 @@
+title: File Access Of Signal Desktops Sensitive Data
+id: 5d6c375a-18ae-4952-b4f6-8b803f6c8555
+status: experimental
+description: |
+    The db.sqlite file in Signal Desktop stores all locally saved messages in an encrypted SQLite database, while config.json contains the decryption key needed to access that data. Since the key is stored in plain text, a threat actor who gains access to both files can decrypt and read sensitive messages without needing the user’s credentials.
+references:
+    - https://cloud.google.com/blog/topics/threat-intelligence/russia-targeting-signal-messenger/
+    - https://vmois.dev/query-signal-desktop-messages-sqlite/
+author: Andreas Braathen (mnemonic.io)
+date: 2025-03-03
+tags:
+    - attack.credential-access
+    - attack.t1003
+logsource:
+    product: windows
+    service: security
+    definition: 'Requirements: System Access Control List (SACL) policy with attributes List folder/read data on Objects'
+detection:
+    selection:
+        EventID: 4663
+        ObjectType: 'File'
+        ObjectName|contains: '\AppData\Roaming\Signal\'
+        ObjectName|endswith:
+            - '\config.json'
+            - '\db.sqlite'
+    filter_signal_process:
+        ProcessName|endswith:
+            - '\signal.exe'
+            - '\signal-portable.exe'
+    condition: selection and not 1 of filter_*
+falsepositives:
+    - Unknown
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Adds analytic for detecting access of Signal Desktops sensitive files containing message data, and key material used for encrypting- and decrypting said data. Multiple threat actors have targeted locally stored data in Signal, WhatsApp and Telegram in recent years.

See also: https://cloud.google.com/blog/topics/threat-intelligence/russia-targeting-signal-messenger/

### Changelog

- new: File Access Of Signal Desktops Sensitive Data

### Example Log Event
```
- System 
  - Provider 
   [ Name]  Microsoft-Windows-Security-Auditing 
   EventID 4663  
  - Execution 
   [ ProcessID]  4 
   [ ThreadID]  112 
   Channel Security 

- EventData 
  SubjectUserSid S-1-5-21-..
  SubjectUserName user1
  SubjectDomainName DOMAIN 
  ObjectServer Security 
  ObjectType File 
  ObjectName C:\Users\user1\AppData\Roaming\Signal\sql\db.sqlite 
  HandleId 0xa44 
  AccessList %%4416  
  AccessMask 0x1 
  ProcessId 0x2818
  ProcessName C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
  ResourceAttributes S:AI 
```