### PR TITLE
new: Detection For CVE-2026-31431 (Copy Fail) Page Cache Mutation Exploit

### DIFF
--- a/rules/linux/auditd/syscall/lnx_auditd_af_alg_aead_socket_cve_2026_31431.yml
+++ b/rules/linux/auditd/syscall/lnx_auditd_af_alg_aead_socket_cve_2026_31431.yml
@@ -1,0 +1,65 @@
+title: AF_ALG AEAD Socket Bind For Page Cache Mutation - CVE-2026-31431
+id: 7641d707-39a7-4976-ac93-ae095bd713e6
+status: experimental
+description: |
+    Detects creation of an AF_ALG (family 38) SOCK_SEQPACKET socket — the kernel
+    crypto userspace interface — followed by a bind() to an "authencesn(...)"
+    AEAD algorithm. Public Copy Fail PoCs (CVE-2026-31431) bind such a socket
+    and use splice(2) to mutate the page cache of SUID binaries (typically
+    /usr/bin/su) for local privilege escalation to root.
+    The high-fidelity signal is the AEAD algorithm name `authencesn(hmac(...),cbc(aes))`,
+    which all known public PoCs require for the read/write page-aliasing
+    primitive. Legitimate AF_ALG callers (cryptsetup, strongSwan, wpa_supplicant)
+    do not bind to authencesn AEAD modes from non-root contexts.
+references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31431
+    - https://copy.fail
+    - https://github.com/theori-io/copy-fail-CVE-2026-31431
+    - https://github.com/badsectorlabs/copyfail-go
+    - https://github.com/iss4cf0ng/CVE-2026-31431-Linux-Copy-Fail
+    - https://hackerspace.pl/~q3k/alpine.py
+author: PV3M
+date: 2026-05-03
+tags:
+    - attack.privilege-escalation
+    - attack.t1068
+    - cve.2026-31431
+logsource:
+    product: linux
+    service: auditd
+    definition: |
+        Required auditd configuration:
+        -a always,exit -F arch=b64 -S socket -F a0=0x26 -k af_alg_socket
+        -a always,exit -F arch=b32 -S socket -F a0=0x26 -k af_alg_socket
+        -a always,exit -F arch=b64 -S bind                -k af_alg_bind
+        -a always,exit -F arch=b32 -S bind                -k af_alg_bind
+detection:
+    selection_socket:
+        type: 'SYSCALL'
+        SYSCALL: 'socket'
+        a0: 26 # AF_ALG = 38 (0x26 in auditd hex)
+        a1: 5  # SOCK_SEQPACKET
+    selection_bind_authencesn:
+        type: 'SOCKADDR'
+        saddr|contains:
+            - '61757468656e6365736e28'    # raw hex of "authencesn(" in sockaddr_alg.salg_name
+            - 'authencesn('               # ASCII match for pipelines that decode saddr
+    filter_main_legitimate_callers:
+        exe|startswith:
+            - '/usr/lib/systemd/'
+            - '/lib/systemd/'
+            - '/usr/sbin/cryptsetup'
+            - '/sbin/cryptsetup'
+            - '/usr/sbin/strongswan'
+            - '/usr/libexec/strongswan'
+            - '/usr/sbin/charon'
+            - '/usr/sbin/pluto'
+            - '/usr/sbin/wpa_supplicant'
+    filter_main_root_session:
+        auid: 0
+    condition: 1 of selection_* and not 1 of filter_main_*
+falsepositives:
+    - Libkcapi self-tests or openssl-engine kernel-crypto fallback (rare)
+    - Custom applications using AEAD authencesn modes via the kernel crypto API
+    - Dm-crypt or LUKS userland tooling not present on the legitimate-caller list
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_python_copy_fail_cve_2026_31431.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_python_copy_fail_cve_2026_31431.yml
@@ -1,0 +1,66 @@
+title: Interpreter Process With Copy Fail PoC Fingerprint - CVE-2026-31431
+id: ff8080d5-3953-4797-a3f2-3be124e0f466
+status: experimental
+description: |
+    Detects an interpreter process whose command line carries the textual
+    fingerprint of public Copy Fail PoCs (CVE-2026-31431): the
+    "authencesn(hmac(sha...),cbc(aes))" AEAD algorithm string, the AF_ALG
+    family literal, the raw socket(38, ...) call, or the os.splice / os.pipe
+    pairing combined with a read-only open of /usr/bin/su.
+    Targets `python -c '...'` one-liners and inline shell snippets where the
+    PoC body is visible in the proctitle. Will not catch base64- or
+    zlib-encoded variants; pair with the auditd companion rule
+    (id: 7641d707-39a7-4976-ac93-ae095bd713e6) for runtime coverage.
+references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-31431
+    - https://copy.fail
+    - https://github.com/theori-io/copy-fail-CVE-2026-31431
+    - https://github.com/tgies/copy-fail-c
+    - https://github.com/badsectorlabs/copyfail-go
+    - https://hackerspace.pl/~q3k/alpine.py
+author: PV3M
+date: 2026-05-03
+tags:
+    - attack.privilege-escalation
+    - attack.execution
+    - attack.t1068
+    - attack.t1059.006
+    - cve.2026-31431
+logsource:
+    product: linux
+    category: process_creation
+detection:
+    selection_interpreter:
+        Image|endswith:
+            - '/python'
+            - '/python3'
+            - '/python2'
+            - '/perl'
+            - '/ruby'
+            - '/bash'
+            - '/sh'
+    selection_indicator_strong:
+        CommandLine|contains:
+            - 'authencesn(hmac(sha256),cbc(aes))'
+            - 'authencesn(hmac(sha512),cbc(aes))'
+            - 'authencesn(hmac(sha1),cbc(aes))'
+            - 'AF_ALG'
+            - 'socket(38,5'
+            - 'socket(38, 5'
+            - 'socket.socket(38'
+    selection_indicator_combo:
+        CommandLine|contains|all:
+            - 'os.splice'
+            - '/usr/bin/su'
+    selection_curl_stage:
+        CommandLine|contains:
+            - 'copy.fail/exp'
+            - 'copy.fail/poc'
+            - 'raw.githubusercontent.com/theori-io/copy-fail'
+            - 'raw.githubusercontent.com/badsectorlabs/copyfail'
+    condition: selection_interpreter and 1 of selection_indicator_* or selection_curl_stage
+falsepositives:
+    - Security research reproducing the public proof-of-concept in a sandbox
+    - Libkcapi reference scripts and kernel-crypto API examples
+    - Authorized red team activity that exercises the public proof-of-concept
+level: high


