### PR TITLE
Add 8 Windows detection rules covering persistence and credential access

### DIFF
--- a/rules/windows/builtin/security/win_security_kerberoasting_rc4_tgs.yml
+++ b/rules/windows/builtin/security/win_security_kerberoasting_rc4_tgs.yml
@@ -1,5 +1,10 @@
 title: Kerberoasting RC4 TGS Request For Non-Machine Account
 id: 947ea8e8-7f35-4711-ad6e-35becf8ac190
+related:
+- id: d04ae2b8-ad54-4de0-bd87-4bc1da66aa59
+  type: similar
+- id: 496a0e47-0a33-4dca-b009-9e6ca3591f39
+  type: similar
 status: experimental
 description: Detects Kerberos service ticket requests using RC4 encryption for non-machine service accounts. In AES-enabled
   environments, RC4 TGS requests can be a useful Kerberoasting signal.
@@ -18,12 +23,15 @@ detection:
   selection:
     EventID: 4769
     TicketEncryptionType: '0x17'
+    Status: '0x0'
   filter_machine:
     ServiceName|endswith: $
   filter_krbtgt:
     ServiceName|contains:
     - krbtgt
     - kadmin
+  filter_machine_requester:
+    TargetUserName|contains: $@
   condition: selection and not 1 of filter_*
 falsepositives:
 - Legacy applications or clients that only support RC4 Kerberos encryption

--- a/rules/windows/builtin/security/win_security_kerberoasting_rc4_tgs.yml
+++ b/rules/windows/builtin/security/win_security_kerberoasting_rc4_tgs.yml
@@ -1,0 +1,32 @@
+title: Kerberoasting RC4 TGS Request For Non-Machine Account
+id: 947ea8e8-7f35-4711-ad6e-35becf8ac190
+status: experimental
+description: Detects Kerberos service ticket requests using RC4 encryption for non-machine service accounts. In AES-enabled
+  environments, RC4 TGS requests can be a useful Kerberoasting signal.
+references:
+- https://attack.mitre.org/techniques/T1558/003/
+- https://adsecurity.org/?p=3458
+author: David Sarkisyan
+date: 2026/05/31
+tags:
+- attack.credential-access
+- attack.t1558.003
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4769
+    TicketEncryptionType: '0x17'
+  filter_machine:
+    ServiceName|endswith: $
+  filter_krbtgt:
+    ServiceName|contains:
+    - krbtgt
+    - kadmin
+  condition: selection and not 1 of filter_*
+falsepositives:
+- Legacy applications or clients that only support RC4 Kerberos encryption
+- Service accounts intentionally configured for RC4 compatibility
+- Mixed-domain environments during encryption hardening projects
+level: high

--- a/rules/windows/builtin/security/win_security_smb_admin_share_access_workstation.yml
+++ b/rules/windows/builtin/security/win_security_smb_admin_share_access_workstation.yml
@@ -1,0 +1,34 @@
+title: SMB Admin Share Access From Remote Host
+id: 8703d261-3b23-46bc-a85b-3f5fde5823b0
+status: experimental
+description: Detects access to administrative SMB shares such as ADMIN$ and drive-letter shares via Windows Security EventID
+  5140. This can indicate lateral movement when initiated from unexpected workstations or non-administrative accounts.
+references:
+- https://attack.mitre.org/techniques/T1021/002/
+author: David Sarkisyan
+date: 2026/05/31
+tags:
+- attack.lateral-movement
+- attack.t1021.002
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 5140
+    ShareName|contains:
+    - \ADMIN$
+    - \C$
+    - \D$
+    - \E$
+  filter_localhost:
+    IpAddress:
+    - 127.0.0.1
+    - ::1
+    - '-'
+  condition: selection and not filter_localhost
+falsepositives:
+- Administrators performing legitimate remote administration
+- Backup, patching, or software deployment tools using administrative shares
+- Vulnerability scanners or inventory systems collecting remote file metadata
+level: medium

--- a/rules/windows/builtin/security/win_security_smb_admin_share_access_workstation.yml
+++ b/rules/windows/builtin/security/win_security_smb_admin_share_access_workstation.yml
@@ -1,8 +1,13 @@
 title: SMB Admin Share Access From Remote Host
 id: 8703d261-3b23-46bc-a85b-3f5fde5823b0
+related:
+- id: 098d7118-55bc-4912-a836-dc6483a8d150
+  type: similar
+- id: b210394c-ba12-4f89-9117-44a2464b9511
+  type: similar
 status: experimental
