### PR TITLE
Add Azure Entra ID identity boundary expansion rules (3 rules)

### DIFF
--- a/rules/cloud/azure/audit_logs/azure_ad_app_redirect_uri_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_app_redirect_uri_modified.yml
@@ -2,11 +2,10 @@ title: Entra ID OAuth Application Redirect URI Modified
 id: 84e8647c-2ba3-475e-a45a-3fa1936fcf37
 status: experimental
 description: |
-    Detects modifications to OAuth application redirect URIs (ReplyUrls) in
-    Entra ID. Adding an attacker-controlled redirect URI to an existing trusted
-    application allows interception of OAuth authorization codes when users
-    authenticate through that application's normal login flow, enabling token
-    theft without requiring a new app registration or consent event.
+    Detects modifications to OAuth application redirect URIs (ReplyUrls) in Entra
+    ID. Adding an attacker-controlled redirect URI to a trusted application allows
+    interception of OAuth authorization codes during normal sign-in flow, enabling
+    token theft without new app registration or consent.
 references:
     - https://learn.microsoft.com/en-us/entra/identity-platform/reply-url
 author: descambiado
@@ -26,7 +25,7 @@ detection:
             - 'ReplyUrls'
     condition: selection_operation and selection_replyurls
 falsepositives:
-    - Developers adding localhost redirect URIs for local development
-    - CI/CD pipelines updating production redirect URIs during deployment
-    - Application owners adding redirect URIs for new platform support
+    - Developers adding localhost URIs during local development
+    - CI/CD pipelines updating production redirect URIs
+    - Application owners adding URIs for new platforms
 level: medium

--- a/rules/cloud/azure/audit_logs/azure_ad_app_redirect_uri_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_app_redirect_uri_modified.yml
@@ -1,6 +1,6 @@
 title: Entra ID OAuth Application Redirect URI Modified
 id: 84e8647c-2ba3-475e-a45a-3fa1936fcf37
-status: test
+status: experimental
 description: |
     Detects modifications to OAuth application redirect URIs (ReplyUrls) in
     Entra ID. Adding an attacker-controlled redirect URI to an existing trusted
@@ -9,7 +9,6 @@ description: |
     theft without requiring a new app registration or consent event.
 references:
     - https://learn.microsoft.com/en-us/entra/identity-platform/reply-url
-    - https://attack.mitre.org/techniques/T1528/
 author: descambiado
 date: 2026-05-20
 tags:

--- a/rules/cloud/azure/audit_logs/azure_ad_app_redirect_uri_modified.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_app_redirect_uri_modified.yml
@@ -1,0 +1,33 @@
+title: Entra ID OAuth Application Redirect URI Modified
+id: 84e8647c-2ba3-475e-a45a-3fa1936fcf37
+status: test
+description: |
+    Detects modifications to OAuth application redirect URIs (ReplyUrls) in
+    Entra ID. Adding an attacker-controlled redirect URI to an existing trusted
+    application allows interception of OAuth authorization codes when users
+    authenticate through that application's normal login flow, enabling token
+    theft without requiring a new app registration or consent event.
+references:
+    - https://learn.microsoft.com/en-us/entra/identity-platform/reply-url
+    - https://attack.mitre.org/techniques/T1528/
+author: descambiado
+date: 2026-05-20
+tags:
+    - attack.credential-access
+    - attack.persistence
+    - attack.t1528
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection_operation:
+        OperationName: 'Update application'
+    selection_replyurls:
+        TargetResources|contains:
+            - 'ReplyUrls'
+    condition: selection_operation and selection_replyurls
+falsepositives:
+    - Developers adding localhost redirect URIs for local development
+    - CI/CD pipelines updating production redirect URIs during deployment
+    - Application owners adding redirect URIs for new platform support
+level: medium

--- a/rules/cloud/azure/audit_logs/azure_ad_guest_to_member_conversion.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_guest_to_member_conversion.yml
@@ -1,6 +1,6 @@
 title: Entra ID Guest Account Converted to Member
 id: b7b0a939-2bbd-4272-85c0-51a51a41674b
