### PR TITLE
Add Azure Entra ID rules: SP credential addition and admin consent high-risk permission

### DIFF
--- a/rules/cloud/azure/audit_logs/azure_ad_admin_consent_application_high_risk_permission.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_admin_consent_application_high_risk_permission.yml
@@ -1,0 +1,42 @@
+title: Admin Consent Granted to Application With High-Risk Application Permission
+id: 90a512e7-4c1a-4b62-aeda-09ce9204dadf
+related:
+    - id: b6b198d5-dbe4-473e-8ec4-51b11e9ab22b
+      type: similar
+status: test
+description: |
+    Detects admin consent grants to applications requesting high-risk application
+    permissions such as Application.ReadWrite.All, RoleManagement.ReadWrite.Directory,
+    or AppRoleAssignment.ReadWrite.All. Unlike delegated consent (covered in the related
+    rule), application permissions grant tenant-wide access without a signed-in user
+    context, are not scoped by Conditional Access, and are not visible to the consenting
+    user's manager. These permissions are commonly abused in OAuth phishing campaigns
+    targeting administrators and in post-compromise persistence scenarios.
+references:
+    - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent
+    - https://attack.mitre.org/techniques/T1528/
+    - https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-193a
+author: descambiado
+date: 2026-05-16
+tags:
+    - attack.credential-access
+    - attack.persistence
+    - attack.t1528
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection_operation:
+        properties.message: 'Consent to application'
+    selection_scope:
+        TargetResources|contains:
+            - 'Application.ReadWrite.All'
+            - 'AppRoleAssignment.ReadWrite.All'
+            - 'RoleManagement.ReadWrite.Directory'
+            - 'Directory.ReadWrite.All'
+            - 'User.ReadWrite.All'
+    condition: selection_operation and selection_scope
+falsepositives:
+    - Legitimate enterprise application deployments requiring directory write access reviewed through a formal application governance process
+    - Microsoft first-party applications during tenant onboarding or product activation
+level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_admin_consent_application_high_risk_permission.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_admin_consent_application_high_risk_permission.yml
@@ -3,7 +3,7 @@ id: 90a512e7-4c1a-4b62-aeda-09ce9204dadf
 related:
     - id: b6b198d5-dbe4-473e-8ec4-51b11e9ab22b
       type: similar
-status: test
+status: experimental
 description: |
     Detects admin consent grants to applications requesting high-risk application
     permissions such as Application.ReadWrite.All, RoleManagement.ReadWrite.Directory,
@@ -14,7 +14,6 @@ description: |
     targeting administrators and in post-compromise persistence scenarios.
 references:
     - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent
-    - https://attack.mitre.org/techniques/T1528/
     - https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-193a
 author: descambiado
 date: 2026-05-16

--- a/rules/cloud/azure/audit_logs/azure_ad_admin_consent_application_high_risk_permission.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_admin_consent_application_high_risk_permission.yml
@@ -5,13 +5,11 @@ related:
       type: similar
 status: experimental
 description: |
-    Detects admin consent grants to applications requesting high-risk application
-    permissions such as Application.ReadWrite.All, RoleManagement.ReadWrite.Directory,
-    or AppRoleAssignment.ReadWrite.All. Unlike delegated consent (covered in the related
-    rule), application permissions grant tenant-wide access without a signed-in user
-    context, are not scoped by Conditional Access, and are not visible to the consenting
-    user's manager. These permissions are commonly abused in OAuth phishing campaigns
-    targeting administrators and in post-compromise persistence scenarios.
+    Detects admin consent grants to OAuth applications requesting high-risk
+    application permissions (Application.ReadWrite.All, RoleManagement.ReadWrite
+    .Directory, AppRoleAssignment.ReadWrite.All). Application permissions grant
+    tenant-wide access without a signed-in user context and are not scoped by
+    Conditional Access, making them a common post-compromise persistence path.
 references:
     - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent
     - https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-193a
@@ -26,7 +24,7 @@ logsource:
     service: auditlogs
 detection:
     selection_operation:
-        properties.message: 'Consent to application'
+        OperationName: 'Consent to application'
     selection_scope:
         TargetResources|contains:
             - 'Application.ReadWrite.All'
