### PR TITLE
Add new powershell rule

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_cmdlet_invocation_via_exported_commands_array_index.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_cmdlet_invocation_via_exported_commands_array_index.yml
@@ -1,0 +1,41 @@
+title: Potential Cmdlet Invocation Via ExportedCommands Array Index
+id: 4ff4ad3e-9fb5-4a70-9962-d6ea58090318
+status: experimental
+description: |
+    Detects PowerShell scripts that enumerate Microsoft.PowerShell.Utility exported commands
+    and invoke cmdlets indirectly by array index. This can be used to evade detections
+    that look for explicit strings such as Invoke-RestMethod or Invoke-Expression.
+references:
+    - https://www.linkedin.com/posts/mark-o-halloran1_clickfix-defense-evasion-tactic-today-i-ugcPost-7453463467736408064-snrp
+author: Norbert Jaśniewicz (AlphaSOC)
+date: 2026-06-11
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.stealth
+    - attack.t1027.010
+logsource:
+    product: windows
+    category: ps_script
+    definition: 'Requirements: Script Block Logging must be enabled'
+detection:
+    selection_module_export_enum:
+        ScriptBlockText|contains|all:
+            - 'Get-Module'
+            - 'ListAvailable'
+            - 'Microsoft.PowerShell.Utility'
+            - 'ExportedCommands'
+            - 'Values'
+    selection_index_used:
+        ScriptBlockText|contains: '[*]'
+    selection_indirect_invocation:
+        - ScriptBlockText|startswith:
+              - '&'
+              - '.'
+        - ScriptBlockText|contains:
+              - ' &'
+              - ' .'
+    condition: all of selection_*
+falsepositives:
+    - Unknown
+level: medium

--- a/rules/windows/powershell/powershell_script/posh_ps_cmdlet_invocation_via_exported_commands_array_index.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_cmdlet_invocation_via_exported_commands_array_index.yml
@@ -28,13 +28,6 @@ detection:
             - 'Values'
     selection_index_used:
         ScriptBlockText|contains: '[*]'
-    selection_indirect_invocation:
-        - ScriptBlockText|startswith:
-              - '&'
-              - '.'
-        - ScriptBlockText|contains:
-              - ' &'
-              - ' .'
     condition: all of selection_*
 falsepositives:
     - Unknown


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

Adds a new Windows PowerShell ScriptBlock rule to detect scripts that enumerate
Microsoft.PowerShell.Utility exported commands and invoke cmdlets indirectly by
array index. This behavior can be used to avoid explicit references to cmdlets
such as Invoke-RestMethod or Invoke-Expression.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: Potential Cmdlet Invocation Via ExportedCommands Array Index

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)