### PR TITLE
Delayed ping followed by self deletion

### DIFF
--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
@@ -1,4 +1,4 @@
-title: Ping Delay via cmd followed by file deletion
+title: Ping Delay via CMD Followed by File Deletion
 id: 6c32f124-9a02-4749-87ab-0b2d4fe27cb2
 status: experimental
 description: |
@@ -13,7 +13,7 @@ references:
 author: Joseph A. M.
 date: 2025-07-02
 tags:
-- attack.defense_evasion
+- attack.defense-evasion
 - attack.t1070
 - attack.t1562
 logsource:

--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
@@ -11,7 +11,7 @@ references:
   - https://www.elastic.co/guide/en/security/8.18/delayed-execution-via-ping.html
   - https://any.run/report/b6c969551f35c5de1ebc234fd688d7aa11eac01008013914dbc53f3e811c7c77/1d977118-9b28-42be-a68f-65915b5e0217
 author: Joseph A. M.
-date: 2025/07/02
+date: 2025-07-02
 tags:
 - attack.defense_evasion
 - attack.t1070

--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
@@ -22,7 +22,8 @@ logsource:
 detection:
     selection:
         CommandLine|contains:
-            - 'cmd.exe /C ping 127.0.0.7 -n 3 > Nul & Del /f /q'
+            - 'cmd.exe /C ping 127.0.0.7 -n 3'
+            - '> Nul & Del /f /q'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
@@ -1,0 +1,32 @@
+title: Ping Delay via cmd followed by file deletion
+id: 6c32f124-9a02-4749-87ab-0b2d4fe27cb2
+status: experimental
+description: |
+    Detects a ping delay to 127.0.0.7 via cmd.exe observed with Mamona ransomeware. 
+    The use of 127.0.0.7 instead of the more common 127.0.0.1 helps it bypass detection rules that specifically look for the default loopback address. 
+    The command also issues the command below to delay execution for three seconds and then deletes itself from disk.
+references:
+  - https://wazuh.com/blog/detecting-and-responding-mamona-ransomware-with-wazuh/
+  - https://coralogix.com/blog/mamona-ransomware-raas-offline-commodity-ransomware-with-custom-encryption/
+  - https://www.elastic.co/guide/en/security/8.18/delayed-execution-via-ping.html
+  - https://any.run/report/b6c969551f35c5de1ebc234fd688d7aa11eac01008013914dbc53f3e811c7c77/1d977118-9b28-42be-a68f-65915b5e0217
+author: Joseph A. M.
+date: 2025/07/02
+tags:
+- attack.defense_evasion
+- attack.t1070
+- attack.t1562
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection:
+    CommandLine|contains:
+      - 'cmd.exe /C ping 127.0.0.7 -n 3 > Nul & Del /f /q'
+  condition: selection
+falsepositives:
+  - Unknown
+level: high
+
+
+

--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
@@ -2,14 +2,14 @@ title: Ping Delay via cmd followed by file deletion
 id: 6c32f124-9a02-4749-87ab-0b2d4fe27cb2
 status: experimental
 description: |
-    Detects a ping delay to 127.0.0.7 via cmd.exe observed with Mamona ransomeware. 
-    The use of 127.0.0.7 instead of the more common 127.0.0.1 helps it bypass detection rules that specifically look for the default loopback address. 
+    Detects a ping delay to 127.0.0.7 via cmd.exe observed with Mamona ransomeware.
+    The use of 127.0.0.7 instead of the more common 127.0.0.1 helps it bypass detection rules that specifically look for the default loopback address.
     The command also issues the command below to delay execution for three seconds and then deletes itself from disk.
 references:
-  - https://wazuh.com/blog/detecting-and-responding-mamona-ransomware-with-wazuh/
-  - https://coralogix.com/blog/mamona-ransomware-raas-offline-commodity-ransomware-with-custom-encryption/
-  - https://www.elastic.co/guide/en/security/8.18/delayed-execution-via-ping.html
-  - https://any.run/report/b6c969551f35c5de1ebc234fd688d7aa11eac01008013914dbc53f3e811c7c77/1d977118-9b28-42be-a68f-65915b5e0217
+    - https://wazuh.com/blog/detecting-and-responding-mamona-ransomware-with-wazuh/
+    - https://coralogix.com/blog/mamona-ransomware-raas-offline-commodity-ransomware-with-custom-encryption/
+    - https://www.elastic.co/guide/en/security/8.18/delayed-execution-via-ping.html
+    - https://any.run/report/b6c969551f35c5de1ebc234fd688d7aa11eac01008013914dbc53f3e811c7c77/1d977118-9b28-42be-a68f-65915b5e0217
 author: Joseph A. M.
 date: 2025-07-02
 tags:
@@ -25,8 +25,5 @@ detection:
       - 'cmd.exe /C ping 127.0.0.7 -n 3 > Nul & Del /f /q'
   condition: selection
 falsepositives:
-  - Unknown
+    - Unknown
 level: high
-
-
-

--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_ping_delay_file_deletion.yml
@@ -17,13 +17,13 @@ tags:
 - attack.t1070
 - attack.t1562
 logsource:
-  product: windows
-  category: process_creation
+    product: windows
+    category: process_creation
 detection:
-  selection:
-    CommandLine|contains:
-      - 'cmd.exe /C ping 127.0.0.7 -n 3 > Nul & Del /f /q'
-  condition: selection
+    selection:
+        CommandLine|contains:
+            - 'cmd.exe /C ping 127.0.0.7 -n 3 > Nul & Del /f /q'
+    condition: selection
 falsepositives:
     - Unknown
 level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

This SIGMA rule is to aid in the detection of two events that happen via the same command:

1. A 3-second ping delay to ```127.0.0.7```
2. Quietly forces the deletion of read-only files present.

This behavior has recently been observed to be related to the recent strain of the Mamona ransomware. 

### Changelog
new: ```proc_creation_win_ping_delay_file_deletion.yml``` - Initial commit of rule.
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
N/A at this moment
### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
N/A at this moment

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
