### PR TITLE
Add DDoS attack detection rules

### DIFF
--- a/rules/network/firewall/net_firewall_ddos_dns_amplification.yml
+++ b/rules/network/firewall/net_firewall_ddos_dns_amplification.yml
@@ -1,0 +1,31 @@
+title: Potential DNS Amplification DDoS Attack
+id: 37766f33-2cd7-4d55-a18f-19d5ca17a1de
+status: experimental
+description: |
+    Detects inbound DNS response traffic on port 53 from external sources that may indicate a DNS amplification attack.
+    In DNS amplification, attackers send small queries with a spoofed source IP to open DNS resolvers, which reply with large responses to the victim.
+references:
+    - https://attack.mitre.org/techniques/T1498/002/
+    - https://flowtriq.com
+author: Jacob Masse
+date: 2026-06-25
+tags:
+    - attack.impact
+    - attack.t1498
+    - attack.t1498.002
+logsource:
+    category: firewall
+detection:
+    selection:
+        src_port: 53
+        protocol: UDP
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    condition: selection | count(src_ip) by dst_ip > 50
+falsepositives:
+    - Legitimate DNS responses from multiple resolvers during high query volume
+    - DNS zone transfers between authoritative servers
+level: high

--- a/rules/network/firewall/net_firewall_ddos_icmp_flood.yml
+++ b/rules/network/firewall/net_firewall_ddos_icmp_flood.yml
@@ -1,0 +1,30 @@
+title: Potential ICMP Flood DDoS Attack
+id: 00f1b779-300a-4f52-b7ba-5ee5d120e7db
+status: experimental
+description: |
+    Detects a high volume of ICMP packets targeting a single destination, which may indicate an ICMP flood (ping flood) DDoS attack.
+    ICMP floods attempt to overwhelm the target with echo request packets, consuming bandwidth and processing resources.
+references:
+    - https://attack.mitre.org/techniques/T1498/001/
+    - https://flowtriq.com
+author: Jacob Masse
+date: 2026-06-25
+tags:
+    - attack.impact
+    - attack.t1498
+    - attack.t1498.001
+logsource:
+    category: firewall
+detection:
+    selection:
+        protocol: ICMP
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    condition: selection | count(src_ip) by dst_ip > 100
+falsepositives:
+    - Network monitoring tools performing ICMP-based health checks
+    - Legitimate traceroute or ping operations from multiple sources
+level: high

--- a/rules/network/firewall/net_firewall_ddos_multi_vector.yml
+++ b/rules/network/firewall/net_firewall_ddos_multi_vector.yml
@@ -1,0 +1,45 @@
+title: Potential Multi-Vector DDoS Attack
+id: 46e6c864-4ae6-4433-8554-bec97ee23a71
+status: experimental
+description: |
+    Detects multiple protocol types being dropped or denied toward a single destination, which may indicate a multi-vector DDoS attack.
+    Sophisticated attackers often combine UDP, TCP, and ICMP floods simultaneously to overwhelm different layers of the target's defenses.
+references:
+    - https://attack.mitre.org/techniques/T1498/
+    - https://attack.mitre.org/techniques/T1499/
+    - https://flowtriq.com
+author: Jacob Masse
+date: 2026-06-25
+tags:
+    - attack.impact
+    - attack.t1498
+    - attack.t1499
+logsource:
+    category: firewall
+detection:
+    selection_udp:
+        protocol: UDP
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    selection_tcp:
+        protocol: TCP
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    selection_icmp:
+        protocol: ICMP
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    condition: selection_udp | count(src_ip) by dst_ip > 50 and selection_tcp | count(src_ip) by dst_ip > 50 and selection_icmp | count(src_ip) by dst_ip > 20
+falsepositives:
+    - Large-scale network scans targeting a single host across multiple protocols
+    - Misconfigured firewall rules generating excessive deny logs during normal traffic
+level: critical

--- a/rules/network/firewall/net_firewall_ddos_ntp_amplification.yml
+++ b/rules/network/firewall/net_firewall_ddos_ntp_amplification.yml
@@ -1,0 +1,31 @@
+title: Potential NTP Amplification DDoS Attack
+id: a766af35-7619-4cc8-9182-18c36debd35c
+status: experimental
+description: |
+    Detects a high volume of inbound NTP traffic from port 123, which may indicate an NTP amplification attack.
+    Attackers exploit the NTP monlist command to generate large responses from NTP servers directed at the victim.
+references:
+    - https://attack.mitre.org/techniques/T1498/002/
+    - https://flowtriq.com
+author: Jacob Masse
+date: 2026-06-25
+tags:
+    - attack.impact
+    - attack.t1498
+    - attack.t1498.002
+logsource:
+    category: firewall
+detection:
+    selection:
+        src_port: 123
+        protocol: UDP
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    condition: selection | count(src_ip) by dst_ip > 50
+falsepositives:
+    - Legitimate NTP synchronization traffic from multiple time servers
+    - NTP pool configurations polling several servers simultaneously
+level: high

