### PR TITLE
Fix: image_load/image_load_susp_unsigned_dll: simplify and use valid statu…

### DIFF
--- a/rules/windows/image_load/image_load_susp_unsigned_dll.yml
+++ b/rules/windows/image_load/image_load_susp_unsigned_dll.yml
@@ -29,24 +29,7 @@ detection:
             - '\rundll32.exe'
     filter_main_signed:
         Signed: 'true'
-    filter_main_sig_status:
-        SignatureStatus:
-            - 'errorChaining'
-            - 'errorCode_endpoint'
-            - 'errorExpired'
-            - 'trusted'
-    filter_main_signed_null:
-        Signed: null
-    filter_main_signed_empty:
-        Signed:
-            - ''
-            - '-'
-    filter_main_sig_status_null:
-        SignatureStatus: null
-    filter_main_sig_status_empty:
-        SignatureStatus:
-            - ''
-            - '-'
+        SignatureStatus: 'Valid'
     condition: selection and not 1 of filter_main_*
 falsepositives:
     - Unknown


### PR DESCRIPTION
…s for SignatureStatus

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Fix and simplify the rule by the use of valid status for SignatureStatus

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

I didn't find any information about the flags currently used for SignatureStatus.

            - 'errorChaining'
            - 'errorCode_endpoint'
            - 'errorExpired'
            - 'trusted'

When looking at other use of this flags
It is 'Valid" or 'Expired'
https://github.com/search?q=repo%3ASigmaHQ%2Fsigma+SignatureStatus&type=code

There is a non consistency in the string used to test in other rules too, sometime with '' or without.... Sometime with first letter as Uppercase, sometime not.

`Get-AuthenticodeSignature` of powershell return `Valid`


There is not explict documentation that I have found.

Example this other rule:
https://github.com/SigmaHQ/sigma/blob/b062d8ad650054cd20836d5ba38031090b8d8c33/rules/windows/image_load/image_load_side_load_non_existent_dlls.yml#L43

I read most of the 3 links attached and not found a valid information about the flags.
On this link
https://www.logpoint.com/en/blog/emerging-threats/latrodectus-the-wrath-of-black-widow/
A request was made to find a signed library with wrong "status" or signed
To me we could do the same by asking for this request all dll "not (signed and valid)"

We are looking for unsigned or untrusted DLL, to me it need to be signed and valid, otherwise it is not a valid case.
Right now if not signed, it could be valid.

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