-status: test
+status: experimental
 description: |
     Detects Entra ID user accounts converted from Guest to Member type via
     the Update user operation. A Guest-to-Member conversion grants the account
@@ -9,11 +9,11 @@ description: |
     tenant access without triggering role assignment alerts.
 references:
     - https://learn.microsoft.com/en-us/entra/external-id/user-properties
-    - https://attack.mitre.org/techniques/T1098/
 author: descambiado
 date: 2026-05-20
 tags:
     - attack.persistence
+    - attack.privilege-escalation
     - attack.t1098
 logsource:
     product: azure

--- a/rules/cloud/azure/audit_logs/azure_ad_guest_to_member_conversion.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_guest_to_member_conversion.yml
@@ -2,11 +2,11 @@ title: Entra ID Guest Account Converted to Member
 id: b7b0a939-2bbd-4272-85c0-51a51a41674b
 status: experimental
 description: |
-    Detects Entra ID user accounts converted from Guest to Member type via
-    the Update user operation. A Guest-to-Member conversion grants the account
-    full directory read access and removes external-identity restrictions, which
-    may indicate an attacker elevating a compromised guest account to persistent
-    tenant access without triggering role assignment alerts.
+    Detects Entra ID user accounts converted from Guest to Member type via the
+    Update user operation. The conversion grants full directory read access and
+    removes external-identity restrictions, which may indicate an attacker
+    elevating a compromised guest account to persistent tenant access without
+    role assignment alerts.
 references:
     - https://learn.microsoft.com/en-us/entra/external-id/user-properties
 author: descambiado
@@ -28,6 +28,6 @@ detection:
             - 'Member'
     condition: selection_operation and selection_usertype
 falsepositives:
-    - B2B collaboration migrations where external users are intentionally promoted to full membership
-    - Organizational restructuring converting former contractors to permanent employees
+    - B2B collaboration migrations promoting external users to membership
+    - Contractor conversions to permanent employees
 level: medium

--- a/rules/cloud/azure/audit_logs/azure_ad_guest_to_member_conversion.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_guest_to_member_conversion.yml
@@ -1,0 +1,33 @@
+title: Entra ID Guest Account Converted to Member
+id: b7b0a939-2bbd-4272-85c0-51a51a41674b
+status: test
+description: |
+    Detects Entra ID user accounts converted from Guest to Member type via
+    the Update user operation. A Guest-to-Member conversion grants the account
+    full directory read access and removes external-identity restrictions, which
+    may indicate an attacker elevating a compromised guest account to persistent
+    tenant access without triggering role assignment alerts.
+references:
+    - https://learn.microsoft.com/en-us/entra/external-id/user-properties
+    - https://attack.mitre.org/techniques/T1098/
+author: descambiado
+date: 2026-05-20
+tags:
+    - attack.persistence
+    - attack.t1098
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection_operation:
+        OperationName: 'Update user'
+    selection_usertype:
+        TargetResources|contains|all:
+            - 'UserType'
+            - 'Guest'
+            - 'Member'
+    condition: selection_operation and selection_usertype
+falsepositives:
+    - B2B collaboration migrations where external users are intentionally promoted to full membership
+    - Organizational restructuring converting former contractors to permanent employees
+level: medium

--- a/rules/cloud/azure/audit_logs/azure_ad_service_principal_owner_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_service_principal_owner_added.yml
@@ -1,6 +1,6 @@
 title: New Owner Added to Entra ID Service Principal
 id: 566610f0-c115-4677-911d-90ad697b8238
-status: test
+status: experimental
 description: |
     Detects additions of new owners to Entra ID service principals. Service
     principal ownership grants full credential management capability without
@@ -12,11 +12,11 @@ description: |
 references:
     - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-app-owners
     - https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
-    - https://attack.mitre.org/techniques/T1098/001/
 author: descambiado
 date: 2026-05-20
 tags:
     - attack.persistence
