### PR TITLE
Improve macOS "Credentials from Password Stores - Keychain" rule

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_creds_from_keychain.yml
+++ b/rules/macos/process_creation/proc_creation_macos_creds_from_keychain.yml
@@ -1,13 +1,13 @@
 title: Credentials from Password Stores - Keychain
 id: b120b587-a4c2-4b94-875d-99c9807d6955
 status: test
-description: Detects passwords dumps from Keychain
+description: Detects credential access and password extraction from macOS Keychain using the security command-line utility
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1555.001/T1555.001.md
     - https://gist.github.com/Capybara/6228955
-author: Tim Ismilyaev, oscd.community, Florian Roth (Nextron Systems)
+author: Tim Ismilyaev, oscd.community, Florian Roth (Nextron Systems), Niicolaa
 date: 2020-10-19
-modified: 2021-11-27
+modified: 2026-01-30
 tags:
     - attack.credential-access
     - attack.t1555.001
@@ -15,16 +15,32 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection1:
-        Image: '/usr/bin/security'
+    selection_binary:
+        Image|endswith: '/security'
+    selection_dump:
         CommandLine|contains:
-            - 'find-certificate'
-            - ' export '
-    selection2:
+            - 'dump-keychain'
+    selection_find_password:
         CommandLine|contains:
-            - ' dump-keychain '
-            - ' login-keychain '
-    condition: 1 of selection*
+            - 'find-internet-password'
+            - 'find-generic-password' # this one is quiet noisy
+    selection_find_args:
+        CommandLine|contains:
+            - ' -w'
+            - ' -g'
+    selection_export:
+        CommandLine|contains:
+            - 'export'
+    filter_export_public:
+        CommandLine|contains:
+            - ' -t certs'
+            - ' -t pubKeys'
+    filter_export_public_override:
+        CommandLine|contains:
+            - 'allKeys'
+            - 'privKeys'
+            - 'identities'
+    condition: selection_binary and ((selection_find_password and selection_find_args) or (selection_export and not (filter_export_public and not filter_export_public_override)))
 falsepositives:
     - Legitimate administration activities
 level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request
Improve macOS "Credentials from Password Stores - Keychain" rule
- Add find-generic-password and find-internet-password with -w/-g flag requirements
- modified export detection with filter to exclude public-only exports (certs/pubKeys)
- Remove find-certificate (public data only) and login-keychain


### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->
update:	Credentials from Password Stores - Keychain

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
n/a
### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
