### PR TITLE
fix(okta): use correct camelCase field names from Okta System Log API

### DIFF
--- a/rules-emerging-threats/2023/TA/Okta-Support-System-Breach/okta_apt_suspicious_user_creation.yml
+++ b/rules-emerging-threats/2023/TA/Okta-Support-System-Breach/okta_apt_suspicious_user_creation.yml
@@ -6,6 +6,7 @@ description: |
     This rule can be enhanced by filtering out known and legitimate username used in your environnement.
 author: Muhammad Faisal (@faisalusuf)
 date: 2023-10-25
+modified: 2026-04-27
 references:
     - https://www.beyondtrust.com/blog/entry/okta-support-unit-breach
     - https://developer.okta.com/docs/reference/api/event-types/

--- a/rules-emerging-threats/2023/TA/Okta-Support-System-Breach/okta_apt_suspicious_user_creation.yml
+++ b/rules-emerging-threats/2023/TA/Okta-Support-System-Breach/okta_apt_suspicious_user_creation.yml
@@ -17,10 +17,10 @@ logsource:
     product: okta
 detection:
     selection:
-        eventtype:
+        eventType:
             - 'user.lifecycle.create'
             - 'user.lifecycle.activate'
-        target.user.display.name|contains: 'svc_network_backup'
+        target.displayName|contains: 'svc_network_backup'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/identity/okta/okta_admin_role_assigned_to_user_or_group.yml
+++ b/rules/identity/okta/okta_admin_role_assigned_to_user_or_group.yml
@@ -17,7 +17,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype:
+        eventType:
             - group.privilege.grant
             - user.account.privilege.grant
     condition: selection

--- a/rules/identity/okta/okta_admin_role_assigned_to_user_or_group.yml
+++ b/rules/identity/okta/okta_admin_role_assigned_to_user_or_group.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.privilege-escalation
     - attack.persistence

--- a/rules/identity/okta/okta_admin_role_assignment_created.yml
+++ b/rules/identity/okta/okta_admin_role_assignment_created.yml
@@ -7,6 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Nikita Khalimonenkov
 date: 2023-01-19
+modified: 2026-04-27
 tags:
     - attack.persistence
 logsource:

--- a/rules/identity/okta/okta_admin_role_assignment_created.yml
+++ b/rules/identity/okta/okta_admin_role_assignment_created.yml
@@ -14,7 +14,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype: 'iam.resourceset.bindings.add'
+        eventType: 'iam.resourceset.bindings.add'
     condition: selection
 falsepositives:
     - Legitimate creation of a new admin role assignment

--- a/rules/identity/okta/okta_api_token_created.yml
+++ b/rules/identity/okta/okta_api_token_created.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.persistence
 logsource:

--- a/rules/identity/okta/okta_api_token_created.yml
+++ b/rules/identity/okta/okta_api_token_created.yml
@@ -15,7 +15,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype: system.api_token.create
+        eventType: system.api_token.create
     condition: selection
 falsepositives:
     - Legitimate creation of an API token by authorized users

--- a/rules/identity/okta/okta_api_token_revoked.yml
+++ b/rules/identity/okta/okta_api_token_revoked.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.impact
 logsource:

--- a/rules/identity/okta/okta_api_token_revoked.yml
+++ b/rules/identity/okta/okta_api_token_revoked.yml
@@ -15,7 +15,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype: system.api_token.revoke
+        eventType: system.api_token.revoke
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/identity/okta/okta_application_modified_or_deleted.yml
+++ b/rules/identity/okta/okta_application_modified_or_deleted.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.impact
 logsource:

--- a/rules/identity/okta/okta_application_modified_or_deleted.yml
+++ b/rules/identity/okta/okta_application_modified_or_deleted.yml
@@ -15,7 +15,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype:
+        eventType:
             - application.lifecycle.update
             - application.lifecycle.delete
     condition: selection

--- a/rules/identity/okta/okta_application_sign_on_policy_modified_or_deleted.yml
+++ b/rules/identity/okta/okta_application_sign_on_policy_modified_or_deleted.yml
@@ -15,7 +15,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype:
+        eventType:
             - application.policy.sign_on.update
             - application.policy.sign_on.rule.delete
     condition: selection

--- a/rules/identity/okta/okta_application_sign_on_policy_modified_or_deleted.yml
+++ b/rules/identity/okta/okta_application_sign_on_policy_modified_or_deleted.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.impact
 logsource:

