### PR TITLE
add: NetSupport Manager RAT cleartext HTTP C2 detection (Zeek)

### DIFF
--- a/rules/network/zeek/zeek_http_netsupport_manager_cleartext_c2.yml
+++ b/rules/network/zeek/zeek_http_netsupport_manager_cleartext_c2.yml
@@ -1,0 +1,32 @@
+title: NetSupport Manager RAT Cleartext HTTP C2
+id: 05ecc93a-4441-46c8-8b29-a19a22538c0b
+status: experimental
+description: |
+    Detects NetSupport Manager client check-in traffic carried over cleartext HTTP on TCP port 443,
+    identified by the "NetSupport Manager/" User-Agent appearing in an HTTP transaction whose responder
+    port is 443. Legitimate NetSupport gateways negotiate TLS on 443; an HTTP analyzer firing in plaintext
+    on the TLS port while carrying this User-Agent is characteristic of the RAT abusing 443 to blend with
+    HTTPS egress.
+references:
+    - https://redcanary.com/blog/misbehaving-rats/
+    - https://blog.talosintelligence.com/detecting-evolving-threats-netsupport-rat/
+    - https://blogs.opentext.com/netsupport-remote-access-trojan-rat-delivered-through-fake-browser-updates-by-socgholish-threat-actors/
+author: cyberlandji
+date: 2026-06-30
+tags:
+    - attack.command-and-control
+    - attack.t1219
+    - attack.t1071.001
+logsource:
+    product: zeek
+    service: http
+detection:
+    selection_ua:
+        user_agent|startswith: 'NetSupport Manager/'
+    selection_port:
+        id.resp_p: 443
+    condition: selection_ua and selection_port
+falsepositives:
+    - Sanctioned NetSupport Manager remote-support sessions misconfigured to use cleartext HTTP on 443
+      instead of TLS. Uncommon; confirm against your authorised remote-support inventory before escalating.
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
Adds a Zeek `http` detection for NetSupport Manager RAT C2 over cleartext HTTP on port 443, matching the `NetSupport Manager/` User-Agent when `id.resp_p` is 443. Legitimate NetSupport uses TLS on 443, so plaintext HTTP carrying this UA is characteristic of the RAT blending C2 with HTTPS egress. Complements existing host-based NetSupport coverage (process_creation) at the network layer. Validated against a real NetSupport Zeek capture; passes sigma-cli check.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->
new: NetSupport Manager RAT Cleartext HTTP C2

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
