### PR TITLE
Update win_security_alert_ruler.yml with a missing mitre att&ck tag

### DIFF
--- a/rules/windows/builtin/security/win_security_alert_ruler.yml
+++ b/rules/windows/builtin/security/win_security_alert_ruler.yml
@@ -15,6 +15,7 @@ tags:
     - attack.discovery
     - attack.execution
     - attack.collection
+    - attack.lateral-movement
     - attack.t1087
     - attack.t1114
     - attack.t1059


### PR DESCRIPTION
Adding attack.lateral-movement since there's no  relevant tactic represented on this rule to cover t1550.002.

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog
update: Hacktool Ruler - adding a mitre att&ck tag.
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
