### PR TITLE
Add detection for NetExec credential dumping modules

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_hktl_netexec_cred_dump_modules.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_netexec_cred_dump_modules.yml
@@ -1,0 +1,39 @@
+title: HackTool - NetExec Credential Dumping Modules
+id: c4edc44d-031f-4ddd-bdc9-7f864bd59a99
+status: test
+description: |
+    Detects execution of NetExec (nxc.exe) with credential dumping modules and flags.
+    NetExec is a post-exploitation tool that includes modules for extracting credentials from LSASS memory (lsassy, nanodump, procdump modules), NTDS database (--ntds flag), SAM database (--sam flag), and LSA secrets (--lsa flag).
+    The --ntds flag and -M lsassy module were observed in an April 2026 intrusion attributed to The Gentlemen ransomware operation, as documented by The DFIR Report.
+    This rule detects both the observed modules and other documented NetExec credential dumping capabilities.
+references:
+    - https://thedfirreport.com/2026/05/11/flash-alert-etherrat-and-tuktuk-c2-end-in-the-gentleman-ransomware/
+    - https://www.netexec.wiki/smb-protocol/obtaining-credentials/dump-lsass
+    - https://github.com/Pennyw0rth/NetExec
+author: Hunter Wright
+date: 2026-05-21
+tags:
+    - attack.credential-access
+    - attack.t1003.001
+    - attack.t1003.002
+    - attack.t1003.003
+    - attack.t1003.004
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        Image|endswith: '\nxc.exe'
+    selection_cred_modules:
+        CommandLine|contains:
+            - ' --ntds'
+            - ' -M lsassy'
+            - ' --sam'
+            - ' --lsa'
+            - ' -M nanodump'
+            - ' -M procdump'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate penetration testing or red team exercises conducted by authorized security professionals (should be coordinated with security team and whitelisted by user account or source host)
+    - Security research activities in isolated lab environments
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

Adds detection for NetExec credential dumping modules observed in recent ransomware intrusions. Detects `nxc.exe` execution with credential dumping flags and modules such as `--ntds`, `-M lsassy`, `--sam`, and `--lsa`.

This rule complements the existing NetExec detection (`proc_creation_win_hktl_netexec.yml`) by focusing specifically on high risk credential access behavior rather than general protocol usage.

### Changelog

`new: HackTool - NetExec Credential Dumping Modules`

### Source Attribution

**Primary source:** The DFIR Report, "Flash Alert: EtherRat and TukTuk C2 End in The Gentleman Ransomware" (published May 11, 2026): https://thedfirreport.com/2026/05/11/flash-alert-etherrat-and-tuktuk-c2-end-in-the-gentleman-ransomware/

Commands observed in the April 2026 intrusion:

    nxc smb [IP] -u [USER] -p [PASSWORD] --ntds
    nxc smb [IP] -u [USER] -p [PASSWORD] -M lsassy
    nxc smb [IP] -u 1.txt -p 2.txt --no-bruteforce --continue-on-success

The rule also detects other documented NetExec credential dumping capabilities not observed in this specific intrusion but present in current NetExec versions: `--sam` (SAM database), `--lsa` (LSA secrets), `-M nanodump`, and `-M procdump`.

The `-M mimikatz` module was excluded because it is marked as deprecated in current NetExec documentation.

**Additional references:**
- https://www.netexec.wiki/smb-protocol/obtaining-credentials/dump-lsass
- https://github.com/Pennyw0rth/NetExec

### MITRE ATT&CK Mapping

- **T1003.001** – OS Credential Dumping: LSASS Memory (`-M lsassy`, `-M nanodump`, `-M procdump`)
- **T1003.002** – OS Credential Dumping: Security Account Manager (`--sam`)
- **T1003.003** – OS Credential Dumping: NTDS (`--ntds`)
- **T1003.004** – OS Credential Dumping: LSA Secrets (`--lsa`)

### False Positives

Potential false positives include authorized penetration testing, red team exercises, and security research in lab environments. These should be whitelisted by user account or source host.

False positives are expected to be rare because NetExec is an offensive security tool not used in standard IT operations, and the specific credential dumping modules have no legitimate administrative use case outside authorized security testing.

### Testing

Local validation with `sigma check` returned 0 errors, 0 condition errors, and 0 issues.

Backend conversions were tested successfully:

**Splunk (Windows pipeline):**

    Image="*\\nxc.exe"
    CommandLine IN ("* --ntds*", "* -M lsassy*", "* --sam*", "* --lsa*", "* -M nanodump*", "* -M procdump*")

**Elasticsearch EQL (ECS Windows):**

    any where process.executable : "*\\nxc.exe"
      and process.command_line like~ ("* --ntds*", "* -M lsassy*", "* --sam*", "* --lsa*", "* -M nanodump*", "* -M procdump*")

### Relationship to Existing Rules

This rule complements `proc_creation_win_hktl_netexec.yml` (ID: `7638e5fe-600c-4289-a968-f49dd537ec7d`) rather than replacing it. The existing rule detects NetExec protocol usage (SMB, RDP, FTP, etc.) and maps to Discovery (T1018) and Lateral Movement (T1021). This new rule focuses specifically on credential dumping operations and maps to Credential Access (T1003.001–004).

SOCs can tune the two rules independently for example, whitelisting authorized penetration testing NetExec usage while always alerting on credential dumping.

### Example Log Event

N/A – new rule based on threat intelligence.

### Fixed Issues

N/A – new detection.