### PR TITLE
Add DPI-based network rule for responder footprints detection

### DIFF
--- a/rules/network/dpi/dpi_responder_footprints_ntlm_credential_theft.yml
+++ b/rules/network/dpi/dpi_responder_footprints_ntlm_credential_theft.yml
@@ -1,0 +1,24 @@
+title: Responder Tool Footprints for NTLM Credential Theft
+id: 8f3a2c4e-7b9d-4d1a-9c3e-2a26128b9d2f
+status: experimental
+description: Detects NTLM traffic patterns indicative of Responder credential harvesting.
+author: Yael Ben Yair
+date: 2025/11/11
+logsource:
+  category: network
+  service: ntlm
+detection:
+  domain_pattern:
+    netbios_domain_name|re: '^[A-Z0-9]{4}$'
+  computer_pattern:
+    netbios_computer_name|re: '^WIN-[A-Z0-9]{11}$'
+  dns_swap_1:
+    dns_computer_name|fieldref: netbios_domain_name
+  dns_swap_2:
+    dns_domain_name|fieldref: netbios_computer_name
+  condition: (domain_pattern or computer_pattern) or (dns_swap_1 or dns_swap_2)
+level: medium
+tags:
+  - attack.credential-access
+  - attack.collection
+  - attack.t1557


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

This Sigma rule detects network-level indicators of NTLM credential theft associated with the use of the Responder tool. The rule is based on deep packet inspection (DPI) and behavioral patterns outlined in the research article https://medium.com/@hx015/responder-tool-footprints-in-ntlm-credential-theft-6f25ec7984d3 

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
