### PR TITLE
Fix false positives in "AWS Attached Malicious Lambda Layer" rule

### DIFF
--- a/rules/cloud/aws/cloudtrail/aws_attached_malicious_lambda_layer.yml
+++ b/rules/cloud/aws/cloudtrail/aws_attached_malicious_lambda_layer.yml
@@ -8,7 +8,7 @@ references:
     - https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionConfiguration.html
 author: Austin Songer
 date: 2021-09-23
-modified: 2022-10-09
+modified: 2025-03-05
 tags:
     - attack.privilege-escalation
 logsource:

--- a/rules/cloud/aws/cloudtrail/aws_attached_malicious_lambda_layer.yml
+++ b/rules/cloud/aws/cloudtrail/aws_attached_malicious_lambda_layer.yml
@@ -18,6 +18,7 @@ detection:
     selection:
         eventSource: lambda.amazonaws.com
         eventName|startswith: 'UpdateFunctionConfiguration'
+        requestParameters.layers|contains: '*'
     condition: selection
 falsepositives:
     - Lambda Layer being attached may be performed by a system administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

The rule generates false positives because it monitors function configuration updates in a generic way, without specifically targeting Lambda Layer changes. Currently, the rule triggers on any configuration update, such as changes to execution time, memory size, or description. The suggestion is to add a new condition field to check if the "requestParameters" contains the "layer" field, ensuring the rule only triggers when Lambda Layers are modified.

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

new: detection:selection:requestParameters.layers|contains - added new condition to ensure the rule triggers only when Lambda Layers are modified.

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

The rule triggers when the function configuration is not related to Lambda Layers changes, such as:
...
    "eventSource": "lambda.amazonaws.com",
    "requestParameters": {
        "ephemeralStorage": {
            "size": 512
        },
        "memorySize": 1024,
        "functionName": "Example-Function-Name",
        "description": "Example function description.",
        "snapStart": {
            "applyOn": "None"
        },
        "timeout": 121
    }
...

The rule should only trigger when the request has the 'layers' field, such as:

...
    "eventSource": "lambda.amazonaws.com",
    "requestParameters": {
        "functionName": "Example-Function-Name",
        "layers": [
            "arn:aws:lambda:us-east-1:123456789123:layer:example-function:1"
        ]
    }
...



<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