-description: Detects access to administrative SMB shares such as ADMIN$ and drive-letter shares via Windows Security EventID
-  5140. This can indicate lateral movement when initiated from unexpected workstations or non-administrative accounts.
+description: Detects remote access to drive-letter administrative SMB shares via Windows Security EventID 5140 from non-machine
+  accounts. This complements existing ADMIN$ and file-creation coverage by focusing on C$, D$, and E$ share access.
 references:
 - https://attack.mitre.org/techniques/T1021/002/
 author: David Sarkisyan
@@ -16,8 +21,7 @@ logsource:
 detection:
   selection:
     EventID: 5140
-    ShareName|contains:
-    - \ADMIN$
+    ShareName|endswith:
     - \C$
     - \D$
     - \E$
@@ -26,7 +30,9 @@ detection:
     - 127.0.0.1
     - ::1
     - '-'
-  condition: selection and not filter_localhost
+  filter_machine_account:
+    SubjectUserName|endswith: $
+  condition: selection and not 1 of filter_*
 falsepositives:
 - Administrators performing legitimate remote administration
 - Backup, patching, or software deployment tools using administrative shares

--- a/rules/windows/builtin/system/microsoft_windows_eventlog/win_event_log_cleared_security_system.yml
+++ b/rules/windows/builtin/system/microsoft_windows_eventlog/win_event_log_cleared_security_system.yml
@@ -1,0 +1,27 @@
+title: Security Or System Event Log Cleared
+id: 66afe85e-6b57-415c-9b10-7f409884d83e
+status: experimental
+description: Detects clearing of the Windows Security or System event logs. Log clearing is often used to hide attacker activity
+  and should be rare outside administrator maintenance.
+references:
+- https://attack.mitre.org/techniques/T1070/001/
+author: David Sarkisyan
+date: 2026/05/31
+tags:
+- attack.defense-impairment
+- attack.t1685.005
+logsource:
+  product: windows
+detection:
+  selection_security:
+    EventID: 1102
+    Channel: Security
+  selection_system:
+    EventID: 104
+    Channel: System
+  condition: 1 of selection_*
+falsepositives:
+- Administrator troubleshooting or log maintenance
+- Automated log rotation workflows in lab or kiosk systems
+- System image preparation or reset procedures
+level: high

--- a/rules/windows/builtin/system/microsoft_windows_eventlog/win_event_log_cleared_security_system.yml
+++ b/rules/windows/builtin/system/microsoft_windows_eventlog/win_event_log_cleared_security_system.yml
@@ -1,5 +1,12 @@
 title: Security Or System Event Log Cleared
 id: 66afe85e-6b57-415c-9b10-7f409884d83e
+related:
+- id: 100ef69e-3327-481c-8e5c-6d80d9507556
+  type: similar
+- id: a62b37e0-45d3-48d9-a517-90c1a1b0186b
+  type: similar
+- id: d99b79d2-0a6f-4f46-ad8b-260b6e17f982
+  type: similar
 status: experimental
 description: Detects clearing of the Windows Security or System event logs. Log clearing is often used to hide attacker activity
   and should be rare outside administrator maintenance.

--- a/rules/windows/process_access/proc_access_win_lsass_dump_access_mask.yml
+++ b/rules/windows/process_access/proc_access_win_lsass_dump_access_mask.yml
@@ -1,8 +1,14 @@
 title: LSASS Access With Credential Dumping Access Mask
 id: df322158-d0e9-4c6a-beb0-932efd0570ce
+related:
+- id: a18dd26b-6450-46de-8c91-9659150cf088
+  type: similar
+- id: 5ef9853e-4d0e-4a70-846f-a9ca37d876da
+  type: similar
 status: experimental
-description: Detects process access to lsass.exe using access masks commonly associated with credential dumping tools. Known
-  security and troubleshooting tools are filtered to keep the signal focused.
+description: Detects process access to lsass.exe using access masks commonly associated with credential dumping tools when
+  the accessing process is running from a user-writable or temporary location. This complements broad LSASS access-mask rules
+  by focusing on suspicious source image paths.
 references:
 - https://attack.mitre.org/techniques/T1003/001/
 author: David Sarkisyan
@@ -36,9 +42,16 @@ detection:
     - \procmon.exe
     - \procmon64.exe
     - \taskmgr.exe
