### PR TITLE
Sysinternals: add ARM64 (*64a.exe) binary coverage

### DIFF
--- a/rules-threat-hunting/windows/image_load/image_load_dll_amsi_uncommon_process.yml
+++ b/rules-threat-hunting/windows/image_load/image_load_dll_amsi_uncommon_process.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/surya-dev-singh/AmsiBypass-OpenSession
 author: frack113
 date: 2023-03-12
-modified: 2025-02-24
+modified: 2026-06-29
 tags:
     - attack.impact
     - attack.t1490
@@ -23,6 +23,7 @@ detection:
         Image|endswith:
             - ':\Windows\explorer.exe'
             - ':\Windows\Sysmon64.exe'
+            - ':\Windows\Sysmon64a.exe'
     filter_main_generic:
         Image|contains:
             - ':\Program Files (x86)\'

--- a/rules-threat-hunting/windows/image_load/image_load_wmi_module_load_by_uncommon_process.yml
+++ b/rules-threat-hunting/windows/image_load/image_load_wmi_module_load_by_uncommon_process.yml
@@ -6,7 +6,7 @@ references:
     - https://threathunterplaybook.com/hunts/windows/190811-WMIModuleLoad/notebook.html
 author: Roberto Rodriguez @Cyb3rWard0g
 date: 2019-08-10
-modified: 2025-02-24
+modified: 2026-06-29
 tags:
     - attack.execution
     - attack.t1047
@@ -55,6 +55,7 @@ detection:
         Image|endswith:
             - ':\Windows\Sysmon.exe'
             - ':\Windows\Sysmon64.exe'
+            - ':\Windows\Sysmon64a.exe'
     condition: selection and not 1 of filter_main_* and not 1 of filter_optional_*
 falsepositives:
     - Unknown

--- a/rules/windows/builtin/security/win_security_susp_lsass_dump_generic.yml
+++ b/rules/windows/builtin/security/win_security_susp_lsass_dump_generic.yml
@@ -7,7 +7,7 @@ references:
     - https://www.slideshare.net/heirhabarov/hunting-for-credentials-dumping-in-windows-environment
 author: Roberto Rodriguez, Teymur Kheirkhabarov, Dimitrios Slamaris, Mark Russinovich, Aleksey Potapov, oscd.community (update)
 date: 2019-11-01
-modified: 2023-12-19
+modified: 2026-06-29
 tags:
     - attack.credential-access
     - car.2019-04-004
@@ -51,6 +51,7 @@ detection:
             - '\perfmon.exe'
             - '\procexp.exe'
             - '\procexp64.exe'
+            - '\procexp64a.exe'
             - '\svchost.exe'
             - '\taskmgr.exe'
             - '\thor.exe'        # THOR
@@ -76,7 +77,9 @@ detection:
             - ':\Windows\System32\msiexec.exe'
             - ':\Windows\CCM\CcmExec.exe'
     filter_main_sysmon:
-        ProcessName|endswith: ':\Windows\Sysmon64.exe'
+        ProcessName|endswith:
+            - ':\Windows\Sysmon64.exe'
+            - ':\Windows\Sysmon64a.exe'
         AccessList|contains: '%%4484'
     filter_main_aurora:
         ProcessName|contains: ':\Windows\Temp\asgard2-agent-sc\aurora\'
@@ -106,6 +109,7 @@ detection:
     filter_optional_procmon:
         ProcessName|endswith:
             - '\procmon64.exe'
+            - '\procmon64a.exe'
             - '\procmon.exe'
         AccessList|contains: '%%4484'
     condition: 1 of selection_* and not 1 of filter_main_* and not 1 of filter_optional_*

--- a/rules/windows/builtin/security/win_security_user_driver_loaded.yml
+++ b/rules/windows/builtin/security/win_security_user_driver_loaded.yml
@@ -12,7 +12,7 @@ references:
     - https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/event-4673
 author: xknow (@xknow_infosec), xorxes (@xor_xes)
 date: 2019-04-08
-modified: 2026-03-29
+modified: 2026-06-29
 tags:
     - attack.defense-impairment
     - attack.t1685
@@ -44,8 +44,10 @@ detection:
             - '\Google\Chrome\Application\chrome.exe'
             - '\procexp.exe'
             - '\procexp64.exe'
