### PR TITLE
fix: issue with event id 30804

### DIFF
--- a/rules-emerging-threats/2023/Exploits/CVE-2023-23397/win_smbclient_connectivity_exploit_cve_2023_23397_outlook_remote_file.yml
+++ b/rules-emerging-threats/2023/Exploits/CVE-2023-23397/win_smbclient_connectivity_exploit_cve_2023_23397_outlook_remote_file.yml
@@ -6,7 +6,7 @@ references:
     - https://www.microsoft.com/en-us/security/blog/2023/03/24/guidance-for-investigating-attacks-using-cve-2023-23397/
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023-04-05
-modified: 2024-03-13
+modified: 2025-03-20
 tags:
     - attack.exfiltration
     - cve.2023-23397
@@ -24,12 +24,18 @@ detection:
             - 30806 # The client re-established its session to the server.
             # - 31001 # Error (Doesn't contain the "ServerAddress" field)
     filter_main_local_ips:
-        ServerAddress|cidr:
+        - ServerAddress|cidr:
             - '10.0.0.0/8'
             - '127.0.0.0/8'
             - '169.254.0.0/16'
             - '172.16.0.0/12'
             - '192.168.0.0/16'
+        - Address|startswith:  # This is for EventID 30804, which doesn't have the "ServerAddress" field, but a field called "Address" and it contains a socket address (IP:Port) and not an IP
+            - '10.'
+            - '127.'
+            - '169.254.'
+            - '172.'
+            - '192.168.'
     condition: selection and not 1 of filter_main_*
 falsepositives:
     - Some false positives may occur from external trusted servers. Apply additional filters accordingly

--- a/rules-emerging-threats/2023/Exploits/CVE-2023-23397/win_smbclient_connectivity_exploit_cve_2023_23397_outlook_remote_file.yml
+++ b/rules-emerging-threats/2023/Exploits/CVE-2023-23397/win_smbclient_connectivity_exploit_cve_2023_23397_outlook_remote_file.yml
@@ -25,17 +25,18 @@ detection:
             # - 31001 # Error (Doesn't contain the "ServerAddress" field)
     filter_main_local_ips:
         - ServerAddress|cidr:
-            - '10.0.0.0/8'
-            - '127.0.0.0/8'
-            - '169.254.0.0/16'
-            - '172.16.0.0/12'
-            - '192.168.0.0/16'
-        - Address|startswith:  # This is for EventID 30804, which doesn't have the "ServerAddress" field, but a field called "Address" and it contains a socket address (IP:Port) and not an IP
-            - '10.'
-            - '127.'
-            - '169.254.'
-            - '172.'
-            - '192.168.'
+              - '10.0.0.0/8'
+              - '127.0.0.0/8'
+              - '169.254.0.0/16'
+              - '172.16.0.0/12'
+              - '192.168.0.0/16'
+        - Address|startswith:
+        # This is for EventID 30804, which doesn't have the "ServerAddress" field, but a field called "Address" and it contains a socket address (IP:Port) and not an IP
+              - '10.'
+              - '127.'
+              - '169.254.'
+              - '172.'
+              - '192.168.'
     condition: selection and not 1 of filter_main_*
 falsepositives:
     - Some false positives may occur from external trusted servers. Apply additional filters accordingly


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

Fixing an issue with the field that is used to filter in the rule "Potential CVE-2023-23397 Exploitation Attempt - SMB"

I applied a broader filter to the correct field name and hope that this method ("string|startswith") works for the socket address in that field.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

fix: changed filter expression for event id 30804 in CVE-2023-23397 exploitation rule

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
We didn't get the raw data, only this:

RULEDATE_1: 2024/03/13
DESCRIPTION_1: Detects (failed) outbound connection attempts to internet facing SMB servers. This could be a sign of potential exploitation attempts of CVE-2023-23397.
AUTHOR_1: Nasreddine Bencherchali (Nextron Systems)
EVENT_ID: 30804
EVENT_LEVEL: 2
EVENT_CHANNEL: Microsoft-Windows-SmbClient/Connectivity
EVENT_COMPUTER: Client01
EVENT_TIME: Wed Mar 15 05:43:52 2024
ENTRY: Reason: 7 Status: 3221225996 InstanceNameLength: 24 InstanceName: \\Device\\LanmanRedirector ServerNameLength: 7 ServerName: \\SERVER AddressLength: 16 Address: \[2 0 1 189 192 168 178 2 0 0 0 0 0 0 0 0\] ConnectionType: 1 InterfaceId: 13 Provider_Name: Microsoft-Windows-SMBClient P

The field contains a socket address, meaning something like 127.0.0.1:445, not just 127.0.0.1. Thus the CIDR modifier can't be applied.

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
