### PR TITLE
Modify proc_creation_win_ping_hex_ip.yml to look for hexidemical strings using regex

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_ping_hex_ip.yml
+++ b/rules/windows/process_creation/proc_creation_win_ping_hex_ip.yml
@@ -7,7 +7,7 @@ references:
     - https://twitter.com/vysecurity/status/977198418354491392
 author: Florian Roth (Nextron Systems)
 date: 2018-03-23
-modified: 2022-01-07
+modified: 2025-04-02
 tags:
     - attack.defense-evasion
     - attack.t1140

--- a/rules/windows/process_creation/proc_creation_win_ping_hex_ip.yml
+++ b/rules/windows/process_creation/proc_creation_win_ping_hex_ip.yml
@@ -19,7 +19,10 @@ detection:
     selection:
         Image|endswith: '\ping.exe'
         CommandLine|contains: '0x'
-    condition: selection
+        CommandLine|re: '0x\w{8}'
+    filter:
+        CommandLine|contains: 'Exception'
+    condition: selection and not filter
 fields:
     - ParentCommandLine
 falsepositives:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
I found false positives in my org's environment when pinging by hostname where the string '0x' is included in the hostname. For example, this rule would identify the command 'ping c0xk2jhf79' when this is a host name, not a hex IP address. Using regex can look for string starting with 0x and containing 8 characters after, representing an IPv4 address and thereby reducing false-positive detections.
### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	Ping Hex IP - using regex to help identify a hex IPv4 address, and excluding rare unhandled exception errors in which hex error codes appears in the error message.
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

   AccountName: SYSTEM
   AccountType: User
   Category: Process Create (rule: ProcessCreate)
   Channel: Microsoft-Windows-Sysmon/Operational
   CommandLine: ping  c0xk2jhf79
   Company: Microsoft Corporation
   CurrentDirectory: F:\
   Description: TCP/IP Ping Command
   Domain: NT AUTHORITY
   EventCreated: 2025-04-02 15:00:35 Eastern Daylight Time
   EventID: 1
   EventReceivedTime: 2025-04-02T15:00:37.461571-04:00

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
