### PR TITLE
add detection rule for suspicious use of BrowserCore.exe in PRT extra…

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_prt_attack_browsercore.yml
+++ b/rules/windows/process_creation/proc_creation_win_prt_attack_browsercore.yml
@@ -24,7 +24,7 @@ detection:
     filter_main_legit_exec_cmd:
         ParentImage|endswith: '\cmd.exe'
         ParentCommandLine|contains: '\\.\pipe\'
-    condition: selection and not 1 of filter_main_*
+    condition: all of selection_* and not 1 of filter_main_*
 falsepositives:
     - Unknown
 level: medium


### PR DESCRIPTION
…ction

<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
Summary of the Pull Request
-->
This pull request adds a Sigma rule to detect suspicious executions of BrowserCore.exe that may indicate attempts to extract Primary Refresh Tokens (PRTs) for Azure AD SSO abuse. The rule identifies process creations where BrowserCore.exe is launched with a command line referencing a specific Chrome extension, excluding cases where the parent process is cmd.exe.
### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>


-->
new: Suspicious Use of BrowserCore.exe for PRT Extraction
### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
