### PR TITLE
Add HackTool - Gogo Scanner Execution Rule

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_hktl_gogo_scanner.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_gogo_scanner.yml
@@ -1,0 +1,46 @@
+title: HackTool - Gogo Scanner Execution
+id: 02b1996d-2f4b-4f4e-bb6f-ceeb05024bd6
+status: experimental
+description: |
+    Detects execution of "gogo" (chainreactors/gogo), a high-performance open-source automated scanning engine designed for red teams.
+    The tool uses distinctive Gogo-specific port-preset tags (e.g. "top1", "top2", "top3", "win", "db", "docker", "oracle") with the "-p" flag, supersmart scan modes ("-m ss", "-m sc"), and config-listing commands ("-P port", "-P workflow").
+    Cisco Talos documented its use by the China-nexus APT group UAT-8302 in their May 2026 report, where the operators downloaded "gogo_windows_amd64.exe" from the official GitHub releases and used it for internal network reconnaissance.
+references:
+    - https://github.com/chainreactors/gogo
+    - https://blog.talosintelligence.com/uat-8302/
+    - https://chainreactors.github.io/wiki/gogo/
+author: Aryu-RU
+date: 2026-05-30
+tags:
+    - attack.discovery
+    - attack.t1046
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith:
+            - '\gogo.exe'
+            - '\gogo_windows_amd64.exe'
+            - '\gogo_windows_386.exe'
+        CommandLine|contains:
+            # Gogo-specific port preset tags (used with the -p flag)
+            - ' -p top1'
+            - ' -p top2'
+            - ' -p top3'
+            - ' -p win'
+            - ' -p db'
+            - ' -p docker'
+            - ' -p oracle'
+            - ' -p dubbo'
+            - ' -p lotus'
+            # Gogo "supersmart" / "smartC" scan modes
+            - ' -m ss'
+            - ' -m sc'
+            # Gogo config-listing commands
+            - ' -P port'
+            - ' -P workflow'
+    condition: selection
+falsepositives:
+    - Legitimate use of gogo by security professionals or system administrators for authorized network assessment.
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

Adds a new `process_creation` rule detecting execution of **gogo** (`chainreactors/gogo`), an
open-source automated network scanning engine designed for red teams.

**Coverage gap:** gogo currently has no detection coverage anywhere in the Sigma ruleset (verified by
grepping the repo for `gogo`, `chainreactors`, and `gogo_windows` — zero matches). The existing
per-tool scanner rules (`proc_creation_win_pua_netscan.yml`, `proc_creation_win_pua_nmap_zenmap.yml`,
`proc_creation_win_pua_nimscan.yml`, `proc_creation_win_pua_advanced_port_scanner.yml`,
`proc_creation_win_pua_advanced_ip_scanner.yml`) cover other tools and would not fire on gogo, and
there is no generic "port-scanner" rule that would catch gogo's CLI behavior.

The rule mirrors the structure of the recently-merged `HackTool - NetExec Execution`
(`proc_creation_win_hktl_netexec.yml`): it anchors on the gogo binary name combined with
distinctive gogo-specific CLI tokens — the project's named port-preset tags (`top1`/`top2`/`top3`,
`win`, `db`, `docker`, `oracle`, `dubbo`, `lotus`), `-m ss`/`-m sc` "supersmart" scan modes, and
`-P port`/`-P workflow` config-listing commands. These tokens are documented in the official
chainreactors/gogo README and are specific to gogo's CLI. Gogo binaries are Go-built and do not
expose a PE `OriginalFileName`, so Image-suffix is the correct anchor (operators frequently rename
the binary, which is a known limitation of this approach — matches the NetExec rule's tradeoff).

**In-the-wild reference:** Cisco Talos's May 2026 report on the China-nexus APT group **UAT-8302**
documents the operators downloading `gogo_windows_amd64.exe` from the official GitHub releases for
internal network reconnaissance.

Validated locally with `tests/test_rules.py`, `tests/test_logsource.py`, `yamllint`, and
`sigma check --validation-config tests/sigma_cli_conf.yml` (0 errors, 0 issues).

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow
-->

new: HackTool - Gogo Scanner Execution

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

_Not applicable — this PR adds a new detection rule, not a false-positive fix._

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

_None._

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