@@ -36,6 +34,6 @@ detection:
             - 'User.ReadWrite.All'
     condition: selection_operation and selection_scope
 falsepositives:
-    - Legitimate enterprise application deployments requiring directory write access reviewed through a formal application governance process
-    - Microsoft first-party applications during tenant onboarding or product activation
+    - Enterprise application deployments reviewed through application governance
+    - Microsoft first-party applications during tenant provisioning
 level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_admin_registered_mfa_method_for_user.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_admin_registered_mfa_method_for_user.yml
@@ -5,7 +5,7 @@ related:
       type: similar
     - id: fa84aaf5-8142-43cd-9ec2-78cfebf878ce
       type: similar
-status: test
+status: experimental
 description: |
     Detects when an administrator registers, updates, or deletes an authentication
     method (MFA) on behalf of another user account. An attacker who has obtained
@@ -20,12 +20,12 @@ description: |
 references:
     - https://learn.microsoft.com/en-us/entra/identity/authentication/howto-mfa-userdevicesettings
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
-    - https://attack.mitre.org/techniques/T1556/006/
 author: descambiado
 date: 2026-05-13
 tags:
     - attack.persistence
-    - attack.defense-evasion
+    - attack.credential-access
+    - attack.defense-impairment
     - attack.t1556.006
 logsource:
     product: azure

--- a/rules/cloud/azure/audit_logs/azure_ad_admin_registered_mfa_method_for_user.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_admin_registered_mfa_method_for_user.yml
@@ -1,5 +1,10 @@
 title: Administrator Registered or Modified MFA Method on Behalf of User
 id: bf01ebb6-7dde-40f4-b502-cd22cb121859
+related:
+    - id: 4d78a000-ab52-4564-88a5-7ab5242b20c7
+      type: similar
+    - id: fa84aaf5-8142-43cd-9ec2-78cfebf878ce
+      type: similar
 status: test
 description: |
     Detects when an administrator registers, updates, or deletes an authentication

--- a/rules/cloud/azure/audit_logs/azure_ad_admin_registered_mfa_method_for_user.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_admin_registered_mfa_method_for_user.yml
@@ -7,16 +7,10 @@ related:
       type: similar
 status: experimental
 description: |
-    Detects when an administrator registers, updates, or deletes an authentication
-    method (MFA) on behalf of another user account. An attacker who has obtained
-    administrator credentials may add a new MFA method to a target account to
-    establish persistent authentication access that survives a password reset on
-    the victim account. Unlike self-service MFA registration, admin-initiated
-    changes to security info are rare in most environments and should be correlated
-    against change management records and help desk tickets. This detection
-    complements azure_change_to_authentication_method, which covers self-service
-    registration, and raises severity because the initiating actor is not the
-    account owner.
+    Detects MFA registration, update, or deletion operations performed by an
+    administrator on behalf of another user account in Entra ID. Admin-initiated
+    changes to security info bypass the account owner and can establish persistent
+    authentication access for an attacker holding admin credentials.
 references:
     - https://learn.microsoft.com/en-us/entra/identity/authentication/howto-mfa-userdevicesettings
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
@@ -38,6 +32,7 @@ detection:
             - 'Admin deleted security info'
     condition: selection
 falsepositives:
-    - Help desk teams performing MFA resets on behalf of locked-out users through approved procedures
-    - Automated identity governance workflows that manage authentication methods programmatically
+    - Help desk MFA resets on behalf of locked-out users
+    - Onboarding workflows registering initial MFA for new hires
+    - Identity governance automation managing security info
 level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_admin_registered_mfa_method_for_user.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_admin_registered_mfa_method_for_user.yml
