### PR TITLE
Add detection rules for CVE-2026-31431 (CopyFail)

### DIFF
--- a/rules-emerging-threats/2026/Exploits/CVE-2026-31431/lnx_auditd_exploit_cve_2026_31431_af_alg_socket.yml
+++ b/rules-emerging-threats/2026/Exploits/CVE-2026-31431/lnx_auditd_exploit_cve_2026_31431_af_alg_socket.yml
@@ -1,0 +1,54 @@
+title: AF_ALG Crypto Socket Creation Outside Disk-Encryption Toolchain - Potential CVE-2026-31431 Exploitation
+id: 9d4d2f2d-3a8e-4b91-b0c6-1f0a5a8b9c01
+status: experimental
+description: |
+    Detects creation of an AF_ALG (kernel userspace crypto API) socket by a process that is not part of the
+    well-known disk-encryption / kernel-crypto-API toolchain.
+    CVE-2026-31431 ("CopyFail") is a Linux kernel local privilege escalation in the algif_aead module that
+    requires the attacker to open an AF_ALG SEQPACKET socket as its first step. Outside of cryptsetup,
+    systemd-cryptsetup, veritysetup, integritysetup, fscrypt and the kcapi-* tooling, AF_ALG sockets are
+    rarely seen in production workloads, so a socket() with domain=AF_ALG (38, 0x26) from any other binary
+    is a strong precursor indicator.
+references:
+    - https://unit42.paloaltonetworks.com/cve-2026-31431-copy-fail/
+    - https://www.wiz.io/blog/copyfail-cve-2026-31431-linux-privilege-escalation-vulnerability
+    - https://www.sysdig.com/blog/cve-2026-31431-copy-fail-linux-kernel-flaw-lets-local-users-gain-root-in-seconds
+    - https://www.microsoft.com/en-us/security/blog/2026/05/01/cve-2026-31431-copy-fail-vulnerability-enables-linux-root-privilege-escalation/
+    - https://www.openwall.com/lists/oss-security/2026/04/29/23
+    - https://man7.org/linux/man-pages/man2/socket.2.html
+author: Tejas Nikam
+date: 2026-06-05
+tags:
+    - attack.privilege-escalation
+    - attack.t1068
+    - cve.2026-31431
+    - detection.emerging-threats
+logsource:
+    product: linux
+    service: auditd
+    definition: |
+        Required auditd configuration (AF_ALG socket family = 38 = 0x26):
+        -a always,exit -F arch=b64 -S socket -F a0=0x26 -k af_alg
+        -a always,exit -F arch=b32 -S socketcall -F a0=0x26 -k af_alg
+detection:
+    selection:
+        type: 'SYSCALL'
+        SYSCALL: 'socket'
+        a0: 26 # AF_ALG (38 decimal, 0x26 hex)
+    filter_main_crypto_tooling:
+        exe|endswith:
+            - '/cryptsetup'
+            - '/systemd-cryptsetup'
+            - '/veritysetup'
+            - '/integritysetup'
+            - '/fscrypt'
+            - '/e4crypt'
+            - '/kcapi-enc'
+            - '/kcapi-dgst'
+            - '/kcapi-rng'
+            - '/kcapi-sym'
+    condition: selection and not 1 of filter_main_*
+falsepositives:
+    - Custom applications that intentionally use the Linux kernel userspace crypto API (AF_ALG) for hardware-accelerated crypto - confirm the binary and tune the allowlist
+    - Container or VM images shipping additional disk-encryption or kernel-crypto helper binaries not listed in the allowlist
+level: medium

