### PR TITLE
CVE-2026-41940 - cPanel and WHM CRLF authentication bypass detection

### DIFF
--- a/rules/linux/auditd/syscall/lnx_auditd_cpanel_crlf_injection_cve_2026_41940.yml
+++ b/rules/linux/auditd/syscall/lnx_auditd_cpanel_crlf_injection_cve_2026_41940.yml
@@ -1,0 +1,39 @@
+title: CVE-2026-41940 cPanel CRLF Injection Session File Access via Auditd
+id: ccf6f929-8577-4f37-a4ac-25174621771b
+related:
+    - id: 984a21f0-4d82-4fdc-a2b7-a0e6a1e51c03
+      type: derived
+    - id: 7aca0427-7e19-4859-af17-40157e2f1f7d
+      type: derived
+    - id: 77964729-4b1b-49e3-a21d-996d335b85d1
+      type: derived
+status: experimental
+description: Detects writes to cPanel session files containing URL-encoded CRLF sequences in the filename as captured by auditd syscall monitoring. In CVE-2026-41940, the CRLF injection causes cpsrvd to write attacker-controlled key=value pairs into session files. Auditd open or write syscalls targeting session paths with encoded CRLF in the filename are a direct artifact of exploitation. Requires auditd configured to monitor /var/cpanel/sessions/ with write syscall auditing enabled.
+references:
+    - https://support.cpanel.net/hc/en-us/articles/40073787579671
+    - https://labs.watchtowr.com/the-internet-is-falling-down-falling-down-falling-down-cpanel-whm-authentication-bypass-cve-2026-41940/
+    - https://www.rapid7.com/blog/post/etr-cve-2026-41940-cpanel-whm-authentication-bypass/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41940
+author: MahmoudSwelam
+date: 2026-05-01
+modified: 2026-05-10
+tags:
+    - attack.initial-access
+    - attack.t1190
+    - attack.credential-access
+    - attack.persistence
+    - attack.t1556
+logsource:
+    product: linux
+    service: auditd
+detection:
+    keywords:
+        - '/var/cpanel/sessions/%0d'
+        - '/var/cpanel/sessions/%0a'
+        - '/usr/local/cpanel/sessions/%0d'
+        - '/usr/local/cpanel/sessions/%0a'
+    condition: keywords
+falsepositives:
+    - Security research environments testing CVE-2026-41940 against local instances
+    - Auditd log replay tools that re-process historical session file events
+level: high

--- a/rules/linux/file_event/file_event_lnx_cpanel_session_write_cve_2026_41940.yml
+++ b/rules/linux/file_event/file_event_lnx_cpanel_session_write_cve_2026_41940.yml
@@ -1,0 +1,48 @@
+title: CVE-2026-41940 cPanel Session File Written by Unexpected Process
+id: 7aca0427-7e19-4859-af17-40157e2f1f7d
+related:
+    - id: 984a21f0-4d82-4fdc-a2b7-a0e6a1e51c03
+      type: derived
+    - id: 77964729-4b1b-49e3-a21d-996d335b85d1
+      type: derived
+status: experimental
+description: Detects suspicious writes to cPanel session files by processes other than the legitimate cpsrvd daemon, or session files with malformed names containing URL-encoded CRLF characters as a direct artifact of CVE-2026-41940 exploitation. Requires auditd with session directory monitoring or Sysmon for Linux.
+references:
+    - https://support.cpanel.net/hc/en-us/articles/40073787579671
+    - https://labs.watchtowr.com/the-internet-is-falling-down-falling-down-falling-down-cpanel-whm-authentication-bypass-cve-2026-41940/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41940
+author: MahmoudSwelam
+date: 2026-05-01
+modified: 2026-05-10
+tags:
+    - attack.initial-access
+    - attack.t1190
+    - attack.lateral-movement
+    - attack.t1550.004
+logsource:
+    product: linux
+    category: file_event
+detection:
+    selection_session_path:
+        TargetFilename|startswith:
+            - '/var/cpanel/sessions/'
+            - '/usr/local/cpanel/sessions/'
+    filter_legitimate_writers:
+        Image|endswith:
+            - '/cpsrvd'
+            - '/cpsrvd-ssl'
+            - '/cpdavd'
+            - '/cpdavd-ssl'
+    selection_malformed_filename:
+        TargetFilename|startswith:
+            - '/var/cpanel/sessions/'
+            - '/usr/local/cpanel/sessions/'
+        TargetFilename|contains:
+            - '%0d'
+            - '%0a'
+    condition: (selection_session_path and not filter_legitimate_writers) or selection_malformed_filename
+falsepositives:
+    - Administrative backup or migration tools in cPanel that copy session directories
+    - Development or testing environments with custom cPanel session handling
+    - Legitimate session filenames may contain hex strings but never URL-encoded CR/LF
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_cpanel_cpsrvd_susp_child_cve_2026_41940.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_cpanel_cpsrvd_susp_child_cve_2026_41940.yml
@@ -1,0 +1,76 @@
+title: CVE-2026-41940 cPanel Service Daemon Suspicious Child Process
+id: 984a21f0-4d82-4fdc-a2b7-a0e6a1e51c03
+related:
+    - id: 77964729-4b1b-49e3-a21d-996d335b85d1
+      type: derived
+    - id: 7aca0427-7e19-4859-af17-40157e2f1f7d
+      type: derived
+status: experimental
+description: Detects post-exploitation command execution from CVE-2026-41940, a critical authentication bypass in cPanel and WHM (CVSS 9.8). After bypassing authentication via CRLF injection into cpsrvd session files, attackers execute arbitrary commands through the cpsrvd or cpdavd daemon running as root. Spawning shells, recon tools, download utilities, or interpreters as direct children of these daemons is strongly anomalous.
+references:
+    - https://support.cpanel.net/hc/en-us/articles/40073787579671
+    - https://labs.watchtowr.com/the-internet-is-falling-down-falling-down-falling-down-cpanel-whm-authentication-bypass-cve-2026-41940/
+    - https://www.rapid7.com/blog/post/etr-cve-2026-41940-cpanel-whm-authentication-bypass/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41940
+author: MahmoudSwelam
+date: 2026-05-01
+modified: 2026-05-10
+tags:
+    - attack.execution
+    - attack.t1059.004
+    - attack.discovery
+    - attack.t1033
+    - attack.persistence
+    - attack.t1505.003
+logsource:
+    product: linux
+    category: process_creation
+detection:
+    selection_parent:
+        ParentImage|endswith:
+            - '/cpsrvd'
+            - '/cpsrvd-ssl'
+            - '/cpdavd'
+            - '/cpdavd-ssl'
+    selection_shell:
+        Image|endswith:
+            - '/bash'
+            - '/sh'
+            - '/dash'
+            - '/zsh'
+            - '/ksh'
+            - '/tcsh'
+    selection_recon:
+        Image|endswith:
+            - '/whoami'
+            - '/id'
+            - '/uname'
+            - '/hostname'
+            - '/ifconfig'
+            - '/ip'
+            - '/netstat'
+            - '/ss'
+            - '/ps'
+            - '/ls'
+    selection_download:
+        Image|endswith:
+            - '/curl'
+            - '/wget'
+            - '/fetch'
+            - '/tftp'
+            - '/ftp'
+    selection_interpreter:
+        Image|endswith:
+            - '/python'
+            - '/python2'
+            - '/python3'
+            - '/perl'
+            - '/ruby'
+            - '/php'
+            - '/node'
+    condition: selection_parent and (selection_shell or selection_recon or selection_download or selection_interpreter)
+falsepositives:
+    - Custom cPanel plugins or hooks that legitimately invoke shell scripts as cpsrvd children
+    - Administrative cPanel update processes that temporarily spawn interpreters
+    - Monitoring agents operating under the cPanel process context
+level: critical

