### PR TITLE
Rule obfuscated powershell explorer

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_powershell_from_explorer_obfuscated.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_from_explorer_obfuscated.yml
@@ -29,5 +29,5 @@ falsepositives:
     - Legitimate administrative scripting using obfuscation
 tags:
     - attack.execution
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1059.001


### PR DESCRIPTION
### Summary of the Pull Request

This pull request adds a Sigma detection rule for identifying obfuscated PowerShell execution launched from explorer.exe. This behavior is suspicious and commonly associated with execution and defense evasion techniques (T1059.001) used by adversaries for stealthy payload delivery or lateral movement.

### Changelog

new: Obfuscated PowerShell Spawned From Explorer

### Example Log Event

```json
{
  "Image": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
  "ParentImage": "C:\\Windows\\explorer.exe",
  "CommandLine": "powershell.exe -nop -enc UwB..."
}

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
