### PR TITLE
Add a missing mitre tag to one rule

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_adplus_memory_dump.yml
+++ b/rules/windows/process_creation/proc_creation_win_adplus_memory_dump.yml
@@ -8,7 +8,7 @@ references:
     - https://twitter.com/nas_bench/status/1534915321856917506
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022-06-09
-modified: 2025-04-09
+modified: 2023-06-23
 tags:
     - attack.defense-evasion
     - attack.execution

--- a/rules/windows/process_creation/proc_creation_win_adplus_memory_dump.yml
+++ b/rules/windows/process_creation/proc_creation_win_adplus_memory_dump.yml
@@ -12,7 +12,7 @@ modified: 2023-06-23
 tags:
     - attack.defense-evasion
     - attack.execution
-    - attack.credential_access
+    - attack.credential-access
     - attack.t1003.001
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_adplus_memory_dump.yml
+++ b/rules/windows/process_creation/proc_creation_win_adplus_memory_dump.yml
@@ -8,7 +8,7 @@ references:
     - https://twitter.com/nas_bench/status/1534915321856917506
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022-06-09
-modified: 2023-06-23
+modified: 2025-04-09
 tags:
     - attack.defense-evasion
     - attack.execution

--- a/rules/windows/process_creation/proc_creation_win_adplus_memory_dump.yml
+++ b/rules/windows/process_creation/proc_creation_win_adplus_memory_dump.yml
@@ -12,6 +12,7 @@ modified: 2023-06-23
 tags:
     - attack.defense-evasion
     - attack.execution
+    - attack.credential_access
     - attack.t1003.001
 logsource:
     category: process_creation


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request
Adding a missing mitre tag to the rule since T1003.001 (OS Credential Dumping: LSASS Memory) is a subtechnique that's part of the credential access tactic.

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

update:	Potential Adplus.EXE Abuse - adding missing mitre tag


<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
