### PR TITLE
Fix proc_creation_win_filefix_browsers.yml

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_filefix_browsers.yml
+++ b/rules/windows/process_creation/proc_creation_win_filefix_browsers.yml
@@ -9,7 +9,7 @@ references:
     - https://mrd0x.com/filefix-clickfix-alternative/
 author: 0xFustang
 date: 2025-06-26
-modified: 2025-06-30
+modified: 2025-07-16
 tags:
     - attack.execution
     - attack.t1204.004
@@ -20,9 +20,18 @@ detection:
     selection:
         ParentImage|endswith:
             - '\brave.exe'
+            - '\browser_broker.exe'
             - '\chrome.exe'
             - '\firefox.exe'
+            - '\iexplore.exe'
+            - '\microsoftedge.exe'
+            - '\microsoftedgecp.exe'
             - '\msedge.exe'
+            - '\msedgewebview2.exe'
+            - '\opera.exe'
+            - '\safari.exe'
+            - '\waterfox.exe'
+            - '\vivaldi.exe'
         Image|endswith:
             - '\bitsadmin.exe'
             - '\certutil.exe'
@@ -31,7 +40,7 @@ detection:
             - '\powershell.exe'
             - '\pwsh.exe'
             - '\regsvr32.exe'
-        CommandLine|contains: '#'
+        CommandLine|re: '(^".+".*|#)'
     condition: selection
 falsepositives:
     - Legitimate use of PowerShell or other utilities launched from browser extensions or automation tools


### PR DESCRIPTION
`#` does not appear in command line logs a  when a filefix attack is executed., at least not nin Falcon FDR logs. Instead, the executable is always wrapped in double quotes. These quotes are not present when extensions are executed.

This PR updates the CommandLine to reflect this  using regex, while maintaining the original CommandLine detection of `#` in case that is still used in other logs, and adds more browser image names

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