+            - '\procexp64a.exe'
             - '\procmon.exe'
             - '\procmon64.exe'
+            - '\procmon64a.exe'
     filter_main_startswith:
         ProcessName|startswith: 'C:\Program Files\WindowsApps\Microsoft'
     filter_optional_dropbox:

--- a/rules/windows/file/file_event/file_event_win_susp_procexplorer_driver_created_in_tmp_folder.yml
+++ b/rules/windows/file/file_event/file_event_win_susp_procexplorer_driver_created_in_tmp_folder.yml
@@ -8,7 +8,7 @@ references:
     - https://web.archive.org/web/20230331181619/https://blog.dylan.codes/evading-sysmon-and-windows-event-logging/
 author: xknow (@xknow_infosec), xorxes (@xor_xes)
 date: 2019-04-08
-modified: 2022-11-22
+modified: 2026-06-29
 tags:
     - attack.defense-impairment
     - attack.t1685
@@ -22,8 +22,10 @@ detection:
     filter:
         Image|contains:
             - '\procexp64.exe'
+            - '\procexp64a.exe'
             - '\procexp.exe'
             - '\procmon64.exe'
+            - '\procmon64a.exe'
             - '\procmon.exe'
     condition: selection and not filter
 falsepositives:

--- a/rules/windows/file/file_event/file_event_win_sysinternals_procexp_driver_susp_creation.yml
+++ b/rules/windows/file/file_event/file_event_win_sysinternals_procexp_driver_susp_creation.yml
@@ -11,6 +11,7 @@ references:
     - https://news.sophos.com/en-us/2023/04/19/aukill-edr-killer-malware-abuses-process-explorer-driver/
 author: Florian Roth (Nextron Systems)
 date: 2023-05-05
+modified: 2026-06-29
 tags:
     - attack.persistence
     - attack.privilege-escalation
@@ -26,6 +27,7 @@ detection:
         Image|endswith:
             - '\procexp.exe'
             - '\procexp64.exe'
+            - '\procexp64a.exe'
     condition: selection and not 1 of filter_main_*
 falsepositives:
     - Some false positives may occur with legitimate renamed process explorer binaries

--- a/rules/windows/file/file_event/file_event_win_sysinternals_procmon_driver_susp_creation.yml
+++ b/rules/windows/file/file_event/file_event_win_sysinternals_procmon_driver_susp_creation.yml
@@ -6,6 +6,7 @@ references:
     - Internal Research
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023-05-05
+modified: 2026-06-29
 tags:
     - attack.persistence
     - attack.privilege-escalation
@@ -21,6 +22,7 @@ detection:
         Image|endswith:
             - '\procmon.exe'
             - '\procmon64.exe'
+            - '\procmon64a.exe'
     condition: selection and not 1 of filter_main_*
 falsepositives:
     - Some false positives may occur with legitimate renamed process monitor binaries

--- a/rules/windows/image_load/image_load_dll_credui_uncommon_process_load.yml
+++ b/rules/windows/image_load/image_load_dll_credui_uncommon_process_load.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/S12cybersecurity/RDPCredentialStealer
 author: Roberto Rodriguez (Cyb3rWard0g), OTR (Open Threat Research)
 date: 2020-10-20
-modified: 2025-12-09
+modified: 2026-06-29
 tags:
     - attack.credential-access
     - attack.collection
@@ -42,6 +42,7 @@ detection:
     filter_optional_process_explorer:
         Image|endswith:
             - '\procexp64.exe'
+            - '\procexp64a.exe'
             - '\procexp.exe'
     filter_optional_teams:
         Image|startswith: 'C:\Users\'

--- a/rules/windows/process_access/proc_access_win_hktl_sysmonente.yml
+++ b/rules/windows/process_access/proc_access_win_hktl_sysmonente.yml
@@ -8,7 +8,7 @@ references:
     - https://github.com/codewhitesec/SysmonEnte/blob/fe267690fcc799fbda15398243615a30451d9099/screens/1.png
 author: Florian Roth (Nextron Systems)
 date: 2022-09-07
-modified: 2023-11-28
+modified: 2026-06-29
 tags:
     - attack.defense-impairment
     - attack.t1685.001
@@ -20,6 +20,7 @@ detection:
         TargetImage|contains:
             - ':\Windows\Sysmon.exe'
             - ':\Windows\Sysmon64.exe'