+    - attack.privilege-escalation
     - attack.t1098.001
 logsource:
     product: azure

--- a/rules/cloud/azure/audit_logs/azure_ad_service_principal_owner_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_service_principal_owner_added.yml
@@ -2,13 +2,11 @@ title: New Owner Added to Entra ID Service Principal
 id: 566610f0-c115-4677-911d-90ad697b8238
 status: experimental
 description: |
-    Detects additions of new owners to Entra ID service principals. Service
-    principal ownership grants full credential management capability without
-    requiring a tenant-wide admin role. An attacker who adds themselves as
-    SP owner can subsequently add password or certificate credentials and
-    authenticate as the SP, bypassing MFA and Conditional Access. This
-    ownership addition is a documented precursor step in Midnight Blizzard-
-    style persistence chains.
+    Detects additions of new owners to Entra ID service principals. SP ownership
+    grants full credential management without requiring a tenant-wide admin role:
+    an owner can add password or certificate credentials and authenticate as the
+    SP, bypassing MFA and Conditional Access. Documented in the 2024 Midnight
+    Blizzard (APT29) Microsoft tenant compromise.
 references:
     - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-app-owners
     - https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
@@ -26,7 +24,7 @@ detection:
         OperationName: 'Add owner to service principal'
     condition: selection
 falsepositives:
-    - Developers adding team members as co-owners during application onboarding
-    - IT governance ownership transfers between teams
-    - Automated provisioning pipelines that assign SP ownership during deployment
+    - Co-owner assignments during application onboarding
+    - Ownership transfers between teams
+    - Automated provisioning pipelines assigning SP ownership
 level: medium

--- a/rules/cloud/azure/audit_logs/azure_ad_service_principal_owner_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_service_principal_owner_added.yml
@@ -1,0 +1,32 @@
+title: New Owner Added to Entra ID Service Principal
+id: 566610f0-c115-4677-911d-90ad697b8238
+status: test
+description: |
+    Detects additions of new owners to Entra ID service principals. Service
+    principal ownership grants full credential management capability without
+    requiring a tenant-wide admin role. An attacker who adds themselves as
+    SP owner can subsequently add password or certificate credentials and
+    authenticate as the SP, bypassing MFA and Conditional Access. This
+    ownership addition is a documented precursor step in Midnight Blizzard-
+    style persistence chains.
+references:
+    - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-app-owners
+    - https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
+    - https://attack.mitre.org/techniques/T1098/001/
+author: descambiado
+date: 2026-05-20
+tags:
+    - attack.persistence
+    - attack.t1098.001
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        OperationName: 'Add owner to service principal'
+    condition: selection
+falsepositives:
+    - Developers adding team members as co-owners during application onboarding
+    - IT governance ownership transfers between teams
+    - Automated provisioning pipelines that assign SP ownership during deployment
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Three detection rules covering Entra ID identity boundary expansion via Service Principal ownership, OAuth redirect URI manipulation, and guest-to-member conversion. All rules query Azure AD AuditLogs on specific OperationName values.

### Changelog

new: New Owner Added to Entra ID Service Principal
new: Entra ID OAuth Application Redirect URI Modified
new: Entra ID Guest Account Converted to Member

### Example Log Event

Sample `Add owner to service principal` event (Azure AD AuditLogs):

```json
{
  "Category": "ApplicationManagement",
  "OperationName": "Add owner to service principal",
  "Result": "success",
  "InitiatedBy": {
    "user": {
      "id": "<initiator-object-id>",
      "userPrincipalName": "<initiator-upn>"
    }
  },
  "TargetResources": [{
    "id": "<service-principal-id>",
    "displayName": "<app-display-name>",
    "type": "ServicePrincipal",
    "modifiedProperties": [{
      "displayName": "ServicePrincipal.Owner",
      "newValue": "[\"<new-owner-user-id>\"]"
    }]
  }]
}
```

Schema reference: https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities

### Fixed Issues

N/A
