### PR TITLE
Add detection for suspicious WMI-based lateral movement with encoded or suspicious command execution

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_wmiprvse_suspicious_shell.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmiprvse_suspicious_shell.yml
@@ -1,0 +1,44 @@
+title: Suspicious PowerShell or CMD Spawned by WMI Provider with Encoded or Recon Commands
+id: 8b3a9f1c-2d7e-4a6f-9c21-1f4b6e2d9a77
+status: experimental
+description: Detects suspicious command shell or PowerShell execution spawned by wmiprvse.exe with encoded or reconnaissance commands. This behavior may indicate WMI-based lateral movement such as Impacket wmiexec where commands are executed remotely without dropping binaries.
+references:
+    - https://attack.mitre.org/techniques/T1047/
+    - https://attack.mitre.org/techniques/T1021/
+author: Aashiq Ahmed
+date: 2026-05-04
+tags:
+    - attack.execution
+    - attack.lateral-movement
+    - attack.t1047
+    - attack.t1021
+logsource:
+    product: windows
+    category: process_creation
+detection:
+    selection_parent:
+        ParentImage|endswith: '\wmiprvse.exe'
+    selection_child:
+        Image|endswith:
+            - '\cmd.exe'
+            - '\powershell.exe'
+            - '\pwsh.exe'
+    selection_suspicious_cli:
+        CommandLine|contains:
+            - '/c'
+            - '-enc'
+            - '-encodedcommand'
+            - 'iex'
+            - 'invoke-expression'
+            - 'downloadstring'
+            - 'frombase64string'
+            - 'whoami'
+            - 'net user'
+            - 'net group'
+            - 'ipconfig'
+            - 'systeminfo'
+    condition: selection_parent and selection_child and selection_suspicious_cli
+falsepositives:
+    - Legitimate administrative use of WMI
+    - Software deployment or monitoring tools using WMI
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

This PR adds a new Windows process creation rule to detect suspicious command shell or PowerShell execution spawned by wmiprvse.exe with encoded or reconnaissance commands.

This behavior may indicate WMI-based lateral movement, such as Impacket wmiexec-style execution, where commands are executed remotely without dropping binaries.

The rule complements existing WMI-related detections by focusing on process creation behavior rather than WMI event logging.

### Changelog

new: Suspicious PowerShell or CMD Spawned by WMI Provider with Encoded or Recon Commands

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these conventions: https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/