### PR TITLE
new: add DAEMON Tools Lite supply chain attack detection rules

### DIFF
--- a/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/dns_query_win_daemon_tools_supply_chain_c2_lookup.yml
+++ b/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/dns_query_win_daemon_tools_supply_chain_c2_lookup.yml
@@ -12,6 +12,7 @@ date: 2026-05-06
 tags:
     - attack.command-and-control
     - attack.t1071.004
+    - attack.initial-access
     - attack.t1195.002
     - detection.emerging-threats
 logsource:

--- a/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/dns_query_win_daemon_tools_supply_chain_c2_lookup.yml
+++ b/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/dns_query_win_daemon_tools_supply_chain_c2_lookup.yml
@@ -1,0 +1,26 @@
+title: DAEMON Tools Supply Chain Backdoor DNS Lookup for Typosquatted C2 Domain
+id: e464ad16-1c1c-4dfe-b8b5-a932889a44cb
+status: experimental
+description: |
+    Detects a DNS query for env-check.daemontools.cc, the typosquatted C2 domain used in the DAEMON Tools Lite supply chain attack (April-May 2026).
+    The legitimate DAEMON Tools domain is daemon-tools.cc.
+    The malicious domain was registered on March 27, 2026 and used as the initial check-in endpoint.
+references:
+    - https://securelist.com/tr/daemon-tools-backdoor/119654/
+author: Swachchhanda Shrawan Poudel (Nextron Systems)
+date: 2026-05-06
+tags:
+    - attack.command-and-control
+    - attack.t1071.004
+    - attack.t1195.002
+    - detection.emerging-threats
+logsource:
+    category: dns_query
+    product: windows
+detection:
+    selection:
+        QueryName: 'env-check.daemontools.cc'
+    condition: selection
+falsepositives:
+    - Unlikely
+level: high

--- a/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/dns_query_win_daemon_tools_supply_chain_c2_lookup.yml
+++ b/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/dns_query_win_daemon_tools_supply_chain_c2_lookup.yml
@@ -2,7 +2,7 @@ title: DAEMON Tools Supply Chain Backdoor DNS Lookup for Typosquatted C2 Domain
 id: e464ad16-1c1c-4dfe-b8b5-a932889a44cb
 status: experimental
 description: |
-    Detects a DNS query for env-check.daemontools.cc, the typosquatted C2 domain used in the DAEMON Tools Lite supply chain attack (April-May 2026).
+    Detects a DNS query for env-check[.]daemontools[.]cc, the typo squatted C2 domain used in the DAEMON Tools Lite supply chain attack (April-May 2026).
     The legitimate DAEMON Tools domain is daemon-tools.cc.
     The malicious domain was registered on March 27, 2026 and used as the initial check-in endpoint.
 references:

--- a/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_compromised_binary_execution.yml
+++ b/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_compromised_binary_execution.yml
@@ -1,0 +1,54 @@
+title: Compromised DAEMON Tools Binary Execution
+id: 4db1192b-7a8d-416c-963e-09d483861d47
+status: experimental
+description: |
+    Detects execution of DAEMON Tools Lite binaries with file versions known to be compromised (12.5.0.2421 to 12.5.0.2434).
+    As part of a supply chain attack discovered in early May 2026, attackers trojanized three binaries inside DAEMON Tools Lite
+    installations signed by Disc Soft Limited: DTHelper.exe, DiscSoftBusServiceLite.exe, and DTShellHlp.exe.
+    The malicious payloads include an information collector, a minimalistic backdoor (shell command execution, file download,
+    in-memory shellcode execution), and QUIC RAT — a C++ implant that injects into notepad.exe and conhost.exe and supports multiple C2 protocols.
+    The campaign commenced on April 8, 2026 and affected users across more than 100 countries. Users with affected versions should immediately update or remove the software.
+references:
+    - https://securelist.com/tr/daemon-tools-backdoor/119654/
+    - https://www.daemon-tools.cc/
+author: Swachchhanda Shrawan Poudel (Nextron Systems)
+date: 2026-05-06
+tags:
+    - attack.initial-access
+    - attack.t1195.002
+    - attack.execution
+    - attack.t1204.002
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith:
+              - '\DTHelper.exe'
+              - '\DiscSoftBusServiceLite.exe'
+              - '\DTShellHlp.exe'
+        - OriginalFileName:
+              - 'DTHelper.exe'
+              - 'DiscSoftBusServiceLite.exe'
+              - 'DTShellHlp.exe'
+    selection_version:
+        FileVersion:
+            - '12.5.0.2421'
+            - '12.5.0.2422'
+            - '12.5.0.2423'
+            - '12.5.0.2424'
+            - '12.5.0.2425'
+            - '12.5.0.2426'
+            - '12.5.0.2427'
+            - '12.5.0.2428'
+            - '12.5.0.2429'
+            - '12.5.0.2430'
+            - '12.5.0.2431'
+            - '12.5.0.2432'
+            - '12.5.0.2433'
+            - '12.5.0.2434'
+    condition: all of selection_*
+falsepositives:
+    - Unlikely
+level: high

