### PR TITLE
Add 4 detection rules for LLM and MCP attack surface

### DIFF
--- a/rules-emerging-threats/2026/AI/file_event_lnx_mcp_config_file_modification.yml
+++ b/rules-emerging-threats/2026/AI/file_event_lnx_mcp_config_file_modification.yml
@@ -1,0 +1,42 @@
+title: Modification Of MCP Or Claude Configuration File - Linux
+id: 89216c0a-8aca-43c1-a74b-b99adf8a2b56
+status: experimental
+description: |
+    Detects writes to Claude Code or Claude Desktop configuration files where MCP server definitions live.
+    Files include .claude.json, ~/.claude/settings.json, ~/.config/Claude/claude_desktop_config.json, and standalone mcp.json files.
+    An attacker who can write a new MCP server entry into these files gains arbitrary tool execution the next time the agent loads, which is a stealthy persistence and command-and-control vector.
+references:
+    - https://modelcontextprotocol.io/docs/concepts/architecture
+    - https://docs.anthropic.com/en/docs/claude-code/settings
+    - https://attack.mitre.org/techniques/T1546/
+    - https://owasp.org/www-project-mcp-top-10/
+author: Punith Gowda (Network Intelligence)
+date: 2026-05-10
+tags:
+    - attack.persistence
+    - attack.t1546
+    - detection.emerging-threats
+logsource:
+    product: linux
+    category: file_event
+detection:
+    selection_path:
+        TargetFilename|endswith:
+            - '/.claude.json'
+            - '/.claude/settings.json'
+            - '/.claude/settings.local.json'
+            - '/.config/Claude/claude_desktop_config.json'
+            - '/mcp.json'
+            - '/.cursor/mcp.json'
+            - '/.continue/config.json'
+    filter_main_legit_writers:
+        Image|endswith:
+            - '/claude'
+            - '/cursor'
+            - '/node'
+    condition: selection_path and not filter_main_legit_writers
+falsepositives:
+    - Claude Code itself (runs as a node process) writing settings; covered by the filter but worth tuning per fleet (path of node binary varies)
+    - Configuration management tooling (Ansible, Chef, Puppet) deploying organisation-approved MCP server entries
+    - Backup or sync agents (rclone, restic, Dropbox client) restoring user dotfiles
+level: high

--- a/rules-emerging-threats/2026/AI/proc_creation_lnx_anthropic_api_key_in_cmdline.yml
+++ b/rules-emerging-threats/2026/AI/proc_creation_lnx_anthropic_api_key_in_cmdline.yml
@@ -1,0 +1,28 @@
+title: Anthropic API Key Pattern In Process Command Line - Linux
+id: e858a877-40df-48cf-a312-7ac00ee446aa
+status: experimental
+description: |
+    Detects long-lived Anthropic API key patterns (sk-ant-api03-...) in the command line of any process.
+    Keys passed as positional arguments are visible to any local user via /proc and ps, and routinely leak into shell history and CI logs.
+references:
+    - https://docs.anthropic.com/en/api/getting-started
+    - https://owasp.org/www-project-top-10-for-large-language-model-applications/
+    - https://nvd.nist.gov/800-53/Rev5/control/IA-5
+    - https://attack.mitre.org/techniques/T1552/001/
+author: Punith Gowda (Network Intelligence)
+date: 2026-05-10
+tags:
+    - attack.credential-access
+    - attack.t1552.001
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection:
+        CommandLine|contains: 'sk-ant-api03-'
+    condition: selection
+falsepositives:
+    - Developer workstations running Anthropic SDK examples that hardcode keys for local testing
+    - Misconfigured CI jobs that expand secrets into argv before the runtime can scrub them
+level: high

--- a/rules-emerging-threats/2026/AI/proc_creation_lnx_claude_session_token_in_cmdline.yml
+++ b/rules-emerging-threats/2026/AI/proc_creation_lnx_claude_session_token_in_cmdline.yml
@@ -1,0 +1,37 @@
+title: Claude Code Session Token Or Bearer Header In Command Line - Linux
+id: 1b9306f4-61af-4d4d-af4d-60229dd391c1
+status: experimental
+description: |
+    Detects credential leakage where a Claude or generic LLM bearer token appears in the visible command line of a process.
+    Looks for sk-ant-... session strings and 'Authorization: Bearer sk-' style headers passed via curl, wget, or direct API invocation. Anything in argv is readable by any local user via /proc and is preserved in shell history and audit logs.
+references:
+    - https://docs.anthropic.com/en/api/getting-started
+    - https://attack.mitre.org/techniques/T1552/001/
+    - https://owasp.org/www-project-top-10-for-large-language-model-applications/
+    - https://cwe.mitre.org/data/definitions/214.html
+author: Punith Gowda (Network Intelligence)
+date: 2026-05-10
+tags:
+    - attack.credential-access
+    - attack.t1552.001
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_tools:
+        Image|endswith:
+            - '/curl'
+            - '/wget'
+            - '/http'
+            - '/httpie'
+    selection_token:
+        CommandLine|contains:
+            - 'Authorization: Bearer sk-'
+            - 'x-api-key: sk-ant-'
+            - 'x-api-key:sk-ant-'
+    condition: selection_tools and selection_token
+falsepositives:
+    - Internal red-team or pentest tooling that intentionally passes tokens via curl for replay testing
+    - Smoke-test scripts in CI that should be migrated to read from a secret manager rather than argv
+level: high

