### PR TITLE
Add correlation rules: MFA fatigue, Azure→AWS pivot, LSASS→AssumeRole

### DIFF
--- a/rules-correlation/cloud/azure_ad_impossible_travel_followed_by_aws_console_login.yml
+++ b/rules-correlation/cloud/azure_ad_impossible_travel_followed_by_aws_console_login.yml
@@ -1,0 +1,39 @@
+title: Azure AD Impossible Travel Followed by AWS Console Login Without MFA
+name: azure_ad_impossible_travel_followed_by_aws_console_login
+id: a1b2c3d4-e5f6-7a8b-9c0d-e1f2a3b4c5d6
+status: experimental
+description: >
+    Detects cross-cloud lateral movement where an Azure AD Identity Protection impossible
+    travel alert for a user is followed within one hour by an AWS console login for the
+    same user without MFA. This sequence indicates a compromised identity being used to
+    pivot from Microsoft to Amazon cloud infrastructure — a pattern observed in attacks
+    targeting organizations with hybrid cloud environments. Actors including APT29 and
+    financially motivated groups have chained compromised Entra ID credentials to AWS
+    access using single-factor authentication paths that bypass MFA requirements.
+    Note: group-by relies on user identity normalization (ECS user.name or CIM user)
+    across both log sources.
+references:
+    - https://attack.mitre.org/techniques/T1078/
+    - https://attack.mitre.org/techniques/T1078/004/
+    - https://www.microsoft.com/en-us/security/blog/2023/07/14/microsoft-mitigates-china-based-threat-actor-storm-0558/
+author: Chris Ray
+date: 2026-05-03
+tags:
+    - attack.initial-access
+    - attack.lateral-movement
+    - attack.t1078
+    - attack.t1078.004
+type: temporal_ordered
+rules:
+    impossible_travel: b2572bf9-e20a-4594-b528-40bde666525a
+    aws_login_no_mfa: 77caf516-34e5-4df9-b4db-20744fea0a60
+group-by:
+    - user.name
+timespan: 1h
+condition:
+    gte: 1
+falsepositives:
+    - Legitimate travel combined with an AWS environment that does not enforce MFA
+    - VPN or proxy use causing false impossible travel detection
+    - Service accounts with shared names across Azure AD and AWS IAM
+level: high

--- a/rules-correlation/cloud/azure_ad_mfa_fatigue.yml
+++ b/rules-correlation/cloud/azure_ad_mfa_fatigue.yml
@@ -1,0 +1,31 @@
+title: Azure AD MFA Fatigue Attack
+name: azure_ad_mfa_fatigue
+id: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
+status: experimental
+description: >
+    Detects MFA fatigue (MFA push spam) attacks where an adversary floods a target user
+    with repeated MFA push requests to induce approval through frustration or confusion.
+    Scattered Spider and APT29 have both used this technique to bypass MFA and gain
+    access to corporate environments. Ten or more MFA denials within a 10-minute window
+    for a single user is a strong indicator of an active fatigue attempt.
+references:
+    - https://attack.mitre.org/techniques/T1621/
+    - https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-320a
+    - https://www.microsoft.com/en-us/security/blog/2022/10/25/how-to-combat-mfa-fatigue/
+author: Chris Ray
+date: 2026-05-03
+tags:
+    - attack.credential-access
+    - attack.t1621
+type: event_count
+rules:
+    mfa_denied: e40f4962-b02b-4192-9bfe-245f7ece1f99
+group-by:
+    - UserPrincipalName
+timespan: 10m
+condition:
+    gte: 10
+falsepositives:
+    - Legitimate user repeatedly mistyping or dismissing MFA prompts during device setup
+    - Authentication testing or automation during provisioning workflows
+level: high

