### PR TITLE
fix: use syscall names instead of ids

### DIFF
--- a/rules/linux/auditd/lnx_auditd_audio_capture.yml
+++ b/rules/linux/auditd/lnx_auditd_audio_capture.yml
@@ -9,7 +9,7 @@ references:
     - https://ecasound.seul.org/ecasound/Documentation/examples.html#fconversions
 author: Pawel Mazur, Milad Cheraghi
 date: 2021-09-04
-modified: 2025-04-26
+modified: 2025-06-05
 tags:
     - attack.collection
     - attack.t1123
@@ -25,7 +25,7 @@ detection:
     selection_syscall_memfd_create:
         type: SYSCALL
         exe|endswith: "/ecasound"
-        syscall: 319
+        syscall: 'memfd_create'
     condition: 1 of selection_*
 falsepositives:
     - Unknown

--- a/rules/linux/auditd/lnx_auditd_clean_disable_dmesg_logs_via_syslog.yml
+++ b/rules/linux/auditd/lnx_auditd_clean_disable_dmesg_logs_via_syslog.yml
@@ -11,6 +11,7 @@ references:
     - https://man7.org/linux/man-pages/man1/dmesg.1.html
 author: Milad Cheraghi
 date: 2025-05-27
+modified: 2025-06-05
 tags:
     - attack.defense-evasion
     - attack.t1070.002
@@ -28,7 +29,7 @@ logsource:
 detection:
     selection:
         type: 'SYSCALL'
-        syscall: 103
+        syscall: 'syslog'
         a0:
             - 4 # SYSLOG_ACTION_READ_CLEAR : Read and clear log
             - 5 # SYSLOG_ACTION_CLEAR: Clear kernel ring buffer (without reading)

--- a/rules/linux/auditd/lnx_auditd_disable_aslr_protection.yml
+++ b/rules/linux/auditd/lnx_auditd_disable_aslr_protection.yml
@@ -13,6 +13,7 @@ references:
     - https://manual.cs50.io/2/personality
 author: Milad Cheraghi
 date: 2025-05-26
+modified: 2025-06-05
 tags:
     - attack.defense-evasion
     - attack.t1562.001
@@ -23,7 +24,7 @@ logsource:
 detection:
     selection:
         type: 'SYSCALL'
-        syscall: 135
+        syscall: 'personality'
         a0: 40000
     condition: selection
 falsepositives:


### PR DESCRIPTION
the integration pipeline or the rule consumer has to take care of the mapping

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog
update: Audio Capture - use syscall name instead of id
update: Clear or Disable Kernel Ring Buffer Logs via Syslog Syscall - use syscall name instead of id
update: Disable ASLR Via Personality Syscall - Linux - use syscall name instead of id
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