+  selection_source_path:
+    SourceImage|contains:
+    - \AppData\
+    - \Users\Public\
+    - \Windows\Temp\
+    - \Temp\
+    - \ProgramData\
   condition: all of selection_* and not 1 of filter_*
 falsepositives:
-- Unlisted EDR or antivirus products inspecting LSASS
-- Administrator troubleshooting with Sysinternals tools not covered by filters
-- Memory diagnostics or crash collection tools
+- Portable administrator troubleshooting tools launched from temporary folders
+- Security products using temporary updater or helper binaries
+- Incident response tooling intentionally staged under ProgramData or Public
 level: high

--- a/rules/windows/process_access/proc_access_win_lsass_dump_access_mask.yml
+++ b/rules/windows/process_access/proc_access_win_lsass_dump_access_mask.yml
@@ -1,0 +1,44 @@
+title: LSASS Access With Credential Dumping Access Mask
+id: df322158-d0e9-4c6a-beb0-932efd0570ce
+status: experimental
+description: Detects process access to lsass.exe using access masks commonly associated with credential dumping tools. Known
+  security and troubleshooting tools are filtered to keep the signal focused.
+references:
+- https://attack.mitre.org/techniques/T1003/001/
+author: David Sarkisyan
+date: 2026/05/31
+tags:
+- attack.credential-access
+- attack.t1003.001
+logsource:
+  product: windows
+  category: process_access
+detection:
+  selection_target:
+    TargetImage|endswith: \lsass.exe
+  selection_access:
+    GrantedAccess:
+    - '0x1010'
+    - '0x1410'
+    - '0x10b0'
+    - '0x1fffff'
+    - '0x1f3fff'
+    - '0x143a'
+  filter_security_tools:
+    SourceImage|endswith:
+    - \MsMpEng.exe
+    - \SenseIR.exe
+    - \csagent.exe
+    - \CylanceSvc.exe
+    - \mbam.exe
+    - \procexp.exe
+    - \procexp64.exe
+    - \procmon.exe
+    - \procmon64.exe
+    - \taskmgr.exe
+  condition: all of selection_* and not 1 of filter_*
+falsepositives:
+- Unlisted EDR or antivirus products inspecting LSASS
+- Administrator troubleshooting with Sysinternals tools not covered by filters
+- Memory diagnostics or crash collection tools
+level: high

--- a/rules/windows/process_creation/proc_creation_win_certutil_remote_download.yml
+++ b/rules/windows/process_creation/proc_creation_win_certutil_remote_download.yml
@@ -1,8 +1,12 @@
 title: Certutil Remote Download Or Decode Activity
 id: cf8a3723-adf8-4076-8268-55589b5256c4
+related:
+- id: 19b08b1c-861d-4e75-a1ef-ea0c1baf202b
+  type: similar
 status: experimental
-description: Detects certutil.exe used with URL cache, split, decode, or encode options and remote URL indicators. Attackers
-  abuse certutil to download or transform payloads using a trusted Windows binary.
+description: Detects certutil.exe used with remote URL indicators and download or decode options where the command line also
+  references a user-writable or temporary path. This complements broader certutil download rules by focusing on suspicious
+  payload staging locations.
 references:
 - https://attack.mitre.org/techniques/T1105/
 - https://attack.mitre.org/techniques/T1218/003/
@@ -17,7 +21,8 @@ logsource:
   category: process_creation
 detection:
   selection_img:
-    Image|endswith: \certutil.exe
+  - Image|endswith: \certutil.exe
+  - OriginalFileName: CertUtil.exe
   selection_remote:
     CommandLine|contains:
     - http://
@@ -36,9 +41,18 @@ detection:
     - download.microsoft.com
     - ctldl.windowsupdate.com
     - www.microsoft.com/pki
-  condition: selection_img and selection_remote and selection_args and not filter_ms_domains
+  selection_susp_path:
+    CommandLine|contains:
+    - \AppData\
+    - \Users\Public\
+    - \Windows\Temp\
+    - \Temp\
+    - \ProgramData\
+    - '%TEMP%'
+    - '%APPDATA%'
+  condition: all of selection_* and not filter_ms_domains
 falsepositives:
-- Certificate troubleshooting that downloads CRLs or CA files from non-Microsoft locations
-- Administrative scripts using certutil to retrieve internal PKI artifacts
+- Certificate troubleshooting that stages files in temporary locations
+- Administrative scripts using certutil to retrieve internal PKI artifacts into ProgramData
 - Security testing in controlled environments
 level: high

