### PR TITLE
fix: Execution Of Non-Existing File - add vmmemWSL exception

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_susp_image_missing.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_image_missing.yml
@@ -6,7 +6,7 @@ references:
     - https://pentestlaboratories.com/2021/12/08/process-ghosting/
 author: Max Altgelt (Nextron Systems)
 date: 2021-12-09
-modified: 2022-12-14
+modified: 2026-07-05
 tags:
     - attack.stealth
 logsource:
@@ -27,10 +27,12 @@ detection:
               - 'Registry'
               - 'MemCompression'
               - 'vmmem'
+              - 'vmmemWSL'
         - CommandLine:
               - 'Registry'
               - 'MemCompression'
               - 'vmmem'
+              - 'vmmemWSL'
     condition: not image_absolute_path and not 1 of filter*
 falsepositives:
     - Unknown

--- a/rules/windows/process_creation/proc_creation_win_susp_image_missing.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_image_missing.yml
@@ -13,6 +13,7 @@ date: 2021-12-09
 modified: 2026-07-05
 tags:
     - attack.stealth
+    - attack.privilege-escalation
     - attack.t1055
 logsource:
     category: process_creation

--- a/rules/windows/process_creation/proc_creation_win_susp_image_missing.yml
+++ b/rules/windows/process_creation/proc_creation_win_susp_image_missing.yml
@@ -1,39 +1,44 @@
 title: Execution Of Non-Existing File
 id: 71158e3f-df67-472b-930e-7d287acaa3e1
 status: test
-description: Checks whether the image specified in a process creation event is not a full, absolute path (caused by process ghosting or other unorthodox methods to start a process)
+description: |
+    Detects process creation events where the Image field lacks an absolute path,
+    which occurs when the backing file no longer exists on disk at the time of
+    logging - commonly caused by Process Ghosting or other unorthodox process creation techniques.
 references:
     - https://pentestlaboratories.com/2021/12/08/process-ghosting/
+    - https://www.elastic.co/blog/process-ghosting-a-new-executable-image-tampering-attack
 author: Max Altgelt (Nextron Systems)
 date: 2021-12-09
 modified: 2026-07-05
 tags:
     - attack.stealth
+    - attack.t1055
 logsource:
     category: process_creation
     product: windows
 detection:
-    image_absolute_path:
+    filter_main_image_absolute_path:
         Image|contains: '\'
-    filter_null:
+    filter_optional_null:
         Image: null
-    filter_empty:
+    filter_optional_empty:
         Image:
             - '-'
             - ''
-    filter_4688:
+    filter_optional_4688:
         - Image:
-              - 'System'
-              - 'Registry'
               - 'MemCompression'
+              - 'Registry'
+              - 'System'
               - 'vmmem'
               - 'vmmemWSL'
         - CommandLine:
-              - 'Registry'
               - 'MemCompression'
+              - 'Registry'
               - 'vmmem'
               - 'vmmemWSL'
-    condition: not image_absolute_path and not 1 of filter*
+    condition: not 1 of filter_main_* and not 1 of filter_optional_*
 falsepositives:
     - Unknown
 level: high


### PR DESCRIPTION
### Summary of the Pull Request

vmmemWSL (the WSL2 utility VM's memory process, spawned by the Hyper-V worker process vmwp.exe) triggers "Execution Of Non-Existing File" because it isn't in the filter_4688 exception list. The rule already excludes the plain vmmem process for the same reason, but Sigma's plain field matching is exact-match, so that entry doesn't cover vmmemWSL. Added vmmemWSL next to vmmem in both the Image and CommandLine filter lists.

### Changelog

fix: Execution Of Non-Existing File - add vmmemWSL exception

### Example Log Event

NewProcessName: vmmemWSL
CommandLine: (empty)
ParentProcessName: C:\Windows\System32\vmwp.exe

### Fixed Issues

Fixes #6096

### SigmaHQ Rule Creation Conventions

N/A, this is a filter update to an existing rule, not a new rule.

---

Verified locally: `tests/test_logsource.py` and `tests/test_rules.py` both pass with no new failures, and `sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml` on the rule comes back with 0 errors and 0 issues.
