### PR TITLE
Add Deno child process and non-mail IMAP detections

### DIFF
--- a/rules/windows/network_connection/net_connection_win_non_mail_client_imap.yml
+++ b/rules/windows/network_connection/net_connection_win_non_mail_client_imap.yml
@@ -7,37 +7,37 @@ description: >
   with Imperial Kitten / Yellow Liderc reporting. Tune approved automation and legacy
   mail clients before alerting; this selector is intentionally broad.
 references:
-  - https://www.crowdstrike.com/en-us/blog/imperial-kitten-deploys-novel-malware-families/
-  - https://www.pwc.com/gx/en/issues/cybersecurity/cyber-threat-intelligence/yellow-liderc-ships-its-scripts-delivers-imaploader-malware.html
+    - https://www.crowdstrike.com/en-us/blog/imperial-kitten-deploys-novel-malware-families/
+    - https://www.pwc.com/gx/en/issues/cybersecurity/cyber-threat-intelligence/yellow-liderc-ships-its-scripts-delivers-imaploader-malware.html
 author: Andrey Pautov
 date: 2026-05-14
 tags:
-  - attack.command-and-control
-  - attack.t1071.003
+    - attack.command-and-control
+    - attack.t1071.003
 logsource:
-  product: windows
-  category: network_connection
+    product: windows
+    category: network_connection
 detection:
-  selection_ports:
-    DestinationPort:
-      - 143
-      - 993
-  filter_mail_clients:
-    Image|endswith:
-      - '\OUTLOOK.EXE'
-      - '\outlook.exe'
-      - '\thunderbird.exe'
-      - '\olk.exe'
-  condition: selection_ports and not filter_mail_clients
+    selection_ports:
+        DestinationPort:
+            - 143
+            - 993
+    filter_mail_clients:
+        Image|endswith:
+            - '\OUTLOOK.EXE'
+            - '\outlook.exe'
+            - '\thunderbird.exe'
+            - '\olk.exe'
+    condition: selection_ports and not filter_mail_clients
 fields:
-  - UtcTime
-  - Computer
-  - User
-  - Image
-  - DestinationHostname
-  - DestinationIp
-  - DestinationPort
+    - UtcTime
+    - Computer
+    - User
+    - Image
+    - DestinationHostname
+    - DestinationIp
+    - DestinationPort
 falsepositives:
-  - Approved mail clients not included in the local allowlist.
-  - Legacy mail-collection scripts or monitoring agents that use IMAP.
+    - Approved mail clients not included in the local allowlist.
+    - Legacy mail-collection scripts or monitoring agents that use IMAP.
 level: low

--- a/rules/windows/network_connection/net_connection_win_non_mail_client_imap.yml
+++ b/rules/windows/network_connection/net_connection_win_non_mail_client_imap.yml
@@ -1,0 +1,43 @@
+title: Non-Mail Client IMAP Connection Hunt Starter
+id: 0f9486c4-2270-4a13-9bd8-f37d3017f7b7
+status: experimental
+description: >
+  Detects non-mail-client processes establishing outbound IMAP or IMAPS connections.
+  This is a behavior-level hunt for IMAPLoader-style command and control associated
+  with Imperial Kitten / Yellow Liderc reporting. Tune approved automation and legacy
+  mail clients before alerting; this selector is intentionally broad.
+references:
+  - https://www.crowdstrike.com/en-us/blog/imperial-kitten-deploys-novel-malware-families/
+  - https://www.pwc.com/gx/en/issues/cybersecurity/cyber-threat-intelligence/yellow-liderc-ships-its-scripts-delivers-imaploader-malware.html
+author: Andrey Pautov
+date: 2026-05-14
+tags:
+  - attack.command-and-control
+  - attack.t1071.003
+logsource:
+  product: windows
+  category: network_connection
+detection:
+  selection_ports:
+    DestinationPort:
+      - 143
+      - 993
+  filter_mail_clients:
+    Image|endswith:
+      - '\OUTLOOK.EXE'
+      - '\outlook.exe'
+      - '\thunderbird.exe'
+      - '\olk.exe'
+  condition: selection_ports and not filter_mail_clients
+fields:
+  - UtcTime
+  - Computer
+  - User
+  - Image
+  - DestinationHostname
+  - DestinationIp
+  - DestinationPort
+falsepositives:
+  - Approved mail clients not included in the local allowlist.
+  - Legacy mail-collection scripts or monitoring agents that use IMAP.
+level: low

