### PR TITLE
Add Jellyfin CVE-2026-35033 FFmpeg argument injection LFI detection

### DIFF
--- a/rules-emerging-threats/2026/Exploits/CVE-2026-35033/proc_creation_lin_exploit_cve_2026_35033.yml
+++ b/rules-emerging-threats/2026/Exploits/CVE-2026-35033/proc_creation_lin_exploit_cve_2026_35033.yml
@@ -1,0 +1,32 @@
+title: Potential CVE-2026-35033 Exploitation - Jellyfin FFmpeg Argument Injection Arbitrary File Read
+id: 6fc1703c-8858-46a3-a82f-c1450077dde4
+status: experimental
+description: |
+    Detects potential exploitation of CVE-2026-35033, an unauthenticated arbitrary file read in Jellyfin (< 10.11.7) via FFmpeg argument injection.
+    The codec and level query parameters of the /Videos/{itemId}/stream endpoint (VideoCodec, AudioCodec, Profile, SubtitleCodec, Level) were concatenated into the FFmpeg command line without validation. The 10.11.7 fix gates each value behind a container-name regex (^[a-zA-Z0-9\-\._,|]{0,40}$) or a numeric level regex, so a legitimate value can never contain a space, "=" or "/".
+    An attacker injects a value such as "h264 -vf drawtext=textfile=/etc/passwd:..." into one of those parameters; the embedded space breaks argument parsing (argument injection) and adds an FFmpeg "drawtext" video filter whose "textfile=" source points at a sensitive server file, rendering its contents into the output stream.
+    Legitimate Jellyfin transcoding never emits the FFmpeg "drawtext" filter or a "textfile=" argument (it uses the "subtitles" filter for subtitle burn-in), so a Jellyfin-spawned ffmpeg process whose command line contains both is high-fidelity for this injection.
+references:
+    - https://github.com/jellyfin/jellyfin/security/advisories/GHSA-jh22-fw8w-2v9x
+    - https://attack.mitre.org/techniques/T1190/
+author: WinstonRedGuard
+date: 2026-06-08
+tags:
+    - attack.initial-access
+    - attack.t1190
+    - detection.emerging-threats
+    - cve.2026-35033
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_ffmpeg:
+        Image|endswith: '/ffmpeg'
+    selection_injection:
+        CommandLine|contains|all:
+            - 'drawtext'
+            - 'textfile='
+    condition: all of selection_*
+falsepositives:
+    - Video-production, broadcast, or watermarking pipelines that legitimately invoke the FFmpeg "drawtext" filter with a "textfile=" source. This is uncommon on a dedicated Jellyfin media-server host. On shared hosts, scope by ParentImage (the Jellyfin server / dotnet process) or correlate the "textfile=" path against sensitive targets (/etc/, /proc/, /root/, path-traversal "..").
+level: high

--- a/rules-emerging-threats/2026/Exploits/CVE-2026-35033/proc_creation_lnx_exploit_cve_2026_35033.yml
+++ b/rules-emerging-threats/2026/Exploits/CVE-2026-35033/proc_creation_lnx_exploit_cve_2026_35033.yml
@@ -8,7 +8,6 @@ description: |
     Legitimate Jellyfin transcoding never emits the FFmpeg "drawtext" filter or a "textfile=" argument (it uses the "subtitles" filter for subtitle burn-in), so a Jellyfin-spawned ffmpeg process whose command line contains both is high-fidelity for this injection.
 references:
     - https://github.com/jellyfin/jellyfin/security/advisories/GHSA-jh22-fw8w-2v9x
-    - https://attack.mitre.org/techniques/T1190/
 author: WinstonRedGuard
 date: 2026-06-08
 tags:


### PR DESCRIPTION
Adds a `process_creation` (linux) detection for CVE-2026-35033 — an unauthenticated arbitrary file read in Jellyfin (< 10.11.7) via FFmpeg argument injection (advisory GHSA-jh22-fw8w-2v9x).

**Detection logic:** a Jellyfin-spawned `ffmpeg` process whose command line contains both `drawtext` and `textfile=`. Derived from the v10.11.6 -> v10.11.7 source diff (`StreamingHelpers.cs ParseParams` now gates codec/level params behind a container-name regex, so legitimate values can never contain a space/`=`/`/`). Confirmed that legitimate Jellyfin transcoding never emits the FFmpeg `drawtext` filter (absent from `EncodingHelper.cs`; subtitle burn-in uses the `subtitles` filter).

**FP scope:** documented for shared hosts running video-production/watermarking ffmpeg pipelines; clean on a dedicated Jellyfin host.