### PR TITLE
registry_event_win_com_hijack_clsid.yml

### DIFF
--- a/rules/windows/registry/registry_event/registry_event_win_com_hijack_clsid.yml
+++ b/rules/windows/registry/registry_event/registry_event_win_com_hijack_clsid.yml
@@ -1,0 +1,37 @@
+title: COM Hijacking via CLSID Registry Key
+id: d3c4e5e7-7fbb-42d9-b308-keys001
+description: Detects registry modifications to CLSID keys under HKCU or HKLM that may indicate persistence via COM hijacking. Attackers can configure these registry keys to point to a malicious InprocServer32 DLL for execution during COM object instantiation.
+status: experimental
+author: (@vVv-Keys)
+date: 2025-06-21
+references:
+  - https://attack.mitre.org/techniques/T1546/015/
+  - https://learn.microsoft.com/en-us/windows/win32/com/component-object-model--com--portal
+  - https://pentestlab.blog/2019/03/04/persistence-com-hijacking/
+logsource:
+  product: windows
+  category: registry_event
+detection:
+  selection:
+    EventID: 13
+    TargetObject|contains:
+      - 'HKCU\\Software\\Classes\\CLSID\\'
+      - 'HKLM\\Software\\Classes\\CLSID\\'
+    Details|contains:
+      - 'InprocServer32'
+  condition: selection
+falsepositives:
+  - Software legitimately configuring custom COM components
+  - In-house applications using dynamic COM registration
+fields:
+  - TargetObject
+  - Details
+  - EventType
+  - ComputerName
+  - UserName
+level: high
+tags:
+  - attack.persistence
+  - attack.t1546.015
+  - red_team
+  - sigma-contrib


### PR DESCRIPTION
feat: add COM hijacking detection via CLSID registry

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

This rule detects registry modifications to CLSID keys under `HKCU` or `HKLM` that suggest potential COM hijacking via malicious `InprocServer32` paths. It enables detection of persistence techniques where attackers hijack COM object instantiation behavior to load attacker-controlled DLLs.

### Changelog

new: COM Hijacking via CLSID Registry Key

### Example Log Event

```json
{
  "EventID": 13,
  "TargetObject": "HKCU\\Software\\Classes\\CLSID\\{CLSID}\\InprocServer32",
  "Details": "C:\\Users\\attacker\\AppData\\Local\\Malicious.dll"
}
```
Fixed Issues
None.

SigmaHQ Rule Creation Conventions
The rule follows all SigmaHQ standards and uses proper field matchers (|contains, |endswith), appropriate tags (MITRE T1546.015), and is fully YAML and schema compliant.