@@ -1,0 +1,38 @@
+title: Administrator Registered or Modified MFA Method on Behalf of User
+id: bf01ebb6-7dde-40f4-b502-cd22cb121859
+status: test
+description: |
+    Detects when an administrator registers, updates, or deletes an authentication
+    method (MFA) on behalf of another user account. An attacker who has obtained
+    administrator credentials may add a new MFA method to a target account to
+    establish persistent authentication access that survives a password reset on
+    the victim account. Unlike self-service MFA registration, admin-initiated
+    changes to security info are rare in most environments and should be correlated
+    against change management records and help desk tickets. This detection
+    complements azure_change_to_authentication_method, which covers self-service
+    registration, and raises severity because the initiating actor is not the
+    account owner.
+references:
+    - https://learn.microsoft.com/en-us/entra/identity/authentication/howto-mfa-userdevicesettings
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
+    - https://attack.mitre.org/techniques/T1556/006/
+author: descambiado
+date: 2026-05-13
+tags:
+    - attack.persistence
+    - attack.defense-evasion
+    - attack.t1556.006
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        OperationName:
+            - 'Admin registered security info'
+            - 'Admin updated security info'
+            - 'Admin deleted security info'
+    condition: selection
+falsepositives:
+    - Help desk teams performing MFA resets on behalf of locked-out users through approved procedures
+    - Automated identity governance workflows that manage authentication methods programmatically
+level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_authentication_methods_policy_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_authentication_methods_policy_modified.yml
@@ -1,0 +1,32 @@
+title: Entra ID Authentication Methods Policy Modified
+id: eaf4cd5a-f700-46ad-ace6-d8caede30ea7
+status: test
+description: |
+    Detects changes to the tenant-wide authentication methods policy, which controls
+    which authentication methods (FIDO2, Microsoft Authenticator, SMS, voice call,
+    software OATH tokens) are enabled or disabled for all users. An attacker with
+    Global Administrator access can weaken tenant-wide authentication by disabling
+    strong methods such as FIDO2 keys or enabling weaker methods susceptible to
+    interception or SIM swapping.
+references:
+    - https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-methods-manage
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities
+    - https://attack.mitre.org/techniques/T1556/006/
+author: descambiado
+date: 2026-05-14
+tags:
+    - attack.defense-evasion
+    - attack.persistence
+    - attack.t1556.006
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        Category: Policy
+        OperationName: 'Update authentication methods policy'
+    condition: selection
+falsepositives:
+    - Authorized changes to authentication methods as part of security hardening
+    - Planned rollout or retirement of authentication methods by identity administrators
+level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_authentication_methods_policy_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_authentication_methods_policy_modified.yml
@@ -2,12 +2,10 @@ title: Entra ID Authentication Methods Policy Modified
 id: eaf4cd5a-f700-46ad-ace6-d8caede30ea7
 status: experimental
 description: |
-    Detects changes to the tenant-wide authentication methods policy, which controls
-    which authentication methods (FIDO2, Microsoft Authenticator, SMS, voice call,
-    software OATH tokens) are enabled or disabled for all users. An attacker with
-    Global Administrator access can weaken tenant-wide authentication by disabling
-    strong methods such as FIDO2 keys or enabling weaker methods susceptible to
-    interception or SIM swapping.
+    Detects modifications to the tenant-wide authentication methods policy in Entra
+    ID. Disabling strong methods (FIDO2, Microsoft Authenticator) or enabling weak
+    methods (SMS, voice) tenant-wide weakens authentication for every user under
+    Global Administrator privileges.
 references:
     - https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-methods-manage
     - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities
@@ -27,6 +25,6 @@ detection:
         OperationName: 'Update authentication methods policy'
     condition: selection
 falsepositives:
-    - Authorized changes to authentication methods as part of security hardening
-    - Planned rollout or retirement of authentication methods by identity administrators
+    - Authorized hardening or rollout of new authentication methods
+    - Scheduled retirement of legacy authentication methods
 level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_authentication_methods_policy_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_authentication_methods_policy_modified.yml
@@ -1,6 +1,6 @@
 title: Entra ID Authentication Methods Policy Modified
 id: eaf4cd5a-f700-46ad-ace6-d8caede30ea7
