### PR TITLE
Add APT36/SideCopy detection rules: CrimsonRAT persistence, XenoRAT task, mshta index.php chain

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_apt_sidecopy_mshta_index_php.yml
+++ b/rules/windows/process_creation/proc_creation_win_apt_sidecopy_mshta_index_php.yml
@@ -1,0 +1,30 @@
+title: SideCopy Mshta.EXE Fetching Remote HTA via index.php Endpoint
+id: 1f650100-d50e-4841-af42-75e5d18e106a
+status: experimental
+description: Detects execution of mshta.exe with a commandline referencing an "index.php" endpoint, which is a signature initial-access TTP used by the SideCopy APT group since at least 2019. The group lures victims with malicious LNK files (often disguised as PDF documents) that invoke mshta.exe to fetch a remote HTML Application (HTA) from a compromised web server via an index.php URL. This pattern is more specific than generic mshta HTTP detection rules and strongly correlates with SideCopy infrastructure.
+references:
+    - https://blog.talosintelligence.com/sidecopy/
+    - https://www.seqrite.com/blog/goodbye-hta-hello-msi-new-ttps-and-clusters-of-an-apt-driven-by-multi-platform-attacks/
+    - https://thehackernews.com/2026/02/apt36-and-sidecopy-launch-cross.html
+    - https://cybersrcc.com/2025/05/02/pakistan-linked-sidecopy-hackers-escalate-indian-cyberattacks-with-curlback-rat-and-spark-rat/
+author: Pyhroff
+date: 2026-06-23
+tags:
+    - attack.initial-access
+    - attack.execution
+    - attack.defense-evasion
+    - attack.t1218.005
+    - attack.t1566.001
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\mshta.exe'
+        - OriginalFileName: 'MSHTA.EXE'
+    selection_cli:
+        CommandLine|contains: 'index.php'
+    condition: all of selection_*
+falsepositives:
+    - Unlikely. Legitimate applications rarely invoke mshta.exe against an index.php endpoint. Internal web applications using PHP are theoretically possible but would be unusual in this context.
+level: high

--- a/rules/windows/process_creation/proc_creation_win_apt_sidecopy_xenorat_schtask.yml
+++ b/rules/windows/process_creation/proc_creation_win_apt_sidecopy_xenorat_schtask.yml
@@ -1,0 +1,27 @@
+title: SideCopy XenoRAT Scheduled Task Persistence
+id: 996bc437-e877-4cfb-8824-1273b02663b1
+status: experimental
+description: Detects creation of the scheduled task named "XenoUpdateManager", which is used by the SideCopy APT group (Pakistan-linked) to persist XenoRAT on compromised hosts. The task name is a hardcoded artifact confirmed across multiple SideCopy campaigns targeting Afghan and Indian government networks in 2025-2026.
+references:
+    - https://www.seqrite.com/blog/operation-xenofiscal-sidecopy-deploying-persistent-xenorat-targeting-the-mof-afghanistan/
+    - https://thehackernews.com/2026/06/pakistan-linked-sidecopy-targets.html
+    - https://socprime.com/active-threats/operation-xenofiscal-sidecopy-deploys-persistent-xenorat-against-afghanistans-ministry-of-finance/
+author: Pyhroff
+date: 2026-06-23
+tags:
+    - attack.persistence
+    - attack.execution
+    - attack.t1053.005
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\schtasks.exe'
+        - OriginalFileName: 'schtasks.exe'
+    selection_task:
+        CommandLine|contains: 'XenoUpdateManager'
+    condition: all of selection_*
+falsepositives:
+    - No legitimate software is known to create a scheduled task named XenoUpdateManager.
+level: high

