### PR TITLE
add rule to detect vshadow.exe with -exec parameter

### DIFF
--- a/rules-threat-hunting/windows/image_load/image_load_dll_bitsproxy_load_by_uncommon_process.yml
+++ b/rules-threat-hunting/windows/image_load/image_load_dll_bitsproxy_load_by_uncommon_process.yml
@@ -1,0 +1,41 @@
+title: BITS Client BitsProxy DLL Loaded By Uncommon Process
+id: e700ff14-1bff-4d1d-9438-738dff5f0466
+status: experimental
+description: |
+    Detects an uncommon process loading the "BitsProxy.dll". This DLL is used when the BITS COM instance or API is used.
+    This detection can be used to hunt for uncommon processes loading this DLL in your environment. Which may indicate potential suspicious activity occurring.
+references:
+    - https://unicornofhunt.com/2025/05/22/When-Unicorns-Go-Quiet-BITS-Jobs-and-the-Art-of-Stealthy-Transfers/
+author: UnicornOfHunt
+date: 2025-06-04
+tags:
+    - attack.defense-evasion
+    - attack.persistence
+    - attack.t1197
+    - detection.threat-hunting
+logsource:
+    category: image_load
+    product: windows
+detection:
+    selection:
+        ImageLoaded|endswith: '\BitsProxy.dll'
+    filter_main_system:
+        Image:
+            - 'C:\Windows\System32\aitstatic.exe'
+            - 'C:\Windows\System32\bitsadmin.exe'
+            - 'C:\Windows\System32\desktopimgdownldr.exe'
+            - 'C:\Windows\System32\DeviceEnroller.exe'
+            - 'C:\Windows\System32\MDMAppInstaller.exe'
+            - 'C:\Windows\System32\ofdeploy.exe'
+            - 'C:\Windows\System32\RecoveryDrive.exe'
+            - 'C:\Windows\System32\Speech_OneCore\common\SpeechModelDownload.exe'
+            # - 'C:\Windows\System32\svchost.exe' # BITS Service - If you collect CommandLine info. Apply a filter for the specific BITS service.
+            - 'C:\Windows\SysWOW64\bitsadmin.exe'
+            - 'C:\Windows\SysWOW64\OneDriveSetup.exe'
+            - 'C:\Windows\SysWOW64\Speech_OneCore\Common\SpeechModelDownload.exe'
+    filter_optional_chrome:
+        Image: 'C:\Program Files\Google\Chrome\Application\chrome.exe'
+    condition: selection and not 1 of filter_main_* and not 1 of filter_optional_*
+falsepositives:
+    - Allowed binaries in the environment that do BITS Jobs
+level: low

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -1,4 +1,4 @@
-title: Execution of vshadow.exe with -exec parameter
+title: Execution of vshadow with exec parameter
 id: d7c75059-2901-4578-b209-8837fd31c6a8
 status: experimental
 description: Detects invocation of vshadow.exe with the -exec parameter by monitoring Windows process creation events (EventID 1) where the target image ends with '\vshadow.exe' and the command line contains '-exec'. While legitimate backup or administrative scripts may use this flag, Attackers can leverage this parameter to hide and execute malware within shadow copies, evading standard detection mechanisms.

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -1,4 +1,4 @@
-title: Execution of vshadow.exe with -exec Parameter
+title: Execution of vshadow.exe with -exec parameter
 id: d7c75059-2901-4578-b209-8837fd31c6a8
 status: experimental
 description: Detects invocation of vshadow.exe with the -exec parameter by monitoring Windows process creation events (EventID 1) where the target image ends with '\vshadow.exe' and the command line contains '-exec'. While legitimate backup or administrative scripts may use this flag, Attackers can leverage this parameter to hide and execute malware within shadow copies, evading standard detection mechanisms.
@@ -13,7 +13,6 @@ logsource:
     category: process_creation
 detection:
     selection:
-        EventID: 1
         Image|endswith: '\vshadow.exe'
         CommandLine|contains: '-exec'
     condition: selection

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -7,15 +7,15 @@ date: 2025-05-26
 references:
     - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Vshadow/
 tags:
-    - attack.t1202     
+    - attack.t1202
 logsource:
     product: windows
     category: process_creation
 detection:
-    selection:       
-      EventID: 1
-      Image|endswith: '\vshadow.exe'
-      CommandLine|contains: '-exec'
+    selection:
+        EventID: 1
+        Image|endswith: '\vshadow.exe'
+        CommandLine|contains: '-exec'
     condition: selection
 falsepositives:
     - System-Backup- or Admin-Tools

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -1,4 +1,4 @@
-title: Execution of Vshadow with Exec Parameter
+title: Proxy Execution via Vshadow
 id: d7c75059-2901-4578-b209-8837fd31c6a8
 status: experimental
 description: |

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -2,9 +2,9 @@ title: Execution of Vshadow with Exec Parameter
 id: d7c75059-2901-4578-b209-8837fd31c6a8
 status: experimental
 description: |
-    Detects invocation of vshadow.exe with the -exec parameter that executes specified script or command after the shadow copies are created but before the VShadow tool exits.
+    Detects the invocation of vshadow.exe with the -exec parameter that executes a specified script or command after the shadow copies are created but before the VShadow tool exits.
     VShadow is a command-line tool that you can use to create and manage volume shadow copies. While legitimate backup or administrative scripts may use this flag,
-    Attackers can leverage this parameter to proxy the execution of malware.
+    attackers can leverage this parameter to proxy the execution of malware.
 author: David Faiss
 date: 2025-05-26
 references:
@@ -24,6 +24,6 @@ detection:
         CommandLine|contains: '-exec'
     condition: all of selection_*
 falsepositives:
