### PR TITLE
Update registry_set_persistence_com_hijacking_builtin.yml

### DIFF
--- a/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
@@ -13,9 +13,10 @@ references:
     - https://blog.talosintelligence.com/uat-5647-romcom/
     - https://global.ptsecurity.com/analytics/pt-esc-threat-intelligence/darkhotel-a-cluster-of-groups-united-by-common-techniques
     - https://threatbook.io/blog/Analysis-of-APT-C-60-Attack-on-South-Korea
+    - https://catalyst.prodaft.com/public/report/inside-the-latest-espionage-campaign-of-nebulous-mantis
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2024-07-16
-modified: 2024-12-14
+modified: 2025-05-06
 tags:
     - attack.persistence
     - attack.t1546.015

--- a/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
+++ b/rules/windows/registry/registry_set/registry_set_persistence_com_hijacking_builtin.yml
@@ -41,6 +41,7 @@ detection:
             - '\{7849596a-48ea-486e-8937-a2a3009f31a9}\'
             - '\{0b91a74b-ad7c-4a9d-b563-29eef9167172}\'
             - '\{603D3801-BD81-11d0-A3A5-00C04FD706EC}\'
+            - '\{30D49246-D217-465F-B00B-AC9DDD652EB7}\'
     selection_susp_location_1:
         Details|contains:
             # Note: Add more suspicious paths and locations


### PR DESCRIPTION

### Summary of the Pull Request

Add more CLSID, seen being used by Romcom malware

### Changelog

update: COM Object Hijacking Via Modification Of Default System CLSID Default Value - add CLSID seen being used by Romcom malware

report: https://catalyst.prodaft.com/public/report/inside-the-latest-espionage-campaign-of-nebulous-mantis/overview

### Example Log Event

### Fixed Issues

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