--- a/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_compromised_binary_execution.yml
+++ b/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_compromised_binary_execution.yml
@@ -7,7 +7,7 @@ description: |
     installations signed by Disc Soft Limited: DTHelper.exe, DiscSoftBusServiceLite.exe, and DTShellHlp.exe.
     The malicious payloads include an information collector, a minimalistic backdoor (shell command execution, file download,
     in-memory shellcode execution), and QUIC RAT — a C++ implant that injects into notepad.exe and conhost.exe and supports multiple C2 protocols.
-    The campaign commenced on April 8, 2026 and affected users across more than 100 countries. Users with affected versions should immediately update or remove the software.
+    The campaign commenced on April 8, 2026 and affected users across more than 100 countries.
 references:
     - https://securelist.com/tr/daemon-tools-backdoor/119654/
     - https://www.daemon-tools.cc/
@@ -26,10 +26,12 @@ detection:
     selection_img:
         - Image|endswith:
               - '\DTHelper.exe'
+              - '\DTProHelper.exe'
               - '\DiscSoftBusServiceLite.exe'
               - '\DTShellHlp.exe'
         - OriginalFileName:
               - 'DTHelper.exe'
+              - 'DTProHelper.exe'
               - 'DiscSoftBusServiceLite.exe'
               - 'DTShellHlp.exe'
     selection_version:

--- a/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_supply_chain_stage_drop.yml
+++ b/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_supply_chain_stage_drop.yml
@@ -25,6 +25,7 @@ detection:
     selection_parent:
         ParentImage|endswith:
             - '\DTHelper.exe'
+            - '\DTProHelper.exe'
             - '\DiscSoftBusServiceLite.exe'
             - '\DTShellHlp.exe'
         Image|endswith: '\cmd.exe'

--- a/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_supply_chain_stage_drop.yml
+++ b/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_supply_chain_stage_drop.yml
@@ -15,6 +15,7 @@ tags:
     - attack.t1105
     - attack.stealth
     - attack.t1218.011
+    - attack.initial-access
     - attack.t1195.002
     - detection.emerging-threats
 logsource:
@@ -27,6 +28,7 @@ detection:
             - '\DiscSoftBusServiceLite.exe'
             - '\DTShellHlp.exe'
         Image|endswith: '\cmd.exe'
+        CommandLine|contains: 'powershell -NoProfile -Command'
     selection_cli_generic_ip:
         CommandLine|contains: 'http://38.180.107.76'
     selection_cli_envchk:

--- a/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_supply_chain_stage_drop.yml
+++ b/rules-emerging-threats/2026/Malware/Daemon-Supply-Chain/proc_creation_win_daemon_supply_chain_stage_drop.yml
@@ -1,0 +1,48 @@
+title: DAEMON Tools Supply Chain Attack Indicators
+id: fa1d05c0-9ea1-4300-b047-ed9872200fd4
+status: experimental
+description: |
+    Detects indicators of the DAEMON Tools supply chain attack, which involves the use of a backdoor in DAEMON Tools software to download and execute malicious payloads.
+    The detection focuses on specific parent processes and command line patterns associated with the attack.
+references:
+    - https://securelist.com/tr/daemon-tools-backdoor/119654/
+author: Swachchhanda Shrawan Poudel (Nextron Systems)
+date: 2026-05-06
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.command-and-control
+    - attack.t1105
+    - attack.stealth
+    - attack.t1218.011
+    - attack.t1195.002
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_parent:
+        ParentImage|endswith:
+            - '\DTHelper.exe'
+            - '\DiscSoftBusServiceLite.exe'
+            - '\DTShellHlp.exe'
+        Image|endswith: '\cmd.exe'
+    selection_cli_generic_ip:
+        CommandLine|contains: 'http://38.180.107.76'
+    selection_cli_envchk:
+        CommandLine|contains|all:
+            - 'New-Object System.Net.WebClient'
+            - 'DownloadFile'
+            - '\Windows\Temp\envchk.exe'
+    selection_cli_mcrypto:
+        CommandLine|contains:
+            - '\ProgramData\Microsoft\mcrypto.chiper'
+            - ':\Windows\Temp\crypto.dll'
+        CommandLine|contains|all:
+            - 'DownloadFile'
+            - 'rundll32.exe'
+            - 'mcrypto_clean'
+    condition: selection_parent and 1 of selection_cli_*
+falsepositives:
+    - Unlikely
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

Adds three new detection rules covering the DAEMON Tools Lite supply chain attack
disclosed in May 2026 (Securelist). Attackers trojanized three signed binaries inside
DAEMON Tools Lite installations (versions 12.5.0.2421–12.5.0.2434) to deliver an
information collector, a minimalistic backdoor, and a QUIC-based RAT that injects into
notepad.exe and conhost.exe. The campaign ran from April 8, 2026 and affected users
across more than 100 countries.

Rules cover three key detection opportunities:
- DNS beacon to the typosquatted C2 domain `env-check.daemontools.cc`
- Process creation from compromised binaries identified by known-bad FileVersion ranges
- Stage-drop activity: IP-based C2 callout, envchk.exe download, and mcrypto payload execution via rundll32

### Changelog

new: DAEMON Tools Supply Chain Backdoor DNS Lookup for Typosquatted C2 Domain
new: Compromised DAEMON Tools Binary Execution
new: DAEMON Tools Supply Chain Attack Indicators

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