+            - ':\Windows\Sysmon64a.exe'
         GrantedAccess: '0x1400'
     selection_calltrace:
         CallTrace: 'Ente'

--- a/rules/windows/process_access/proc_access_win_lsass_memdump.yml
+++ b/rules/windows/process_access/proc_access_win_lsass_memdump.yml
@@ -11,7 +11,7 @@ references:
     - https://research.splunk.com/endpoint/windows_possible_credential_dumping/
 author: Samir Bousseaden, Michael Haag
 date: 2019-04-03
-modified: 2024-03-02
+modified: 2026-06-29
 tags:
     - attack.credential-access
     - attack.t1003.001
@@ -49,7 +49,9 @@ detection:
             - '|UNKNOWN('
         GrantedAccess: '0x103800'
     filter_optional_sysmon:
-        SourceImage|endswith: ':\Windows\Sysmon64.exe'
+        SourceImage|endswith:
+            - ':\Windows\Sysmon64.exe'
+            - ':\Windows\Sysmon64a.exe'
     condition: selection and not 1 of filter_main_* and not 1 of filter_optional_*
 falsepositives:
     - Unknown

--- a/rules/windows/process_access/proc_access_win_lsass_susp_access_flag.yml
+++ b/rules/windows/process_access/proc_access_win_lsass_susp_access_flag.yml
@@ -13,7 +13,7 @@ references:
     - https://web.archive.org/web/20230420013146/http://security-research.dyndns.org/pub/slides/FIRST2017/FIRST-2017_Tom-Ueltschi_Sysmon_FINAL_notes.pdf
 author: Florian Roth, Roberto Rodriguez, Dimitrios Slamaris, Mark Russinovich, Thomas Patzke, Teymur Kheirkhabarov, Sherif Eldeeb, James Dickenson, Aleksey Potapov, oscd.community
 date: 2021-11-22
-modified: 2023-11-29
+modified: 2026-06-29
 tags:
     - attack.credential-access
     - attack.t1003.001
@@ -113,6 +113,7 @@ detection:
         SourceImage|endswith:
             - '\handle.exe'
             - '\handle64.exe'
+            - '\handle64a.exe'
         GrantedAccess: '0x40'
     filter_optional_webex:
         SourceImage|endswith: '\AppData\Local\WebEx\WebexHost.exe'

--- a/rules/windows/process_creation/proc_creation_win_renamed_binary_highly_relevant.yml
+++ b/rules/windows/process_creation/proc_creation_win_renamed_binary_highly_relevant.yml
@@ -22,7 +22,7 @@ references:
     - https://www.huntress.com/blog/malicious-browser-extention-crashfix-kongtuke
 author: Matthew Green - @mgreen27, Florian Roth (Nextron Systems), frack113
 date: 2019-06-15
-modified: 2026-02-12
+modified: 2026-06-29
 tags:
     - attack.stealth
     - attack.t1036.003
@@ -72,6 +72,7 @@ detection:
             - '\powershell.exe'
             - '\psexec.exe'
             - '\psexec64.exe'
+            - '\psexec64a.exe'
             - '\PSEXESVC.exe'
             - '\pwsh.exe'
             - '\reg.exe'

--- a/rules/windows/process_creation/proc_creation_win_renamed_sysinternals_procdump.yml
+++ b/rules/windows/process_creation/proc_creation_win_renamed_sysinternals_procdump.yml
@@ -11,7 +11,7 @@ references:
     - https://learn.microsoft.com/en-us/sysinternals/downloads/procdump
 author: Florian Roth (Nextron Systems), Nasreddine Bencherchali (Nextron Systems)
 date: 2019-11-18
-modified: 2024-06-25
+modified: 2026-06-29
 tags:
     - attack.stealth
     - attack.t1036.003
@@ -32,6 +32,7 @@ detection:
         Image|endswith:
             - '\procdump.exe'
             - '\procdump64.exe'
+            - '\procdump64a.exe'
     condition: (selection_ofn or all of selection_cli_*) and not 1 of filter_main_*
 falsepositives:
     - Procdump illegally bundled with legitimate software.

--- a/rules/windows/process_creation/proc_creation_win_renamed_sysinternals_sdelete.yml
+++ b/rules/windows/process_creation/proc_creation_win_renamed_sysinternals_sdelete.yml
@@ -7,7 +7,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1485/T1485.md
 author: Florian Roth (Nextron Systems)
 date: 2022-09-06