--- a/rules-correlation/endpoint/win_lsass_dump_followed_by_aws_sts_assumerole.yml
+++ b/rules-correlation/endpoint/win_lsass_dump_followed_by_aws_sts_assumerole.yml
@@ -1,0 +1,40 @@
+title: Windows LSASS Credential Dump Followed by AWS STS AssumeRole
+name: win_lsass_dump_followed_by_aws_sts_assumerole
+id: c3d4e5f6-a7b8-9c0d-e1f2-a3b4c5d6e7f8
+status: experimental
+description: >
+    Detects a credential theft → cloud pivot chain: LSASS memory access from a
+    non-system account on a Windows endpoint followed within four hours by an AWS
+    STS AssumeRole call from the same user identity. Attackers who dump LSASS to
+    extract credentials on an endpoint frequently pivot to cloud infrastructure using
+    harvested IAM access keys or credentials stored in memory by AWS CLI, tools
+    such as Mimikatz, or credential managers. ALPHV/BlackCat, Scattered Spider, and
+    LAPSUS$ have all combined endpoint credential harvesting with subsequent AWS API
+    access as part of multi-stage intrusions.
+    Note: group-by relies on user identity normalization (ECS user.name or CIM user)
+    across Windows Security and AWS CloudTrail log sources.
+references:
+    - https://attack.mitre.org/techniques/T1003/001/
+    - https://attack.mitre.org/techniques/T1078/004/
+    - https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-320a
+author: Chris Ray
+date: 2026-05-03
+tags:
+    - attack.credential-access
+    - attack.lateral-movement
+    - attack.t1003.001
+    - attack.t1078.004
+type: temporal_ordered
+rules:
+    lsass_access: 962fe167-e48d-4fd6-9974-11e5b9a5d6d1
+    aws_assumerole: 905d389b-b853-46d0-9d3d-dea0d3a3cd49
+group-by:
+    - user.name
+timespan: 4h
+condition:
+    gte: 1
+falsepositives:
+    - Security tooling or EDR performing legitimate LSASS inspection combined with authorized AWS API use
+    - Penetration testing or red team exercises
+    - Incident responders running credential auditing tools while investigating an AWS environment
+level: high


### PR DESCRIPTION
## Summary

Adds three Sigma correlation rules in a new `rules-correlation/` directory, covering cross-source detection chains that cannot be expressed in standard single-logsource Sigma rules.

These reference existing SigmaHQ rules by ID and follow the Sigma correlation specification.

---

### Rules

**1. `rules-correlation/cloud/azure_ad_mfa_fatigue.yml`** (T1621)
- Type: `event_count`
- Detects MFA push fatigue: ≥10 MFA denials for a single user within 10 minutes
- References: `e40f4962` (Multifactor Authentication Denied)
- Actor context: Scattered Spider, APT29 — documented in CISA AA23-320A

**2. `rules-correlation/cloud/azure_ad_impossible_travel_followed_by_aws_console_login.yml`** (T1078, T1078.004)
- Type: `temporal_ordered`
- Detects Azure AD impossible travel alert followed within 1 hour by AWS console login without MFA for the same user — cross-cloud identity pivot pattern
- References: `b2572bf9` (Impossible Travel) → `77caf516` (AWS Successful Console Login Without MFA)
- Note: `group-by: user.name` requires SIEM normalization across Azure AD and AWS CloudTrail log sources

**3. `rules-correlation/endpoint/win_lsass_dump_followed_by_aws_sts_assumerole.yml`** (T1003.001, T1078.004)
- Type: `temporal_ordered`
- Detects Windows LSASS credential access followed within 4 hours by AWS STS AssumeRole — endpoint credential theft → cloud pivot
- References: `962fe167` (LSASS Access From Non System Account) → `905d389b` (AWS STS AssumeRole Misuse)
- Note: `group-by: user.name` requires SIEM normalization across Windows Security and AWS CloudTrail log sources
- Actor context: ALPHV/BlackCat, Scattered Spider, LAPSUS$

---

## Notes

- `rules-correlation/` directory is new — proposing it as the home for Sigma correlation rules. Happy to adjust the path per maintainer preference.
- Cross-source `group-by` fields (`user.name`) follow ECS normalization conventions; CIM equivalent is `user`.
- All referenced base rules are existing SigmaHQ rules in good standing.