### PR TITLE
new: Potential GeoServer CVE-2024-36401 OGC Filter Evaluation Exploitation Attempt

### DIFF
--- a/rules-emerging-threats/2024/Exploits/CVE-2024-36401/web_cve_2024_36401_geoserver_ogc_filter_evaluation.yml
+++ b/rules-emerging-threats/2024/Exploits/CVE-2024-36401/web_cve_2024_36401_geoserver_ogc_filter_evaluation.yml
@@ -1,0 +1,42 @@
+title: Potential GeoServer CVE-2024-36401 OGC Filter Evaluation Exploitation Attempt
+id: ebc6bb82-4efc-43dd-b8ed-92ec9465fadb
+status: experimental
+description: |
+    Detects potential exploitation attempts of CVE-2024-36401, an unauthenticated
+    remote code execution vulnerability in GeoServer. The flaw is caused by unsafe
+    evaluation of OGC API property names as JXPath expressions in WFS, WMS, WPS and
+    WCS requests, allowing attackers to execute arbitrary Java code via parameters
+    such as propertyName, valueReference, or sortBy.
+references:
+    - https://nvd.nist.gov/vuln/detail/CVE-2024-36401
+    - https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv
+    - https://github.com/vulhub/vulhub/tree/master/geoserver/CVE-2024-36401
+author: Colorful White (GDUT)
+date: 2026-05-27
+tags:
+    - attack.initial-access
+    - attack.t1190
+    - cve.2024-36401
+    - detection.emerging-threats
+logsource:
+    category: webserver
+detection:
+    selection_endpoint:
+        cs-uri-stem|contains: '/geoserver/'
+    selection_ogc_param:
+        cs-uri-query|contains:
+            - 'propertyName='
+            - 'valueReference='
+            - 'sortBy='
+    selection_payload:
+        cs-uri-query|contains:
+            - 'exec(java.lang'
+            - 'Runtime.getRuntime'
+            - 'getRuntime()'
+            - 'ProcessBuilder'
+            - 'java.lang.Runtime'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate WFS/WMS clients submitting complex XPath expressions referencing
+      Java classes (extremely uncommon in production deployments)
+level: high


### PR DESCRIPTION
### Summary of the Pull Request
  
  Adds an emerging-threats detection rule for **CVE-2024-36401**, an unauthenticated
  remote code execution in GeoServer caused by unsafe evaluation of OGC API property
  names as JXPath expressions. The rule fires when a request hits a `/geoserver/`
  endpoint **and** carries one of the vulnerable OGC parameters (`propertyName=`,
  `valueReference=`, `sortBy=`) **and** that parameter value contains a Java
  expression payload (`exec(java.lang`, `Runtime.getRuntime`, `ProcessBuilder`,
  etc.). All three conditions must match, which keeps false positives low while
  still catching the publicly documented exploit shapes.
  
  Validated locally with `python tests/test_logsource.py` (3 tests, OK) and
  `python tests/test_rules.py` (11 tests, OK). Detection logic was sanity-checked
  against the [vulhub reproduction container](https://github.com/vulhub/vulhub/tree/master/geoserver/CVE-2024-36401).
  
  ### Changelog
  
  new: Potential GeoServer CVE-2024-36401 OGC Filter Evaluation Exploitation Attempt
  
  ### Example Log Event
  
  <!--
  Fill this in case of false positive fixes
  -->
  
  ### Fixed Issues
  
  <!--
  Link the fixed issues here, in case your commit fixes issues with rules or code
  -->
  
  ### SigmaHQ Rule Creation Conventions
  
  - If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
  
  ---
