### PR TITLE
Create susp_proc_spawned_from_winlogon.yml

### DIFF
--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_susp_proc_spawned_from_winlogon.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_susp_proc_spawned_from_winlogon.yml
@@ -1,31 +1,36 @@
 title: Suspicious Process Spawned from Winlogon
 id: 9c7f4d2e-3b6a-4f18-9e2d-2a7f8b6c4f1a
-status: test
-description: Detects cmd.exe launched where the initiating/parent process is winlogon.exe and the initiating account is 'SYSTEM' or 'NETWORK', excluding target accounts containing those same substrings. This pattern can detect instances where a device has been compromised, drive decrypted, and had normally benign binaries that execute as SYSTEM like sticky keys, utilman, and such replaced with a more useful binary for exploitation by a threat actor. I wrote the original detection in KQL leveraging the Microsoft Defender for Endpoint table DeviceProcessEvents. The logic of the detection only detects a replacement of benign binaries with cmd.exe, but cmd.exe could be replaced with powershell, or a compiled exploit. Though a compiled exploit would probably be poor opsec from the TA.
+status: experimental
+description: |
+  Detects cmd.exe launched where the initiating process is winlogon.exe and the initiating account is SYSTEM or NETWORK.
+  This behaviour may indicate replacement of benign accessibility executables (such as StickyKeys or Utilman) with cmd.exe to gain elevated access during or after system compromise.
+
 references:
   - https://medium.com/@enyel.salas84/exploiting-sticky-keys-via-sethc-exe-for-privilege-escalation-on-windows-03a15f2fd560
 author: Kaden Butt (Kaiber)
 date: 2025-11-22
 modified: 2025-11-22
 tags:
-  - attack.execution
   - attack.t1059
-  - microsoft.defender
+  - attack.t1546.008
+  - product.mde
 logsource:
   category: process_creation
   product: windows
 detection:
-  selection_mde:
-    InitiatingProcessAccountName|contains:
-      - "system"
-      - "network"
+  selection_parent:
     InitiatingProcessFolderPath|endswith: '\windows\system32\winlogon.exe'
-    ProcessAVersioninfoOriginalFileName|iexact: 'cmd.exe'
-  exclude_target_account:
+  selection_original_filename:
+    ProcessVersionInfoOriginalFileName|iexact: 'cmd.exe'
+  selection_initiating_account:
+    InitiatingProcessAccountName|contains:
+      - SYSTEM
+      - NETWORK
+  filter_target_account:
     AccountName|contains:
-      - "system"
-      - "network"
-  condition: all of selection_mde and not 1 of exclude_target_account
+      - SYSTEM
+      - NETWORK
+  condition: all of selection_* and not 1 of filter_target_account
 
 falsepositives:
   - Custom shells configured to cmd.exe for certain users via (HKCU\\Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Shell or policy).


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

This PR introduces a new MDE-based Windows threat-hunting detection rule that identifies cmd.exe spawned by winlogon.exe under SYSTEM or NETWORK initiating accounts. The rule highlights potential replacement of benign accessibility binaries to achieve elevated command execution during or after system compromise.

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog
new: Winlogon Spawning Cmd.exe Under System/Network Initiation – initial rule creation
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
