### PR TITLE
Suspicious Process Spawning from IIS Worker Process Chain (aka Webshell Indicator) - Covering SharePoint CVE-2025-53770 ToolShell

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_iis_webshell.yml
+++ b/rules/windows/process_creation/proc_creation_win_iis_webshell.yml
@@ -1,0 +1,64 @@
+title: Suspicious IIS Worker Process Spawning Post-Exploitation Reconnaissance or PowerShell Commands
+id: b1843456-a9c9-43e2-b83d-d5123f76f7aa
+status: experimental
+description: | 
+    Detects potentially malicious behavior where the IIS worker process (w3wp.exe) spawns cmd.exe, which in turn launches either PowerShell with 
+    obfuscation,  download, or execution commands, or net.exe used for user, domain, or share enumeration. This activity pattern is commonly 
+    observed in webshell usage, post-exploitation frameworks, or active exploitation of web applications (e.g. ToolShell in recent SharePoint RCE)
+author: TristanInSec
+date: 2025-07-24
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.discovery
+    - attack.t1018
+    - attack.persistence
+    - attack.t1027.010
+    - attack.t1505.003
+references:
+    - https://www.linkedin.com/posts/jhencinski_rapid7-mdr-is-detecting-active-exploitation-activity-7352685211240783872-EU4p
+    - https://msrc.microsoft.com/blog/2025/07/customer-guidance-for-sharepoint-vulnerability-cve-2025-53770/
+    - https://attack.mitre.org/techniques/T1505/003/ # Web Shell
+    - https://attack.mitre.org/techniques/T1059/001/ # PowerShell
+    - https://attack.mitre.org/techniques/T1027/010/ # Obfuscated Files or Information: Command Obfuscation
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    cmd_spawned_by_w3wp:
+      ParentImage|endswith: '\w3wp.exe'
+      Image|endswith: '\cmd.exe'
+    powershell_spawned_by_cmd:
+      ParentImage|endswith: '\cmd.exe'
+      Image|endswith:
+        - '\powershell.exe'
+        - '\pwsh.exe'
+      CommandLine|contains:
+        - '-e'
+        - '-enc'
+        - '-encodedcommand'
+        - '-ec'
+        - '::FromBase64String'
+        - 'iwr'
+        - 'Invoke-WebRequest'
+        - 'iex'
+        - 'Invoke-Expression'
+        - 'DownloadFile'
+        - 'System.Net.WebClient'
+        - 'Start-Process'
+        - 'New-Object'
+        - 'Invoke-Command'
+    net_spawned_by_cmd:
+      ParentImage|endswith: '\cmd.exe'
+      Image|endswith: '\net.exe'
+      CommandLine|contains:
+        - 'user'
+        - 'group'
+        - 'domain'
+        - 'share'
+    condition: cmd_spawned_by_w3wp and (powershell_spawned_by_cmd or net_spawned_by_cmd)
+falsepositives:
+    - Legitimate administrative scripts executed through IIS
+    - Management tools that use IIS worker processes
+    - Web application management agents
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_iis_webshell.yml
+++ b/rules/windows/process_creation/proc_creation_win_iis_webshell.yml
@@ -1,10 +1,10 @@
 title: Suspicious Process Spawning from IIS Worker Process Chain (Webshell Indicator)
 id: b1843456-a9c9-43e2-b83d-d5123f76f7aa
 status: experimental
-description: | 
+description: |
     Detects suspicious processes spawned by IIS worker process (w3wp.exe) either directly or through cmd.exe/powershell.exe intermediary.
     Covers attack chains: w3wp.exe → suspicious_process, w3wp.exe → cmd.exe → suspicious_process, and w3wp.exe → powershell.exe → suspicious_process.
-    This activity pattern is commonly observed in webshell usage, post-exploitation frameworks, or active exploitation 
+    This activity pattern is commonly observed in webshell usage, post-exploitation frameworks, or active exploitation
     of web applications including recent SharePoint RCE vulnerabilities.
 author: TristanInSec
 date: 2025-07-24
@@ -32,15 +32,15 @@ detection:
     # Direct spawning: w3wp.exe → suspicious_process
     selection_exec_from_w3wp:
         ParentImage|endswith: '\w3wp.exe'
-    
+
     # Intermediary spawning: w3wp.exe → cmd.exe/powershell.exe → suspicious_process
     selection_exec_from_shell:
         GrandParentImage|endswith: '\w3wp.exe'
-        ParentImage|endswith: 
+        ParentImage|endswith:
             - '\cmd.exe'
             - '\powershell.exe'
             - '\pwsh.exe'
