### PR TITLE
Add detection rules for AdaptixC2 and HavocC2 default profiles

### DIFF
--- a/rules/web/proxy_generic/proxy_hktl_havoc_c2_default_uri_pattern.yml
+++ b/rules/web/proxy_generic/proxy_hktl_havoc_c2_default_uri_pattern.yml
@@ -1,0 +1,30 @@
+title: HackTool - HavocC2 Demon Agent Default Listener URI Pattern
+id: 904af643-c3e9-4c13-8c3d-992d5873b24f
+status: experimental
+description: >
+    Detects Havoc C2 framework Demon agent beacon requests using the hardcoded
+    default URI list defined in the stock Havoc listener profile. The URIs
+    '/funny_cat.gif' and '/helloworld.js' are the framework defaults and are
+    not expected in any legitimate enterprise web traffic.
+references:
+    - https://havocframework.com/docs/profiles
+    - https://www.immersivelabs.com/resources/c7-blog/havoc-c2-framework-a-defensive-operators-guide
+    - https://github.com/HavocFramework/Havoc
+author: ideabib
+date: 2026-04-21
+modified: 2026-04-21
+tags:
+    - attack.command_and_control
+    - attack.t1071.001
+logsource:
+    category: proxy
+    product: windows
+detection:
+    selection:
+        cs-uri-stem|contains:
+            - '/funny_cat.gif'
+            - '/helloworld.js'
+    condition: selection
+falsepositives:
+    - None expected in enterprise environments
+level: critical

--- a/rules/web/proxy_generic/proxy_hktl_havoc_c2_default_useragent.yml
+++ b/rules/web/proxy_generic/proxy_hktl_havoc_c2_default_useragent.yml
@@ -1,0 +1,35 @@
+title: HackTool - HavocC2 Demon Agent Default Chrome 96 User-Agent
+id: a014dfd2-4797-4169-ae02-cd50cd274733
+status: experimental
+description: >
+    Detects the Havoc C2 framework Demon agent using its hardcoded default
+    User-Agent string: Chrome 96.0.4664.110 on Windows 7 WOW64. Chrome 96
+    reached end-of-life in January 2022 and is no longer present in legitimate
+    enterprise traffic. The combination of EOL Chrome version and Windows 7
+    WOW64 platform string is a high-confidence indicator of the Havoc Demon
+    agent operating with an unmodified default profile.
+references:
+    - https://havocframework.com/docs/profiles
+    - https://www.immersivelabs.com/resources/c7-blog/havoc-c2-framework-a-defensive-operators-guide
+    - https://github.com/HavocFramework/Havoc
+author: ideabib
+date: 2026-04-21
+modified: 2026-04-21
+tags:
+    - attack.command_and_control
+    - attack.t1071.001
+logsource:
+    category: proxy
+    product: windows
+detection:
+    selection:
+        c-useragent|contains|all:
+            - 'Windows NT 6.1'
+            - 'WOW64'
+            - 'Chrome/96.0.4664.110'
+    filter_edge:
+        c-useragent|contains: 'Edg/'
+    condition: selection and not filter_edge
+falsepositives:
+    - Extremely outdated Chrome 96 installations on genuine Windows 7 systems (verify host OS and patch currency)
+level: high

--- a/rules/windows/process_creation/proc_creation_win_hktl_adaptixc2_ps_stager.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_adaptixc2_ps_stager.yml
@@ -1,0 +1,33 @@
+title: HackTool - AdaptixC2 PowerShell Stager In-Memory Loader
+id: 2f3da1e7-70c9-41b1-ab8e-e3630ae76d51
+status: experimental
+description: >
+    Detects AdaptixC2 PowerShell stager pattern combining VirtualAlloc and
+    GetDelegateForFunctionPointer in a single command line, consistent with
+    the XOR-decode to shellcode execution chain documented by Unit 42 (Sep 2025).
+    AdaptixC2 has been confirmed in use by Russian-nexus ransomware groups since 2024.
+references:
+    - https://unit42.paloaltonetworks.com/adaptixc2-post-exploitation-framework/
+    - https://github.com/Adaptix-Framework/AdaptixC2
+author: ideabib
+date: 2026-04-21
+modified: 2026-04-21
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.defense_evasion
+    - attack.t1620
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\\powershell.exe'
+        CommandLine|contains|all:
+            - 'VirtualAlloc'
+            - 'GetDelegateForFunctionPointer'
+    condition: selection
+falsepositives:
+    - Legitimate security tooling or in-memory loading frameworks during authorized red team exercises
+    - Some obfuscated PowerShell loaders used by legitimate software (verify signing and parent process)
+level: high

