### PR TITLE
Add 10 Sigma rules for Atlassian Cloud and Jira audit events

### DIFF
--- a/rules/cloud/atlassian/audit/atlassian_audit_api_tokens_exported.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_api_tokens_exported.yml
@@ -1,0 +1,29 @@
+title: Atlassian Organization API Tokens Exported
+id: d4920455-150f-4a07-bc74-eb06778ea419
+status: experimental
+description: |
+    Detects an export of API tokens from the Atlassian organization admin panel.
+    An API token export produces a file containing active API tokens for user
+    accounts in the organization. These tokens can be used to authenticate
+    against Atlassian APIs as the token owner without requiring a password or
+    MFA, making them high-value credential material for an attacker seeking
+    persistent or lateral access across Jira, Confluence, and Bitbucket.
+references:
+    - https://support.atlassian.com/organization-administration/docs/manage-api-tokens-for-your-organization/
+    - https://developer.atlassian.com/cloud/admin/organization/rest/api-group-audit-events/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.credential-access
+    - attack.t1528
+logsource:
+    product: atlassian
+    service: audit
+detection:
+    selection:
+        attributes.action: 'export_api_tokens'
+    condition: selection
+falsepositives:
+    - Authorized security audit of active API tokens by an organization admin
+    - Compliance review requiring enumeration of all active authentication tokens
+level: high

--- a/rules/cloud/atlassian/audit/atlassian_audit_assets_schema_deleted.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_assets_schema_deleted.yml
@@ -1,0 +1,29 @@
+title: Atlassian Assets Object Schema Deleted
+id: dcf36a86-c3ae-4dca-8d75-f1c54c0b0719
+status: experimental
+description: |
+    Detects deletion of an object schema in Atlassian Assets (formerly Insight).
+    An object schema deletion removes the entire configuration, all object types,
+    attributes, and references defined within it, and may also purge associated
+    asset records. This is a destructive and largely irreversible action. In
+    production environments an Assets schema typically underpins CMDB, hardware
+    inventory, or software asset management workflows, making its deletion a
+    significant operational and forensic impact event.
+references:
+    - https://support.atlassian.com/jira-service-management-cloud/docs/what-is-assets/
+    - https://developer.atlassian.com/cloud/admin/organization/rest/api-group-audit-events/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.impact
+    - attack.t1485
+logsource:
+    product: atlassian
+    service: audit
+detection:
+    selection:
+        attributes.action: 'assets_object_schema_deleted'
+    condition: selection
+falsepositives:
+    - Authorized decommission of a deprecated or test Assets schema by an admin
+level: high

--- a/rules/cloud/atlassian/audit/atlassian_audit_bitbucket_ssh_key_added.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_bitbucket_ssh_key_added.yml
@@ -1,0 +1,30 @@
+title: Atlassian Bitbucket Cloud SSH Key Authorized for User
+id: 95b74a5f-957c-4a38-b004-73c1cff620cc
+status: experimental
+description: |
+    Detects when an SSH key is authorized for a Bitbucket Cloud user account
+    via the Atlassian organization admin audit log. Adding an SSH key grants
+    the holder the ability to clone, push, and pull repositories over SSH
+    without requiring a password or personal access token. An attacker who
+    gains admin access may add their own SSH key to a privileged account
+    to maintain persistent access to source code repositories even after
+    a password reset.
+references:
+    - https://support.atlassian.com/bitbucket-cloud/docs/set-up-an-ssh-key/
+    - https://developer.atlassian.com/cloud/admin/organization/rest/api-group-audit-events/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.persistence
+    - attack.t1098.004
+logsource:
+    product: atlassian
+    service: audit
+detection:
+    selection:
+        attributes.action: 'bitbucket_cloud_user_ssh_key_authorized'
+    condition: selection
+falsepositives:
+    - Developer adding a new SSH key for a new workstation or CI/CD pipeline
+    - IT administrator setting up SSH access for a new team member
+level: high

--- a/rules/cloud/atlassian/audit/atlassian_audit_bitbucket_ssh_key_added.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_bitbucket_ssh_key_added.yml
@@ -16,6 +16,7 @@ author: Ivan Saakov
 date: 2026-05-10
 tags:
     - attack.persistence
+    - attack.privilege-escalation
     - attack.t1098.004
 logsource:
     product: atlassian
@@ -28,3 +29,4 @@ falsepositives:
     - Developer adding a new SSH key for a new workstation or CI/CD pipeline
     - IT administrator setting up SSH access for a new team member
 level: high
+

--- a/rules/cloud/atlassian/audit/atlassian_audit_group_role_revoked.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_group_role_revoked.yml
@@ -1,0 +1,28 @@
+title: Atlassian Organization Group Role Revoked
+id: 6393b6a0-03ae-4259-ba7b-6f809c5e4693
+status: experimental
+description: |
+    Detects revocation of a role from a group in the Atlassian organization.
+    Revoking roles from groups removes access for all members of the affected
+    group simultaneously. An attacker with admin access may revoke roles from
+    security or operations groups to degrade their ability to respond to an
+    ongoing incident, effectively impairing defenses at scale.
+references:
+    - https://support.atlassian.com/user-management/docs/give-users-admin-permissions/
+    - https://developer.atlassian.com/cloud/admin/organization/rest/api-group-audit-events/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.impact
+    - attack.t1531
+logsource:
+    product: atlassian
+    service: audit
+detection:
+    selection:
+        attributes.action: 'group_revoked_role'
+    condition: selection
+falsepositives:
+    - Legitimate role cleanup or access review by an IT administrator
+    - Planned permission restructuring as part of a security policy update
+level: medium

--- a/rules/cloud/atlassian/audit/atlassian_audit_oauth_client_created.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_oauth_client_created.yml
@@ -1,0 +1,28 @@
+title: Atlassian Organization OAuth Client Created
+id: 76ac4b02-7d9d-47f9-a975-1c06c1ed9817
+status: experimental
+description: |
+    Detects creation of a new OAuth client application in the Atlassian organization.
+    OAuth clients can be used to obtain long-lived access tokens that authenticate
+    as a user or service account without requiring a password. An attacker with
+    admin access may create a rogue OAuth client to establish a persistent backdoor
+    that survives password changes and MFA enforcement.
+references:
+    - https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
+    - https://developer.atlassian.com/cloud/admin/organization/rest/api-group-audit-events/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.persistence
+    - attack.t1136.003
+logsource:
+    product: atlassian
+    service: audit
+detection:
+    selection:
+        attributes.action: 'oauth_client_created'
+    condition: selection
+falsepositives:
+    - Legitimate integration setup by a developer or IT administrator
+    - New third-party application onboarding approved by the security team
+level: high

--- a/rules/cloud/atlassian/audit/atlassian_audit_org_admin_granted.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_org_admin_granted.yml
@@ -1,0 +1,29 @@
+title: Atlassian Organization Admin Privileges Granted
+id: 2989b2b6-656a-4fa9-a7f9-0864ae1fd1e5
+status: experimental
+description: |
+    Detects when organization-level admin privileges are granted to a user in
+    Atlassian Cloud. Organization admins have unrestricted access to all products,
+    users, and billing settings across the entire Atlassian organization. Granting
+    this role to an unauthorized account is a high-impact privilege escalation
+    that provides broad access to Jira, Confluence, Bitbucket, and all other
+    connected Atlassian products.
+references:
+    - https://support.atlassian.com/organization-administration/docs/manage-an-atlassian-organization/
+    - https://developer.atlassian.com/cloud/admin/organization/rest/api-group-audit-events/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098
+logsource:
+    product: atlassian
+    service: audit
+detection:
+    selection:
+        attributes.action: 'added_org_admin'
+    condition: selection
+falsepositives:
+    - Legitimate admin provisioning by an IT administrator or organization owner
+level: high

