### PR TITLE
Add detection for device code phishing from non-compliant devices

### DIFF
--- a/rules/cloud/azure/signin_logs/azure_app_device_code_auth_non_compliant.yml
+++ b/rules/cloud/azure/signin_logs/azure_app_device_code_auth_non_compliant.yml
@@ -1,0 +1,55 @@
+title: Successful Device Code Authentication from Non-Compliant Device
+id: 972ff2cc-77fd-4319-a470-7bf8ff30f273
+related:
+    - id: 248649b7-d64f-46f0-9fb2-a52774166fb5
+      type: similar
+    - id: 4f77e1d7-3982-4ee0-8489-abf2d6b75284
+      type: similar
+status: test
+description: |
+    Detects a successful OAuth 2.0 device code authentication flow completed from
+    a device not marked as compliant in Entra ID. Legitimate device code usage
+    (Azure CLI, input-constrained hardware) typically occurs on managed, compliant
+    devices or known service principals. Successful device code auth from a
+    non-compliant device is a strong indicator of OAuth phishing — the attacker
+    tricks a victim into entering an attacker-generated device code, completing
+    the auth on the attacker's behalf and obtaining a valid access token without
+    triggering an MFA challenge against the attacker's session.
+    Used by APT29 (Midnight Blizzard) as a primary initial access technique
+    against cloud-only tenants, documented in multiple Microsoft MSTIC advisories.
+references:
+    - https://attack.mitre.org/techniques/T1528/
+    - https://attack.mitre.org/techniques/T1566/002/
+    - https://www.microsoft.com/en-us/security/blog/2025/01/31/new-ttps-observed-in-midnight-blizzard-attacks/
+    - https://www.rfc-editor.org/rfc/rfc8628
+author: Chris Ray
+date: 2026-04-29
+tags:
+    - attack.initial-access
+    - attack.t1566.002
+    - attack.credential-access
+    - attack.t1528
+    - attack.t1078.004
+logsource:
+    product: azure
+    service: signinlogs
+detection:
+    selection:
+        AuthenticationProtocol: deviceCode
+        ResultType: '0'
+    filter_compliant:
+        DeviceDetail.isCompliant: 'True'
+    condition: selection and not filter_compliant
+fields:
+    - UserPrincipalName
+    - IPAddress
+    - UserAgent
+    - AppDisplayName
+    - DeviceDetail.deviceId
+    - DeviceDetail.isCompliant
+    - Location.countryOrRegion
+falsepositives:
+    - Azure CLI, Azure PowerShell, and VS Code Azure extensions authenticating from unmanaged personal devices
+    - Microsoft Teams Rooms and Surface Hub devices not enrolled in Intune
+    - CI/CD pipelines using device code flow from unmanaged build agents
+level: medium

--- a/rules/cloud/azure/signin_logs/azure_app_device_code_auth_non_compliant.yml
+++ b/rules/cloud/azure/signin_logs/azure_app_device_code_auth_non_compliant.yml
@@ -5,7 +5,7 @@ related:
       type: similar
     - id: 4f77e1d7-3982-4ee0-8489-abf2d6b75284
       type: similar
-status: test
+status: experimental
 description: |
     Detects a successful OAuth 2.0 device code authentication flow completed from
     a device not marked as compliant in Entra ID. Legitimate device code usage
@@ -18,16 +18,18 @@ description: |
     Used by APT29 (Midnight Blizzard) as a primary initial access technique
     against cloud-only tenants, documented in multiple Microsoft MSTIC advisories.
 references:
-    - https://attack.mitre.org/techniques/T1528/
-    - https://attack.mitre.org/techniques/T1566/002/
     - https://www.microsoft.com/en-us/security/blog/2025/01/31/new-ttps-observed-in-midnight-blizzard-attacks/
     - https://www.rfc-editor.org/rfc/rfc8628
 author: Chris Ray
 date: 2026-04-29
+modified: 2026-05-04
 tags:
     - attack.initial-access
-    - attack.t1566.002
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.defense-evasion
     - attack.credential-access
+    - attack.t1566.002
     - attack.t1528
     - attack.t1078.004
 logsource:
@@ -36,18 +38,10 @@ logsource:
 detection:
     selection:
         AuthenticationProtocol: deviceCode
-        ResultType: '0'
+        ResultType: 0
     filter_compliant:
         DeviceDetail.isCompliant: 'True'
     condition: selection and not filter_compliant
-fields:
-    - UserPrincipalName
-    - IPAddress
-    - UserAgent
-    - AppDisplayName
-    - DeviceDetail.deviceId
-    - DeviceDetail.isCompliant
-    - Location.countryOrRegion
 falsepositives:
     - Azure CLI, Azure PowerShell, and VS Code Azure extensions authenticating from unmanaged personal devices
     - Microsoft Teams Rooms and Surface Hub devices not enrolled in Intune


### PR DESCRIPTION
## Summary

This rule detects the specific combination that characterizes OAuth device code phishing: a **successful** device code authentication flow completed from a **non-compliant device**.

Two related rules already exist in this directory:
- `azure_app_device_code_authentication.yml` (`248649b7`) — detects any device code auth (broad)
- `azure_ad_sign_ins_from_noncompliant_devices.yml` (`4f77e1d7`) — detects any non-compliant device sign-in (broad)

This rule is the intersection: `deviceCode + ResultType=0 + NOT isCompliant=True`. That intersection maps directly to the phishing scenario — an attacker generates a device code, tricks a victim into entering it, and completes auth on their behalf. The attacker's session is never compliant; the victim's MFA prompt is satisfied but protects the wrong session.

## Threat context

Used by APT29 (Midnight Blizzard) as documented in the Microsoft MSTIC advisory (January 2025). The technique bypasses MFA because the MFA challenge is issued to the victim's browser, while the token is delivered to the attacker's device code listener. Standard conditional access policies that require compliant devices would block this — but most tenants do not enforce device compliance on all apps.

## Why not just combine the two existing rules?

The existing rules fire on legitimate traffic:
- Developers using Azure CLI from personal laptops hit `azure_ad_sign_ins_from_noncompliant_devices`
- Any input-constrained device hits `azure_app_device_code_authentication`

The intersection is significantly lower noise and specifically actionable.

## Test environment

Validated against Entra ID sign-in log schema. `AuthenticationProtocol=deviceCode` and `DeviceDetail.isCompliant` are documented fields in the Microsoft Entra sign-in log schema.