### PR TITLE
Add Azure AD password spray detection via SigninLogs (T1110.003)

### DIFF
--- a/rules/cloud/azure/signin_logs/azure_ad_password_spray_via_signinlogs.yml
+++ b/rules/cloud/azure/signin_logs/azure_ad_password_spray_via_signinlogs.yml
@@ -1,0 +1,47 @@
+title: Password Spray Attack via Azure AD Sign-In Logs
+id: 4b7e9f3a-1c2d-4e8b-a9d5-6f0c3b8e7a2d
+status: test
+description: |
+    Detects password spray attacks against Azure AD by identifying a single source IP
+    generating multiple failed authentication attempts across a high number of distinct
+    user accounts within a short time window. Unlike brute force, password spray uses
+    one or a small number of common passwords across many accounts to avoid per-account
+    lockout policies.
+references:
+    - https://attack.mitre.org/techniques/T1110/003/
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-azure-monitor-sign-ins-log-schema
+    - https://learn.microsoft.com/en-us/entra/identity-protection/concept-identity-protection-risks
+author: Divine Augustine
+date: 2026-03-08
+tags:
+    - attack.credential-access
+    - attack.t1110.003
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        ResultType|startswith:
+            - '5'
+            - '7'
+            - '6'
+    filter_mfa_and_interrupts:
+        ResultType:
+            - '50140'
+            - '70043'
+            - '50074'
+            - '0'
+    condition: selection and not filter_mfa_and_interrupts | count(UserPrincipalName) by IPAddress > 3
+    timeframe: 10m
+falsepositives:
+    - VPN gateways or proxy servers that route authentication for many users through a single IP
+    - On-premises ADFS connectors or legacy authentication services
+    - Automated testing or monitoring tools authenticating on behalf of multiple service accounts
+    - Helpdesk environments where agents authenticate as multiple users from one jump host
+fields:
+    - IPAddress
+    - UserPrincipalName
+    - ResultType
+    - AppDisplayName
+    - Location
+level: high


### PR DESCRIPTION
## Summary of the Pull Request

Adds a new Sigma detection rule for T1110.003 (Brute Force: Password Spraying) targeting Azure AD SigninLogs. The rule detects a single source IP generating failed authentications against more than 3 distinct user accounts within a 10-minute window. This complements existing identity_protection rules which rely on Entra ID Protection's riskdetection service and require P2 licensing — this rule uses raw SigninLogs and is deployable without P2.

## Changelog

new: Password Spray Attack via Azure AD Sign-In Logs (T1110.003) — aggregation-based detection using SigninLogs

## Example Log Event

N/A — rule uses aggregation condition across multiple events

## Fixed Issues

N/A

## SigmaHQ Rule Creation Conventions

- logsource: product: azure, service: signinlogs
- status: test
- falsepositives documented
- MITRE ATT&CK tag: attack.t1110.003
