### PR TITLE
Add detection for PowerShell reflective DLL loading via .NET reflection methods

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_powershell_reflective_assembly_loading.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_reflective_assembly_loading.yml
@@ -1,0 +1,33 @@
+title: Reflective DLL Loading via PowerShell .NET Reflection Methods
+id: d4a58a8d-51c2-4c46-98ed-83395df55826
+status: experimental
+description: Detects PowerShell scripts using .NET reflection methods to load assemblies directly from memory without writing to disk. This technique is commonly used by penetration testing frameworks like PowerSploit and Cobalt Strike beacons to execute .NET assemblies reflectively.
+references:
+    - https://attack.mitre.org/techniques/T1620/
+    - https://github.com/PowerShellMafia/PowerSploit/blob/master/CodeExecution/Invoke-ReflectivePEInjection.ps1
+    - https://www.cobaltstrike.com/help-beacon-object-files
+author: AJ Jeffreys
+date: 2026/04/24
+tags:
+    - attack.defense_evasion
+    - attack.t1620
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        - CommandLine|contains|all:
+            - '[System.Reflection.Assembly]::Load'
+            - '[byte[]]'
+        - CommandLine|contains|all:
+            - 'Assembly.Load'
+            - 'Convert]::FromBase64String'
+        - CommandLine|contains|all:
+            - 'Reflection.Assembly'
+            - 'GetMethod('
+            - '.Invoke('
+    condition: selection
+falsepositives:
+    - Legitimate PowerShell modules that use reflection for dynamic assembly loading (rare in enterprise environments)
+    - Custom enterprise applications using PowerShell for .NET assembly management
+level: high


### PR DESCRIPTION
## Description

This rule detects PowerShell scripts using .NET reflection methods to load assemblies directly from memory, a technique commonly employed by offensive security tools and malware.

## Technique Coverage

- **MITRE ATT&CK**: T1620 - Reflective Code Loading
- **Focus**: PowerShell-based reflective assembly loading using .NET reflection APIs

## Detection Logic

The rule identifies PowerShell command lines containing specific combinations of:
- `[System.Reflection.Assembly]::Load` with byte array indicators
- `Assembly.Load` with Base64 decoding functions
- Reflection API calls combined with method invocation patterns

## Why This Rule Adds Value

While SigmaHQ has generic reflective loading rules, this specifically targets the PowerShell + .NET reflection vector that is heavily used by:
- PowerSploit's `Invoke-ReflectivePEInjection`
- Cobalt Strike beacon object files
- Empire framework modules

The detection is specific enough to avoid triggering on normal PowerShell usage while catching this particular abuse pattern.

## Testing

Rule should trigger on:
```powershell
[System.Reflection.Assembly]::Load([byte[]]$assembly).GetType("Program").GetMethod("Main").Invoke($null, $null)
```

And similar reflective loading patterns common in offensive PowerShell tooling.