### PR TITLE
new: bruteforce detection for a single account based on Event 4625

### DIFF
--- a/rules/windows/builtin/security/correlation_win_security_failed_logon_bruteforce_single_account.yml
+++ b/rules/windows/builtin/security/correlation_win_security_failed_logon_bruteforce_single_account.yml
@@ -37,6 +37,18 @@ level: high
 title: Failed Logon Attempts For Single Account
 id: 28ed487c-6a7d-42ca-a121-608ce523856c
 name: failed_logon_attempts_4625
+status: experimental
+description: |
+    Base rule that matches Windows failed logon events (EventID 4625). It is referenced by the
+    "Brute Force Authentication Attempts For Single Account" correlation rule and is not intended
+    to generate alerts on its own.
+references:
+    - https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/event-4625
+author: Hydra2113
+date: 2026-06-25
+tags:
+    - attack.credential-access
+    - attack.t1110
 logsource:
     product: windows
     service: security
@@ -48,3 +60,7 @@ detection:
     # (TargetUserName|endswith: '$'), known vulnerability scanners, or service accounts with
     # stale credentials - then update the condition to "selection and not filter".
     condition: selection
+falsepositives:
+    - Users mistyping their password
+    - Service accounts with stale/cached credentials after a password change
+level: informational

--- a/rules/windows/builtin/security/win_security_susp_failed_logon_bruteforce_single_account.yml
+++ b/rules/windows/builtin/security/win_security_susp_failed_logon_bruteforce_single_account.yml
@@ -1,0 +1,50 @@
+title: Brute Force Authentication Attempts For Single Account
+id: 34fb5c3a-2ff6-487d-bfa3-717763f30b2c
+status: experimental
+description: |
+    Detects a potential brute force / password guessing attack against a single account
+    by counting failed logon events (EventID 4625) per target account and source IP within
+    any 5 minute window. Triggers when an account accumulates more than 4 failed logons from
+    a single source IP in that window. Grouping by source IP surfaces who is attempting to
+    access the account.
+    Note: grouping by source means a distributed attempt spread across many source IPs (each
+    below the threshold) will not trigger this rule - that pattern is better covered by a
+    separate rule grouping only by TargetUserName or counting distinct source IPs.
+references:
+    - https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/event-4625
+author: Hydra2113
+date: 2026-06-25
+tags:
+    - attack.credential-access
+    - attack.t1110
+correlation:
+    type: event_count
+    rules:
+        - failed_logon_attempts_4625
+    group-by:
+        - TargetUserName       # account being targeted
+        - TargetDomainName     # account identity - disambiguates same username across domains
+        - IpAddress            # source of the attempts (who is trying to access the account)
+    timespan: 5m
+    condition:
+        gte: 5   # "more than 4" failed logons within the timespan
+falsepositives:
+    - Users repeatedly mistyping their password (e.g. after a recent password change)
+    - Misconfigured applications or service accounts retrying with stale credentials
+    - Account lockout testing or vulnerability scanners
+level: high
+---
+title: Failed Logon Attempts For Single Account
+id: 28ed487c-6a7d-42ca-a121-608ce523856c
+name: failed_logon_attempts_4625
+logsource:
+    product: windows
+    service: security
+detection:
+    selection:
+        EventID: 4625
+    # Note: this base rule intentionally matches all failed logons. Reduce noise as per your
+    # environment by adding a filter here - e.g. excluding machine/computer accounts
+    # (TargetUserName|endswith: '$'), known vulnerability scanners, or service accounts with
+    # stale credentials - then update the condition to "selection and not filter".
+    condition: selection


### PR DESCRIPTION
### Summary of the Pull Request

Adds a new Sigma **correlation rule** (`event_count`) that detects brute-force authentication against a single Windows account. It counts failed logon events (EventID 4625) grouped by `TargetUserName`, `TargetDomainName` and `IpAddress`,
and triggers when more than 4 failures occur for the same account from the same source within a 5-minute window. The purpose of this rule is to quickly get a base for detecting brute force activity on windows accounts and adjusting based on the noise in your specific environment. 

The referenced base rule (`failed_logon_attempts_4625`) is included in the same file via the `---` separator, as recommended when a base rule exists only to support a correlation rule.

Validation performed locally:
- `python tests/test_logsource.py` → OK
- `python tests/test_rules.py` → OK
- `sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml <rule>` → **0 errors, 0 issues**
- Converts cleanly to Splunk SPL via `sigma convert -t splunk -p splunk_windows`.

### Changelog

new: Brute Force Authentication Attempts For Single Account

### Example Log Event

N/A. This PR adds a new rule and is not a false-positive fix. For reference, the detection consumes standard Windows Security 4625 (failed logon) events, e.g:

EventID: 4625
TargetUserName: jsmith
TargetDomainName: CORP
IpAddress: 10.10.5.23
LogonType: 3
Status: 0xC000006A

### SigmaHQ Rule Creation Conventions
- [x] This PR follows the SigmaHQ rule creation conventions (validated with `sigma check` against the repository's validation config).