### PR TITLE
chore: give back list of promoted rules

### DIFF
--- a/.github/workflows/sigma-rule-promoter.yml
+++ b/.github/workflows/sigma-rule-promoter.yml
@@ -21,10 +21,19 @@ jobs:
       uses: actions/setup-python@v4.5.0
       with:
         python-version: 3.11
-    - name: Execute Rule Promoter Script
+    - name: Install dependencies
+      run: pip install --force-reinstall pySigma; pip install --force-reinstall sigma-cli
+    - name: Install a compatible backend
       run: |
-        pip install pySigma
-        python tests/promote_rules_status.py
+        BACKEND=`sigma plugin list -t backend -s stable | awk '/\| yes / {print $2}' | xargs shuf -n1 -e`
+        sigma plugin install -f $BACKEND
+    - name: Execute Rule Promoter Script
+      run: python tests/promote_rules_status.py | tee --append promoted_rules
+    - name: Convert artifacts
+      run: |
+        TARGET=`sigma list targets | awk '!/Identifier/ && /\| [a-zA-Z]/ {print $2}' | xargs shuf -n1 -e`
+        PIPELINE=`sigma list pipelines | awk '!/Identifier/ && /\| [a-zA-Z]/ {print $2}' | xargs shuf -n1 -e`
+        cat promoted_rules | xargs -I {} sh -c "echo 'RULE {}, TARGET $TARGET, PIPELINE $PIPELINE'; sigma convert -t $TARGET --pipeline $PIPELINE {}"
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
       with:

--- a/tests/promote_rules_status.py
+++ b/tests/promote_rules_status.py
@@ -1,43 +1,46 @@
 from datetime import datetime
 from sigma.collection import SigmaCollection
+from typing import Iterator
 
-path_to_rules = [
+PATH_TO_RULES = [
     "rules",
     "rules-emerging-threats",
     "rules-placeholder",
     "rules-threat-hunting",
     "rules-compliance",
 ]
-nb_days = 300
+
+NB_DAYS = 300
 
 
-def get_rules_to_promote():
-    today = datetime.now().date()
-    rules_to_promote = []
+def is_experimental_and_older_than_ref(sigmaHQrule: "sigma.rule.SigmaRule") -> bool:
+    last_update = sigmaHQrule.modified if sigmaHQrule.modified else sigmaHQrule.date
 
-    rule_paths = SigmaCollection.resolve_paths(path_to_rules)
+    return (
+        str(sigmaHQrule.status) == "experimental"
+        and (datetime.now().date() - last_update).days >= NB_DAYS
+    )
+
+
+def get_rules_to_promote() -> Iterator[str]:
+    rule_paths = SigmaCollection.resolve_paths(PATH_TO_RULES)
     rule_collection = SigmaCollection.load_ruleset(rule_paths, collect_errors=True)
-    for sigmaHQrule in rule_collection:
-        if str(sigmaHQrule.status) == "experimental":
-            last_update = (
-                sigmaHQrule.modified if sigmaHQrule.modified else sigmaHQrule.date
-            )
-            difference = (today - last_update).days
-            if difference >= nb_days:
-                rules_to_promote.append(sigmaHQrule.source.path)
 
-    return rules_to_promote
+    return (
+        rule.source.path
+        for rule in filter(is_experimental_and_older_than_ref, rule_collection)
+    )
 
 
-def promote_rules(rules_to_promote):
-    for file_ in rules_to_promote:
-        with open(file_, "r", encoding="utf8") as f:
-            data = f.read().replace("\nstatus: experimental", "\nstatus: test")
+def promote_rule(rule: str) -> str:
+    with open(rule, "r", encoding="utf8") as f:
+        data = f.read().replace("\nstatus: experimental", "\nstatus: test")
 
-        with open(file_, "w", encoding="utf8") as f:
-            f.write(data)
+    with open(rule, "w", encoding="utf8") as f:
+        f.write(data)
+
+    return rule
 
 
 if __name__ == "__main__":
-    rules_to_promote = get_rules_to_promote()
-    promote_rules(rules_to_promote)
+    [promote_rule(rule) for rule in get_rules_to_promote()]

--- a/tests/promote_rules_status.py
+++ b/tests/promote_rules_status.py
@@ -43,4 +43,4 @@ def promote_rule(rule: str) -> str:
 
 
 if __name__ == "__main__":
-    [promote_rule(rule) for rule in get_rules_to_promote()]
+    print("\n".join(str(promote_rule(rule)) for rule in get_rules_to_promote()))


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

`tests/promote_rules_status.py` gives back no output,
```shell
# .venv/bin/python3 tests/promote_rules_status.py; echo $?
0
```

And does not tell which rules when promoted. Now, the rules are given back. 

Moreover, the building of artifacts is added into the promotion workflow.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

chore: update tests/promote_rules_status.py to return the promoted rules
chore: .github/workflows/sigma-rule-promoter.yml to build artifacts of promoted rules

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