--- a/rules/windows/registry/registry_set/registry_set_hktl_adaptixc2_run_key_updater.yml
+++ b/rules/windows/registry/registry_set/registry_set_hktl_adaptixc2_run_key_updater.yml
@@ -1,0 +1,33 @@
+title: HackTool - AdaptixC2 Loader Persistence via Updater Run Key
+id: 14f23aee-0f21-4c3b-b64f-88677e9b82d2
+status: experimental
+description: >
+    Detects AdaptixC2 loader persistence mechanism that creates a registry run key
+    named exactly 'Updater' under HKCU Software\Microsoft\Windows\CurrentVersion\Run.
+    This specific key name and path combination was documented in Unit 42's analysis
+    of AdaptixC2 deployments by Russian ransomware actors in 2025.
+references:
+    - https://unit42.paloaltonetworks.com/adaptixc2-post-exploitation-framework/
+    - https://attack.mitre.org/techniques/T1547/001/
+author: ideabib
+date: 2026-04-21
+modified: 2026-04-21
+tags:
+    - attack.persistence
+    - attack.t1547.001
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        TargetObject|contains: '\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run\\'
+        Details|contains: 'Updater'
+    filter_legitimate:
+        Details|contains:
+            - 'OneDrive'
+            - 'GoogleUpdate'
+            - 'MicrosoftEdgeUpdate'
+    condition: selection and not filter_legitimate
+falsepositives:
+    - Legitimate software coincidentally naming a run key 'Updater' - validate the binary path and signing status
+level: high


### PR DESCRIPTION
## Summary

This PR adds 4 new Sigma rules targeting default/unmodified configurations
of the AdaptixC2 and Havoc C2 (Demon agent) frameworks. These frameworks
are actively exploited in the wild — AdaptixC2 has been confirmed in use
by Russian ransomware groups since late 2024. No dedicated Sigma rules
exist in SigmaHQ for either framework.

---

## Rules Added

### AdaptixC2
| File | Technique | Level |
|------|-----------|-------|
| `proc_creation_win_hktl_adaptixc2_ps_stager.yml` | T1059.001 / T1620 | High |
| `registry_set_hktl_adaptixc2_run_key_updater.yml` | T1547.001 | High |

### Havoc C2 (Demon Agent)
| File | Technique | Level |
|------|-----------|-------|
| `proxy_hktl_havoc_c2_default_useragent.yml` | T1071.001 | High |
| `proxy_hktl_havoc_c2_default_uri_pattern.yml` | T1071.001 | Critical |

---

## Detection Logic

**AdaptixC2 PS Stager** — Targets PowerShell processes combining
`VirtualAlloc` + `GetDelegateForFunctionPointer` in a single command line,
consistent with the XOR-decode → shellcode execution chain documented by
Unit 42 (Sep 2025).

**AdaptixC2 Run Key** — Detects creation of a registry run key named
`Updater` under `HKCU\...\Run`, a persistence artifact documented in the
same Unit 42 analysis. Includes filters for known legitimate software
(OneDrive, GoogleUpdate, MicrosoftEdgeUpdate).

**Havoc Default UA** — The Demon agent ships with a hardcoded Chrome 96
(2021-era) User-Agent on Windows 7 WOW64. Chrome 96 is EOL and not
present in modern enterprise traffic, making this a high-confidence signal.
Includes filter for Edge browser reporting Chrome version strings.

**Havoc Default URIs** — The stock Havoc listener profile hardcodes
`/funny_cat.gif` and `/helloworld.js` as default beacon URIs. These are
trivially anomalous in enterprise proxy logs.

---

## References
- https://unit42.paloaltonetworks.com/adaptixc2-post-exploitation-framework/
- https://www.immersivelabs.com/resources/c7-blog/havoc-c2-framework-a-defensive-operators-guide
- https://havocframework.com/docs/profiles
- https://hunt.io/blog/adaptixc2-uncovered-capabilities-tactics-hunting
- https://www.rescana.com/post/adaptixc2-under-fire-russian-ransomware-gangs-weaponize-open-source-c2-framework-for-advanced-attac

## Testing
- All 4 rules validated with `python tests/test_rules.py` — 11 tests, 0 errors, OK
- False positives documented inline per rule
- Havoc UA rule includes filter for Edge browser reporting Chrome version strings

## ATT&CK Coverage
`T1059.001` `T1620` `T1547.001` `T1071.001`