### PR TITLE
Author line missing in EDR Freeze Tool Rule

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_hktl_edr_freeze.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_edr_freeze.yml
@@ -9,6 +9,7 @@ date: 2025-09-24
 references:
     - https://www.zerosalarium.com/2025/09/EDR-Freeze-Puts-EDRs-Antivirus-Into-Coma.html
     - https://github.com/TwoSevenOneT/EDR-Freeze
+author: Swachchhanda Shrawan Poudel (Nextron Systems)
 tags:
     - attack.defense-evasion
     - attack.t1562.001


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

I added the author line to prevent sigma rule parsing for tools that require the author line.

### Changelog

fix: Hacktool - EDR-Freeze Execution

### Fixed Issues

Missing `author`

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