--- a/rules/identity/okta/okta_fastpass_phishing_detection.yml
+++ b/rules/identity/okta/okta_fastpass_phishing_detection.yml
@@ -18,7 +18,7 @@ detection:
     selection:
         outcome.reason: 'FastPass declined phishing attempt'
         outcome.result: FAILURE
-        eventtype: user.authentication.auth_via_mfa
+        eventType: user.authentication.auth_via_mfa
     condition: selection
 falsepositives:
     - Unlikely

--- a/rules/identity/okta/okta_fastpass_phishing_detection.yml
+++ b/rules/identity/okta/okta_fastpass_phishing_detection.yml
@@ -8,6 +8,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2023-05-07
+modified: 2026-04-27
 tags:
     - attack.initial-access
     - attack.t1566

--- a/rules/identity/okta/okta_identity_provider_created.yml
+++ b/rules/identity/okta/okta_identity_provider_created.yml
@@ -16,7 +16,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype: 'system.idp.lifecycle.create'
+        eventType: 'system.idp.lifecycle.create'
     condition: selection
 falsepositives:
     - When an admin creates a new, authorised identity provider.

--- a/rules/identity/okta/okta_identity_provider_created.yml
+++ b/rules/identity/okta/okta_identity_provider_created.yml
@@ -7,6 +7,7 @@ references:
     - https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection
 author: kelnage
 date: 2023-09-07
+modified: 2026-04-27
 tags:
     - attack.privilege-escalation
     - attack.persistence

--- a/rules/identity/okta/okta_mfa_reset_or_deactivated.yml
+++ b/rules/identity/okta/okta_mfa_reset_or_deactivated.yml
@@ -18,7 +18,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype:
+        eventType:
             - user.mfa.factor.deactivate
             - user.mfa.factor.reset_all
     condition: selection

--- a/rules/identity/okta/okta_mfa_reset_or_deactivated.yml
+++ b/rules/identity/okta/okta_mfa_reset_or_deactivated.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-21
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.persistence
     - attack.credential-access

--- a/rules/identity/okta/okta_network_zone_deactivated_or_deleted.yml
+++ b/rules/identity/okta/okta_network_zone_deactivated_or_deleted.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.impact
 logsource:

--- a/rules/identity/okta/okta_network_zone_deactivated_or_deleted.yml
+++ b/rules/identity/okta/okta_network_zone_deactivated_or_deleted.yml
@@ -15,7 +15,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype:
+        eventType:
             - zone.deactivate
             - zone.delete
     condition: selection

--- a/rules/identity/okta/okta_new_behaviours_admin_console.yml
+++ b/rules/identity/okta/okta_new_behaviours_admin_console.yml
@@ -7,7 +7,7 @@ references:
     - https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection
 author: kelnage
 date: 2023-09-07
-modified: 2024-06-26
+modified: 2026-04-27
 tags:
     - attack.privilege-escalation
     - attack.persistence

--- a/rules/identity/okta/okta_new_behaviours_admin_console.yml
+++ b/rules/identity/okta/okta_new_behaviours_admin_console.yml
@@ -19,11 +19,11 @@ logsource:
     service: okta
 detection:
     selection_event:
-        eventtype: 'policy.evaluate_sign_on'
-        target.displayname: 'Okta Admin Console'
+        eventType: 'policy.evaluate_sign_on'
+        target.displayName: 'Okta Admin Console'
     selection_positive:
-        - debugcontext.debugdata.behaviors|contains: 'POSITIVE'
-        - debugcontext.debugdata.logonlysecuritydata|contains: 'POSITIVE'
+        - debugContext.debugData.behaviors|contains: 'POSITIVE'
+        - debugContext.debugData.logOnlySecurityData|contains: 'POSITIVE'
     condition: all of selection_*
 falsepositives:
     - When an admin begins using the Admin Console and one of Okta's heuristics incorrectly identifies the behavior as being unusual.

--- a/rules/identity/okta/okta_password_in_alternateid_field.yml
+++ b/rules/identity/okta/okta_password_in_alternateid_field.yml
@@ -19,7 +19,7 @@ logsource:
     service: okta
 detection:
     selection:
-        legacyeventtype: 'core.user_auth.login_failed'
+        legacyEventType: 'core.user_auth.login_failed'
     filter_main:
         # Okta service account names start with 0oa
         # Email addresses are the default format for Okta usernames, so attempt
