### PR TITLE
Timer new rule

### DIFF
--- a/rules/linux/auditd/lnx_auditd_apt_conf_d_pesistence.yml
+++ b/rules/linux/auditd/lnx_auditd_apt_conf_d_pesistence.yml
@@ -1,4 +1,3 @@
----
 title: APT Persistence via apt.conf.d Configuration
 id: 8f4e2b3a-1d5f-4e2a-9b1c-7e8d9f0a1b2c
 status: experimental

--- a/rules/linux/auditd/lnx_auditd_apt_conf_d_pesistence.yml
+++ b/rules/linux/auditd/lnx_auditd_apt_conf_d_pesistence.yml
@@ -1,0 +1,41 @@
+---
+title: APT Persistence via apt.conf.d Configuration
+id: 8f4e2b3a-1d5f-4e2a-9b1c-7e8d9f0a1b2c
+status: experimental
+description: |
+    Detects persistence via malicious configuration
+    files in /etc/apt/apt.conf.d/ that execute code
+    during apt operations This leverages auditd rules
+    to monitor openat syscalls by /usr/bin/apt
+    on files in the directory.
+author: Ali AtashGar
+date: 2025-09-15
+tags:
+    - attack.persistence
+    - attack.t1546.016
+    - attack.t1197
+references:
+    - https://securityboulevard.com/2024/10/linux-persistence-mechanisms-and-how-to-find-them/
+    - https://matheuzsecurity.github.io/hacking/linux-threat-hunting-persistence/
+    - https://hadess.io/the-art-of-linux-persistence/
+    - https://www.elastic.co/security-labs/sequel-on-persistence-mechanisms
+    - https://systemweakness.com/code-execution-with-apt-update-in-crontab-privesc-in-linux-e6d6ffa8d076
+    - https://github.com/elastic/protections-artifacts/blob/main/behavior/rules/linux/persistence_apt_package_manager_command_execution.toml
+    - https://stmxcsr.com/persistence/persistence-linux.html
+logsource:
+    product: linux
+    service: auditd
+detection:
+    selection:
+        - event_id: SYSCALL
+          exe: '/usr/bin/apt'
+          syscall: 257
+          key: 'apt_backdoor'
+        - event_id: PATH
+          name|startswith: '/etc/apt/apt.conf.d/'
+    condition: selection
+falsepositives:
+    - Legitimate APT configurations or updates that create or modify
+     files in /etc/apt/apt.conf.d/. Verify by inspecting file
+     contents for malicious hooks like APT::Update::Pre-Invoke.
+level: high

--- a/rules/linux/auditd/lnx_auditd_apt_conf_d_pesistence.yml
+++ b/rules/linux/auditd/lnx_auditd_apt_conf_d_pesistence.yml
@@ -26,11 +26,11 @@ logsource:
     service: auditd
 detection:
     selection:
-        - event_id: SYSCALL
+        - type: SYSCALL
           exe: '/usr/bin/apt'
           syscall: 257
           key: 'apt_backdoor'
-        - event_id: PATH
+        - type: PATH
           name|startswith: '/etc/apt/apt.conf.d/'
     condition: selection
 falsepositives:

--- a/rules/linux/auditd/lnx_auditd_sys_timer_creation.yml
+++ b/rules/linux/auditd/lnx_auditd_sys_timer_creation.yml
@@ -1,0 +1,46 @@
+title: Detect Creation of System Timer Files in Linux
+id: 8d2f4a1b-7e5c-4f3a-9b2e-6c1d4f7a3e4b
+status: experimental
+description: |
+  This Sigma rule detects the creation of system timer files in Linux
+  via auditd logs.It monitors file creation events
+  in the timers.target.wants directories,
+  which may be used by attackers for persistence.
+  Such actions could indicate attempts to maintain access
+  by scheduling malicious tasks via systemd timers.
+author: AAtashGar
+date: 2025-09-04
+tags:
+    - attack.persistence
+    - attack.t1053
+    - attack.t1053.006
+logsource:
+    product: linux
+    service: auditd
+    definition: |
+      Required auditd configuration:
+      -w /lib/systemd/system/timers.target.wants -p wa -k Hunting_systemTimer
+      -w /etc/systemd/system/timers.target.wants -p wa -k Hunting_systemTimer
+detection:
+    selection_sys:
+        type: SYSCALL
+        syscall: 257
+        key: Hunting_systemTimer
+    selection_pth_create:
+        type: PATH
+        nametype: CREATE
+        name|startswith:
+            - '/lib/systemd/system/timers.target.wants/'
+            - '/etc/systemd/system/timers.target.wants/'
+    selection_pth_parent:
+        type: PATH
+        nametype: PARENT
+        name|startswith:
+            - '/lib/systemd/system/timers.target.wants/'
+            - '/etc/systemd/system/timers.target.wants/'
+    condition: selection_sys and selection_pth_create and selection_pth_parent
+falsepositives:
+    - Legitimate administrative activities creating or modifying system timers.
+    - System updates or package installations that involve timer configurations.
+    - Development or testing environments where timers are frequently created.
+level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.
!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

This pull request adds a new Sigma rule to detect the creation of system timer files in Linux via auditd logs. The rule monitors file creation events in the `timers.target.wants` directories, which could be used by attackers for persistence through systemd timers.

### Changelog

new: Detect Creation of System Timer Files in Linux

### Example Log Event

```
type=PROCTITLE msg=audit(1756992946.638:315): proctitle=6E616E6F002F6C69622F73797374656D642F73797374656D2F74696D6572732E7461726765742E77616E74732F616C692E74696D6572
type=PATH msg=audit(1756992946.638:315): item=1 name="/lib/systemd/system/timers.target.wants/ali.timer" inode=3801536 dev=08:02 mode=0100644 ouid=0 ogid=0 rdev=00:00 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=PATH msg=audit(1756992946.638:315): item=0 name="/lib/systemd/system/timers.target.wants/" inode=3806036 dev=08:02 mode=040755 ouid=0 ogid=0 rdev=00:00 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0
type=CWD msg=audit(1756992946.638:315): cwd="/home/nooranet"
type=SYSCALL msg=audit(1756992946.638:315): arch=c000003e syscall=257 success=yes exit=3 a0=ffffff9c a1=55b324c016f0 a2=241 a3=1b6 items=2 ppid=2326 pid=2410 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=5 comm="nano" exe="/usr/bin/nano" subj=unconfined key="Hunting_service"
```

### Fixed Issues

None

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