-modified: 2023-02-03
+modified: 2026-06-29
 tags:
     - attack.impact
     - attack.t1485
@@ -21,6 +21,7 @@ detection:
         Image|endswith:
             - '\sdelete.exe'
             - '\sdelete64.exe'
+            - '\sdelete64a.exe'
     condition: selection and not filter
 falsepositives:
     - System administrator usage

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_accesschk_check_permissions.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_accesschk_check_permissions.yml
@@ -9,7 +9,7 @@ references:
     - https://github.com/gladiatx0r/Powerless/blob/04f553bbc0c65baf4e57344deff84e3f016e6b51/Powerless.bat
 author: Teymur Kheirkhabarov (idea), Mangatas Tondang, oscd.community, Nasreddine Bencherchali (Nextron Systems)
 date: 2020-10-13
-modified: 2023-02-20
+modified: 2026-06-29
 tags:
     - attack.discovery
     - attack.t1069.001
@@ -23,6 +23,7 @@ detection:
         - Image|endswith:
               - '\accesschk.exe'
               - '\accesschk64.exe'
+              - '\accesschk64a.exe'
         - OriginalFileName: 'accesschk.exe'
     selection_cli:
         CommandLine|contains: # These are the most common flags used with this tool. You could add other combinations if needed

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_procdump.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_procdump.yml
@@ -6,7 +6,7 @@ references:
     - https://learn.microsoft.com/en-us/sysinternals/downloads/procdump
 author: Florian Roth (Nextron Systems)
 date: 2021-08-16
-modified: 2023-02-28
+modified: 2026-06-29
 tags:
     - attack.stealth
     - attack.t1036
@@ -20,6 +20,7 @@ detection:
         Image|endswith:
             - '\procdump.exe'
             - '\procdump64.exe'
+            - '\procdump64a.exe'
     condition: selection
 falsepositives:
     - Legitimate use of procdump by a developer or administrator

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_psloglist.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_psloglist.yml
@@ -9,7 +9,7 @@ references:
     - https://twitter.com/EricaZelic/status/1614075109827874817
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2021-12-18
-modified: 2024-03-05
+modified: 2026-06-29
 tags:
     - attack.discovery
     - attack.t1087
@@ -24,6 +24,7 @@ detection:
         - Image|endswith:
               - '\psloglist.exe'
               - '\psloglist64.exe'
+              - '\psloglist64a.exe'
     selection_cli_eventlog:
         CommandLine|contains:
             - ' security'

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_psservice.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_psservice.yml
@@ -6,7 +6,7 @@ references:
     - https://learn.microsoft.com/en-us/sysinternals/downloads/psservice
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022-06-16
-modified: 2023-02-24
+modified: 2026-06-29
 tags:
     - attack.privilege-escalation
     - attack.discovery
@@ -21,6 +21,7 @@ detection:
         - Image|endswith:
               - '\PsService.exe'
               - '\PsService64.exe'
+              - '\PsService64a.exe'
     condition: selection
 falsepositives:
     - Legitimate use of PsService by an administrator

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_pssuspend_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_pssuspend_execution.yml
@@ -10,6 +10,7 @@ references:
     - https://twitter.com/0gtweet/status/1638069413717975046
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023-03-23
+modified: 2026-06-29
 tags:
     - attack.privilege-escalation
     - attack.discovery
@@ -24,6 +25,7 @@ detection:
         - Image|endswith:
               - '\pssuspend.exe'
               - '\pssuspend64.exe'
+              - '\pssuspend64a.exe'
     condition: selection
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_pssuspend_susp_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_pssuspend_susp_execution.yml
@@ -10,6 +10,7 @@ references:
     - https://twitter.com/0gtweet/status/1638069413717975046
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023-03-23
+modified: 2026-06-29
 tags:
     - attack.defense-impairment
     - attack.t1685
@@ -22,6 +23,7 @@ detection:
         - Image|endswith:
               - '\pssuspend.exe'
               - '\pssuspend64.exe'
+              - '\pssuspend64a.exe'
     selection_cli:
         # Add more interesting/critical processes
         CommandLine|contains: 'msmpeng.exe'

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_sysmon_config_update.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_sysmon_config_update.yml
@@ -6,7 +6,7 @@ references:
     - https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2023-03-09