--- a/rules-emerging-threats/2026/Exploits/CVE-2026-31431/lnx_auditd_exploit_cve_2026_31431_algif_aead_module_load.yml
+++ b/rules-emerging-threats/2026/Exploits/CVE-2026-31431/lnx_auditd_exploit_cve_2026_31431_algif_aead_module_load.yml
@@ -1,0 +1,45 @@
+title: algif_aead Kernel Module Load - Potential CVE-2026-31431 Pre-Exploitation
+id: 8c70c8a2-1c7e-4e22-b3a5-9e0d2f4a6c12
+status: experimental
+description: |
+    Detects an explicit load of the algif_aead kernel module (the userspace AEAD crypto interface).
+    CVE-2026-31431 ("CopyFail") exploits a logic flaw in algif_aead to perform a controlled 4-byte
+    write into the page cache of any readable file, typically corrupting the in-memory copy of a
+    setuid binary such as /usr/bin/su to gain root.
+    The module is autoloaded on demand by AF_ALG socket creation, but is rarely needed on production
+    servers (it is typically only used by cryptsetup, fscrypt and a handful of kcapi-* tools), so an
+    explicit modprobe / insmod / kmod load of algif_aead by anything other than the disk-encryption
+    toolchain or a known config-management process tree is a strong precursor signal.
+references:
+    - https://unit42.paloaltonetworks.com/cve-2026-31431-copy-fail/
+    - https://www.wiz.io/blog/copyfail-cve-2026-31431-linux-privilege-escalation-vulnerability
+    - https://www.sysdig.com/blog/cve-2026-31431-copy-fail-linux-kernel-flaw-lets-local-users-gain-root-in-seconds
+    - https://www.secwest.net/copyfail-mitigation
+    - https://ubuntu.com/blog/copy-fail-vulnerability-fixes-available
+author: Tejas Nikam
+date: 2026-06-05
+tags:
+    - attack.privilege-escalation
+    - attack.t1068
+    - cve.2026-31431
+    - detection.emerging-threats
+logsource:
+    product: linux
+    service: auditd
+detection:
+    selection_modprobe:
+        type: 'EXECVE'
+        a0|endswith:
+            - 'modprobe'
+            - 'insmod'
+            - 'kmod'
+    selection_module_arg:
+        - a1|contains: 'algif_aead'
+        - a2|contains: 'algif_aead'
+        - a3|contains: 'algif_aead'
+    condition: selection_modprobe and selection_module_arg
+falsepositives:
+    - Initial boot of hosts running full-disk encryption (cryptsetup) - the module will be autoloaded but typically without an explicit modprobe in EXECVE
+    - Configuration management (Ansible, Puppet, Chef, cloud-init) loading kernel modules from a managed allowlist - filter on auid / parent process if needed
+    - Storage or backup tooling that ships its own kernel-crypto helpers
+level: medium

--- a/rules-emerging-threats/2026/Exploits/CVE-2026-31431/lnx_auditd_exploit_cve_2026_31431_splice_to_af_alg.yml
+++ b/rules-emerging-threats/2026/Exploits/CVE-2026-31431/lnx_auditd_exploit_cve_2026_31431_splice_to_af_alg.yml
@@ -1,0 +1,77 @@
+title: Splice Syscall Accessing Setuid Binary Path - Potential CVE-2026-31431 Exploitation
+id: 7a4f8b1d-2c9a-4f0e-9b27-6c1e3a5d8f23
+status: experimental
+description: |
+    Detects a splice() syscall paired with an auditd PATH record pointing at a privileged setuid binary
+    (su, sudo, mount, passwd, newgrp, chsh, chfn, gpasswd) by a non-root caller.
+    This is the late-stage signature of CVE-2026-31431 ("CopyFail") exploitation: after creating an
+    AF_ALG socket and triggering the algif_aead scatter/gather bug, the exploit uses splice() to drive
+    a 4-byte overwrite into the page cache backing a setuid binary. The on-disk file is never modified,
+    so file-integrity monitors that hash the file from disk will miss the compromise - splice() against
+    a privileged binary by an unprivileged process is the durable detection signal.
+    Verified against live auditd telemetry on Amazon Linux 2023: the splice() syscall emits a SYSCALL
+    record with no associated PATH record (items=0) because splice operates on file descriptors, while
+    the preceding open()/openat() that obtained the fd emits the PATH record on a separate audit message
+    with the same correlation ID. This rule therefore requires an ingest pipeline that joins PATH records
+    to their parent SYSCALL (auparse, auditbeat, Wazuh, falco) - see logsource.definition.
+references:
+    - https://unit42.paloaltonetworks.com/cve-2026-31431-copy-fail/
+    - https://www.sysdig.com/blog/cve-2026-31431-copy-fail-linux-kernel-flaw-lets-local-users-gain-root-in-seconds
+    - https://www.wiz.io/blog/copyfail-cve-2026-31431-linux-privilege-escalation-vulnerability
+    - https://xint.io/blog/copy-fail-linux-distributions
+    - https://man7.org/linux/man-pages/man2/splice.2.html
+author: Tejas Nikam
+date: 2026-06-05
+modified: 2026-06-08
+tags:
+    - attack.privilege-escalation
+    - attack.t1068
+    - cve.2026-31431
+    - detection.emerging-threats
+logsource:
+    product: linux
+    service: auditd
+    definition: |
+        Required auditd configuration:
+        -a always,exit -F arch=b64 -S splice -F auid!=0 -F auid!=-1 -k copyfail_splice
+        -a always,exit -F arch=b32 -S splice -F auid!=0 -F auid!=-1 -k copyfail_splice
+
+        Required ingest pipeline:
+        Linux audit emits the splice() SYSCALL record and the PATH record of the underlying file as
+        two separate audit messages joined only by their msg=audit(timestamp:serial) correlation ID
+        (the splice SYSCALL record itself has items=0 because splice operates on file descriptors).
+        This rule's selection_target_path matches the PATH record produced by the preceding
+        open()/openat() of the setuid binary; selection_syscall matches the splice() SYSCALL record.
+        Both must be joined for the condition to fire, which happens automatically in auparse,
+        Elastic auditbeat, Wazuh, and Falco's audit plugin. Raw line-by-line audit.log ingestion
+        will not match this rule - either route audit events through one of those tools, or use an
+        equivalent backend-side correlation by msg ID / pid.
+detection:
+    selection_syscall:
+        type: 'SYSCALL'
+        SYSCALL: 'splice'
+    selection_target_path:
+        type: 'PATH'
+        name:
+            - '/usr/bin/su'
+            - '/bin/su'
+            - '/usr/bin/sudo'
+            - '/bin/sudo'
+            - '/usr/bin/mount'
+            - '/bin/mount'
+            - '/usr/bin/umount'
+            - '/bin/umount'
+            - '/usr/bin/passwd'
+            - '/usr/bin/newgrp'
+            - '/usr/bin/chsh'
+            - '/usr/bin/chfn'
+            - '/usr/bin/gpasswd'
+            - '/usr/bin/pkexec'
+    filter_main_root_caller:
+        auid: 0
+    condition: selection_syscall and selection_target_path and not 1 of filter_main_*
+falsepositives:
+    - Backup, antivirus or file-integrity tooling that uses splice() to read privileged binaries - identify the binary via the exe field and tune
+    - Container runtimes copying setuid helpers during image build (uncommon outside of build hosts)
+    - Silent non-match (no alert at all) when the ingest pipeline does not stitch PATH records onto their parent SYSCALL record - see logsource.definition
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