@@ -27,7 +27,7 @@ detection:
         # If your Okta configuration uses different character restrictions, you
         # will need to update this regular expression to reflect that or disable the rule for your environment
         # Possible false negatives are failed login attempts with a password that looks like a valid email address
-        actor.alternateid|re: '(^0oa.*|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,10})'
+        actor.alternateId|re: '(^0oa.*|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,10})'
     condition: selection and not filter_main
 falsepositives:
     - Unlikely

--- a/rules/identity/okta/okta_password_in_alternateid_field.yml
+++ b/rules/identity/okta/okta_password_in_alternateid_field.yml
@@ -10,7 +10,7 @@ references:
     - https://help.okta.com/en-us/Content/Topics/users-groups-profiles/usgp-create-character-restriction.htm
 author: kelnage
 date: 2023-04-03
-modified: 2023-10-25
+modified: 2026-04-27
 tags:
     - attack.credential-access
     - attack.t1552

--- a/rules/identity/okta/okta_policy_modified_or_deleted.yml
+++ b/rules/identity/okta/okta_policy_modified_or_deleted.yml
@@ -15,7 +15,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype:
+        eventType:
             - policy.lifecycle.update
             - policy.lifecycle.delete
     condition: selection

--- a/rules/identity/okta/okta_policy_modified_or_deleted.yml
+++ b/rules/identity/okta/okta_policy_modified_or_deleted.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.impact
 logsource:

--- a/rules/identity/okta/okta_policy_rule_modified_or_deleted.yml
+++ b/rules/identity/okta/okta_policy_rule_modified_or_deleted.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.impact
 logsource:

--- a/rules/identity/okta/okta_policy_rule_modified_or_deleted.yml
+++ b/rules/identity/okta/okta_policy_rule_modified_or_deleted.yml
@@ -15,7 +15,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype:
+        eventType:
             - policy.rule.update
             - policy.rule.delete
     condition: selection

--- a/rules/identity/okta/okta_security_threat_detected.yml
+++ b/rules/identity/okta/okta_security_threat_detected.yml
@@ -16,7 +16,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype: security.threat.detected
+        eventType: security.threat.detected
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/identity/okta/okta_security_threat_detected.yml
+++ b/rules/identity/okta/okta_security_threat_detected.yml
@@ -8,7 +8,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.command-and-control
 logsource:

--- a/rules/identity/okta/okta_suspicious_activity_enduser_report.yml
+++ b/rules/identity/okta/okta_suspicious_activity_enduser_report.yml
@@ -7,6 +7,7 @@ references:
     - https://github.com/okta/workflows-templates/blob/1164f0eb71ce47c9ddc7d850e9ab87b5a2b42333/workflows/suspicious_activity_reported/readme.md
 author: kelnage
 date: 2023-09-07
+modified: 2026-04-27
 tags:
     - attack.resource-development
     - attack.t1586.003

--- a/rules/identity/okta/okta_suspicious_activity_enduser_report.yml
+++ b/rules/identity/okta/okta_suspicious_activity_enduser_report.yml
@@ -15,7 +15,7 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype: 'user.account.report_suspicious_activity_by_enduser'
+        eventType: 'user.account.report_suspicious_activity_by_enduser'
     condition: selection
 falsepositives:
     - If an end-user incorrectly identifies normal activity as suspicious.

--- a/rules/identity/okta/okta_unauthorized_access_to_app.yml
+++ b/rules/identity/okta/okta_unauthorized_access_to_app.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.impact
 logsource:

--- a/rules/identity/okta/okta_unauthorized_access_to_app.yml
+++ b/rules/identity/okta/okta_unauthorized_access_to_app.yml
@@ -15,7 +15,7 @@ logsource:
     service: okta
 detection:
     selection:
-        displaymessage: User attempted unauthorized access to app
+        displayMessage: User attempted unauthorized access to app
     condition: selection
 falsepositives:
     - User might of believe that they had access.

--- a/rules/identity/okta/okta_user_account_locked_out.yml
+++ b/rules/identity/okta/okta_user_account_locked_out.yml
@@ -7,7 +7,7 @@ references:
     - https://developer.okta.com/docs/reference/api/event-types/
 author: Austin Songer @austinsonger
 date: 2021-09-12
