### PR TITLE
Add rule detecting inbound SSH drops on MikroTik WAN

### DIFF
--- a/rules/network/net_firewall_mikrotik_ssh_drop.yml
+++ b/rules/network/net_firewall_mikrotik_ssh_drop.yml
@@ -1,0 +1,21 @@
+title: MikroTik Inbound SSH Drop on WAN
+id: 9b1c5e42-7a8d-43f1-b924-a12c8b7f3d64
+status: experimental
+description: Detects inbound SSH traffic arriving on the external WAN interface that was dropped by the router's firewall rules. This is typically indicative of automated internet scanning.
+author: OriolesMagic333
+date: 2026-07-02
+logsource:
+    category: firewall
+    product: mikrotik
+detection:
+    selection:
+        in_interface|contains: 'WAN'
+        dst_port: 22
+        protocol: 'TCP'
+        message|contains: 'DROP'
+    condition: selection
+falsepositives:
+    - Internet background radiation (expected behavior on public IPs)
+level: low
+tags:
+    - attack.t1046 # Network Service Discovery


### PR DESCRIPTION
### Summary of the Pull Request

This PR adds a new rule to detect automated reconnaissance and SSH scanning directed at the external WAN interface of MikroTik edge routers. It utilizes parsed firewall logs to identify dropped TCP connections targeting port 22, which is indicative of internet background radiation or targeted brute-force setup phases.

### Changelog

new: MikroTik Inbound SSH Drop on WAN

### Example Log Event

```json
{
  "in_interface": "ether5[WAN]",
  "dst_port": 22,
  "protocol": "TCP",
  "message": "firewall,info PW_DROP_INPUT input: in:ether5[WAN] out:(unknown 0), proto TCP (SYN), 203.0.113.5:44342->192.168.88.10:22, len 52"
}
```

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- [x] If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)