--- a/rules/windows/process_creation/proc_creation_win_certutil_remote_download.yml
+++ b/rules/windows/process_creation/proc_creation_win_certutil_remote_download.yml
@@ -1,0 +1,44 @@
+title: Certutil Remote Download Or Decode Activity
+id: cf8a3723-adf8-4076-8268-55589b5256c4
+status: experimental
+description: Detects certutil.exe used with URL cache, split, decode, or encode options and remote URL indicators. Attackers
+  abuse certutil to download or transform payloads using a trusted Windows binary.
+references:
+- https://attack.mitre.org/techniques/T1105/
+- https://attack.mitre.org/techniques/T1218/003/
+author: David Sarkisyan
+date: 2026/05/31
+tags:
+- attack.command-and-control
+- attack.t1105
+- attack.t1218.003
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection_img:
+    Image|endswith: \certutil.exe
+  selection_remote:
+    CommandLine|contains:
+    - http://
+    - https://
+    - ftp://
+  selection_args:
+    CommandLine|contains:
+    - -urlcache
+    - -split
+    - -f
+    - -decode
+    - -decodehex
+    - -encode
+  filter_ms_domains:
+    CommandLine|contains:
+    - download.microsoft.com
+    - ctldl.windowsupdate.com
+    - www.microsoft.com/pki
+  condition: selection_img and selection_remote and selection_args and not filter_ms_domains
+falsepositives:
+- Certificate troubleshooting that downloads CRLs or CA files from non-Microsoft locations
+- Administrative scripts using certutil to retrieve internal PKI artifacts
+- Security testing in controlled environments
+level: high

--- a/rules/windows/process_creation/proc_creation_win_powershell_susp_encoded_long.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_susp_encoded_long.yml
@@ -1,8 +1,11 @@
 title: PowerShell Suspicious Long Encoded Command
 id: d142c406-7870-4c22-bb3e-d51f23d01005
+related:
+- id: fb843269-508c-4b76-8b8d-88679db22ce7
+  type: similar
 status: experimental
-description: Detects PowerShell execution with encoded command flags and suspicious execution context. This complements broad
-  encoded-command detections by requiring suspicious parents or common web-delivery strings.
+description: Detects PowerShell execution with encoded command flags from suspicious parent processes or with command-line
+  web delivery indicators. This complements broad encoded-command detections by adding parent-process context.
 references:
 - https://attack.mitre.org/techniques/T1059/001/
 author: David Sarkisyan
@@ -15,9 +18,12 @@ logsource:
   category: process_creation
 detection:
   selection_img:
-    Image|endswith:
+  - Image|endswith:
     - \powershell.exe
     - \pwsh.exe
+  - OriginalFileName:
+    - PowerShell.EXE
+    - pwsh.dll
   selection_encoded:
     CommandLine|contains:
     - ' -enc '

--- a/rules/windows/process_creation/proc_creation_win_powershell_susp_encoded_long.yml
+++ b/rules/windows/process_creation/proc_creation_win_powershell_susp_encoded_long.yml
@@ -1,0 +1,57 @@
+title: PowerShell Suspicious Long Encoded Command
+id: d142c406-7870-4c22-bb3e-d51f23d01005
+status: experimental
+description: Detects PowerShell execution with encoded command flags and suspicious execution context. This complements broad
+  encoded-command detections by requiring suspicious parents or common web-delivery strings.
+references:
+- https://attack.mitre.org/techniques/T1059/001/
+author: David Sarkisyan
+date: 2026/05/31
+tags:
+- attack.execution
+- attack.t1059.001
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection_img:
+    Image|endswith:
+    - \powershell.exe
+    - \pwsh.exe
+  selection_encoded:
+    CommandLine|contains:
+    - ' -enc '
+    - ' -encodedcommand '
+    - ' /enc '
+    - ' /encodedcommand '
+    - '-e '
+  selection_susp_context:
+    CommandLine|contains:
+    - FromBase64String
+    - DownloadString
+    - IEX
+    - Invoke-Expression
+    - http://
+    - https://
+  selection_susp_parent:
+    ParentImage|endswith:
+    - \winword.exe
+    - \excel.exe
+    - \powerpnt.exe
+    - \outlook.exe
+    - \wscript.exe
+    - \cscript.exe
+    - \mshta.exe
+    - \rundll32.exe
+    - \regsvr32.exe
+  filter_automation_parent:
+    ParentImage|endswith:
+    - \ccmexec.exe
+    - \Microsoft.Management.Services.IntuneWindowsAgent.exe
+    - \AzureConnectedMachineAgent.exe
+  condition: selection_img and selection_encoded and (selection_susp_context or selection_susp_parent) and not filter_automation_parent
+falsepositives:
+- Enterprise deployment scripts that use encoded PowerShell with suspicious-looking strings
+- Helpdesk tooling that launches PowerShell from management agents
+- Security testing frameworks in approved labs
+level: high