--- a/rules/web/webserver_generic/web_cpanel_crlf_login_cve_2026_41940.yml
+++ b/rules/web/webserver_generic/web_cpanel_crlf_login_cve_2026_41940.yml
@@ -1,0 +1,45 @@
+title: CVE-2026-41940 cPanel CRLF Injection in Login Request
+id: 77964729-4b1b-49e3-a21d-996d335b85d1
+related:
+    - id: 984a21f0-4d82-4fdc-a2b7-a0e6a1e51c03
+      type: derived
+    - id: 7aca0427-7e19-4859-af17-40157e2f1f7d
+      type: derived
+status: experimental
+description: Detects CRLF injection attempts exploiting CVE-2026-41940 in cPanel and WHM. The exploit POSTs to /login/?login_only=1 with a crafted Authorization header whose decoded value contains raw CRLF sequences followed by user=root, injecting arbitrary key=value pairs into the cpsrvd session file.
+references:
+    - https://support.cpanel.net/hc/en-us/articles/40073787579671
+    - https://labs.watchtowr.com/the-internet-is-falling-down-falling-down-falling-down-cpanel-whm-authentication-bypass-cve-2026-41940/
+    - https://www.rapid7.com/blog/post/etr-cve-2026-41940-cpanel-whm-authentication-bypass/
+    - https://nvd.nist.gov/vuln/detail/CVE-2026-41940
+author: MahmoudSwelam
+date: 2026-05-01
+modified: 2026-05-10
+tags:
+    - attack.initial-access
+    - attack.t1190
+logsource:
+    category: webserver
+detection:
+    selection_login_trigger:
+        cs-method: 'POST'
+        cs-uri-stem|contains: '/login/'
+        cs-uri-query|contains: 'login_only=1'
+    selection_crlf_stem:
+        cs-uri-stem|contains: '%0d%0a'
+    selection_crlf_query:
+        cs-uri-query|contains: '%0d%0a'
+    filter_known_scanners:
+        cs-user-agent|contains:
+            - 'Shodan'
+            - 'censys'
+            - 'zgrab'
+            - 'masscan'
+            - 'Nmap'
+            - 'Nikto'
+    condition: (selection_login_trigger or selection_crlf_stem or selection_crlf_query) and not filter_known_scanners
+falsepositives:
+    - Legitimate automated cPanel login scripts using the login_only=1 parameter
+    - Security scanners performing authorized CVE validation against cPanel instances
+    - Some cPanel API clients may use login_only=1 programmatically
+level: high


### PR DESCRIPTION
## Summary
Adds 4 Sigma detection rules for CVE-2026-41940, a critical CVSS 9.8
authentication bypass in cPanel and WHM caused by CRLF injection into
session files via a crafted Authorization header. Actively exploited
in the wild since February 2026. Added to CISA KEV on April 29 2026.

## Rules added
- rules/web/webserver_generic/web_cpanel_crlf_login_cve_2026_41940.yml
- rules/linux/process_creation/proc_creation_lnx_cpanel_cpsrvd_susp_child_cve_2026_41940.yml
- rules/linux/file_event/file_event_lnx_cpanel_session_write_cve_2026_41940.yml
- rules/linux/auditd/syscall/lnx_auditd_cpanel_crlf_injection_cve_2026_41940.yml

## ATT&CK coverage
T1190, T1059.004, T1033, T1505.003, T1550.004, T1556

## References
- https://support.cpanel.net/hc/en-us/articles/40073787579671
- https://labs.watchtowr.com/the-internet-is-falling-down-falling-down-falling-down-cpanel-whm-authentication-bypass-cve-2026-41940/
- https://nvd.nist.gov/vuln/detail/CVE-2026-41940