### PR TITLE
Add detection: BadUSB PowerShell execution via Windows Run dialog

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_badusb_powershell_run_dialog.yml
+++ b/rules/windows/process_creation/proc_creation_win_badusb_powershell_run_dialog.yml
@@ -1,0 +1,57 @@
+title: BadUSB PowerShell Execution via Windows Run Dialog
+id: 7a3f1c2e-9b4d-4e8a-bc61-2d5f8e3a7c91
+status: test
+description: Detects PowerShell spawned by explorer.exe with hidden window and execution cradle flags, consistent with HID injection payloads that open the Run dialog via WIN+R and type a PowerShell command.
+references:
+    - https://github.com/descambiado/flipper-purple-team
+    - https://docs.flipper.net/bad-usb
+    - https://attack.mitre.org/techniques/T1059/001/
+    - https://attack.mitre.org/techniques/T1564/003/
+author: descambiado
+date: 2026-05-23
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.defense_evasion
+    - attack.t1564.003
+    - attack.initial_access
+    - attack.t1200
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_process:
+        - Image|endswith:
+              - '\powershell.exe'
+              - '\pwsh.exe'
+        - OriginalFileName:
+              - 'PowerShell.EXE'
+              - 'pwsh.dll'
+    selection_parent:
+        ParentImage|endswith: '\explorer.exe'
+    selection_hidden:
+        CommandLine|contains|all:
+            - '-WindowStyle'
+            - 'Hidden'
+    selection_cradle:
+        CommandLine|contains:
+            - '-EncodedCommand'
+            - '-ExecutionPolicy Bypass'
+            - 'DownloadString'
+            - 'IEX'
+            - 'Invoke-Expression'
+            - 'WebClient'
+            - 'Start-Process'
+            - '-NoProfile'
+            - '-NonInteractive'
+    filter_main_installers:
+        # Software installers occasionally invoke PowerShell via the Windows shell
+        ParentCommandLine|contains:
+            - 'setup'
+            - 'install'
+            - 'Update'
+    condition: (selection_process and selection_parent and selection_hidden and selection_cradle) and not 1 of filter_main_*
+falsepositives:
+    - Legitimate software installers that invoke PowerShell through the Windows shell with hidden windows
+    - IT automation tools that chain through explorer.exe (uncommon)
+level: high


### PR DESCRIPTION
## Summary

Adds a process creation rule for PowerShell spawned by `explorer.exe` with hidden window flags and execution cradle indicators, consistent with HID injection payloads (Flipper Zero, Rubber Ducky, O.MG Cable) that use WIN+R to open the Windows Run dialog and type a PowerShell command.

## Detection logic

- `Image` ends with `\powershell.exe` or `\pwsh.exe` (also matches on `OriginalFileName` to catch renames)
- `ParentImage` ends with `\explorer.exe` (Run dialog produces this parent)
- `CommandLine` contains `-WindowStyle Hidden` (both tokens required)
- `CommandLine` contains at least one execution cradle indicator: `-EncodedCommand`, `IEX`, `DownloadString`, `WebClient`, `Invoke-Expression`, `-ExecutionPolicy Bypass`, `Start-Process`, `-NoProfile`, `-NonInteractive`

Filter excludes parent processes with installer keywords in their command line to reduce false positives from software installers.

## Relationship to existing rules

`proc_creation_win_powershell_non_interactive_execution.yml` detects generic non-interactive PowerShell from GUI parents at low severity with many expected false positives. This rule is specific to the hidden window + execution cradle combination and is rated high.

## References

- https://github.com/descambiado/flipper-purple-team (payload + forensic breakdown)
- https://docs.flipper.net/bad-usb
- T1059.001, T1564.003, T1200