--- a/rules-emerging-threats/2026/AI/proc_creation_lnx_mcp_server_install_unapproved_registry.yml
+++ b/rules-emerging-threats/2026/AI/proc_creation_lnx_mcp_server_install_unapproved_registry.yml
@@ -1,0 +1,56 @@
+title: MCP Server Installed From Non-Approved Registry - Linux
+id: f8adc8ec-515a-4d6b-9998-b419d6906ee8
+status: experimental
+description: |
+    Detects installation of Model Context Protocol (MCP) servers via 'claude mcp add', 'mcp install', or npm/pip install of mcp-server-* packages from sources other than the official MCP registry at registry.modelcontextprotocol.io.
+    Untrusted MCP servers run with the same privileges as the calling agent and have direct tool-execution access, making this a high-value supply-chain backdoor vector.
+    Note: local development paths, git URLs, and 'npm link' installs intentionally fire here. Tune via the filter or via private-registry allow-listing.
+references:
+    - https://modelcontextprotocol.io/docs/concepts/architecture
+    - https://registry.modelcontextprotocol.io/
+    - https://owasp.org/www-project-mcp-top-10/
+    - https://docs.anthropic.com/en/docs/claude-code/mcp
+author: Punith Gowda (Network Intelligence)
+date: 2026-05-10
+tags:
+    - attack.initial-access
+    - attack.execution
+    - attack.t1195.002
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_claude_mcp:
+        CommandLine|contains:
+            - 'claude mcp add'
+            - 'mcp install'
+    selection_pkg_install:
+        Image|endswith:
+            - '/npm'
+            - '/npx'
+            - '/yarn'
+            - '/pnpm'
+            - '/pip'
+            - '/pip3'
+            - '/uv'
+            - '/uvx'
+        CommandLine|contains:
+            - 'mcp-server-'
+            - '@modelcontextprotocol/server-'
+            - 'mcp-server@'
+    filter_main_official_registry:
+        CommandLine|contains: 'registry.modelcontextprotocol.io'
+    filter_main_official_packages:
+        CommandLine|endswith:
+            - '@modelcontextprotocol/server-filesystem'
+            - '@modelcontextprotocol/server-git'
+            - '@modelcontextprotocol/server-github'
+            - '@modelcontextprotocol/server-postgres'
+            - '@modelcontextprotocol/server-sqlite'
+    condition: (selection_claude_mcp or selection_pkg_install) and not 1 of filter_main_*
+falsepositives:
+    - Internal MCP servers published to a private registry that the SOC has not yet allow-listed
+    - Developers iterating on a local MCP server via 'npm link' or editable installs
+    - Tuning required for orgs using the official MCP packages with version pins (e.g. '@modelcontextprotocol/server-git@0.6.2')
+level: high


### PR DESCRIPTION
## Summary
Net-new coverage for AI-application attack surface. As of this PR the repo has zero rules referencing Claude, MCP, or OpenAI API keys despite both being primary 2025-2026 enterprise attack vectors (verified by ``git grep`` of ``rules/``, ``rules-emerging-threats/``, and ``rules-threat-hunting/``).

## Rules added

1. **Anthropic API Key Pattern In Process Command Line** (high) — ``sk-ant-api03-`` credential pattern visible in argv (T1552.001).

2. **MCP Server Installed From Non-Approved Registry** (high) — ``claude mcp add`` / ``mcp install`` / npm/pip/uv install of ``mcp-server-*`` from sources other than the official ``registry.modelcontextprotocol.io`` (T1195.002 supply-chain compromise). Local development paths, ``npm link``, and git URLs intentionally fire here; description and falsepositives call this out for tuning.

3. **Claude Code Session Token Or Bearer Header In Command Line** (high) — Bearer / x-api-key headers smuggled through ``curl`` / ``wget`` / ``httpie`` argv (T1552.001).

4. **Modification Of MCP Or Claude Configuration File** (high) — file_event rule for writes to ``.claude.json``, ``~/.claude/settings.json``, ``claude_desktop_config.json``, ``.cursor/mcp.json``, ``.continue/config.json`` by anything other than the official client binaries (T1546 persistence).

All rules use the ``filter_main_*`` naming idiom, ``status: experimental``, ``Punith Gowda (Network Intelligence)`` author convention, and carry realistic ``falsepositives``.

## Validation
- ``python3.10 tests/test_logsource.py`` — PASS (3/3, 40s)
- ``python3.10 tests/test_rules.py`` — PASS (11/11, 92s)
- All field names conform to ``tests/logsource.json`` taxonomy
- All UUIDs are fresh v4 and unique across the repo

## Note on directory
``rules-emerging-threats/2026/`` currently has ``Exploits/``, ``Malware/``, ``TA/`` subdirs. ``AI/`` is proposed as a new sibling for AI-application attack surface. Happy to relocate to ``rules-threat-hunting/`` or flatten into ``2026/`` with ``llm_`` / ``mcp_`` filename prefix if maintainers prefer; just point me at the canonical home for this category.

## What was deliberately dropped pre-submission
A fifth rule for prompt-injection signatures in HTTP request bodies was authored and then dropped after review: the canonical Sigma ``proxy`` taxonomy lacks a body-content field, and reframing to ``c-uri-query`` produced a rule that would not fire against any real LLM API call (prompts ride in JSON bodies, not URIs). Worth bringing back when the proxy taxonomy gains a body field, or as a vendor-extended-field rule.