--- a/rules/windows/process_creation/proc_creation_win_schtasks_create_non_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_create_non_system.yml
@@ -1,0 +1,51 @@
+title: Scheduled Task Creation By Non-System Process
+id: 1a971e10-acef-4350-bbcd-a8b3e00f7df9
+status: experimental
+description: Detects scheduled task creation via schtasks.exe from non-system and non-service parents. This focuses on user-context
+  task creation, which is commonly used for persistence and privilege escalation after initial execution.
+references:
+- https://attack.mitre.org/techniques/T1053/005/
+author: David Sarkisyan
+date: 2026/05/31
+tags:
+- attack.persistence
+- attack.privilege-escalation
+- attack.t1053.005
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection_img:
+    Image|endswith: \schtasks.exe
+  selection_create:
+    CommandLine|contains:
+    - /create
+    - -create
+  selection_susp_path:
+    CommandLine|contains:
+    - \AppData\\
+    - \Temp\\
+    - \Users\\Public\\
+    - \ProgramData\\
+    - '%TEMP%'
+    - '%APPDATA%'
+    - http://
+    - https://
+  filter_system_user:
+    User|contains:
+    - SYSTEM
+    - LOCAL SERVICE
+    - NETWORK SERVICE
+    - TrustedInstaller
+  filter_service_parent:
+    ParentImage|endswith:
+    - \services.exe
+    - \svchost.exe
+    - \taskhostw.exe
+    - \taskeng.exe
+  condition: all of selection_* and not 1 of filter_*
+falsepositives:
+- Legitimate software installers creating per-user scheduled maintenance tasks
+- Administrator scripts deploying scheduled jobs from user-writable paths
+- Endpoint management agents running task creation from a user context
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_schtasks_create_non_system.yml
+++ b/rules/windows/process_creation/proc_creation_win_schtasks_create_non_system.yml
@@ -1,5 +1,8 @@
 title: Scheduled Task Creation By Non-System Process
 id: 1a971e10-acef-4350-bbcd-a8b3e00f7df9
+related:
+- id: 92626ddd-662c-49e3-ac59-f6535f12d189
+  type: similar
 status: experimental
 description: Detects scheduled task creation via schtasks.exe from non-system and non-service parents. This focuses on user-context
   task creation, which is commonly used for persistence and privilege escalation after initial execution.
@@ -16,17 +19,18 @@ logsource:
   category: process_creation
 detection:
   selection_img:
-    Image|endswith: \schtasks.exe
+  - Image|endswith: \schtasks.exe
+  - OriginalFileName: schtasks.exe
   selection_create:
     CommandLine|contains:
     - /create
     - -create
   selection_susp_path:
     CommandLine|contains:
-    - \AppData\\
-    - \Temp\\
-    - \Users\\Public\\
-    - \ProgramData\\
+    - \AppData\
+    - \Temp\
+    - \Users\Public\
+    - \ProgramData\
     - '%TEMP%'
     - '%APPDATA%'
     - http://

--- a/rules/windows/registry/registry_set/registry_set_run_key_susp_parent.yml
+++ b/rules/windows/registry/registry_set/registry_set_run_key_susp_parent.yml
@@ -1,5 +1,10 @@
 title: Run Key Persistence Added By Suspicious Process
 id: 90b04fdf-7d2b-4545-b066-5de3bea5b7d9
+related:
+- id: 97a2aa09-98d6-4f3c-847d-383a7df5f0e1
+  type: similar
+- id: 9bf63a8f-6c5f-4f62-8a8b-4d3dfcdf7f5d
+  type: similar
 status: experimental
 description: Detects Run or RunOnce registry persistence written by scripting engines, LOLBins, command shells, or Office
   applications. This is narrower than broad Run key monitoring and focuses on suspicious initiating processes.

