### PR TITLE
new: Chromium --load-extension Detection for Linux and macOS

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_browsers_chromium_load_extension.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_browsers_chromium_load_extension.yml
@@ -19,7 +19,7 @@ references:
     - https://github.com/cedowens/Dump-Chrome-Cookies
     - https://www.electronjs.org/docs/latest/api/command-line-switches
 author: PersonalRules
-date: 2026/04/21
+date: 2026-04-21
 tags:
     - attack.persistence
     - attack.t1176.001

--- a/rules/linux/process_creation/proc_creation_lnx_browsers_chromium_load_extension.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_browsers_chromium_load_extension.yml
@@ -1,0 +1,37 @@
+title: Potential Malicious Extension Loading via Chromium Flag on Linux
+id: 888fb8a4-5004-4449-b3b2-a42da785f21f
+related:
+    - id: 97663168-bf6e-4acf-84dd-3c1abe1ca5f1
+      type: similar
+    - id: 88d6e60c-759d-4ac1-a447-c0f1466c2d21
+      type: similar
+status: experimental
+description: |
+    Detects the use of the '--load-extension' Chromium flag on any
+    process on Linux. This parameter exists in all Chromium-based
+    applications including browsers (Chrome, Edge, Brave, etc.),
+    Electron apps (Discord, Slack, VS Code, Teams, etc.), and CEF
+    framework applications. Adversaries may abuse this feature to
+    load malicious extensions for persistence, credential theft,
+    cookie stealing, or browser session hijacking.
+references:
+    - https://redcanary.com/blog/chromeloader/
+    - https://github.com/cedowens/Dump-Chrome-Cookies
+    - https://www.electronjs.org/docs/latest/api/command-line-switches
+author: PersonalRules
+date: 2026/04/21
+tags:
+    - attack.persistence
+    - attack.t1176.001
+logsource:
+    product: linux
+    category: process_creation
+detection:
+    selection:
+        CommandLine|contains: '--load-extension='
+    condition: selection
+falsepositives:
+    - Automated testing frameworks such as Selenium, Cypress, or Playwright
+    - Browser extension development and debugging
+    - Electron app development using remote debugging or custom extensions
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_browsers_chromium_load_extension.yml
+++ b/rules/macos/process_creation/proc_creation_macos_browsers_chromium_load_extension.yml
@@ -1,0 +1,37 @@
+title: Potential Malicious Extension Loading via Chromium Flag on macOS
+id: 3300b617-be88-4245-8229-72a071cfede9
+related:
+    - id: 4100c0d0-3cd6-4178-b5e4-1b614b9db77e
+      type: similar
+    - id: 88d6e60c-759d-4ac1-a447-c0f1466c2d21
+      type: similar
+status: experimental
+description: |
+    Detects the use of the '--load-extension' Chromium flag on any
+    process on macOS. This parameter exists in all Chromium-based
+    applications including browsers (Chrome, Edge, Brave, etc.),
+    Electron apps (Discord, Slack, VS Code, Teams, etc.), and CEF
+    framework applications. Threat actors abuse this to load
+    malicious extensions for cookie theft, session hijacking, or
+    persistence.
+references:
+    - https://redcanary.com/blog/chromeloader/
+    - https://cedowens.medium.com/remotely-dumping-chrome-cookies-revisited-b25343257209
+    - https://www.electronjs.org/docs/latest/api/command-line-switches
+author: PersonalRules
+date: 2026/04/21
+tags:
+    - attack.persistence
+    - attack.t1176.001
+logsource:
+    product: macos
+    category: process_creation
+detection:
+    selection:
+        CommandLine|contains: '--load-extension='
+    condition: selection
+falsepositives:
+    - Automated testing frameworks such as Selenium, Cypress, or Playwright
+    - Browser extension development and debugging
+    - Electron app development using remote debugging or custom extensions
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_browsers_chromium_load_extension.yml
+++ b/rules/macos/process_creation/proc_creation_macos_browsers_chromium_load_extension.yml
@@ -19,7 +19,7 @@ references:
     - https://cedowens.medium.com/remotely-dumping-chrome-cookies-revisited-b25343257209
     - https://www.electronjs.org/docs/latest/api/command-line-switches
 author: PersonalRules
-date: 2026/04/21
+date: 2026-04-21
 tags:
     - attack.persistence
     - attack.t1176.001


### PR DESCRIPTION
### Summary of the Pull Request

Adds detection rules for the `--load-extension` Chromium flag on **Linux** and **macOS** platforms. These rules complement the existing Windows rule (`proc_creation_win_browsers_chromium_load_extension.yml`, id: `88d6e60c`).

The `--load-extension` flag is a Chromium command-line switch that exists in **all Chromium-based applications**, including:
- Browsers (Chrome, Edge, Brave, Opera, Vivaldi)
- Electron desktop apps (Discord, Slack, VS Code, Teams, Signal, etc.)
- CEF framework applications

This parameter can be abused to load malicious extensions for persistence, credential theft, cookie stealing, or browser session hijacking. Known malware campaigns such as ChromeLoader use this technique to load malicious browser extensions via script interpreters.

Unlike the existing Windows rule, these rules do **not** filter by `Image` (process name). This is intentional — the `--load-extension` parameter is a universal Chromium flag, not limited to browser binaries. Limiting detection to specific process names creates a bypass opportunity through Electron/CEF applications.

### Changelog

new: Potential Malicious Extension Loading via Chromium Flag on Linux
new: Potential Malicious Extension Loading via Chromium Flag on macOS

### References

- https://redcanary.com/blog/chromeloader/
- https://github.com/cedowens/Dump-Chrome-Cookies
- https://www.electronjs.org/docs/latest/api/command-line-switches
- https://unit42.paloaltonetworks.com/chromeloader-malware/
- https://www.mandiant.com/resources/blog/lnk-between-browsers