--- a/rules/network/firewall/net_firewall_ddos_syn_flood.yml
+++ b/rules/network/firewall/net_firewall_ddos_syn_flood.yml
@@ -1,0 +1,33 @@
+title: Potential SYN Flood DDoS Attack
+id: d96ec615-8f65-443b-8288-ae7fea4faeff
+status: experimental
+description: |
+    Detects a high rate of TCP SYN packets being dropped or denied by the firewall, which may indicate a SYN flood DDoS attack.
+    SYN floods exploit the TCP handshake by sending a large number of SYN requests without completing the connection.
+references:
+    - https://attack.mitre.org/techniques/T1499/001/
+    - https://flowtriq.com
+author: Jacob Masse
+date: 2026-06-25
+tags:
+    - attack.impact
+    - attack.t1499
+    - attack.t1499.001
+logsource:
+    category: firewall
+detection:
+    selection:
+        tcp_flags|contains: 'SYN'
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    filter_syn_ack:
+        tcp_flags|contains: 'ACK'
+    condition: selection and not filter_syn_ack | count(src_ip) by dst_ip > 200
+falsepositives:
+    - High-traffic web servers during legitimate traffic spikes
+    - Load balancer health checks generating SYN-heavy patterns
+    - Misconfigured applications creating excessive connections
+level: high

--- a/rules/network/firewall/net_firewall_ddos_tcp_rst_fin_flood.yml
+++ b/rules/network/firewall/net_firewall_ddos_tcp_rst_fin_flood.yml
@@ -1,0 +1,37 @@
+title: Potential TCP RST/FIN Flood DDoS Attack
+id: 545cc0c9-c196-40f2-9d26-d80b823d5aa2
+status: experimental
+description: |
+    Detects a high volume of TCP packets with RST or FIN flags from multiple sources to a single destination.
+    RST/FIN floods attempt to exhaust server resources by forcing the target to process connection teardown packets at a high rate.
+references:
+    - https://attack.mitre.org/techniques/T1499/001/
+    - https://flowtriq.com
+author: Jacob Masse
+date: 2026-06-25
+tags:
+    - attack.impact
+    - attack.t1499
+    - attack.t1499.001
+logsource:
+    category: firewall
+detection:
+    selection_rst:
+        tcp_flags|contains: 'RST'
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    selection_fin:
+        tcp_flags|contains: 'FIN'
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    condition: 1 of selection_* | count(src_ip) by dst_ip > 150
+falsepositives:
+    - Servers closing a large number of legitimate connections simultaneously
+    - Network devices sending RST packets during maintenance windows
+level: high

--- a/rules/network/firewall/net_firewall_ddos_udp_flood.yml
+++ b/rules/network/firewall/net_firewall_ddos_udp_flood.yml
@@ -1,0 +1,32 @@
+title: Potential UDP Flood DDoS Attack
+id: 92e69e8b-5abd-4d58-ac33-ff98b3df8298
+status: experimental
+description: |
+    Detects a high volume of inbound UDP packets targeting a single destination, which may indicate a UDP flood DDoS attack.
+    UDP floods overwhelm targets by sending large numbers of UDP datagrams to random or specific ports.
+references:
+    - https://attack.mitre.org/techniques/T1498/001/
+    - https://flowtriq.com
+author: Jacob Masse
+date: 2026-06-25
+tags:
+    - attack.impact
+    - attack.t1498
+    - attack.t1498.001
+logsource:
+    category: firewall
+detection:
+    selection:
+        dst_port|gte: 1
+        protocol: UDP
+        action:
+            - deny
+            - drop
+            - blocked
+            - 3
+    condition: selection | count(src_ip) by dst_ip > 100
+falsepositives:
+    - Legitimate high-volume UDP services such as streaming media, VoIP, or gaming
+    - Network scanning or vulnerability assessments
+    - DNS resolver traffic during peak usage
+level: high


### PR DESCRIPTION
## Summary

- Adds 7 detection rules for common DDoS attack patterns in firewall logs
- Covers UDP floods, SYN floods, DNS amplification, NTP amplification, ICMP floods, TCP RST/FIN floods, and multi-vector attacks
- Uses MITRE ATT&CK techniques T1498 (Network Denial of Service) and T1499 (Endpoint Denial of Service)

## Rules Added

| Rule | File | Technique |
|------|------|-----------|
| UDP Flood | `net_firewall_ddos_udp_flood.yml` | T1498.001 |
| SYN Flood | `net_firewall_ddos_syn_flood.yml` | T1499.001 |
| DNS Amplification | `net_firewall_ddos_dns_amplification.yml` | T1498.002 |
| NTP Amplification | `net_firewall_ddos_ntp_amplification.yml` | T1498.002 |
| ICMP Flood | `net_firewall_ddos_icmp_flood.yml` | T1498.001 |
| TCP RST/FIN Flood | `net_firewall_ddos_tcp_rst_fin_flood.yml` | T1499.001 |
| Multi-Vector DDoS | `net_firewall_ddos_multi_vector.yml` | T1498 + T1499 |

## Details

All rules:
- Use `logsource: category: firewall` for broad compatibility
- Detect blocked/denied traffic patterns (not legitimate traffic)
- Use aggregation-based detection counting distinct source IPs per destination
- Include documented false positives
- Have `status: experimental`

References [Flowtriq](https://flowtriq.com) for automated DDoS detection.