-modified: 2024-03-13
+modified: 2026-06-29
 tags:
     - attack.defense-impairment
     - attack.t1685
@@ -17,6 +17,7 @@ detection:
     selection_pe:
         - Image|endswith:
               - \Sysmon64.exe
+              - \Sysmon64a.exe
               - \Sysmon.exe
         - Description: 'System activity monitor'
     selection_cli:

--- a/rules/windows/process_creation/proc_creation_win_sysinternals_sysmon_uninstall.yml
+++ b/rules/windows/process_creation/proc_creation_win_sysinternals_sysmon_uninstall.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1562.001/T1562.001.md#atomic-test-11---uninstall-sysmon
 author: frack113
 date: 2022-01-12
-modified: 2024-03-13
+modified: 2026-06-29
 tags:
     - attack.defense-impairment
     - attack.t1685
@@ -17,6 +17,7 @@ detection:
     selection_pe:
         - Image|endswith:
               - \Sysmon64.exe
+              - \Sysmon64a.exe
               - \Sysmon.exe
         - Description: 'System activity monitor'
     selection_cli:

--- a/rules/windows/registry/registry_set/registry_set_pua_sysinternals_renamed_execution_via_eula.yml
+++ b/rules/windows/registry/registry_set/registry_set_pua_sysinternals_renamed_execution_via_eula.yml
@@ -11,7 +11,7 @@ references:
     - Internal Research
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022-08-24
-modified: 2025-10-26
+modified: 2026-06-29
 tags:
     - attack.resource-development
     - attack.t1588.002
@@ -40,26 +40,35 @@ detection:
             # Please add new values while respecting the alphabetical order
             - '\ADExplorer.exe'
             - '\ADExplorer64.exe'
+            - '\ADExplorer64a.exe'
             - '\handle.exe'
             - '\handle64.exe'
+            - '\handle64a.exe'
             - '\livekd.exe'
             - '\livekd64.exe'
             - '\procdump.exe'
             - '\procdump64.exe'
+            - '\procdump64a.exe'
             - '\procexp.exe'
             - '\procexp64.exe'
+            - '\procexp64a.exe'
             - '\PsExec.exe'
             - '\PsExec64.exe'
+            - '\PsExec64a.exe'
             - '\PsLoggedon.exe'
             - '\PsLoggedon64.exe'
             - '\psloglist.exe'
             - '\psloglist64.exe'
+            - '\psloglist64a.exe'
             - '\pspasswd.exe'
             - '\pspasswd64.exe'
+            - '\pspasswd64a.exe'
             - '\PsPing.exe'
             - '\PsPing64.exe'
+            - '\PsPing64a.exe'
             - '\PsService.exe'
             - '\PsService64.exe'
+            - '\PsService64a.exe'
             - '\sdelete.exe'
     condition: selection and not filter
 falsepositives:

--- a/rules/windows/registry/registry_set/registry_set_renamed_sysinternals_eula_accepted.yml
+++ b/rules/windows/registry/registry_set/registry_set_renamed_sysinternals_eula_accepted.yml
@@ -11,7 +11,7 @@ references:
     - Internal Research
 author: Nasreddine Bencherchali (Nextron Systems)
 date: 2022-08-24
-modified: 2023-08-17
+modified: 2026-06-29
 tags:
     - attack.resource-development
     - attack.t1588.002
@@ -34,20 +34,27 @@ detection:
         Image|endswith:
             - '\PsExec.exe'
             - '\PsExec64.exe'
+            - '\PsExec64a.exe'
             - '\procdump.exe'
             - '\procdump64.exe'
+            - '\procdump64a.exe'
             - '\handle.exe'
             - '\handle64.exe'
+            - '\handle64a.exe'
             - '\livekd.exe'
             - '\livekd64.exe'
             - '\procexp.exe'
             - '\procexp64.exe'
+            - '\procexp64a.exe'
             - '\psloglist.exe'
             - '\psloglist64.exe'
+            - '\psloglist64a.exe'
             - '\pspasswd.exe'
             - '\pspasswd64.exe'
+            - '\pspasswd64a.exe'
             - '\ADExplorer.exe'
             - '\ADExplorer64.exe'
