### PR TITLE
Update rule Suspicious File Characteristics Due to Missing Fields to include additional values

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
@@ -47,7 +47,7 @@ detection:
         Company: null
     folder:
         Image|contains: '\Downloads\'
-    condition: (selection1 or selection2 or selection3) and folder
+    condition: (1 of selection*) and folder
 falsepositives:
     - Unknown
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
@@ -7,7 +7,7 @@ references:
     - https://www.virustotal.com/#/file/276a765a10f98cda1a38d3a31e7483585ca3722ecad19d784441293acf1b7beb/detection
 author: Markus Neis, Sander Wiebing
 date: 2018-11-22
-modified: 2026-03-23
+modified: 2026-03-24
 tags:
     - attack.execution
     - attack.t1059.006
@@ -16,38 +16,27 @@ logsource:
     category: process_creation
 detection:
     selection1:
-        Description:
-            - '\?'
-            - ''
-        FileVersion:
-            - '\?'
-            - ''
-    selection1-null:
+        Description: '\?'
+        FileVersion: '\?'
+    selection2:
+        Description: '\?'
+        Product: '\?'
+    selection3:
+        Description: '\?'
+        Company: '\?'
+    selection4:
+        Description: ''
+        FileVersion: ''
+        Product: ''
+        Company: ''
+    selection4-null:
         Description: null
         FileVersion: null
-    selection2:
-        Description:
-            - '\?'
-            - ''
-        Product:
-            - '\?'
-            - ''
-    selection2-null:
-        Description: null
         Product: null
-    selection3:
-        Description:
-            - '\?'
-            - ''
-        Company:
-            - '\?'
-            - ''
-    selection3-null:
-        Description: null
         Company: null
     folder:
         Image|contains: '\Downloads\'
     condition: (1 of selection*) and folder
 falsepositives:
-    - Unknown
-level: medium
+    - Some legitimate files can have those fields empty
+level: low

--- a/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
@@ -16,14 +16,35 @@ logsource:
     category: process_creation
 detection:
     selection1:
-        Description: '\?'
-        FileVersion: '\?'
+        Description:
+            - '\?'
+            - ''
+        FileVersion:
+            - '\?'
+            - ''
+    selection1-null:
+        Description: null
+        FileVersion: null
     selection2:
-        Description: '\?'
-        Product: '\?'
+        Description:
+            - '\?'
+            - ''
+        Product:
+            - '\?'
+            - ''
+    selection2-null:
+        Description: null
+        Product: null
     selection3:
-        Description: '\?'
-        Company: '\?'
+        Description:
+            - '\?'
+            - ''
+        Company:
+            - '\?'
+            - ''
+    selection3-null:
+        Description: null
+        Company: null
     folder:
         Image|contains: '\Downloads\'
     condition: (selection1 or selection2 or selection3) and folder

--- a/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
@@ -7,7 +7,7 @@ references:
     - https://www.virustotal.com/#/file/276a765a10f98cda1a38d3a31e7483585ca3722ecad19d784441293acf1b7beb/detection
 author: Markus Neis, Sander Wiebing
 date: 2018-11-22
-modified: 2022-10-09
+modified: 2026-03-23
 tags:
     - attack.execution
     - attack.t1059.006

--- a/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
@@ -38,5 +38,5 @@ detection:
         Image|contains: '\Downloads\'
     condition: (1 of selection*) and folder
 falsepositives:
-    - Some legitimate files can have those fields empty
+    - Rarely there are benign executables that have no VERSION INFORMATION that need to be base lined
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_file_characteristics.yml
@@ -39,4 +39,4 @@ detection:
     condition: (1 of selection*) and folder
 falsepositives:
     - Some legitimate files can have those fields empty
-level: low
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

After testing generation of executable with py2exe or pyinstaller with python3.12, the fields listed in this rule (Description, FileVersion, Product, Company) are empty, not equals to '?'.

### Changelog

update:	Suspicious File Characteristics Due to Missing Fields - Adding empty string or null as potential values to check

### Example Log Event

### Fixed Issues

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
