### PR TITLE
Macos doesn't use passwd shadow system, which uses the x, it uses * instead

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_local_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_local_account.yml
@@ -50,8 +50,7 @@ detection:
             - '/users'
             - '/last'
     selection_home_dir_listing:
-        Image|endswith:
-            - '/ls'
+        Image|endswith: '/ls'
         CommandLine|endswith:
             - '/Users'
             - "/Users'"

--- a/rules/macos/process_creation/proc_creation_macos_local_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_local_account.yml
@@ -1,12 +1,16 @@
 title: Local System Accounts Discovery - MacOs
 id: ddf36b67-e872-4507-ab2e-46bda21b842c
 status: test
-description: Detects enumeration of local systeam accounts on MacOS
+description: |
+    Detects enumeration of local system accounts on MacOS systems.
+    This can be used by attackers to identify accounts for lateral movement or privilege escalation.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1087.001/T1087.001.md
+    - https://ss64.com/osx/dscl.html
+    - https://ss64.com/mac/dscacheutil.html
 author: Alejandro Ortuno, oscd.community
 date: 2020-10-08
-modified: 2022-11-27
+modified: 2026-07-07
 tags:
     - attack.discovery
     - attack.t1087.001
@@ -14,28 +18,49 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection_1:
+    selection_dscl:
         Image|endswith: '/dscl'
         CommandLine|contains|all:
             - 'list'
             - '/users'
-    selection_2:
+    selection_dscacheutil:
         Image|endswith: '/dscacheutil'
         CommandLine|contains|all:
             - '-q'
             - 'user'
-    selection_3:
+    selection_root:
         CommandLine|contains: '''*:0:'''
-    selection_4:
-        Image|endswith: '/cat'
+    selection_passwd_sudo:
+        Image|endswith:
+            - '/cat'
+            - '/awk'
+            - '/grep'
         CommandLine|contains:
             - '/etc/passwd'
             - '/etc/sudoers'
-    selection_5:
+    selection_id:
         Image|endswith: '/id'
-    selection_6:
+    selection_lsof:
         Image|endswith: '/lsof'
         CommandLine|contains: '-u'
+    selection_logged_in_users:
+        Image|endswith:
+            - '/who'
+            - '/w'
+            - '/users'
+            - '/last'
+    selection_home_dir_listing:
+        Image|endswith:
+            - '/ls'
+        CommandLine|endswith:
+            - '/Users'
+            - "/Users'"
+            - '/Users"'
+    selection_loginwindow_prefs:
+        Image|endswith:
+            - '/defaults' # defaults read /Library/Preferences/com.apple.loginwindow
+            - '/plutil' # plutil -p /Library/Preferences/com.apple.loginwindow.plist
+        CommandLine|contains: 'com.apple.loginwindow'
     condition: 1 of selection*
 falsepositives:
     - Legitimate administration activities

--- a/rules/macos/process_creation/proc_creation_macos_local_account.yml
+++ b/rules/macos/process_creation/proc_creation_macos_local_account.yml
@@ -25,7 +25,7 @@ detection:
             - '-q'
             - 'user'
     selection_3:
-        CommandLine|contains: '''x:0:'''
+        CommandLine|contains: '''*:0:'''
     selection_4:
         Image|endswith: '/cat'
         CommandLine|contains:


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
Signature seems to be written for Linux and/or other shadow based /etc/passwd Unix'es
### Changelog
Macos uses * and not x as place holder for the salted password
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