--- a/rules/windows/registry/registry_set/registry_set_run_key_susp_parent.yml
+++ b/rules/windows/registry/registry_set/registry_set_run_key_susp_parent.yml
@@ -1,0 +1,41 @@
+title: Run Key Persistence Added By Suspicious Process
+id: 90b04fdf-7d2b-4545-b066-5de3bea5b7d9
+status: experimental
+description: Detects Run or RunOnce registry persistence written by scripting engines, LOLBins, command shells, or Office
+  applications. This is narrower than broad Run key monitoring and focuses on suspicious initiating processes.
+references:
+- https://attack.mitre.org/techniques/T1547/001/
+author: David Sarkisyan
+date: 2026/05/31
+tags:
+- attack.persistence
+- attack.t1547.001
+logsource:
+  product: windows
+  category: registry_set
+detection:
+  selection_key:
+    TargetObject|contains:
+    - \Software\Microsoft\Windows\CurrentVersion\Run
+    - \Software\Microsoft\Windows\CurrentVersion\RunOnce
+  selection_initiator:
+    Image|endswith:
+    - \powershell.exe
+    - \pwsh.exe
+    - \wscript.exe
+    - \cscript.exe
+    - \mshta.exe
+    - \rundll32.exe
+    - \regsvr32.exe
+    - \cmd.exe
+    - \certutil.exe
+    - \bitsadmin.exe
+    - \winword.exe
+    - \excel.exe
+    - \outlook.exe
+  condition: selection_key and selection_initiator
+falsepositives:
+- Legitimate installer wrappers that use cmd.exe or PowerShell
+- Enterprise software deployment scripts creating startup entries
+- User logon helpers deployed by corporate management tooling
+level: high


### PR DESCRIPTION
## Summary

Adds 8 Windows Sigma rules covering persistence, credential access, lateral movement, execution, defense impairment, and command-and-control / LOLBin activity.

After a second pass against existing upstream rules, this PR was tightened to reduce duplicate overlap: overlapping rules now include `related` metadata, broader detections were narrowed with source-path, parent-process, requester, or admin-share constraints, and process-creation rules include `OriginalFileName` alternatives where useful.

## Rules Added

| File | Technique | Differentiation |
|---|---|---|
| `proc_creation_win_schtasks_create_non_system.yml` | T1053.005 | Scheduled task creation via `schtasks.exe` from non-system context with suspicious path indicators |
| `registry_set_run_key_susp_parent.yml` | T1547.001 | Run/RunOnce key writes from scripting engines, LOLBins, command shells, or Office processes |
| `proc_access_win_lsass_dump_access_mask.yml` | T1003.001 | LSASS access with credential-dumping access masks from user-writable or temporary source paths |
| `win_security_kerberoasting_rc4_tgs.yml` | T1558.003 | Successful RC4 TGS requests for non-machine service accounts, with machine requester filtering |
| `win_security_smb_admin_share_access_workstation.yml` | T1021.002 | Remote C$/D$/E$ admin-share access from non-machine accounts, complementing existing ADMIN$ and file-write rules |
| `proc_creation_win_powershell_susp_encoded_long.yml` | T1059.001 | Encoded PowerShell with suspicious parent-process context or clear web-delivery indicators |
| `win_event_log_cleared_security_system.yml` | T1685.005 | Security/System event log clear coverage using current SigmaHQ ATT&CK tag convention; linked to existing similar rules |
| `proc_creation_win_certutil_remote_download.yml` | T1105 / T1218.003 | certutil remote URL + download/decode options plus user-writable/temp staging path indicators |

## Validation

- YAML syntax check passed for all 8 rules
- `sigma check` completed with 0 errors, 0 condition errors, and 0 validation issues for all 8 rules after refinements
- No filename conflicts found in the current upstream tree
- Rules placed into current SigmaHQ directory conventions

## Notes

The original local task referenced T1070.001 for event log clearing, but current SigmaHQ validation rejects `attack.t1070.001`. Existing upstream event-log-clear rules use `attack.defense-impairment` / `attack.t1685.005`, so this PR uses the current valid convention.

## Checklist

- [x] Fresh UUIDs
- [x] ATT&CK tags validated by sigma-cli
- [x] False positives documented
- [x] Related metadata added for overlapping upstream coverage
- [x] Rules marked experimental
- [x] YAML and Sigma validation passed
- [x] No filename conflicts found
- [ ] Tested against production event volume