--- a/rules/cloud/atlassian/audit/atlassian_audit_org_session_reset.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_org_session_reset.yml
@@ -1,0 +1,29 @@
+title: Atlassian Organization-Wide Session Reset
+id: dc94117b-fffe-4bb5-9408-efd16593f47b
+status: experimental
+description: |
+    Detects a forced organization-wide session reset in Atlassian Cloud, which
+    immediately invalidates all active user sessions across every product in the
+    organization. While this action can be a legitimate security response to a
+    suspected compromise, it can also be used by an attacker with admin access
+    to disrupt operations, lock out active defenders during an incident, or
+    cover tracks by forcing re-authentication that clears session-based audit
+    trails.
+references:
+    - https://support.atlassian.com/security-and-access-policies/docs/reset-all-user-sessions/
+    - https://developer.atlassian.com/cloud/admin/organization/rest/api-group-audit-events/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.impact
+    - attack.t1531
+logsource:
+    product: atlassian
+    service: audit
+detection:
+    selection:
+        attributes.action: 'auth_policy_reset_sessions'
+    condition: selection
+falsepositives:
+    - Legitimate security response action by an organization admin following a suspected account compromise
+level: high

--- a/rules/cloud/atlassian/audit/atlassian_audit_service_account_created.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_service_account_created.yml
@@ -1,0 +1,29 @@
+title: Atlassian Organization Service Account Created
+id: e510e849-0585-4816-a532-b67766a428a0
+status: experimental
+description: |
+    Detects the creation of a new service account in the Atlassian organization.
+    Service accounts have programmatic access to Atlassian APIs and typically
+    operate without MFA requirements. An attacker with org admin access may
+    create a service account to maintain persistent API-level access that is
+    less visible than human accounts and may not be included in standard
+    user offboarding processes.
+references:
+    - https://support.atlassian.com/user-management/docs/create-and-manage-service-accounts/
+    - https://developer.atlassian.com/cloud/admin/organization/rest/api-group-audit-events/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.persistence
+    - attack.t1136.003
+logsource:
+    product: atlassian
+    service: audit
+detection:
+    selection:
+        attributes.action: 'service_account_created'
+    condition: selection
+falsepositives:
+    - Legitimate service account creation by an IT administrator for a new integration
+    - Automated provisioning pipeline creating accounts for CI/CD workflows
+level: high

--- a/rules/cloud/atlassian/audit/atlassian_audit_service_account_updated.yml
+++ b/rules/cloud/atlassian/audit/atlassian_audit_service_account_updated.yml
@@ -1,0 +1,29 @@
+title: Atlassian Organization Service Account Updated
+id: 03105f42-427b-499a-9776-97298f09ee3d
+status: experimental
+description: |
+    Detects modification of a service account in the Atlassian organization,
+    including changes to its display name, email, or associated permissions.
+    An attacker with org admin access may modify an existing service account
+    to expand its privileges, redirect its email for token recovery, or rename
+    it to blend in with legitimate accounts while maintaining persistent access.
+references:
+    - https://support.atlassian.com/user-management/docs/create-and-manage-service-accounts/
+    - https://developer.atlassian.com/cloud/admin/organization/rest/api-group-audit-events/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098
+logsource:
+    product: atlassian
+    service: audit
+detection:
+    selection:
+        attributes.action: 'service_account_updated'
+    condition: selection
+falsepositives:
+    - Legitimate service account maintenance by an IT administrator
+    - Planned update to service account credentials as part of rotation policy
+level: medium

--- a/rules/cloud/jira/audit/jira_audit_admin_group_modified.yml
+++ b/rules/cloud/jira/audit/jira_audit_admin_group_modified.yml
@@ -1,0 +1,30 @@
+title: Jira Admin Group Membership Changed
+id: 4231e524-ea15-44ce-9188-e3658def57bb
+status: experimental
+description: |
+    Detects changes to Jira groups whose name contains "admin", indicating
+    that membership in an administrative group was added or removed. Jira admin
+    groups typically grant project administration, user management, and
+    global configuration rights across Jira projects. Adding an unauthorized
+    account to an admin group is a common privilege escalation path following
+    initial access to a Jira admin account.
+references:
+    - https://support.atlassian.com/jira-cloud-administration/docs/manage-groups/
+    - https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-groups/
+author: Ivan Saakov
+date: 2026-05-10
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098
+logsource:
+    product: jira
+    service: audit
+detection:
+    selection:
+        objectItem.name|contains: 'admin'
+    condition: selection
+falsepositives:
+    - Legitimate group membership changes performed by a Jira administrator
+    - Automated provisioning updating group membership as part of onboarding
+level: high

--- a/tests/logsource.json
+++ b/tests/logsource.json
@@ -1,6 +1,6 @@
 {
     "title": "Field name by logsource",
-    "version": "20230113",
+    "version": "20251205",
     "legit": {
         "windows": {
             "common": [
@@ -402,6 +402,7 @@
                     "ServerName"
                 ],
                 "smbclient-connectivity": [],
+                "smbserver-connectivity": [],
                 "taskscheduler": [
                     "TaskName",
                     "UserContext",
@@ -465,7 +466,9 @@
                     "PackageFullName",
                     "PackageSourceUri",
                     "PackageDisplayName",
-                    "CallingProcess"
+                    "CallingProcess",
+                    "Flags",
+                    "HasFullTrust"
                 ],
                 "appxpackaging-om": [
                     "subjectName"
@@ -506,7 +509,17 @@
                     "Message"
                 ],
                 "capi2": [],
-                "certificateservicesclient-lifecycle-system": []
+                "certificateservicesclient-lifecycle-system": [],
+                "iis-configuration": [
+                    "PhysicalPath",
+                    "ConfigPath",
+                    "EffectiveLocationPath",
+                    "Configuration",
+                    "TokenCacheModule",
+                    "EditOperationType",
+                    "OldValue",
+                    "NewValue"
+                ]
             }
         },
         "linux": {
@@ -814,6 +827,7 @@
                     "success",
                     "suid",
                     "syscall",
+                    "SYSCALL",
                     "table",
                     "tclass",
                     "tcontext",
@@ -861,6 +875,7 @@
                     "cs-cookie",
                     "cs-host",
                     "cs-method",
+                    "cs-uri-stem",
                     "r-dns",
                     "cs-referrer",
                     "cs-version",
@@ -915,6 +930,31 @@
                 "duo": [],
                 "ldp": [],
                 "syslog": []
+            }
+        },
+        "fortigate": {
+            "common": [],
+            "empty": [],
+            "category": {},
+            "service": {
+                "event": [
+                    "devname",
+                    "devid",
+                    "logid",
+                    "type",
+                    "subtype",
+                    "level",
+                    "vd",
+                    "logdesc",
+                    "user",
+                    "ui",
+                    "action",
+                    "cfgtid",
+                    "cfgpath",
+                    "cfgobj",
+                    "cfgattr",
+                    "msg"
+                ]
             }
         },
         "fortios": {
@@ -1067,7 +1107,8 @@
             "category": {},
             "service": {
                 "gcp.audit": [],
-                "google_workspace.admin": []
+                "google_workspace.admin": [],
+                "google_workspace.login": []
             }
         },
         "github": {
@@ -1286,9 +1327,10 @@
                 ],
                 "file_event": [
                     "CommandLine",
-                    "ParentImage",
+                    "IntegrityLevel",
+                    "MagicHeader",
                     "ParentCommandLine",
-                    "MagicHeader"
+                    "ParentImage"
                 ],
                 "image_load": [
                     "CommandLine"
@@ -1315,6 +1357,14 @@
                     "SourceFilename",
                     "TargetFilename",
                     "MagicHeader"
+                ]
+            },
+            "service": {}
+        },
+        "empty": {
+            "category": {
+                "webserver": [
+                    "cs-content-type"
                 ]
             },
             "service": {}

--- a/tests/logsource.json
+++ b/tests/logsource.json
@@ -1113,22 +1113,6 @@
                 "onelogin.events": []
             }
         },
