### PR TITLE
Create Possible_IPV6_DNS_Takeover.yml

### DIFF
--- a/rules/windows/builtin/system/microsoft_windows_IphIpsvc/Possible_IPV6_DNS_Takeover.yml
+++ b/rules/windows/builtin/system/microsoft_windows_IphIpsvc/Possible_IPV6_DNS_Takeover.yml
@@ -1,0 +1,29 @@
+title: Possible IPV6 DNS Takeover
+id: d476d1-53a18e-cb907e-d12a01e9b523
+status: test
+description: New ISATAP router was set successfully
+references:
+    - https://www.blackhillsinfosec.com/mitm6-strikes-again-the-dark-side-of-ipv6/
+    - https://redfoxsec.com/blog/ipv6-dns-takeover/
+    - https://www.securityhq.com/blog/malicious-isatap-tunneling-unearthed-on-windows-server/
+author: hamid
+date: 2024-04-02
+tags:
+    - attack.initial_access
+    - attack.privilege_escalation
+    - attack.execution
+    - attack.t1557
+    - attack.t1565.002
+logsource:
+    product: windows
+    service: system
+detection:
+    selection:
+        EventID: 4100
+        Provider_Name: 'Microsoft-Windows-Iphlpsvc'
+    filter:
+        IsatapRouter|contains: '127.0.0.1'
+    condition: selection and not filter
+falsepositives:
+    - Unknown
+level: high


### PR DESCRIPTION
This rule detects a possible IPv6 DNS takeover using ISATAP configuration events (Event ID 4100).

Below is a screenshot showing evidence of the logs and the attack.
![1_attack](https://github.com/user-attachments/assets/4640c6da-6812-4412-8281-27c2ca0676ff)
![2_logs](https://github.com/user-attachments/assets/c526519a-e801-424d-b29d-d6695b278339)

You can find the full details in my write-up on Medium:
https://medium.com/@ninnesoturan/detecting-ipv6-dns-takeover-a54a6a88be1f