-    - System-Backup- or Admin-Tools
+    - System backup or administrator tools
     - Legitimate administrative scripts
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -1,4 +1,4 @@
-title: Execution of vshadow with exec parameter
+title: Execution of Vshadow with Exec Parameter
 id: d7c75059-2901-4578-b209-8837fd31c6a8
 status: experimental
 description: Detects invocation of vshadow.exe with the -exec parameter by monitoring Windows process creation events (EventID 1) where the target image ends with '\vshadow.exe' and the command line contains '-exec'. While legitimate backup or administrative scripts may use this flag, Attackers can leverage this parameter to hide and execute malware within shadow copies, evading standard detection mechanisms.

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -17,10 +17,12 @@ logsource:
     product: windows
     category: process_creation
 detection:
-    selection:
-        Image|endswith: '\vshadow.exe'
+    selection_img:
+        - Image|endswith: '\vshadow.exe'
+        - OriginalFileName: 'vshadow.exe'
+    selection_cli:
         CommandLine|contains: '-exec'
-    condition: selection
+    condition: all of selection_*
 falsepositives:
     - System-Backup- or Admin-Tools
     - Legitimate administrative scripts

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -5,19 +5,19 @@ description: Detects invocation of vshadow.exe with the -exec parameter by monit
 author: David Faiss
 date: 2025-05-26
 references:
-  - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Vshadow/
+    - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Vshadow/
 tags:
-  - attack.t1202      
+    - attack.t1202     
 logsource:
-  product: windows
-  category: process_creation
+    product: windows
+    category: process_creation
 detection:
-  selection:         
-    EventID: 1
-    Image|endswith: '\vshadow.exe'
-    CommandLine|contains: '-exec'
-  condition: selection
+    selection:       
+      EventID: 1
+      Image|endswith: '\vshadow.exe'
+      CommandLine|contains: '-exec'
+    condition: selection
 falsepositives:
-  - System-Backup- or Admin-Tools
-  - Legitimate administrative scripts
+    - System-Backup- or Admin-Tools
+    - Legitimate administrative scripts
 level: high

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -9,6 +9,7 @@ author: David Faiss
 date: 2025-05-26
 references:
     - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Vshadow/
+    - https://learn.microsoft.com/en-us/windows/win32/vss/vshadow-tool-and-sample
 tags:
     - attack.defense-evasion
     - attack.t1202

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -26,4 +26,4 @@ detection:
 falsepositives:
     - System-Backup- or Admin-Tools
     - Legitimate administrative scripts
-level: high
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -10,6 +10,7 @@ date: 2025-05-26
 references:
     - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Vshadow/
 tags:
+    - attack.defense-evasion
     - attack.t1202
 logsource:
     product: windows

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -4,7 +4,7 @@ status: experimental
 description: |
     Detects invocation of vshadow.exe with the -exec parameter that executes specified script or command after the shadow copies are created but before the VShadow tool exits.
     VShadow is a command-line tool that you can use to create and manage volume shadow copies. While legitimate backup or administrative scripts may use this flag,
-    Attackers can leverage this parameter to hide and execute malware within shadow copies, evading standard detection mechanisms.
+    Attackers can leverage this parameter to proxy the execution of malware.
 author: David Faiss
 date: 2025-05-26
 references:

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -1,0 +1,23 @@
+title: Execution of vshadow.exe with -exec Parameter
+id: d7c75059-2901-4578-b209-8837fd31c6a8
+status: experimental
+description: Detects invocation of vshadow.exe with the -exec parameter by monitoring Windows process creation events (EventID 1) where the target image ends with '\vshadow.exe' and the command line contains '-exec'. While legitimate backup or administrative scripts may use this flag, Attackers can leverage this parameter to hide and execute malware within shadow copies, evading standard detection mechanisms.
+author: David Faiss
+date: 2025-05-26
+references:
+  - https://lolbas-project.github.io/lolbas/OtherMSBinaries/Vshadow/
+tags:
+  - attack.t1202      
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection:         
+    EventID: 1
+    Image|endswith: '\vshadow.exe'
+    CommandLine|contains: '-exec'
+  condition: selection
+falsepositives:
+  - System-Backup- or Admin-Tools
+  - Legitimate administrative scripts
+level: high

--- a/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
+++ b/rules/windows/process_creation/proc_creation_win_vshadow_exec.yml
@@ -1,7 +1,10 @@
 title: Execution of Vshadow with Exec Parameter
 id: d7c75059-2901-4578-b209-8837fd31c6a8
 status: experimental
-description: Detects invocation of vshadow.exe with the -exec parameter by monitoring Windows process creation events (EventID 1) where the target image ends with '\vshadow.exe' and the command line contains '-exec'. While legitimate backup or administrative scripts may use this flag, Attackers can leverage this parameter to hide and execute malware within shadow copies, evading standard detection mechanisms.
+description: |
+    Detects invocation of vshadow.exe with the -exec parameter that executes specified script or command after the shadow copies are created but before the VShadow tool exits.
+    VShadow is a command-line tool that you can use to create and manage volume shadow copies. While legitimate backup or administrative scripts may use this flag,
+    Attackers can leverage this parameter to hide and execute malware within shadow copies, evading standard detection mechanisms.
 author: David Faiss
 date: 2025-05-26
 references:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request
A short summary of your pull request.
Adds a new Sigma detection rule Execution of vshadow.exe with -exec Parameter that flags any process creation EventID 1 invoking vshadow.exe with the -exec switch. This helps identify potential misuse of volume shadow copy to hide and execute malware.
<!--
**Please note that this section is required and must be filled**

-->

### Changelog
new: Proxy Execution via Vshadow - detect invocation of `vshadow.exe` with `-exec` to spot hidden malware execution
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