-        "1password": {
-            "common": [],
-            "empty": [],
-            "category": {},
-            "service": {
-                "1password": [
-                    "action",
-                    "object_type",
-                    "category",
-                    "user.email",
-                    "target_user.email",
-                    "item_uuid",
-                    "vault_uuid"
-                ]
-            }
-        },
         "huawei": {
             "common": [],
             "empty": [],

--- a/tests/logsource.json
+++ b/tests/logsource.json
@@ -1,447 +1,1339 @@
 {
     "title": "Field name by logsource",
     "version": "20230113",
-    "legit":{
-        "windows":{
-            "common": ["EventID", "Provider_Name","Channel","Computer","Security_UserID"],
+    "legit": {
+        "windows": {
+            "common": [
+                "EventID",
+                "Provider_Name",
+                "Channel",
+                "Computer",
+                "Security_UserID"
+            ],
             "empty": [],
-            "category":{
-                "process_creation": ["CommandLine", "Company", "CurrentDirectory", "Description", "FileVersion",
-                                    "Hashes", "Image", "IntegrityLevel", "LogonGuid", "LogonId", "OriginalFileName",
-                                    "ParentCommandLine", "ParentImage", "ParentProcessGuid", "ParentProcessId",
-                                    "ParentUser", "ProcessGuid", "ProcessId", "Product", "TerminalSessionId", "User", "GrandParentImage"],
-                "file_change": ["CreationUtcTime", "Image", "PreviousCreationUtcTime", "ProcessGuid", "ProcessId", "TargetFilename", "User"],
-                "network_connection": ["DestinationHostname", "DestinationIp", "DestinationIsIpv6", "DestinationPort",
-                                    "DestinationPortName", "Image", "Initiated", "ProcessGuid", "ProcessId", "Protocol", "SourceHostname",
-                                    "SourceIp", "SourceIsIpv6", "SourcePort", "SourcePortName", "User", "ParentImage"],
-                "sysmon_status": ["Configuration", "ConfigurationFileHash", "SchemaVersion", "State", "Version"],
-                "process_termination":["Image", "ProcessGuid", "ProcessId", "User"],
-                "driver_load":["Hashes", "ImageLoaded", "Signature", "SignatureStatus", "Signed"],
-                "image_load":["Company", "Description", "FileVersion", "Hashes", "Image", "ImageLoaded", "OriginalFileName", "ProcessGuid",
-                            "ProcessId", "Product", "Signature", "SignatureStatus", "Signed", "User"],
-                "create_remote_thread":["NewThreadId", "SourceImage", "SourceProcessGuid", "SourceProcessId", "SourceUser", "StartAddress",
-                                        "StartFunction", "StartModule", "TargetImage", "TargetProcessGuid", "TargetProcessId", "TargetUser"],
-                "raw_access_thread":["Device", "Image", "ProcessGuid", "ProcessId", "User"],
-                "process_access":["CallTrace", "GrantedAccess", "SourceImage", "SourceProcessGUID", "SourceProcessId", "SourceThreadId",
-                                "SourceUser", "TargetImage", "TargetProcessGUID", "TargetProcessId", "TargetUser"],
-                "raw_access_read":["CreationUtcTime", "Image", "ProcessGuid", "ProcessId", "TargetFilename", "User"],
-                "file_event":["ProcessGuid", "ProcessId", "Image", "TargetFilename", "CreationUtcTime", "User"],
-                "file_executable_detected":["ProcessGuid", "ProcessId", "Image", "TargetFilename", "Hashes", "User"],
-                "registry_add":["EventType", "ProcessGuid", "ProcessId", "Image", "TargetObject", "User"],
-                "registry_delete":["Details", "EventType", "Image", "ProcessGuid", "ProcessId", "TargetObject"],
-                "registry_set":["Details", "EventType", "Image", "ProcessGuid", "ProcessId", "TargetObject", "User"],
-                "registry_rename":["EventType", "Image", "NewName", "ProcessGuid", "ProcessId", "TargetObject", "User"],
-                "registry_event":["Details", "EventType", "Image", "NewName", "ProcessGuid", "ProcessId", "TargetObject", "User"],
-                "create_stream_hash":["Contents", "CreationUtcTime", "Hash", "Image", "ProcessGuid", "ProcessId", "TargetFilename", "User"],
-                "pipe_created":["EventType", "Image", "PipeName", "ProcessGuid", "ProcessId", "User"],
-                "wmi_event":["Consumer", "Destination", "EventNamespace", "EventType", "Filter", "Name", "Operation", "Query", "Type", "User"],
-                "dns_query":["Image", "ProcessGuid", "ProcessId", "QueryName", "QueryResults", "QueryStatus", "User"],
-                "file_delete":["Archived", "Hashes", "Image", "IsExecutable", "ProcessGuid", "ProcessId", "TargetFilename", "User"],
-                "clipboard_capture":["Archived", "ClientInfo", "Hashes", "Image", "ProcessGuid", "ProcessId", "Session", "User"],
-                "process_tampering":["Image", "ProcessGuid", "ProcessId", "Type", "User"],
-                "file_block":["Hashes", "Image", "ProcessGuid", "ProcessId", "TargetFilename", "User"],
-                "ps_module":["ContextInfo", "UserData", "Payload"],
-                "ps_script":["MessageNumber", "MessageTotal", "ScriptBlockText", "ScriptBlockId", "Path"],
-                "file_access":["Irp", "FileObject", "IssuingThreadId", "CreateOptions", "CreateAttributes", "ShareAccess", "FileName"],
-                "file_rename":["Irp", "FileObject", "FileKey", "ExtraInformation", "IssuingThreadId", "InfoClass", "FilePath"],
-                "ps_classic_start":[],
-                "ps_classic_provider_start":[],
-                "sysmon_error":[]
+            "category": {
+                "process_creation": [
+                    "CommandLine",
+                    "Company",
+                    "CurrentDirectory",
+                    "Description",
+                    "FileVersion",
+                    "Hashes",
+                    "Image",
+                    "IntegrityLevel",
+                    "LogonGuid",
+                    "LogonId",
+                    "OriginalFileName",
+                    "ParentCommandLine",
+                    "ParentImage",
+                    "ParentProcessGuid",
+                    "ParentProcessId",
+                    "ParentUser",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Product",
+                    "TerminalSessionId",
+                    "User",
+                    "GrandParentImage"
+                ],
+                "file_change": [
+                    "CreationUtcTime",
+                    "Image",
+                    "PreviousCreationUtcTime",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "TargetFilename",
+                    "User"
+                ],
+                "network_connection": [
+                    "DestinationHostname",
+                    "DestinationIp",
+                    "DestinationIsIpv6",
+                    "DestinationPort",
+                    "DestinationPortName",
+                    "Image",
+                    "Initiated",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Protocol",
+                    "SourceHostname",
+                    "SourceIp",
+                    "SourceIsIpv6",
+                    "SourcePort",
+                    "SourcePortName",
+                    "User",
+                    "ParentImage"
+                ],
+                "sysmon_status": [
+                    "Configuration",
+                    "ConfigurationFileHash",
+                    "SchemaVersion",
+                    "State",
+                    "Version"
+                ],
+                "process_termination": [
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "User"
+                ],
+                "driver_load": [
+                    "Hashes",
+                    "ImageLoaded",
+                    "Signature",
+                    "SignatureStatus",
+                    "Signed"
+                ],
+                "image_load": [
+                    "Company",
+                    "Description",
+                    "FileVersion",
+                    "Hashes",
+                    "Image",
+                    "ImageLoaded",
+                    "OriginalFileName",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Product",
+                    "Signature",
+                    "SignatureStatus",
+                    "Signed",
+                    "User"
+                ],
+                "create_remote_thread": [
+                    "NewThreadId",
+                    "SourceImage",
+                    "SourceProcessGuid",
+                    "SourceProcessId",
+                    "SourceUser",
+                    "StartAddress",
+                    "StartFunction",
+                    "StartModule",
+                    "TargetImage",
+                    "TargetProcessGuid",
+                    "TargetProcessId",
+                    "TargetUser"
+                ],
+                "raw_access_thread": [
+                    "Device",
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "User"
+                ],
+                "process_access": [
+                    "CallTrace",
+                    "GrantedAccess",
+                    "SourceImage",
+                    "SourceProcessGUID",
+                    "SourceProcessId",
+                    "SourceThreadId",
+                    "SourceUser",
+                    "TargetImage",
+                    "TargetProcessGUID",
+                    "TargetProcessId",
+                    "TargetUser"
+                ],
+                "raw_access_read": [
+                    "CreationUtcTime",
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "TargetFilename",
+                    "User"
+                ],
+                "file_event": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "TargetFilename",
+                    "CreationUtcTime",
+                    "User"
+                ],
+                "file_executable_detected": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "TargetFilename",
+                    "Hashes",
+                    "User"
+                ],
+                "registry_add": [
+                    "EventType",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "TargetObject",
+                    "User"
+                ],
+                "registry_delete": [
+                    "Details",
+                    "EventType",
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "TargetObject"
+                ],
+                "registry_set": [
+                    "Details",
+                    "EventType",
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "TargetObject",
+                    "User"
+                ],
+                "registry_rename": [
+                    "EventType",
+                    "Image",
+                    "NewName",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "TargetObject",
+                    "User"
+                ],
+                "registry_event": [
+                    "Details",
+                    "EventType",
+                    "Image",
+                    "NewName",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "TargetObject",
+                    "User"
+                ],
+                "create_stream_hash": [
+                    "Contents",
+                    "CreationUtcTime",
+                    "Hash",
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "TargetFilename",
+                    "User"
+                ],
+                "pipe_created": [
+                    "EventType",
+                    "Image",
+                    "PipeName",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "User"
+                ],
+                "wmi_event": [
+                    "Consumer",
+                    "Destination",
+                    "EventNamespace",
+                    "EventType",
+                    "Filter",
+                    "Name",
+                    "Operation",
+                    "Query",
+                    "Type",
+                    "User"
+                ],
+                "dns_query": [
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "QueryName",
+                    "QueryResults",
+                    "QueryStatus",
+                    "User"
+                ],
+                "file_delete": [
+                    "Archived",
+                    "Hashes",
+                    "Image",
+                    "IsExecutable",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "TargetFilename",
+                    "User"
+                ],
+                "clipboard_capture": [
+                    "Archived",
+                    "ClientInfo",
+                    "Hashes",
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Session",
+                    "User"
+                ],
+                "process_tampering": [
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Type",
+                    "User"
+                ],
+                "file_block": [
+                    "Hashes",
+                    "Image",
+                    "ProcessGuid",
+                    "ProcessId",
+                    "TargetFilename",
+                    "User"
+                ],
+                "ps_module": [
+                    "ContextInfo",
+                    "UserData",
+                    "Payload"
+                ],
+                "ps_script": [
+                    "MessageNumber",
+                    "MessageTotal",
+                    "ScriptBlockText",
+                    "ScriptBlockId",
+                    "Path"
+                ],
+                "file_access": [
+                    "Irp",
+                    "FileObject",
+                    "IssuingThreadId",
+                    "CreateOptions",
+                    "CreateAttributes",
+                    "ShareAccess",
+                    "FileName"
+                ],
+                "file_rename": [
+                    "Irp",
+                    "FileObject",
+                    "FileKey",
+                    "ExtraInformation",
+                    "IssuingThreadId",
+                    "InfoClass",
+                    "FilePath"
+                ],
+                "ps_classic_start": [],
+                "ps_classic_provider_start": [],
+                "sysmon_error": []
             },
-            "service":{
-                "bitlocker": ["VolumeName", "VolumeMountPoint", "ProtectorGUID", "ProtectorType"],
-                "bits-client":["RemoteName", "LocalName", "processPath", "processId"],
-                "codeintegrity-operational":["FileNameLength", "FileNameBuffer", "ProcessNameLength", "ProcessNameBuffer",
-                                            "RequestedPolicy", "ValidatedPolicy", "Status"],
-                "diagnosis-scripted": ["PackagePath", "PackageId"],
-                "firewall-as":["Action", "ApplicationPath", "ModifyingApplication"],
-                "ldap":["ScopeOfSearch", "SearchFilter", "DistinguishedName", "AttributeList", "ProcessId"],
-                "ntlm":["CallerPID", "ClientDomainName", "ClientLUID", "ClientUserName", "DomainName", "MechanismOID",
-                        "ProcessName", "SChannelName", "SChannelType", "TargetName", "UserName", "WorkstationName"],
-                "openssh":["process", "payload"],
-                "security-mitigations":["ProcessPathLength", "ProcessPath", "ProcessCommandLineLength", "ProcessCommandLine",
-                                        "ProcessId", "ProcessCreateTime", "ProcessStartKey", "ProcessSignatureLevel",
-                                        "ProcessSectionSignatureLevel", "ProcessProtection", "TargetThreadId", "TargetThreadCreateTime",
-                                        "RequiredSignatureLevel", "SignatureLevel", "ImageNameLength", "ImageName"],
-                "shell-core":["Name", "AppID", "Flags"],
-                "smbclient-security":["Reason", "Status", "ShareNameLength", "ShareName", "ObjectNameLength", "ObjectName",
-                                    "UserNameLength", "UserName", "ServerNameLength", "ServerName"],
-                "smbclient-connectivity":[],
-                "taskscheduler":["TaskName", "UserContext", "Path", "ProcessID", "Priority", "UserName"],
-                "terminalservices-localsessionmanager":["User", "SessionID", "Address"],
-                "iis":["date", "time", "c-ip", "cs-username", "s-sitename", "s-computername", "s-ip", "cs-method",
-                        "cs-uri-stem", "cs-uri-query", "s-port", "cs-method", "sc-status", "sc-win32-status",
-                        "sc-bytes", "cs-bytes", "time-taken", "cs-version", "cs-host", "cs-user-agent",
-                        "cs-referer", "cs-cookie"],
-                "application":[],
-                "sysmon":[],
-                "powershell":[],
-                "powershell-classic":[],
-                "security":[],
-                "system":[],
-                "windefend":[],
-                "wmi":[],
-                "microsoft-servicebus-client":[],
-                "printservice-operational":[],
-                "driver-framework":[],
-                "dns-server-analytic":[],
-                "dns-server":[],
-                "printservice-admin":[],
-                "msexchange-management":[],
-                "applocker":[],
-                "vhdmp":[],
-                "appxdeployment-server":["Path", "AppId", "FilePath", "ErrorCode", "DeploymentOperation", "PackageFullName", "PackageSourceUri", "PackageDisplayName", "CallingProcess"],
-                "appxpackaging-om":["subjectName"],
-                "lsa-server":["TargetUserSid", "TargetUserName", "TargetDomainName", "TargetLogonId", "TargetLogonGuid", "EventOrginal", "EventCountTotal", "SidList"],
-                "dns-client":["QueryName", "QueryType", "QueryOptions", "QueryStatus", "QueryResults", "NetworkIndex", "InterfaceIndex", "Status", "ClientPID", "QueryBlob", "DnsServerIpAddress", "ResponseStatus", "SendBlob", "SendBlobContext", "AddressLength", "Address"],
-                "appmodel-runtime":["ProcessID", "PackageName", "ImageName", "ApplicationName", "Message"],
-                "capi2":[],
-                "certificateservicesclient-lifecycle-system":[]
+            "service": {
+                "bitlocker": [
+                    "VolumeName",
+                    "VolumeMountPoint",
+                    "ProtectorGUID",
+                    "ProtectorType"
+                ],
+                "bits-client": [
+                    "RemoteName",
+                    "LocalName",
+                    "processPath",
+                    "processId"
+                ],
+                "codeintegrity-operational": [
+                    "FileNameLength",
+                    "FileNameBuffer",
+                    "ProcessNameLength",
+                    "ProcessNameBuffer",
+                    "RequestedPolicy",
+                    "ValidatedPolicy",
+                    "Status"
+                ],
+                "diagnosis-scripted": [
+                    "PackagePath",
+                    "PackageId"
+                ],
+                "firewall-as": [
+                    "Action",
+                    "ApplicationPath",
+                    "ModifyingApplication"
+                ],
+                "ldap": [
+                    "ScopeOfSearch",
+                    "SearchFilter",
+                    "DistinguishedName",
+                    "AttributeList",
+                    "ProcessId"
+                ],
+                "ntlm": [
+                    "CallerPID",
+                    "ClientDomainName",
+                    "ClientLUID",
+                    "ClientUserName",
+                    "DomainName",
+                    "MechanismOID",
+                    "ProcessName",
+                    "SChannelName",
+                    "SChannelType",
+                    "TargetName",
+                    "UserName",
+                    "WorkstationName"
+                ],
+                "openssh": [
+                    "process",
+                    "payload"
+                ],
+                "security-mitigations": [
+                    "ProcessPathLength",
+                    "ProcessPath",
+                    "ProcessCommandLineLength",
+                    "ProcessCommandLine",
+                    "ProcessId",
+                    "ProcessCreateTime",
+                    "ProcessStartKey",
+                    "ProcessSignatureLevel",
+                    "ProcessSectionSignatureLevel",
+                    "ProcessProtection",
+                    "TargetThreadId",
+                    "TargetThreadCreateTime",
+                    "RequiredSignatureLevel",
+                    "SignatureLevel",
+                    "ImageNameLength",
+                    "ImageName"
+                ],
+                "shell-core": [
+                    "Name",
+                    "AppID",
+                    "Flags"
+                ],
+                "smbclient-security": [
+                    "Reason",
+                    "Status",
+                    "ShareNameLength",
+                    "ShareName",
+                    "ObjectNameLength",
+                    "ObjectName",
+                    "UserNameLength",
+                    "UserName",
+                    "ServerNameLength",
+                    "ServerName"
+                ],
+                "smbclient-connectivity": [],
+                "taskscheduler": [
+                    "TaskName",
+                    "UserContext",
+                    "Path",
+                    "ProcessID",
+                    "Priority",
+                    "UserName"
+                ],
+                "terminalservices-localsessionmanager": [
+                    "User",
+                    "SessionID",
+                    "Address"
+                ],
+                "iis": [
+                    "date",
+                    "time",
+                    "c-ip",
+                    "cs-username",
+                    "s-sitename",
+                    "s-computername",
+                    "s-ip",
+                    "cs-method",
+                    "cs-uri-stem",
+                    "cs-uri-query",
+                    "s-port",
+                    "cs-method",
+                    "sc-status",
+                    "sc-win32-status",
+                    "sc-bytes",
+                    "cs-bytes",
+                    "time-taken",
+                    "cs-version",
+                    "cs-host",
+                    "cs-user-agent",
+                    "cs-referer",
+                    "cs-cookie"
+                ],
+                "application": [],
+                "sysmon": [],
+                "powershell": [],
+                "powershell-classic": [],
+                "security": [],
+                "system": [],
+                "windefend": [],
+                "wmi": [],
+                "microsoft-servicebus-client": [],
+                "printservice-operational": [],
+                "driver-framework": [],
+                "dns-server-analytic": [],
+                "dns-server": [],
+                "printservice-admin": [],
+                "msexchange-management": [],
+                "applocker": [],
+                "vhdmp": [],
+                "appxdeployment-server": [
+                    "Path",
+                    "AppId",
+                    "FilePath",
+                    "ErrorCode",
+                    "DeploymentOperation",
+                    "PackageFullName",
+                    "PackageSourceUri",
+                    "PackageDisplayName",
+                    "CallingProcess"
+                ],
+                "appxpackaging-om": [
+                    "subjectName"
+                ],
+                "lsa-server": [
+                    "TargetUserSid",
+                    "TargetUserName",
+                    "TargetDomainName",
+                    "TargetLogonId",
+                    "TargetLogonGuid",
+                    "EventOrginal",
+                    "EventCountTotal",
+                    "SidList"
+                ],
+                "dns-client": [
+                    "QueryName",
+                    "QueryType",
+                    "QueryOptions",
+                    "QueryStatus",
+                    "QueryResults",
+                    "NetworkIndex",
+                    "InterfaceIndex",
+                    "Status",
+                    "ClientPID",
+                    "QueryBlob",
+                    "DnsServerIpAddress",
+                    "ResponseStatus",
+                    "SendBlob",
+                    "SendBlobContext",
+                    "AddressLength",
+                    "Address"
+                ],
+                "appmodel-runtime": [
+                    "ProcessID",
+                    "PackageName",
+                    "ImageName",
+                    "ApplicationName",
+                    "Message"
+                ],
+                "capi2": [],
+                "certificateservicesclient-lifecycle-system": []
             }
         },
-        "linux":{
+        "linux": {
             "common": [],
             "empty": [],
-            "category":{
-                "process_creation": ["ProcessGuid", "ProcessId", "Image", "FileVersion", "Description", "Product", "Company", "OriginalFileName",
-                                    "CommandLine", "CurrentDirectory", "User", "LogonGuid", "LogonId", "TerminalSessionId", "IntegrityLevel", "Hashes",
-                                    "ParentProcessGuid", "ParentProcessId", "ParentImage", "ParentCommandLine", "ParentUser"],
-                "network_connection": ["ProcessGuid", "ProcessId", "Image", "User", "Protocol", "Initiated", "SourceIsIpv6", "SourceIp", "SourceHostname",
-                                    "SourcePort", "SourcePortName", "DestinationIsIpv6", "DestinationIp", "DestinationHostname", "DestinationPort",
-                                    "DestinationPortName"],
-                "process_termination": ["ProcessGuid", "ProcessId", "Image", "User"],
-                "raw_access_read": ["ProcessGuid", "ProcessId", "Image", "Device", "User"],
-                "file_event": ["ProcessGuid", "ProcessId", "Image", "TargetFilename", "CreationUtcTime", "User"],
-                "sysmon_status": ["Configuration", "ConfigurationFileHash"],
-                "file_delete": ["ProcessGuid", "ProcessId", "User", "Image", "TargetFilename", "Hashes", "IsExecutable", "Archived"]
+            "category": {
+                "process_creation": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "FileVersion",
+                    "Description",
+                    "Product",
+                    "Company",
+                    "OriginalFileName",
+                    "CommandLine",
+                    "CurrentDirectory",
+                    "User",
+                    "LogonGuid",
+                    "LogonId",
+                    "TerminalSessionId",
+                    "IntegrityLevel",
+                    "Hashes",
+                    "ParentProcessGuid",
+                    "ParentProcessId",
+                    "ParentImage",
+                    "ParentCommandLine",
+                    "ParentUser"
+                ],
+                "network_connection": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "User",
+                    "Protocol",
+                    "Initiated",
+                    "SourceIsIpv6",
+                    "SourceIp",
+                    "SourceHostname",
+                    "SourcePort",
+                    "SourcePortName",
+                    "DestinationIsIpv6",
+                    "DestinationIp",
+                    "DestinationHostname",
+                    "DestinationPort",
+                    "DestinationPortName"
+                ],
+                "process_termination": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "User"
+                ],
+                "raw_access_read": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "Device",
+                    "User"
+                ],
+                "file_event": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "TargetFilename",
+                    "CreationUtcTime",
+                    "User"
+                ],
+                "sysmon_status": [
+                    "Configuration",
+                    "ConfigurationFileHash"
+                ],
+                "file_delete": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "User",
+                    "Image",
+                    "TargetFilename",
+                    "Hashes",
+                    "IsExecutable",
+                    "Archived"
+                ]
             },
-            "service":{
-                "auditd": ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9",
-                    "acct", "acl", "action", "added", "addr", "apparmor", "arch", "argc", "audit_backlog_limit", "audit_backlog_wait_time",
-                    "audit_enabled", "audit_failure", "auid", "banners", "bool", "bus", "cap_fe,cap_fi", "cap_fp", "cap_fver", "cap_pa", "cap_pe", "cap_pi",
-                    "cap_pp", "capability", "category", "cgroup", "changed", "cipher", "class", "cmd", "code", "comm", "compat", "cwd", "daddr", "data",
-                    "default-context", "dev", "dev", "device", "dir", "direction", "dmac", "dport", "egid", "enforcing", "entries", "errno", "euid", "exe",
-                    "exit", "fam", "family", "fd", "fe", "feature", "fi", "file", "flags", "format", "fp", "fsgid", "fsuid", "fver", "gid", "grantors", "grp",
-                    "hook", "hostname", "icmp_type", "id", "igid", "img-ctx", "inif", "ino", "inode", "inode_gid", "inode_uid", "invalid_context", "ioctlcmd",
-                    "ip", "ipid", "ipx-net", "item", "items", "iuid", "kernel", "key", "kind", "ksize", "laddr", "len", "list", "lport", "mac", "macproto", "maj",
-                    "major", "minor", "mode", "model", "msg", "name", "nametype", "nargs", "net", "new", "new_gid", "new_lock", "new_pe", "new_pi", "new_pp",
-                    "new-chardev", "new-disk", "new-enabled", "new-fs", "new-level", "new-log_passwd", "new-mem", "new-net", "new-range", "new-rng", "new-role",
-                    "new-seuser", "new-vcpu", "nlnk-fam", "nlnk-grp", "nlnk-pid", "oauid", "obj", "obj_gid", "obj_uid", "ocomm", "oflag", "ogid", "old", "old_enforcing",
-                    "old_lock", "old_pa", "old_pe", "old_pi", "old_pp", "old_prom", "old_val", "old-auid", "old-chardev", "old-disk", "old-enabled", "old-fs",
-                    "old-level", "old-log_passwd", "old-mem", "old-net", "old-range", "old-rng", "old-role", "old-ses", "old-seuser", "old-vcpu", "op", "opid",
-                    "oses", "ouid", "outif", "pa", "parent", "path", "pe", "per", "perm", "perm_mask", "permissive", "pfs", "pi", "pid", "pp", "ppid", "printer",
-                    "proctitle", "prom", "proto", "qbytes", "range", "rdev", "reason", "removed", "res", "resrc", "result", "role", "rport", "saddr", "sauid",
-                    "scontext", "selected-context", "seperm", "seperms", "seqno", "seresult", "ses", "seuser", "sgid", "sig", "sigev_signo", "smac", "spid",
-                    "sport", "state", "subj", "success", "suid", "syscall", "table", "tclass", "tcontext", "terminal", "tty", "type", "uid", "unit", "uri", "user",
-                    "uuid", "val", "val", "ver", "virt", "vm", "vm-ctx", "vm-pid", "watch"],
-                "vsftpd":[],
-                "sshd":[],
-                "syslog":[],
-                "guacamole":[],
-                "auth":[],
-                "clamav":[],
-                "modsecurity":[],
-                "sudo":[],
-                "cron":[]
+            "service": {
+                "auditd": [
+                    "a0",
+                    "a1",
+                    "a2",
+                    "a3",
+                    "a4",
+                    "a5",
+                    "a6",
+                    "a7",
+                    "a8",
+                    "a9",
+                    "acct",
+                    "acl",
+                    "action",
+                    "added",
+                    "addr",
+                    "apparmor",
+                    "arch",
+                    "argc",
+                    "audit_backlog_limit",
+                    "audit_backlog_wait_time",
+                    "audit_enabled",
+                    "audit_failure",
+                    "auid",
+                    "banners",
+                    "bool",
+                    "bus",
+                    "cap_fe,cap_fi",
+                    "cap_fp",
+                    "cap_fver",
+                    "cap_pa",
+                    "cap_pe",
+                    "cap_pi",
+                    "cap_pp",
+                    "capability",
+                    "category",
+                    "cgroup",
+                    "changed",
+                    "cipher",
+                    "class",
+                    "cmd",
+                    "code",
+                    "comm",
+                    "compat",
+                    "cwd",
+                    "daddr",
+                    "data",
+                    "default-context",
+                    "dev",
+                    "dev",
+                    "device",
+                    "dir",
+                    "direction",
+                    "dmac",
+                    "dport",
+                    "egid",
+                    "enforcing",
+                    "entries",
+                    "errno",
+                    "euid",
+                    "exe",
+                    "exit",
+                    "fam",
+                    "family",
+                    "fd",
+                    "fe",
+                    "feature",
+                    "fi",
+                    "file",
+                    "flags",
+                    "format",
+                    "fp",
+                    "fsgid",
+                    "fsuid",
+                    "fver",
+                    "gid",
+                    "grantors",
+                    "grp",
+                    "hook",
+                    "hostname",
+                    "icmp_type",
+                    "id",
+                    "igid",
+                    "img-ctx",
+                    "inif",
+                    "ino",
+                    "inode",
+                    "inode_gid",
+                    "inode_uid",
+                    "invalid_context",
+                    "ioctlcmd",
+                    "ip",
+                    "ipid",
+                    "ipx-net",
+                    "item",
+                    "items",
+                    "iuid",
+                    "kernel",
+                    "key",
+                    "kind",
+                    "ksize",
+                    "laddr",
+                    "len",
+                    "list",
+                    "lport",
+                    "mac",
+                    "macproto",
+                    "maj",
+                    "major",
+                    "minor",
+                    "mode",
+                    "model",
+                    "msg",
+                    "name",
+                    "nametype",
+                    "nargs",
+                    "net",
+                    "new",
+                    "new_gid",
+                    "new_lock",
+                    "new_pe",
+                    "new_pi",
+                    "new_pp",
+                    "new-chardev",
+                    "new-disk",
+                    "new-enabled",
+                    "new-fs",
+                    "new-level",
+                    "new-log_passwd",
+                    "new-mem",
+                    "new-net",
+                    "new-range",
+                    "new-rng",
+                    "new-role",
+                    "new-seuser",
+                    "new-vcpu",
+                    "nlnk-fam",
+                    "nlnk-grp",
+                    "nlnk-pid",
+                    "oauid",
+                    "obj",
+                    "obj_gid",
+                    "obj_uid",
+                    "ocomm",
+                    "oflag",
+                    "ogid",
+                    "old",
+                    "old_enforcing",
+                    "old_lock",
+                    "old_pa",
+                    "old_pe",
+                    "old_pi",
+                    "old_pp",
+                    "old_prom",
+                    "old_val",
+                    "old-auid",
+                    "old-chardev",
+                    "old-disk",
+                    "old-enabled",
+                    "old-fs",
+                    "old-level",
+                    "old-log_passwd",
+                    "old-mem",
+                    "old-net",
+                    "old-range",
+                    "old-rng",
+                    "old-role",
+                    "old-ses",
+                    "old-seuser",
+                    "old-vcpu",
+                    "op",
+                    "opid",
+                    "oses",
+                    "ouid",
+                    "outif",
+                    "pa",
+                    "parent",
+                    "path",
+                    "pe",
+                    "per",
+                    "perm",
+                    "perm_mask",
+                    "permissive",
+                    "pfs",
+                    "pi",
+                    "pid",
+                    "pp",
+                    "ppid",
+                    "printer",
+                    "proctitle",
+                    "prom",
+                    "proto",
+                    "qbytes",
+                    "range",
+                    "rdev",
+                    "reason",
+                    "removed",
+                    "res",
+                    "resrc",
+                    "result",
+                    "role",
+                    "rport",
+                    "saddr",
+                    "sauid",
+                    "scontext",
+                    "selected-context",
+                    "seperm",
+                    "seperms",
+                    "seqno",
+                    "seresult",
+                    "ses",
+                    "seuser",
+                    "sgid",
+                    "sig",
+                    "sigev_signo",
+                    "smac",
+                    "spid",
+                    "sport",
+                    "state",
+                    "subj",
+                    "success",
+                    "suid",
+                    "syscall",
+                    "table",
+                    "tclass",
+                    "tcontext",
+                    "terminal",
+                    "tty",
+                    "type",
+                    "uid",
+                    "unit",
+                    "uri",
+                    "user",
+                    "uuid",
+                    "val",
+                    "val",
+                    "ver",
+                    "virt",
+                    "vm",
+                    "vm-ctx",
+                    "vm-pid",
+                    "watch"
+                ],
+                "vsftpd": [],
+                "sshd": [],
+                "syslog": [],
+                "guacamole": [],
+                "auth": [],
+                "clamav": [],
+                "modsecurity": [],
+                "sudo": [],
+                "cron": []
             }
         },
-        "empty":{
+        "empty": {
             "common": [],
-            "empty": ["not_found"],
-            "category":{
-                "proxy":["c-uri", "c-uri-extension", "c-uri-query", "c-uri-stem", "c-useragent", "cs-bytes", "cs-cookie",
-                        "cs-host", "cs-method", "r-dns", "cs-referrer", "cs-version", "sc-bytes", "sc-status", "src_ip", "dst_ip",
-                        "cs-uri"],
-                "webserver":["date", "time", "c-ip", "cs-username", "s-sitename", "s-computername", "s-ip", "cs-method",
-                            "cs-uri-stem", "cs-uri-query", "s-port", "cs-method", "sc-status", "sc-win32-status",
-                            "sc-bytes", "cs-bytes", "time-taken", "cs-version", "cs-host", "cs-user-agent",
-                            "cs-referer", "cs-cookie"],
-                "antivirus":[],
-                "database":[],
-                "dns":[],
-                "firewall":[]
+            "empty": [
+                "not_found"
+            ],
+            "category": {
+                "proxy": [
+                    "c-uri",
+                    "c-uri-extension",
+                    "c-uri-query",
+                    "c-uri-stem",
+                    "c-useragent",
+                    "cs-bytes",
+                    "cs-cookie",
+                    "cs-host",
+                    "cs-method",
+                    "r-dns",
+                    "cs-referrer",
+                    "cs-version",
+                    "sc-bytes",
+                    "sc-status",
+                    "src_ip",
+                    "dst_ip",
+                    "cs-uri"
+                ],
+                "webserver": [
+                    "date",
+                    "time",
+                    "c-ip",
+                    "cs-username",
+                    "s-sitename",
+                    "s-computername",
+                    "s-ip",
+                    "cs-method",
+                    "cs-uri-stem",
+                    "cs-uri-query",
+                    "s-port",
+                    "cs-method",
+                    "sc-status",
+                    "sc-win32-status",
+                    "sc-bytes",
+                    "cs-bytes",
+                    "time-taken",
+                    "cs-version",
+                    "cs-host",
+                    "cs-user-agent",
+                    "cs-referer",
+                    "cs-cookie"
+                ],
+                "antivirus": [],
+                "database": [],
+                "dns": [],
+                "firewall": []
             },
-            "service":{
-                "apache":[],
-                "netflow":[],
-                "nginx":[]
+            "service": {
+                "apache": [],
+                "netflow": [],
+                "nginx": []
             }
         },
-        "cisco":{
+        "cisco": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "aaa":[],
-                "bgp":[],
-                "duo":[],
-                "ldp":[],
-                "syslog":[]
+            "category": {},
+            "service": {
+                "aaa": [],
+                "bgp": [],
+                "duo": [],
+                "ldp": [],
+                "syslog": []
             }
         },
-        "fortios":{
+        "fortios": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
+            "category": {},
+            "service": {
                 "sslvpnd": []
             }
         },
-        "paloalto":{
+        "paloalto": {
             "common": [],
             "empty": [],
-            "category":{
+            "category": {
                 "file_event": []
             },
-            "service":{
+            "service": {
                 "globalprotect": []
             }
         },
-        "django":{
+        "django": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "kubernetes":{
+        "kubernetes": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{
+            "service": {
                 "audit": []
             }
         },
-        "python":{
+        "python": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "qualys":{
+        "qualys": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "rpc_firewall":{
+        "rpc_firewall": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "ruby_on_rails":{
+        "ruby_on_rails": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "modsecurity":{
+        "modsecurity": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "spring":{
+        "spring": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "sql":{
+        "sql": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "jvm":{
+        "jvm": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "nodejs":{
+        "nodejs": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "opencanary":{
+        "opencanary": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "velocity":{
+        "velocity": {
             "common": [],
             "empty": [],
-            "category":{
-                "application":[]
+            "category": {
+                "application": []
             },
-            "service":{}
+            "service": {}
         },
-        "aws":{
+        "aws": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "cloudtrail":[]
+            "category": {},
+            "service": {
+                "cloudtrail": []
             }
         },
-        "azure":{
+        "azure": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "activitylogs":[],
-                "auditlogs":[],
-				"riskdetection":[],
-				"pim":[],
-                "signinlogs":[]
+            "category": {},
+            "service": {
+                "activitylogs": [],
+                "auditlogs": [],
+                "riskdetection": [],
+                "pim": [],
+                "signinlogs": []
             }
         },
-        "gcp":{
+        "gcp": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "gcp.audit":[],
-                "google_workspace.admin":[]
+            "category": {},
+            "service": {
+                "gcp.audit": [],
+                "google_workspace.admin": []
             }
         },
-        "github":{
+        "github": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "audit":[]
+            "category": {},
+            "service": {
+                "audit": []
             }
         },
-        "bitbucket":{
+        "bitbucket": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "audit":[]
+            "category": {},
+            "service": {
+                "audit": []
             }
         },
-        "m365":{
+        "m365": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "audit":[],
-                "exchange":[],
-                "threat_detection":[],
-                "threat_management":[]
+            "category": {},
+            "service": {
+                "audit": [],
+                "exchange": [],
+                "threat_detection": [],
+                "threat_management": []
             }
         },
-        "okta":{
+        "okta": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "okta":[]
+            "category": {},
+            "service": {
+                "okta": []
             }
         },
-        "onelogin":{
+        "onelogin": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "onelogin.events":[]
+            "category": {},
+            "service": {
+                "onelogin.events": []
             }
         },
-        "huawei":{
+        "1password": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "bgp":[]
+            "category": {},
+            "service": {
+                "1password": [
+                    "action",
+                    "object_type",
+                    "category",
+                    "user.email",
+                    "target_user.email",
+                    "item_uuid",
+                    "vault_uuid"
+                ]
             }
         },
-        "juniper":{
+        "huawei": {
             "common": [],
             "empty": [],
-            "category":{},
-            "service":{
-                "bgp":[]
+            "category": {},
+            "service": {
+                "bgp": []
             }
         },
-        "zeek":{
+        "juniper": {
             "common": [],
             "empty": [],
-            "category":{
+            "category": {},
+            "service": {
+                "bgp": []
+            }
+        },
+        "zeek": {
+            "common": [],
+            "empty": [],
+            "category": {},
+            "service": {
+                "kerberos": [],
+                "smb_files": [],
+                "rdp": [],
+                "http": [],
+                "dns": [],
+                "dce_rpc": [],
+                "x509": []
+            }
+        },
+        "macos": {
+            "common": [],
+            "empty": [],
+            "category": {
+                "process_creation": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "FileVersion",
+                    "Description",
+                    "Product",
+                    "Company",
+                    "OriginalFileName",
+                    "CommandLine",
+                    "CurrentDirectory",
+                    "User",
+                    "LogonGuid",
+                    "LogonId",
+                    "TerminalSessionId",
+                    "IntegrityLevel",
+                    "Hashes",
+                    "ParentProcessGuid",
+                    "ParentProcessId",
+                    "ParentImage",
+                    "ParentCommandLine",
+                    "ParentUser"
+                ],
+                "network_connection": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "User",
+                    "Protocol",
+                    "Initiated",
+                    "SourceIsIpv6",
+                    "SourceIp",
+                    "SourceHostname",
+                    "SourcePort",
+                    "SourcePortName",
+                    "DestinationIsIpv6",
+                    "DestinationIp",
+                    "DestinationHostname",
+                    "DestinationPort",
+                    "DestinationPortName"
+                ],
+                "process_termination": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "User"
+                ],
+                "raw_access_read": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "Device",
+                    "User"
+                ],
+                "file_event": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "Image",
+                    "TargetFilename",
+                    "CreationUtcTime",
+                    "User"
+                ],
+                "sysmon_status": [
+                    "Configuration",
+                    "ConfigurationFileHash"
+                ],
+                "file_delete": [
+                    "ProcessGuid",
+                    "ProcessId",
+                    "User",
+                    "Image",
+                    "TargetFilename",
+                    "Hashes",
+                    "IsExecutable",
+                    "Archived"
+                ]
             },
-            "service":{
-                "kerberos":[],
-                "smb_files":[],
-                "rdp":[],
-                "http":[],
-                "dns":[],
-                "dce_rpc":[],
-                "x509":[]
-            }
+            "service": {}
         },
-        "macos":{
+        "atlassian": {
             "common": [],
             "empty": [],
-            "category":{
-                "process_creation": ["ProcessGuid", "ProcessId", "Image", "FileVersion", "Description", "Product", "Company", "OriginalFileName",
-                                    "CommandLine", "CurrentDirectory", "User", "LogonGuid", "LogonId", "TerminalSessionId", "IntegrityLevel", "Hashes",
-                                    "ParentProcessGuid", "ParentProcessId", "ParentImage", "ParentCommandLine", "ParentUser"],
-                "network_connection": ["ProcessGuid", "ProcessId", "Image", "User", "Protocol", "Initiated", "SourceIsIpv6", "SourceIp", "SourceHostname",
-                                    "SourcePort", "SourcePortName", "DestinationIsIpv6", "DestinationIp", "DestinationHostname", "DestinationPort",
-                                    "DestinationPortName"],
-                "process_termination": ["ProcessGuid", "ProcessId", "Image", "User"],
-                "raw_access_read": ["ProcessGuid", "ProcessId", "Image", "Device", "User"],
-                "file_event": ["ProcessGuid", "ProcessId", "Image", "TargetFilename", "CreationUtcTime", "User"],
-                "sysmon_status": ["Configuration", "ConfigurationFileHash"],
-                "file_delete": ["ProcessGuid", "ProcessId", "User", "Image", "TargetFilename", "Hashes", "IsExecutable", "Archived"]
-            },
-            "service":{
+            "category": {},
+            "service": {
+                "audit": [
+                    "attributes.action",
+                    "attributes.actor.email",
+                    "attributes.actor.name",
+                    "attributes.location.ip",
+                    "attributes.context{}.attributes.email",
+                    "attributes.context{}.attributes.name"
+                ]
             }
-        }    
+        },
+        "jira": {
+            "common": [],
+            "empty": [],
+            "category": {},
+            "service": {
+                "audit": [
+                    "objectItem.name",
+                    "object",
+                    "summary",
+                    "authorAccountId",
+                    "src_ip"
+                ]
+            }
+        }
     },
-    "addon":{
-        "windows":{
-            "category":{
-                "process_creation": ["GrandparentCommandLine"],
-                "network_connection": ["CommandLine", "ParentImage"],
-                "create_remote_thread": ["User", "SourceCommandLine", "SourceParentProcessId", "SourceParentImage",
-                                    "SourceParentCommandLine", "TargetCommandLine", "TargetParentProcessId", "TargetParentImage", "TargetParentCommandLine",
-                                    "IsInitialThread", "RemoteCreation"],
-                "file_delete": ["CommandLine", "ParentImage", "ParentCommandLine"],
-                "file_event": ["CommandLine", "ParentImage", "ParentCommandLine", "MagicHeader"],
-                "image_load": ["CommandLine"],
-                "process_access": ["SourceCommandLine", "CallTraceExtended"],
-                "file_access":["Image", "CommandLine", "ParentImage", "ParentCommandLine", "User", "TargetFilename"],
-                "file_rename":["Image", "CommandLine", "ParentImage", "ParentCommandLine", "User", "OriginalFileName", "SourceFilename", "TargetFilename", "MagicHeader"]
+    "addon": {
+        "windows": {
+            "category": {
+                "process_creation": [
+                    "GrandparentCommandLine"
+                ],
+                "network_connection": [
+                    "CommandLine",
+                    "ParentImage"
+                ],
+                "create_remote_thread": [
+                    "User",
+                    "SourceCommandLine",
+                    "SourceParentProcessId",
+                    "SourceParentImage",
+                    "SourceParentCommandLine",
+                    "TargetCommandLine",
+                    "TargetParentProcessId",
+                    "TargetParentImage",
+                    "TargetParentCommandLine",
+                    "IsInitialThread",
+                    "RemoteCreation"
+                ],
+                "file_delete": [
+                    "CommandLine",
+                    "ParentImage",
+                    "ParentCommandLine"
+                ],
+                "file_event": [
+                    "CommandLine",
+                    "ParentImage",
+                    "ParentCommandLine",
+                    "MagicHeader"
+                ],
+                "image_load": [
+                    "CommandLine"
+                ],
+                "process_access": [
+                    "SourceCommandLine",
+                    "CallTraceExtended"
+                ],
+                "file_access": [
+                    "Image",
+                    "CommandLine",
+                    "ParentImage",
+                    "ParentCommandLine",
+                    "User",
+                    "TargetFilename"
+                ],
+                "file_rename": [
+                    "Image",
+                    "CommandLine",
+                    "ParentImage",
+                    "ParentCommandLine",
+                    "User",
+                    "OriginalFileName",
+                    "SourceFilename",
+                    "TargetFilename",
+                    "MagicHeader"
+                ]
             },
-            "service":{}
+            "service": {}
         }
     }
 }


### PR DESCRIPTION
Summary of the Pull Request
Add 10 Sigma detection rules for Atlassian Cloud organization and Jira audit logs.

Rules cover high-impact administrative actions across the Atlassian platform:
privilege escalation via org admin grants, persistent access via OAuth clients
and service accounts, credential theft via API token export, and destructive
actions including session resets and asset schema deletion. Two new logsources
are introduced: product: atlassian / service: audit (organization-level admin
audit API) and product: jira / service: audit (Jira native audit trail).


Changelog
new: Atlassian Organization Admin Privileges Granted
new: Atlassian Organization OAuth Client Created
new: Atlassian Organization Service Account Created
new: Atlassian Organization-Wide Session Reset
new: Atlassian Organization API Tokens Exported
new: Atlassian Assets Object Schema Deleted
new: Atlassian Organization Group Role Revoked
new: Atlassian Organization Service Account Updated
new: Atlassian Bitbucket Cloud SSH Key Authorized for User
new: Jira Admin Group Membership Changed
chore: add atlassian and jira logsources to tests/logsource.json