### PR TITLE
Add detection for Hyper-V VM forced shutdown (ransomware preparation)

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_hyperv_vm_forced_shutdown.yml
+++ b/rules/windows/process_creation/proc_creation_win_hyperv_vm_forced_shutdown.yml
@@ -1,0 +1,47 @@
+title: Hyper-V Virtual Machine Forced Shutdown
+id: a18c0b6c-456a-4c0e-a1b8-9c8e0d5f4e3a
+status: test
+description: |
+    Detects forced shutdown of Hyper-V virtual machines via PowerShell Stop-VM cmdlet.
+    Ransomware operators commonly shut down VMs before encryption to release file locks
+    on VHDX files, enabling successful encryption. This technique was observed in Kyber
+    ransomware (Rapid7, 2026) and other campaigns targeting virtualized environments.
+    The rule focuses on forced shutdown operations (-Force, -TurnOff) and bulk VM
+    shutdown patterns (Get-VM combined with Stop-VM) which are strong indicators of
+    malicious intent.
+    Note: This rule intentionally does not detect Stop-VM -Save (graceful shutdown with
+    state save) to reduce false positives from legitimate VM maintenance. Ransomware
+    typically uses -Force or -TurnOff for immediate impact.
+references:
+    - https://www.rapid7.com/blog/post/tr-kyber-ransomware-double-trouble-windows-esxi-attacks-explained/
+    - https://learn.microsoft.com/en-us/powershell/module/hyper-v/stop-vm
+author: Hunter Wright
+date: 2026-05-29
+tags:
+    - attack.impact
+    - attack.t1489
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        Image|endswith:
+            - '\powershell.exe'
+            - '\pwsh.exe'
+    selection_cmdlet:
+        CommandLine|contains: 'Stop-VM'
+    selection_force:
+        CommandLine|contains:
+            - '-Force'
+            - '-TurnOff'
+    selection_bulk:
+        CommandLine|contains|all:
+            - 'Get-VM'
+            - 'Stop-VM'
+    condition: selection_img and selection_cmdlet and (selection_force or selection_bulk)
+falsepositives:
+    - Legitimate Hyper-V administration and maintenance activities
+    - Automated VM lifecycle management scripts
+    - Disaster recovery testing and failover procedures
+    - Hyper-V Replica planned failover operations
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

Detects forced shutdown of Hyper-V virtual machines via the PowerShell `Stop-VM` cmdlet. Ransomware operators commonly shut down VMs before encryption to release file locks on VHDX files, enabling successful encryption of the virtual disk.

Per Rapid7's analysis of Kyber ransomware: "Each VM is terminated with a hard stop (-TurnOff) which forces an abrupt shutdown, releasing file locks so the malware can encrypt."

**Detection Logic:**
- Forced shutdown flags: `-Force` or `-TurnOff` parameters
- Bulk VM shutdown: `Get-VM | Stop-VM` patterns

The `-Save` flag was intentionally excluded to reduce false positives, as it is more commonly used in legitimate VM maintenance than in ransomware operations (which use immediate hard stops to release file locks quickly).

### Relationship to Existing Rules

SigmaHQ has an existing Hyper-V cmdlet rule (`posh_ps_susp_hyper_v_condlet.yml`) that detects VM creation for evasion (T1564.006) via Script Block Logging.

This rule complements that detection in three ways:
- **Different log source**: `process_creation` instead of `ps_script`, so it works in environments without Script Block Logging enabled (a common visibility gap)
- **Different attacker objective**: T1489 (service stop for impact) instead of T1564.006 (defense evasion)
- **Different attack phase**: pre-encryption ransomware preparation instead of initial-access evasion

### False Positives

Hyper-V administrators using `-Force` to terminate unresponsive VMs (when integration services fail to respond to graceful shutdown) may trigger this rule. Recommended mitigations: whitelist Hyper-V admin accounts, exclude scheduled maintenance windows, or correlate with subsequent encryption activity for higher confidence.

### References

- https://www.rapid7.com/blog/post/tr-kyber-ransomware-double-trouble-windows-esxi-attacks-explained/
- https://learn.microsoft.com/en-us/powershell/module/hyper-v/stop-vm

### Changelog

`new: Hyper-V Virtual Machine Forced Shutdown`

### Example Log Event

N/A – new detection rule based on threat intelligence.

### Fixed Issues

N/A – new detection.

### Testing

Validated with sigma-cli:

**Syntax Check:**

```
=== Summary ===
Found 0 errors, 0 condition errors and 0 issues.
```

**Backend Conversions:**

Splunk (pipeline: `splunk_windows`):

```
Image IN ("*\\powershell.exe", "*\\pwsh.exe") CommandLine="*Stop-VM*" CommandLine IN ("*-Force*", "*-TurnOff*") OR (CommandLine="*Get-VM*" CommandLine="*Stop-VM*")
```

Elasticsearch EQL (pipeline: `ecs_windows`):

```
any where (process.executable like~ ("*\\powershell.exe", "*\\pwsh.exe")) and process.command_line:"*Stop-VM*" and ((process.command_line like~ ("*-Force*", "*-TurnOff*")) or (process.command_line:"*Get-VM*" and process.command_line:"*Stop-VM*"))
```