### PR TITLE
Add Exchange inbox rule external forwarding and suppression detection (M365)

### DIFF
--- a/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
+++ b/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
@@ -40,6 +40,7 @@ detection:
         Parameters|contains:
             - 'DeleteMessage'
             - 'MarkAsRead'
+            - 'MoveToFolder'
     condition: selection_operation and (selection_forwarding or selection_suppression)
 falsepositives:
     - Legitimate users configuring email forwarding to a personal or secondary account

--- a/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
+++ b/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
@@ -22,7 +22,7 @@ tags:
     - attack.collection
     - attack.t1114.003
     - attack.defense_evasion
-    - attack.t1070
+    - attack.t1070.008
 logsource:
     product: m365
     service: exchange

--- a/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
+++ b/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
@@ -15,7 +15,7 @@ description: |
 references:
     - https://learn.microsoft.com/en-us/security/operations/incident-response-playbook-phishing
     - https://attack.mitre.org/techniques/T1114/003/
-    - https://attack.mitre.org/techniques/T1070/
+    - https://attack.mitre.org/techniques/T1070/008/
 author: Tashnim Asgar (lanceterminal)
 date: 2026/04/08
 tags:

--- a/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
+++ b/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
@@ -14,8 +14,6 @@ description: |
     indicator of account compromise.
 references:
     - https://learn.microsoft.com/en-us/security/operations/incident-response-playbook-phishing
-    - https://attack.mitre.org/techniques/T1114/003/
-    - https://attack.mitre.org/techniques/T1070/008/
 author: Tashnim Asgar (lanceterminal)
 date: 2026-04-08
 tags:

--- a/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
+++ b/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
@@ -17,11 +17,11 @@ references:
     - https://attack.mitre.org/techniques/T1114/003/
     - https://attack.mitre.org/techniques/T1070/008/
 author: Tashnim Asgar (lanceterminal)
-date: 2026/04/08
+date: 2026-04-08
 tags:
     - attack.collection
     - attack.t1114.003
-    - attack.defense_evasion
+    - attack.defense-evasion
     - attack.t1070.008
 logsource:
     product: m365

--- a/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
+++ b/rules/cloud/m365/exchange/microsoft365_exchange_inbox_rule_exfil_forwarding.yml
@@ -1,0 +1,48 @@
+title: Suspicious Exchange Inbox Rule Configured for External Forwarding or Message Suppression
+id: 756232a0-5b3d-4665-86a1-12187c1bd427
+status: experimental
+description: |
+    Detects creation or modification of Exchange Online inbox rules that configure
+    external email forwarding, redirection, or message deletion. This technique is
+    consistently observed as a post-compromise persistence and collection mechanism
+    following successful phishing attacks.
+
+    After gaining access to a victim mailbox, adversaries routinely create inbox rules
+    to silently forward email to attacker-controlled external addresses (T1114.003) and
+    optionally suppress evidence by deleting the originals from the victim inbox. These
+    rules persist across password resets unless explicitly removed, making them a high-value
+    indicator of account compromise.
+references:
+    - https://learn.microsoft.com/en-us/security/operations/incident-response-playbook-phishing
+    - https://attack.mitre.org/techniques/T1114/003/
+    - https://attack.mitre.org/techniques/T1070/
+author: Tashnim Asgar (lanceterminal)
+date: 2026/04/08
+tags:
+    - attack.collection
+    - attack.t1114.003
+    - attack.defense_evasion
+    - attack.t1070
+logsource:
+    product: m365
+    service: exchange
+detection:
+    selection_operation:
+        Operation:
+            - 'New-InboxRule'
+            - 'Set-InboxRule'
+    selection_forwarding:
+        Parameters|contains:
+            - 'ForwardTo'
+            - 'ForwardAsAttachmentTo'
+            - 'RedirectTo'
+    selection_suppression:
+        Parameters|contains:
+            - 'DeleteMessage'
+            - 'MarkAsRead'
+    condition: selection_operation and (selection_forwarding or selection_suppression)
+falsepositives:
+    - Legitimate users configuring email forwarding to a personal or secondary account
+    - IT or compliance-driven forwarding rules for archival or legal hold purposes
+    - Helpdesk-created rules during mailbox migration or consolidation workflows
+level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request
Adds a new detection rule for suspicious Exchange Online inbox rule creation or modification that configures external email forwarding or message suppression. This is a consistent post-phishing persistence and collection technique where adversaries forward victim email to attacker-controlled addresses and delete originals to hide activity.
<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog
new: Suspicious Exchange Inbox Rule Configured for External Forwarding or Message Suppression
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
