### PR TITLE
Bug: Remove erroneous blank filter 

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_browser_launch_from_document_reader_process.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_browser_launch_from_document_reader_process.yml
@@ -29,7 +29,6 @@ detection:
             - '\maxthon.exe'
             - '\seamonkey.exe'
             - '\vivaldi.exe'
-            - ''
         CommandLine|contains: 'http'
     condition: selection
 falsepositives:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request
The blank filter here seems to negate the rest of the `Image|endswith` filter. I believe this is erroneous and was either accidentally left in or was intended to be filled out with another path. I can only speak to how this is converted to Elastic EQL syntax but in that case, this section of the filter becomes ```process.executable like~ ("*\\brave.exe", "*\\chrome.exe", "*\\firefox.exe", "*\\msedge.exe", "*\\opera.exe", "*\\maxthon.exe", "*\\seamonkey.exe", "*\\vivaldi.exe", "*")```. Notice the `"*"` portion which catches any executable, not just the browsers listed before.  

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog
fix: Potential Suspicious Browser Launch From Document Reader Process - remove blank filter in Image|endswith
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