Adds three high-fidelity auditd-based Sigma rules detecting exploitation of **CVE-2026-31431 ("CopyFail")** — a Linux kernel local privilege escalation in the `algif_aead` userspace crypto interface (AF_ALG socket family). The flaw allows an unprivileged caller to perform a controlled 4-byte write into the page cache of any readable file, typically corrupting the in-memory copy of a setuid binary such as `/usr/bin/su` to inherit root. It affects all mainstream distros shipping a stock kernel since 2017 (Ubuntu, RHEL, Debian, SUSE, AlmaLinux, Amazon Linux).

The three rules cover three independent points in the exploit chain so an analyst gets corroborating signals even if one stage is missed in the indexed window:

| File | Logsource | Stage | Level |
|---|---|---|---|
| `lnx_auditd_exploit_cve_2026_31431_af_alg_socket.yml` | linux/auditd | AF_ALG socket creation outside the cryptsetup/kcapi/fscrypt toolchain | medium |
| `lnx_auditd_exploit_cve_2026_31431_algif_aead_module_load.yml` | linux/auditd | Explicit `modprobe`/`insmod`/`kmod` load of `algif_aead` | medium |
| `lnx_auditd_exploit_cve_2026_31431_splice_to_af_alg.yml` | linux/auditd | `splice()` syscall paired with PATH record for a setuid binary, by `auid!=0` | high |

References used for each rule are embedded in the YAML and span Palo Alto Unit 42, Microsoft, Wiz, Sysdig, secwest.net, Xint, oss-security and the Ubuntu advisory.

Local validation passes for: `yamllint --strict`, `sigma check --fail-on-error --fail-on-issues` (pysigma + pySigma-validators-sigmahq 0.20), `tests/test_logsource.py`, `tests/test_rules.py`, and the duplicate-id grep.

### Changelog

new: AF_ALG Crypto Socket Creation Outside Disk-Encryption Toolchain - Potential CVE-2026-31431 Exploitation
new: algif_aead Kernel Module Load - Potential CVE-2026-31431 Pre-Exploitation
new: Splice Syscall Accessing Setuid Binary Path - Potential CVE-2026-31431 Exploitation

### Example Log Event

<!-- N/A — this PR adds new detections, not FP fixes. -->

### Fixed Issues

<!-- N/A -->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)