### PR TITLE
Adjust provider name selection in kerberos-key-distribution-center rules

### DIFF
--- a/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_cert_use_no_strong_mapping.yml
+++ b/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_cert_use_no_strong_mapping.yml
@@ -16,7 +16,9 @@ logsource:
     service: system
 detection:
     selection:
-        Provider_Name: 'Kerberos-Key-Distribution-Center'
+        Provider_Name:
+            - 'Kerberos-Key-Distribution-Center'
+            - 'Microsoft-Windows-Kerberos-Key-Distribution-Center'
         EventID:
             - 39
             - 41 # For Windows Server 2008 R2 SP1 and Windows Server 2008 SP2

--- a/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_cert_use_no_strong_mapping.yml
+++ b/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_cert_use_no_strong_mapping.yml
@@ -9,6 +9,7 @@ references:
     - https://support.microsoft.com/en-us/topic/kb5014754-certificate-based-authentication-changes-on-windows-domain-controllers-ad2c23b0-15d8-4340-a468-4d4f3b188f16
 author: '@br4dy5'
 date: 2023-10-09
+modified: 2025-09-22
 tags:
     - attack.privilege-escalation
 logsource:

--- a/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_rc4_downgrade.yml
+++ b/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_rc4_downgrade.yml
@@ -14,7 +14,9 @@ logsource:
 detection:
     selection:
         EventID: 42
-        Provider_Name: 'Kerberos-Key-Distribution-Center'
+        Provider_Name:
+            - 'Kerberos-Key-Distribution-Center'
+            - 'Microsoft-Windows-Kerberos-Key-Distribution-Center'
         Level: 2  # Error
     condition: selection
 falsepositives:

--- a/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_rc4_downgrade.yml
+++ b/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_rc4_downgrade.yml
@@ -6,6 +6,7 @@ references:
     - https://support.microsoft.com/en-us/topic/kb5021131-how-to-manage-the-kerberos-protocol-changes-related-to-cve-2022-37966-fd837ac3-cdec-4e76-a6ec-86e67501407d
 author: Florian Roth (Nextron Systems)
 date: 2022-11-09
+modified: 2025-09-22
 tags:
     - attack.privilege-escalation
 logsource:

--- a/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_tgs_no_suitable_encryption_key_found.yml
+++ b/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_tgs_no_suitable_encryption_key_found.yml
@@ -17,7 +17,9 @@ logsource:
     service: system
 detection:
     selection:
-        Provider_Name: 'Microsoft-Windows-Kerberos-Key-Distribution-Center'
+        Provider_Name:
+            - 'Kerberos-Key-Distribution-Center'
+            - 'Microsoft-Windows-Kerberos-Key-Distribution-Center'
         EventID:
             - 16 # KDCEVENT_NO_KEY_INTERSECTION_TGS
             - 27 # KDCEVENT_UNSUPPORTED_ETYPE_REQUEST_TGS

--- a/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_tgs_no_suitable_encryption_key_found.yml
+++ b/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_tgs_no_suitable_encryption_key_found.yml
@@ -9,6 +9,7 @@ references:
     - https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/kdc-event-16-27-des-encryption-disabled
 author: '@SerkinValery'
 date: 2024-03-07
+modified: 2025-09-22
 tags:
     - attack.credential-access
     - attack.t1558.003


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request
Sigma rules within [windows/bultin/system/microsoft_windows_kerberos_key_distribution_center/](https://github.com/SigmaHQ/sigma/tree/master/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center) use different `Provider_Name` variables:
-  `Kerberos-Key-Distribution-Center` and
-  `Microsoft-Windows-Kerberos-Key-Distribution-Center`

It seems that both provider names are valid, so I updated the rules to match both names.

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

update: [win_system_kdcsvc_cert_use_no_strong_mapping.yml](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_cert_use_no_strong_mapping.yml) - update provider name selection
update: [win_system_kdcsvc_rc4_downgrade.yml](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_rc4_downgrade.yml) - update provider name selection
update: [win_system_kdcsvc_tgs_no_suitable_encryption_key_found.yml](https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/system/microsoft_windows_kerberos_key_distribution_center/win_system_kdcsvc_tgs_no_suitable_encryption_key_found.yml) - update provider name selection

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
This PR fixes #5589.
### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