-modified: 2022-10-09
+modified: 2026-04-27
 tags:
     - attack.impact
     - attack.t1531

--- a/rules/identity/okta/okta_user_account_locked_out.yml
+++ b/rules/identity/okta/okta_user_account_locked_out.yml
@@ -16,7 +16,7 @@ logsource:
     service: okta
 detection:
     selection:
-        displaymessage: Max sign in attempts exceeded
+        displayMessage: Max sign in attempts exceeded
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/identity/okta/okta_user_created.yml
+++ b/rules/identity/okta/okta_user_created.yml
@@ -13,7 +13,7 @@ logsource:
     product: okta
 detection:
     selection:
-        eventtype: 'user.lifecycle.create'
+        eventType: 'user.lifecycle.create'
     condition: selection
 falsepositives:
     - Legitimate and authorized user creation

--- a/rules/identity/okta/okta_user_created.yml
+++ b/rules/identity/okta/okta_user_created.yml
@@ -4,6 +4,7 @@ status: test
 description: Detects new user account creation
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023-10-25
+modified: 2026-04-27
 references:
     - https://developer.okta.com/docs/reference/api/event-types/
 tags:

--- a/rules/identity/okta/okta_user_session_start_via_anonymised_proxy.yml
+++ b/rules/identity/okta/okta_user_session_start_via_anonymised_proxy.yml
@@ -15,8 +15,8 @@ logsource:
     service: okta
 detection:
     selection:
-        eventtype: 'user.session.start'
-        securitycontext.isproxy: 'true'
+        eventType: 'user.session.start'
+        securityContext.isProxy: 'true'
     condition: selection
 falsepositives:
     - If a user requires an anonymising proxy due to valid justifications.

--- a/rules/identity/okta/okta_user_session_start_via_anonymised_proxy.yml
+++ b/rules/identity/okta/okta_user_session_start_via_anonymised_proxy.yml
@@ -7,6 +7,7 @@ references:
     - https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection
 author: kelnage
 date: 2023-09-07
+modified: 2026-04-27
 tags:
     - attack.defense-evasion
     - attack.t1562.006


### PR DESCRIPTION
## Summary

- Fix all 20 Okta rules to use the correct camelCase field names as documented in the [Okta System Log API](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/SystemLog/). The rules previously used all-lowercase field names (`eventtype`, `displaymessage`, `securitycontext.isproxy`, etc.), which forced every consumer to create a processing pipeline to map field names before rules could match raw Okta events.
- Two existing rules (`okta_admin_activity_from_proxy_query` and `okta_password_health_report_query`) already used the correct camelCase, proving the inconsistency.
- The emerging-threat rule `okta_apt_suspicious_user_creation` also had a wrong field path (`target.user.display.name`) which is corrected to `target.displayName` per the Okta `LogTarget` schema.

## Field name changes

| Old (lowercase) | New (camelCase) | Rules affected |
|---|---|---|
| `eventtype` | `eventType` | 18 |
| `displaymessage` | `displayMessage` | 2 |
| `securitycontext.isproxy` | `securityContext.isProxy` | 1 |
| `debugcontext.debugdata.behaviors` | `debugContext.debugData.behaviors` | 1 |
| `debugcontext.debugdata.logonlysecuritydata` | `debugContext.debugData.logOnlySecurityData` | 1 |
| `legacyeventtype` | `legacyEventType` | 1 |
| `actor.alternateid` | `actor.alternateId` | 1 |
| `target.displayname` | `target.displayName` | 1 |
| `target.user.display.name` | `target.displayName` | 1 (wrong path, not just wrong case) |

## Files changed

- 19 rules in `rules/identity/okta/`
- 1 rule in `rules-emerging-threats/2023/TA/Okta-Support-System-Breach/`
- 0 changes to `rules-threat-hunting/` (already correct)

## Why this matters

Without this fix, raw Okta System Log events will never match these rules unless the consumer adds a `field_name_mapping` pipeline to translate lowercase rule fields to Okta's camelCase. Every pySigma backend, rsigma user, and custom evaluator consuming Okta events has to work around this. Fixing the rules at the source eliminates the need for the workaround entirely, as pointed out by @nasbench on Discord.

## Reference

- [Okta System Log API - LogEvent schema](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/SystemLog/)
- [Okta Event Types catalog](https://developer.okta.com/docs/reference/api/event-types/)