--- a/rules/windows/registry/registry_set/registry_set_apt36_sidecopy_persistence.yml
+++ b/rules/windows/registry/registry_set/registry_set_apt36_sidecopy_persistence.yml
@@ -1,0 +1,27 @@
+title: APT36/SideCopy CrimsonRAT and ElizaRAT Registry Persistence
+id: 727bc0c1-da26-4d46-a4bf-aff11117a949
+status: experimental
+description: Detects registry modifications associated with APT36 (Transparent Tribe) and SideCopy persistence mechanisms. CrimsonRAT stores configuration under HKCU\Software\CrimsonRAT, ElizaRAT uses HKLM\SYSTEM\ElizaRAT\Persistence, and the CapraStart run key ensures autostart on logon. These are signature artifacts of Pakistan-linked campaigns targeting Indian and Afghan government entities.
+references:
+    - https://www.seqrite.com/blog/operation-xenofiscal-sidecopy-deploying-persistent-xenorat-targeting-the-mof-afghanistan/
+    - https://thehackernews.com/2026/02/apt36-and-sidecopy-launch-cross.html
+    - https://freemindtronic.com/apt36-cyberespionage-group-technical-reference-guide-v1-1/
+    - https://arxiv.org/html/2510.04118v1
+author: Pyhroff
+date: 2026-06-23
+tags:
+    - attack.persistence
+    - attack.t1547.001
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        TargetObject|contains:
+            - '\Software\CrimsonRAT'
+            - '\SYSTEM\ElizaRAT\Persistence'
+            - '\CurrentVersion\Run\CapraStart'
+    condition: selection
+falsepositives:
+    - Unlikely. These registry paths are not used by any known legitimate software.
+level: high


### PR DESCRIPTION
## Summary

Three new `experimental` rules covering APT36 (Transparent Tribe) / SideCopy TTPs with no prior Sigma coverage. This Pakistan-linked threat cluster has been consistently targeting Indian and Afghan government/defence networks, with campaigns escalating through 2025–2026 (Operation XENOFISCAL, cross-platform RAT campaign).

### Rules added

| File | What it detects | ATT&CK |
|------|-----------------|--------|
| `registry_set_apt36_sidecopy_persistence.yml` | CrimsonRAT (`\Software\CrimsonRAT`), ElizaRAT (`\SYSTEM\ElizaRAT\Persistence`), CapraStart run key | T1547.001 |
| `proc_creation_win_apt_sidecopy_xenorat_schtask.yml` | `schtasks.exe` creating the hardcoded `XenoUpdateManager` task used to persist XenoRAT | T1053.005 |
| `proc_creation_win_apt_sidecopy_mshta_index_php.yml` | `mshta.exe` fetching a remote HTA via an `index.php` endpoint — SideCopy signature TTP since 2019 | T1218.005, T1566.001 |

### Why these are not duplicates

- The existing `proc_creation_win_mshta_http.yml` detects any `http://` / `https://` URL in mshta commandlines. The new rule is more specific: it requires `index.php` in the path, which is the hardcoded endpoint pattern SideCopy uses on compromised PHP servers and reduces analyst fatigue on generic mshta-HTTP noise.
- No existing Sigma rules reference APT36, SideCopy, CrimsonRAT, ElizaRAT, or XenoRAT.

### References

- https://www.seqrite.com/blog/operation-xenofiscal-sidecopy-deploying-persistent-xenorat-targeting-the-mof-afghanistan/
- https://thehackernews.com/2026/06/pakistan-linked-sidecopy-targets.html
- https://thehackernews.com/2026/02/apt36-and-sidecopy-launch-cross.html
- https://blog.talosintelligence.com/sidecopy/
- https://socprime.com/active-threats/operation-xenofiscal-sidecopy-deploys-persistent-xenorat-against-afghanistans-ministry-of-finance/
- https://arxiv.org/html/2510.04118v1 (Cyber Warfare During Operation Sindoor — detection framework)

### False positive notes

- Registry rule: no known legitimate software writes to `\Software\CrimsonRAT`, `\SYSTEM\ElizaRAT\Persistence`, or `\Run\CapraStart`.
- XenoUpdateManager task: no legitimate software creates a scheduled task with this exact name.
- mshta index.php: mshta.exe loading remote PHP endpoints is not a pattern used by any known benign software.