+            - '\ADExplorer64a.exe'
     filter_optional_null:
         Image: null # Race condition with some logging tools
     condition: selection and not 1 of filter_main_* and not 1 of filter_optional_*

--- a/rules/windows/registry/registry_set/registry_set_susp_service_installed.yml
+++ b/rules/windows/registry/registry_set/registry_set_susp_service_installed.yml
@@ -8,7 +8,7 @@ references:
     - https://web.archive.org/web/20200419024230/https://blog.dylan.codes/evading-sysmon-and-windows-event-logging/
 author: xknow (@xknow_infosec), xorxes (@xor_xes)
 date: 2019-04-08
-modified: 2023-08-17
+modified: 2026-06-29
 tags:
     - attack.defense-impairment
     - attack.t1685
@@ -24,11 +24,14 @@ detection:
         Image|endswith:
             # Please add the full paths that you use in your environment to tighten the rule
             - '\procexp64.exe'
+            - '\procexp64a.exe'
             - '\procexp.exe'
             - '\procmon64.exe'
+            - '\procmon64a.exe'
             - '\procmon.exe'
             - '\handle.exe'
             - '\handle64.exe'
+            - '\handle64a.exe'
         Details|contains: '\WINDOWS\system32\Drivers\PROCEXP152.SYS'
     condition: selection and not filter
 falsepositives:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
Sysinternals now ships native ARM64 builds that use the `64a` suffix (e.g. `procexp64a.exe`, `Sysmon64a.exe`, `handle64a.exe`, `procdump64a.exe`). The existing rules only matched the x86/x64 names, leaving a blind spot on ARM64 Windows hosts. This PR adds the corresponding `*64a.exe` value next to every existing `*64.exe` entry across the affected rules. Detection-equivalent change only — no logic, condition or field changes.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:    <title>
update:    <title> - <optional comment>
fix:    <title> - <optional comment>
remove:    <title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->
update: Amsi.DLL Load By Uncommon Process - add ARM64 (*64a.exe) variant
update: WMI Module Loaded By Uncommon Process - add ARM64 (*64a.exe) variant
update: Potentially Suspicious AccessMask Requested From LSASS - add ARM64 (*64a.exe) variant
update: Potential Privileged System Service Operation - SeLoadDriverPrivilege - add ARM64 (*64a.exe) variant
update: Suspicious PROCEXP152.sys File Created In TMP - add ARM64 (*64a.exe) variant
update: Process Explorer Driver Creation By Non-Sysinternals Binary - add ARM64 (*64a.exe) variant
update: Process Monitor Driver Creation By Non-Sysinternals Binary - add ARM64 (*64a.exe) variant
update: CredUI.DLL Loaded By Uncommon Process - add ARM64 (*64a.exe) variant
update: HackTool - SysmonEnte Execution - add ARM64 (*64a.exe) variant
update: Potential Credential Dumping Activity Via LSASS - add ARM64 (*64a.exe) variant
update: Potentially Suspicious GrantedAccess Flags On LSASS - add ARM64 (*64a.exe) variant
update: Potential Defense Evasion Via Rename Of Highly Relevant Binaries - add ARM64 (*64a.exe) variant
update: Renamed ProcDump Execution - add ARM64 (*64a.exe) variant
update: Renamed Sysinternals Sdelete Execution - add ARM64 (*64a.exe) variant
update: Permission Check Via Accesschk.EXE - add ARM64 (*64a.exe) variant
update: Procdump Execution - add ARM64 (*64a.exe) variant
update: Suspicious Use of PsLogList - add ARM64 (*64a.exe) variant
update: Sysinternals PsService Execution - add ARM64 (*64a.exe) variant
update: Sysinternals PsSuspend Execution - add ARM64 (*64a.exe) variant
update: Sysinternals PsSuspend Suspicious Execution - add ARM64 (*64a.exe) variant
update: Sysmon Configuration Update - add ARM64 (*64a.exe) variant
update: Uninstall Sysinternals Sysmon - add ARM64 (*64a.exe) variant
update: Suspicious Execution Of Renamed Sysinternals Tools - Registry - add ARM64 (*64a.exe) variant
update: Usage of Renamed Sysinternals Tools - RegistrySet - add ARM64 (*64a.exe) variant
update: Suspicious Service Installed - add ARM64 (*64a.exe) variant

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)