-    
+
     # PowerShell with suspicious execution patterns
     selection_powershell_suspicious:
         Image|endswith:
@@ -61,7 +61,7 @@ detection:
             - 'Start-Process'
             - 'New-Object'
             - 'Invoke-Command'
-    
+
     # Reconnaissance and system tools
     selection_recon_tools:
         Image|endswith:
@@ -71,7 +71,7 @@ detection:
             - '\query.exe'
             - '\wmic.exe'
             - '\reg.exe'
-    
+
     # Network reconnaissance tools with specific commands
     selection_net_recon:
         Image|endswith: '\net.exe'
@@ -82,7 +82,7 @@ detection:
             - 'share'
             - 'localgroup'
             - 'view'
-    
+
     # Proxy execution binaries
     selection_proxy_execution:
         Image|endswith:
@@ -91,7 +91,7 @@ detection:
             - '\mshta.exe'
             - '\cscript.exe'
             - '\wscript.exe'
-    
+
     # Download and file transfer tools with context
     selection_download_tools:
         Image|endswith:
@@ -106,7 +106,7 @@ detection:
             - '-url'
             - '-urlcache'
             - 'download'
-        
+
     condition: (1 of selection_exec_from_*) and (selection_powershell_suspicious or selection_recon_tools or selection_net_recon or selection_proxy_execution or selection_download_tools)
 falsepositives:
     - Legitimate administrative scripts executed through IIS applications

--- a/rules/windows/process_creation/proc_creation_win_iis_webshell.yml
+++ b/rules/windows/process_creation/proc_creation_win_iis_webshell.yml
@@ -1,10 +1,11 @@
-title: Suspicious IIS Worker Process Spawning Post-Exploitation Reconnaissance or PowerShell Commands
+title: Suspicious Process Spawning from IIS Worker Process Chain (Webshell Indicator)
 id: b1843456-a9c9-43e2-b83d-d5123f76f7aa
 status: experimental
 description: | 
-    Detects potentially malicious behavior where the IIS worker process (w3wp.exe) spawns cmd.exe, which in turn launches either PowerShell with 
-    obfuscation,  download, or execution commands, or net.exe used for user, domain, or share enumeration. This activity pattern is commonly 
-    observed in webshell usage, post-exploitation frameworks, or active exploitation of web applications (e.g. ToolShell in recent SharePoint RCE)
+    Detects suspicious processes spawned by IIS worker process (w3wp.exe) either directly or through cmd.exe/powershell.exe intermediary.
+    Covers attack chains: w3wp.exe → suspicious_process, w3wp.exe → cmd.exe → suspicious_process, and w3wp.exe → powershell.exe → suspicious_process.
+    This activity pattern is commonly observed in webshell usage, post-exploitation frameworks, or active exploitation 
+    of web applications including recent SharePoint RCE vulnerabilities.
 author: TristanInSec
 date: 2025-07-24
 tags:
@@ -15,50 +16,101 @@ tags:
     - attack.persistence
     - attack.t1027.010
     - attack.t1505.003
+    - attack.t1055
 references:
     - https://www.linkedin.com/posts/jhencinski_rapid7-mdr-is-detecting-active-exploitation-activity-7352685211240783872-EU4p
     - https://msrc.microsoft.com/blog/2025/07/customer-guidance-for-sharepoint-vulnerability-cve-2025-53770/
     - https://attack.mitre.org/techniques/T1505/003/ # Web Shell
     - https://attack.mitre.org/techniques/T1059/001/ # PowerShell
     - https://attack.mitre.org/techniques/T1027/010/ # Obfuscated Files or Information: Command Obfuscation
+    - https://attack.mitre.org/techniques/T1018/ # Remote System Discovery
+    - https://attack.mitre.org/techniques/T1055/ # Process Injection
 logsource:
     category: process_creation
     product: windows
 detection:
-    cmd_spawned_by_w3wp:
-      ParentImage|endswith: '\w3wp.exe'
-      Image|endswith: '\cmd.exe'
-    powershell_spawned_by_cmd:
-      ParentImage|endswith: '\cmd.exe'
-      Image|endswith:
-        - '\powershell.exe'
-        - '\pwsh.exe'
-      CommandLine|contains:
-        - '-e'
-        - '-enc'
-        - '-encodedcommand'
-        - '-ec'
-        - '::FromBase64String'
-        - 'iwr'
-        - 'Invoke-WebRequest'
-        - 'iex'
-        - 'Invoke-Expression'
-        - 'DownloadFile'
-        - 'System.Net.WebClient'
-        - 'Start-Process'
-        - 'New-Object'
-        - 'Invoke-Command'
-    net_spawned_by_cmd:
-      ParentImage|endswith: '\cmd.exe'
-      Image|endswith: '\net.exe'
-      CommandLine|contains:
-        - 'user'
-        - 'group'
-        - 'domain'
-        - 'share'
-    condition: cmd_spawned_by_w3wp and (powershell_spawned_by_cmd or net_spawned_by_cmd)
+    # Direct spawning: w3wp.exe → suspicious_process
+    selection_exec_from_w3wp:
+        ParentImage|endswith: '\w3wp.exe'
+    
+    # Intermediary spawning: w3wp.exe → cmd.exe/powershell.exe → suspicious_process
+    selection_exec_from_shell:
+        GrandParentImage|endswith: '\w3wp.exe'
+        ParentImage|endswith: 
+            - '\cmd.exe'
+            - '\powershell.exe'
+            - '\pwsh.exe'
+    
+    # PowerShell with suspicious execution patterns
+    selection_powershell_suspicious:
+        Image|endswith:
+            - '\powershell.exe'
+            - '\pwsh.exe'
+        CommandLine|contains:
+            - '-e'
+            - '-enc'
+            - '-encodedcommand'
+            - '-ec'
+            - '::FromBase64String'
+            - 'iwr'
+            - 'Invoke-WebRequest'
+            - 'iex'
+            - 'Invoke-Expression'
+            - 'DownloadFile'
+            - 'System.Net.WebClient'
+            - 'Start-Process'
+            - 'New-Object'
+            - 'Invoke-Command'
+    
+    # Reconnaissance and system tools
+    selection_recon_tools:
+        Image|endswith:
+            - '\whoami.exe'
+            - '\systeminfo.exe'
+            - '\tasklist.exe'
+            - '\query.exe'
+            - '\wmic.exe'
+            - '\reg.exe'
+    
+    # Network reconnaissance tools with specific commands
+    selection_net_recon:
+        Image|endswith: '\net.exe'
+        CommandLine|contains:
+            - 'user'
+            - 'group'
+            - 'domain'
+            - 'share'
+            - 'localgroup'
+            - 'view'
+    
+    # Proxy execution binaries
+    selection_proxy_execution:
+        Image|endswith:
+            - '\rundll32.exe'
+            - '\regsvr32.exe'
+            - '\mshta.exe'
+            - '\cscript.exe'
+            - '\wscript.exe'
+    
+    # Download and file transfer tools with context
+    selection_download_tools:
+        Image|endswith:
+            - '\curl.exe'
+            - '\wget.exe'
+            - '\certutil.exe'
+            - '\bitsadmin.exe'
+        CommandLine|contains:
+            - 'http://'
+            - 'https://'
+            - 'ftp://'
+            - '-url'
+            - '-urlcache'
+            - 'download'
+        
+    condition: (1 of selection_exec_from_*) and (selection_powershell_suspicious or selection_recon_tools or selection_net_recon or selection_proxy_execution or selection_download_tools)
 falsepositives:
-    - Legitimate administrative scripts executed through IIS
-    - Management tools that use IIS worker processes
-    - Web application management agents
-level: medium
+    - Legitimate administrative scripts executed through IIS applications
+    - Web application management and deployment tools
+    - Monitoring agents that use IIS worker processes
+    - SharePoint Timer Jobs and maintenance tasks
+level: low


### PR DESCRIPTION
### Summary of the Pull Request

Adds detection rule for suspicious processes spawned by IIS worker process (w3wp.exe) targeting webshell post-exploitation activities. Covers direct spawning and intermediary attack chains through cmd.exe/powershell.exe.

Addresses recent SharePoint "ToolShell" (CVE-2025-53770) exploitation patterns and common webshell techniques.

### Changelog

new: Suspicious Process Spawning from IIS Worker Process Chain (Webshell Indicator)

### Example Log Event

#### Direct spawning example
ParentImage: w3wp.exe
Image: net.exe
CommandLine: net.exe user

#### Intermediary spawning example  
GrandParentImage: w3wp.exe
ParentImage: cmd.exe 
Image: powershell.exe
CommandLine: powershell.exe -enc (...)

### Fixed Issues

N/A - New detection rule

### SigmaHQ Rule Creation Conventions

- [X] Follows standard naming convention: `proc_creation_win_iis_webshell.yml`
- [X] MITRE ATT&CK techniques properly mapped
- [X] Windows process creation log source
- [X] False positives documented
- [X] References current threat intelligence (CVE-2025-53770)
- [X] Conservative risk level for new rule