--- a/rules/windows/process_creation/proc_creation_win_deno_susp_child_process.yml
+++ b/rules/windows/process_creation/proc_creation_win_deno_susp_child_process.yml
@@ -3,34 +3,34 @@ id: d87100fd-60cc-4899-a5d0-10423873eb1d
 status: experimental
 description: Detects suspicious child process execution from the Deno runtime, a behavior useful for MuddyWater/Dindoor-inspired hunting.
 references:
-  - https://www.threathunter.ai/blog/stryker-handala-mois-muddywater-unified-brief-detection-pack-v3
+    - https://www.threathunter.ai/blog/stryker-handala-mois-muddywater-unified-brief-detection-pack-v3
 author: Andrey Pautov
 date: 2026-05-13
 tags:
-  - attack.execution
-  - attack.t1059
+    - attack.execution
+    - attack.t1059
 logsource:
-  product: windows
-  category: process_creation
+    product: windows
+    category: process_creation
 detection:
-  selection_parent:
-    ParentImage|endswith: '\deno.exe'
-  selection_child:
-    Image|endswith:
-      - '\cmd.exe'
-      - '\powershell.exe'
-      - '\pwsh.exe'
-      - '\wscript.exe'
-      - '\cscript.exe'
-      - '\rundll32.exe'
-  condition: selection_parent and selection_child
+    selection_parent:
+        ParentImage|endswith: '\deno.exe'
+    selection_child:
+        Image|endswith:
+            - '\cmd.exe'
+            - '\powershell.exe'
+            - '\pwsh.exe'
+            - '\wscript.exe'
+            - '\cscript.exe'
+            - '\rundll32.exe'
+    condition: selection_parent and selection_child
 fields:
-  - UtcTime
-  - Computer
-  - User
-  - ParentImage
-  - Image
-  - CommandLine
+    - UtcTime
+    - Computer
+    - User
+    - ParentImage
+    - Image
+    - CommandLine
 falsepositives:
-  - Developer automation using Deno to orchestrate local shell commands.
+    - Developer automation using Deno to orchestrate local shell commands.
 level: medium

--- a/rules/windows/process_creation/proc_creation_win_deno_susp_child_process.yml
+++ b/rules/windows/process_creation/proc_creation_win_deno_susp_child_process.yml
@@ -1,0 +1,36 @@
+title: Deno Runtime Spawns Shell Or Scripting Interpreter
+id: d87100fd-60cc-4899-a5d0-10423873eb1d
+status: experimental
+description: Detects suspicious child process execution from the Deno runtime, a behavior useful for MuddyWater/Dindoor-inspired hunting.
+references:
+  - https://www.threathunter.ai/blog/stryker-handala-mois-muddywater-unified-brief-detection-pack-v3
+author: Andrey Pautov
+date: 2026-05-13
+tags:
+  - attack.execution
+  - attack.t1059
+logsource:
+  product: windows
+  category: process_creation
+detection:
+  selection_parent:
+    ParentImage|endswith: '\deno.exe'
+  selection_child:
+    Image|endswith:
+      - '\cmd.exe'
+      - '\powershell.exe'
+      - '\pwsh.exe'
+      - '\wscript.exe'
+      - '\cscript.exe'
+      - '\rundll32.exe'
+  condition: selection_parent and selection_child
+fields:
+  - UtcTime
+  - Computer
+  - User
+  - ParentImage
+  - Image
+  - CommandLine
+falsepositives:
+  - Developer automation using Deno to orchestrate local shell commands.
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Adds two behavior-focused Windows detection rules derived from public reporting on Iranian threat activity:

- Suspicious shell or script interpreter execution spawned by the Deno runtime
- Non-mail-client processes establishing IMAP/IMAPS connections

Both rules are behavior-oriented, include public primary/vendor references, and document expected false positives.

### Changelog

new: Deno Runtime Spawns Shell Or Scripting Interpreter
new: Non-Mail Client IMAP Connection Hunt Starter

### Example Log Event

Not applicable; new rules.

### Fixed Issues

None.

### SigmaHQ Rule Creation Conventions

Validated locally with:

- `python tests/test_logsource.py`
- `python tests/test_rules.py`