### PR DESCRIPTION
## Summary

Adds two atomic Sigma rules covering the public Copy Fail proof-of-concept chain (CVE-2026-31431) — a Linux kernel page-cache mutation flaw that allows local privilege escalation by overwriting SUID binaries (typically \`/usr/bin/su\`) in memory via AF_ALG + splice(2).

There is currently no public Sigma coverage for this CVE. The published PoCs landed within the last week and are circulating on MalwareBazaar; one variant was caught by Florian Roth's signature-base YARA rule \`EXPL_LNX_Copy_Fail_Artefacts_CVE_2026_31431_Apr26\`. These rules cover the runtime side that YARA cannot.

## Rules

| File | Logsource | Fidelity |
|---|---|---|
| \`rules/linux/auditd/syscall/lnx_auditd_af_alg_aead_socket_cve_2026_31431.yml\` | linux / auditd | high |
| \`rules/linux/process_creation/proc_creation_lnx_python_copy_fail_cve_2026_31431.yml\` | linux / process_creation | high |

**Rule 1 (auditd)** — detects \`socket(AF_ALG, SOCK_SEQPACKET)\` paired with a \`bind()\` to an \`authencesn(...)\` AEAD algorithm. AF_ALG with that AEAD mode is the load-bearing primitive for the page-cache write-back; legitimate callers (cryptsetup, strongSwan, wpa_supplicant) are filtered. Includes the required \`auditd\` rule snippet under \`logsource.definition\`.

**Rule 2 (process_creation)** — detects interpreter (\`python\` / \`perl\` / \`bash\`) invocations whose proctitle contains the PoC fingerprint: the literal \`authencesn(hmac(sha*),cbc(aes))\` AEAD string, the \`AF_ALG\` family token, the raw \`socket(38, ...)\` call, the \`os.splice\` + \`/usr/bin/su\` pairing, or known staging URLs (\`copy.fail/exp\`, \`copy.fail/poc\`, the PoC GitHub raw URLs). Defeated by base64/zlib-encoded variants — pair with rule 1 for runtime coverage.

## Validation

- \`sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml\` → 0 errors, 0 issues
- \`python tests/test_logsource.py\` → 3/3 OK
- Both rules render cleanly to Splunk SPL via \`sigma convert -t splunk\`
- Filenames within the 65-char cap (49 / 54 chars)

## Caveats (please read)

- Rules are **spec-validated only — not yet field-tested against live exploit telemetry**. Status is \`experimental\` to reflect this. If a maintainer has a kernel-vulnerable Vagrant box / sandbox to run a true-positive validation, that would strengthen confidence; happy to follow up.
- The auditd \`a0=26\` value matches the hex form auditd writes by default. Pipelines that normalize hex-to-decimal will need to remap to \`a0=38\`.
- A correlation-style sub-rule (same PID opens SUID binary read-only AND opens AF_ALG socket within 30s, near-zero FP) was authored locally but is **not** included in this PR — happy to submit separately if the maintainers want it.

## References

- https://nvd.nist.gov/vuln/detail/CVE-2026-31431
- https://copy.fail
- https://github.com/theori-io/copy-fail-CVE-2026-31431
- https://github.com/badsectorlabs/copyfail-go
- https://github.com/iss4cf0ng/CVE-2026-31431-Linux-Copy-Fail
- https://hackerspace.pl/~q3k/alpine.py

## Checklist

- [x] Rules pass \`sigma check\` with the SigmaHQ validator config
- [x] Rules pass \`tests/test_logsource.py\`
- [x] Filenames follow naming conventions
- [x] Conventions match existing rules in target folders
- [x] CVE tag (\`cve.2026-31431\`) and ATT&CK tags (\`attack.t1068\`, \`attack.t1059.006\`) included
- [ ] Field-tested against live exploit (see Caveats)