-status: test
+status: experimental
 description: |
     Detects changes to the tenant-wide authentication methods policy, which controls
     which authentication methods (FIDO2, Microsoft Authenticator, SMS, voice call,
@@ -11,12 +11,12 @@ description: |
 references:
     - https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-methods-manage
     - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities
-    - https://attack.mitre.org/techniques/T1556/006/
 author: descambiado
 date: 2026-05-14
 tags:
-    - attack.defense-evasion
     - attack.persistence
+    - attack.credential-access
+    - attack.defense-impairment
     - attack.t1556.006
 logsource:
     product: azure

--- a/rules/cloud/azure/audit_logs/azure_ad_cross_tenant_access_setting_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_cross_tenant_access_setting_modified.yml
@@ -1,6 +1,6 @@
 title: Entra ID Cross-Tenant Access Setting Created or Modified
 id: 9ae9b60b-014b-4b74-87eb-6c5fa3f304e0
-status: test
+status: experimental
 description: |
     Detects creation, modification, or deletion of Entra ID cross-tenant access
     settings. These settings control B2B trust relationships between tenants,
@@ -11,11 +11,11 @@ description: |
 references:
     - https://learn.microsoft.com/en-us/entra/external-id/cross-tenant-access-overview
     - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities
-    - https://attack.mitre.org/techniques/T1098/
 author: descambiado
 date: 2026-05-14
 tags:
     - attack.persistence
+    - attack.privilege-escalation
     - attack.t1098
 logsource:
     product: azure

--- a/rules/cloud/azure/audit_logs/azure_ad_cross_tenant_access_setting_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_cross_tenant_access_setting_modified.yml
@@ -3,11 +3,9 @@ id: 9ae9b60b-014b-4b74-87eb-6c5fa3f304e0
 status: experimental
 description: |
     Detects creation, modification, or deletion of Entra ID cross-tenant access
-    settings. These settings control B2B trust relationships between tenants,
-    including inbound and outbound access, MFA trust, and device compliance trust.
-    An attacker with Global Administrator privileges can add an attacker-controlled
-    tenant as a trusted partner to enable persistent cross-tenant access that
-    survives credential rotation in the victim tenant.
+    settings (B2B inbound/outbound, MFA trust, device compliance trust). An
+    attacker with Global Administrator privileges can establish a trusted partner
+    tenant for persistent cross-tenant access that survives credential rotation.
 references:
     - https://learn.microsoft.com/en-us/entra/external-id/cross-tenant-access-overview
     - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities
@@ -29,6 +27,6 @@ detection:
             - 'Update cross-tenant access settings'
     condition: selection
 falsepositives:
-    - Authorized configuration of B2B direct connect or cross-tenant synchronization
-    - Tenant restructuring or partner onboarding performed by approved administrators
+    - Authorized B2B direct connect or cross-tenant synchronization configuration
+    - Partner onboarding by approved administrators
 level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_cross_tenant_access_setting_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_cross_tenant_access_setting_modified.yml
@@ -1,0 +1,34 @@
+title: Entra ID Cross-Tenant Access Setting Created or Modified
+id: 9ae9b60b-014b-4b74-87eb-6c5fa3f304e0
+status: test
+description: |
+    Detects creation, modification, or deletion of Entra ID cross-tenant access
+    settings. These settings control B2B trust relationships between tenants,
+    including inbound and outbound access, MFA trust, and device compliance trust.
+    An attacker with Global Administrator privileges can add an attacker-controlled
+    tenant as a trusted partner to enable persistent cross-tenant access that
+    survives credential rotation in the victim tenant.
+references:
+    - https://learn.microsoft.com/en-us/entra/external-id/cross-tenant-access-overview
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities
+    - https://attack.mitre.org/techniques/T1098/
+author: descambiado
+date: 2026-05-14
+tags:
+    - attack.persistence
+    - attack.t1098
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        OperationName:
+            - 'Create a partner cross-tenant access setting'
+            - 'Update a partner cross-tenant access setting'
+            - 'Delete a partner cross-tenant access setting'
+            - 'Update cross-tenant access settings'
+    condition: selection
+falsepositives:
+    - Authorized configuration of B2B direct connect or cross-tenant synchronization
+    - Tenant restructuring or partner onboarding performed by approved administrators
+level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_guest_user_added_to_privileged_role.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_guest_user_added_to_privileged_role.yml
@@ -1,6 +1,6 @@
 title: Guest User Added to Privileged Entra ID Role
 id: 1f52cd1a-34ee-4f32-852a-4aa3ed62e08b
-status: test
+status: experimental
 description: |
     Detects when an external guest user (identified by the '#EXT#' marker in the UPN)
     is directly assigned to a privileged Entra ID directory role. Attackers who have
@@ -12,7 +12,6 @@ description: |
 references:
     - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/manage-roles-portal
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
-    - https://attack.mitre.org/techniques/T1098/003/
 author: descambiado
 date: 2026-05-13
 tags:

--- a/rules/cloud/azure/audit_logs/azure_ad_guest_user_added_to_privileged_role.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_guest_user_added_to_privileged_role.yml
@@ -2,13 +2,10 @@ title: Guest User Added to Privileged Entra ID Role
 id: 1f52cd1a-34ee-4f32-852a-4aa3ed62e08b
 status: experimental
 description: |
-    Detects when an external guest user (identified by the '#EXT#' marker in the UPN)
-    is directly assigned to a privileged Entra ID directory role. Attackers who have
-    compromised a privileged account may add guest identities they control to
-    high-privilege roles to establish persistence across tenant boundaries.
-    This technique allows an attacker to maintain access even after the initially
-    compromised internal account is remediated, because the guest identity is
-    anchored in an external tenant that the victim organisation does not control.
+    Detects assignment of an external guest user (identified by the #EXT# marker
+    in the UPN) to a privileged Entra ID directory role. An attacker with admin
+    credentials can use this to establish persistent privileged access anchored in
+    an external tenant outside the victim's control.
 references:
     - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/manage-roles-portal
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
@@ -28,6 +25,6 @@ detection:
         TargetResources|contains: '#EXT#'
     condition: selection
 falsepositives:
-    - Deliberate cross-tenant collaboration where a guest is legitimately added to a privileged role
-    - Automated provisioning pipelines that use external guest identities for service accounts
+    - Cross-tenant collaboration intentionally granting guests privileged access
+    - Provisioning of external service accounts as guests
 level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_guest_user_added_to_privileged_role.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_guest_user_added_to_privileged_role.yml
@@ -1,0 +1,34 @@
+title: Guest User Added to Privileged Entra ID Role
+id: 1f52cd1a-34ee-4f32-852a-4aa3ed62e08b
+status: test
+description: |
+    Detects when an external guest user (identified by the '#EXT#' marker in the UPN)
+    is directly assigned to a privileged Entra ID directory role. Attackers who have
+    compromised a privileged account may add guest identities they control to
+    high-privilege roles to establish persistence across tenant boundaries.
+    This technique allows an attacker to maintain access even after the initially
+    compromised internal account is remediated, because the guest identity is
+    anchored in an external tenant that the victim organisation does not control.
+references:
+    - https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/manage-roles-portal
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
+    - https://attack.mitre.org/techniques/T1098/003/
+author: descambiado
+date: 2026-05-13
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098.003
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        Category: RoleManagement
+        OperationName: 'Add member to role.'
+        TargetResources|contains: '#EXT#'
+    condition: selection
+falsepositives:
+    - Deliberate cross-tenant collaboration where a guest is legitimately added to a privileged role
+    - Automated provisioning pipelines that use external guest identities for service accounts
+level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_named_location_deleted_or_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_named_location_deleted_or_modified.yml
@@ -8,10 +8,9 @@ related:
 status: experimental
 description: |
     Detects deletion or modification of Entra ID named locations. Named locations
-    are IP range or country definitions used as conditions in Conditional Access
-    policies. Deleting or modifying a named location can silently neutralize
-    IP-based or country-based access controls while leaving the CA policy intact
-    and appearing enabled.
+    are referenced by Conditional Access policies for IP-based or country-based
+    access control; modifying or deleting them can silently neutralize a CA policy
+    while leaving the policy itself enabled.
 references:
     - https://learn.microsoft.com/en-us/entra/identity/conditional-access/location-condition
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-infrastructure#conditional-access
@@ -31,6 +30,6 @@ detection:
             - 'Update named location'
     condition: selection
 falsepositives:
-    - Authorized IP range updates to reflect legitimate network changes
-    - Consolidation or renaming of named location objects by administrators
+    - Legitimate IP range updates reflecting network changes
+    - Renaming or consolidation of named location objects
 level: medium

--- a/rules/cloud/azure/audit_logs/azure_ad_named_location_deleted_or_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_named_location_deleted_or_modified.yml
@@ -1,5 +1,10 @@
 title: Entra ID Named Location Deleted or Modified
 id: d3bd4d0b-fc19-4fd8-a42a-a1b40406a8ae
+related:
+    - id: 50a3c7aa-ec29-44a4-92c1-fce229eef6fc
+      type: similar
+    - id: 26e7c5e2-6545-481e-b7e6-050143459635
+      type: similar
 status: test
 description: |
     Detects deletion or modification of Entra ID named locations. Named locations

--- a/rules/cloud/azure/audit_logs/azure_ad_named_location_deleted_or_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_named_location_deleted_or_modified.yml
@@ -5,7 +5,7 @@ related:
       type: similar
     - id: 26e7c5e2-6545-481e-b7e6-050143459635
       type: similar
-status: test
+status: experimental
 description: |
     Detects deletion or modification of Entra ID named locations. Named locations
     are IP range or country definitions used as conditions in Conditional Access
@@ -15,11 +15,10 @@ description: |
 references:
     - https://learn.microsoft.com/en-us/entra/identity/conditional-access/location-condition
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-infrastructure#conditional-access
-    - https://attack.mitre.org/techniques/T1562/001/
 author: descambiado
 date: 2026-05-14
 tags:
-    - attack.defense-evasion
+    - attack.defense-impairment
     - attack.t1562.001
 logsource:
     product: azure

--- a/rules/cloud/azure/audit_logs/azure_ad_named_location_deleted_or_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_named_location_deleted_or_modified.yml
@@ -1,0 +1,32 @@
+title: Entra ID Named Location Deleted or Modified
+id: d3bd4d0b-fc19-4fd8-a42a-a1b40406a8ae
+status: test
+description: |
+    Detects deletion or modification of Entra ID named locations. Named locations
+    are IP range or country definitions used as conditions in Conditional Access
+    policies. Deleting or modifying a named location can silently neutralize
+    IP-based or country-based access controls while leaving the CA policy intact
+    and appearing enabled.
+references:
+    - https://learn.microsoft.com/en-us/entra/identity/conditional-access/location-condition
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-infrastructure#conditional-access
+    - https://attack.mitre.org/techniques/T1562/001/
+author: descambiado
+date: 2026-05-14
+tags:
+    - attack.defense-evasion
+    - attack.t1562.001
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        Category: Policy
+        OperationName:
+            - 'Delete named location'
+            - 'Update named location'
+    condition: selection
+falsepositives:
+    - Authorized IP range updates to reflect legitimate network changes
+    - Consolidation or renaming of named location objects by administrators
+level: medium

--- a/rules/cloud/azure/audit_logs/azure_ad_oauth_consent_high_risk_permission.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_oauth_consent_high_risk_permission.yml
@@ -3,7 +3,7 @@ id: b6b198d5-dbe4-473e-8ec4-51b11e9ab22b
 related:
     - id: 9b2cc4c4-2ad4-416d-8e8e-ee6aa6f5035a
       type: similar
-status: test
+status: experimental
 description: |
     Detects when an end user grants consent to an application requesting high-risk
     OAuth 2.0 delegated permissions. Permissions such as Mail.ReadWrite,
@@ -17,12 +17,10 @@ description: |
 references:
     - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/user-consent-and-permissions
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#end-user-consent
-    - https://attack.mitre.org/techniques/T1528/
 author: descambiado
 date: 2026-05-13
 tags:
     - attack.credential-access
-    - attack.initial-access
     - attack.t1528
 logsource:
     product: azure

--- a/rules/cloud/azure/audit_logs/azure_ad_oauth_consent_high_risk_permission.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_oauth_consent_high_risk_permission.yml
@@ -1,5 +1,8 @@
 title: End User Consent to Application With High-Risk OAuth Permission
 id: b6b198d5-dbe4-473e-8ec4-51b11e9ab22b
+related:
+    - id: 9b2cc4c4-2ad4-416d-8e8e-ee6aa6f5035a
+      type: similar
 status: test
 description: |
     Detects when an end user grants consent to an application requesting high-risk

--- a/rules/cloud/azure/audit_logs/azure_ad_oauth_consent_high_risk_permission.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_oauth_consent_high_risk_permission.yml
@@ -1,0 +1,44 @@
+title: End User Consent to Application With High-Risk OAuth Permission
+id: b6b198d5-dbe4-473e-8ec4-51b11e9ab22b
+status: test
+description: |
+    Detects when an end user grants consent to an application requesting high-risk
+    OAuth 2.0 delegated permissions. Permissions such as Mail.ReadWrite,
+    Files.ReadWrite.All, and full_access_as_app provide broad access to mailboxes
+    and files and are commonly abused in phishing and illicit consent-grant attacks.
+    An attacker who tricks a user into consenting to a malicious OAuth application
+    gains persistent access to the user's data without requiring credentials after
+    the initial consent event. This rule complements the broader end-user consent
+    rule by raising severity only when the requested scope is considered high risk,
+    reducing noise while surfacing the most dangerous consent grants.
+references:
+    - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/user-consent-and-permissions
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#end-user-consent
+    - https://attack.mitre.org/techniques/T1528/
+author: descambiado
+date: 2026-05-13
+tags:
+    - attack.credential-access
+    - attack.initial-access
+    - attack.t1528
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection_operation:
+        OperationName: 'Consent to application'
+    selection_scope:
+        TargetResources|contains:
+            - 'Mail.ReadWrite'
+            - 'Files.ReadWrite.All'
+            - 'Mail.Send'
+            - 'MailboxSettings.ReadWrite'
+            - 'full_access_as_app'
+            - 'EWS.AccessAsUser.All'
+            - 'Directory.ReadWrite.All'
+            - 'RoleManagement.ReadWrite.Directory'
+    condition: selection_operation and selection_scope
+falsepositives:
+    - Legitimate enterprise applications that require broad mailbox or file access
+    - IT-approved productivity integrations reviewed through a formal application consent review process
+level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_oauth_consent_high_risk_permission.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_oauth_consent_high_risk_permission.yml
@@ -5,15 +5,10 @@ related:
       type: similar
 status: experimental
 description: |
-    Detects when an end user grants consent to an application requesting high-risk
-    OAuth 2.0 delegated permissions. Permissions such as Mail.ReadWrite,
-    Files.ReadWrite.All, and full_access_as_app provide broad access to mailboxes
-    and files and are commonly abused in phishing and illicit consent-grant attacks.
-    An attacker who tricks a user into consenting to a malicious OAuth application
-    gains persistent access to the user's data without requiring credentials after
-    the initial consent event. This rule complements the broader end-user consent
-    rule by raising severity only when the requested scope is considered high risk,
-    reducing noise while surfacing the most dangerous consent grants.
+    Detects end-user consent grants to OAuth applications requesting high-risk
+    delegated permissions (Mail.ReadWrite, Files.ReadWrite.All, full_access_as_app,
+    Directory.ReadWrite.All). Illicit consent grants targeting these scopes
+    provide persistent attacker access to user data without credential theft.
 references:
     - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/user-consent-and-permissions
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#end-user-consent
@@ -40,6 +35,6 @@ detection:
             - 'RoleManagement.ReadWrite.Directory'
     condition: selection_operation and selection_scope
 falsepositives:
-    - Legitimate enterprise applications that require broad mailbox or file access
-    - IT-approved productivity integrations reviewed through a formal application consent review process
+    - Enterprise productivity integrations approved through application governance
+    - Microsoft first-party applications during tenant provisioning
 level: high

--- a/rules/cloud/azure/audit_logs/azure_ad_sp_credentials_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_sp_credentials_added.yml
@@ -1,0 +1,35 @@
+title: Service Principal Credentials Added to Entra ID Application
+id: 333e02d6-a376-499a-a6d9-6b14de262072
+related:
+    - id: cbb67ecc-fb70-4467-9350-c910bdf7c628
+      type: similar
+status: test
+description: |
+    Detects when a password credential or certificate is added to an Entra ID
+    service principal via the "Add service principal credentials" operation.
+    This operation creates a new client secret or X.509 key that can be used to
+    authenticate as the application identity. Attackers who gain Application
+    Administrator or tenant-level write access use this technique to establish
+    persistent access that survives password resets and is not tied to any human
+    account subject to MFA or Conditional Access.
+references:
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-credentials
+    - https://attack.mitre.org/techniques/T1098/001/
+    - https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
+author: descambiado
+date: 2026-05-16
+tags:
+    - attack.persistence
+    - attack.t1098.001
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        properties.message: 'Add service principal credentials'
+    condition: selection
+falsepositives:
+    - Legitimate key rotation by application owners during scheduled maintenance
+    - CI/CD pipeline automation adding deployment certificates for newly registered applications
+    - Infrastructure-as-code tooling managing service principal lifecycle
+level: medium

--- a/rules/cloud/azure/audit_logs/azure_ad_sp_credentials_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_sp_credentials_added.yml
@@ -3,7 +3,7 @@ id: 333e02d6-a376-499a-a6d9-6b14de262072
 related:
     - id: cbb67ecc-fb70-4467-9350-c910bdf7c628
       type: similar
-status: test
+status: experimental
 description: |
     Detects when a password credential or certificate is added to an Entra ID
     service principal via the "Add service principal credentials" operation.
@@ -14,12 +14,12 @@ description: |
     account subject to MFA or Conditional Access.
 references:
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-credentials
-    - https://attack.mitre.org/techniques/T1098/001/
     - https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
 author: descambiado
 date: 2026-05-16
 tags:
     - attack.persistence
+    - attack.privilege-escalation
     - attack.t1098.001
 logsource:
     product: azure

--- a/rules/cloud/azure/audit_logs/azure_ad_sp_credentials_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_sp_credentials_added.yml
@@ -5,13 +5,11 @@ related:
       type: similar
 status: experimental
 description: |
-    Detects when a password credential or certificate is added to an Entra ID
-    service principal via the "Add service principal credentials" operation.
-    This operation creates a new client secret or X.509 key that can be used to
-    authenticate as the application identity. Attackers who gain Application
-    Administrator or tenant-level write access use this technique to establish
-    persistent access that survives password resets and is not tied to any human
-    account subject to MFA or Conditional Access.
+    Detects "Add service principal credentials" operations in Entra ID audit
+    logs. Adding a password or certificate to a Service Principal grants
+    application-identity authentication that bypasses user-bound MFA and
+    Conditional Access. Observed in the 2024 Microsoft tenant compromise
+    (Midnight Blizzard / APT29).
 references:
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-credentials
     - https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
@@ -26,10 +24,10 @@ logsource:
     service: auditlogs
 detection:
     selection:
-        properties.message: 'Add service principal credentials'
+        OperationName: 'Add service principal credentials'
     condition: selection
 falsepositives:
-    - Legitimate key rotation by application owners during scheduled maintenance
-    - CI/CD pipeline automation adding deployment certificates for newly registered applications
-    - Infrastructure-as-code tooling managing service principal lifecycle
+    - Scheduled credential rotation by application owners
+    - CI/CD pipelines adding deployment certificates
+    - Identity governance tooling managing SP lifecycle
 level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Two detection rules: Service Principal credential addition (Midnight Blizzard / APT29 persistence technique documented in the January 2024 Microsoft tenant compromise) and admin consent to OAuth applications requesting high-risk application permissions.

Note: this branch is based on `add-azure-entra-id-identity-detections` (#6012). Once #6012 merges, this branch will be rebased so only the two new files appear in the diff.

### Changelog

new: Service Principal Credentials Added to Entra ID Application
new: Admin Consent Granted to Application With High-Risk Application Permission

### Example Log Event

Sample `Add service principal credentials` event (Azure AD AuditLogs):

```json
{
  "Category": "ApplicationManagement",
  "OperationName": "Add service principal credentials",
  "Result": "success",
  "InitiatedBy": {
    "user": {
      "id": "<initiator-object-id>",
      "userPrincipalName": "<initiator-upn>"
    }
  },
  "TargetResources": [{
    "id": "<service-principal-object-id>",
    "displayName": "<app-display-name>",
    "type": "ServicePrincipal",
    "modifiedProperties": [{
      "displayName": "KeyDescription",
      "newValue": "[\"KeyIdentifier=<guid>,KeyType=Password,KeyUsage=Verify,DisplayName=<secret-name>\"]"
    }]
  }]
}
```

Schema reference: https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities

### Fixed Issues

N/A
