### PR TITLE
Add New Rule - Potential OpenSSH Daemon Exploitation Attempt - Client Crash Penalty

### DIFF
--- a/rules/linux/builtin/sshd/lnx_sshd_penalty_caused_crash.yml
+++ b/rules/linux/builtin/sshd/lnx_sshd_penalty_caused_crash.yml
@@ -1,0 +1,28 @@
+title: Potential OpenSSH Daemon Exploitation Attempt - Client Crash Penalty
+id: ff3aa76d-69ef-441a-b67e-0342925d43a3
+status: experimental
+description: |
+    Detects the OpenSSH daemon applying a "caused crash" PerSourcePenalties penalty against a client address whose behaviour crashed the sshd pre-auth session process.
+    A pre-authentication crash of sshd triggered by client behaviour is a strong indicator of an exploitation attempt against the SSH daemon, such as memory corruption or race condition exploits (e.g. CVE-2024-6387 "regreSSHion").
+    The PerSourcePenalties feature was introduced in OpenSSH 9.8 and is enabled by default. This rule matches the penalty creation, its activation, and subsequent refused connections from the penalised address.
+references:
+    - https://www.openssh.com/txt/release-9.8
+    - https://man.openbsd.org/sshd_config#PerSourcePenalties
+    - https://github.com/openssh/openssh-portable/blob/8e65f996e535d395968870b20478b4e167d10aca/srclimit.c
+author: Jose Argento
+date: 2026-07-10
+tags:
+    - attack.initial-access
+    - attack.t1190
+logsource:
+    product: linux
+    service: sshd
+    definition: 'Requirements: OpenSSH 9.8 or later with PerSourcePenalties enabled (default)'
+detection:
+    keywords:
+        - 'penalty: caused crash'
+    condition: keywords
+falsepositives:
+    - Legitimate but buggy SSH client implementations that trigger a crash in the sshd pre-auth session process
+    - Crashes caused by sshd bugs unrelated to malicious client behaviour
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
This PR adds a new rule detecting the OpenSSH daemon applying a "caused crash" PerSourcePenalties penalty. The PerSourcePenalties feature was introduced in OpenSSH 9.8 and is enabled by default: when the pre-auth session process of sshd crashes due to client behaviour, sshd itself correlates the event and penalises the source address with the dedicated penalty reason `caused crash` (default `crash:90s`).

A client-triggered pre-authentication crash of sshd is a strong indicator of an exploitation attempt against the daemon, such as memory corruption or race condition exploits (e.g. CVE-2024-6387 "regreSSHion"). Since the correlation is performed by sshd and emitted as a single high-signal log event, the rule stays purely event-based (no counting/threshold logic required on the backend).

The keyword matches both the penalty creation (`srclimit_penalise`) and the subsequent refused connections (`drop connection ... penalty: caused crash`) from the penalised address.

The rule was validated with `sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml`, `tests/test_rules.py` and `tests/test_logsource.py`, all passing. Log events below were captured from a real OpenSSH server on Ubuntu (journalctl), with the source IP replaced by an RFC 5737 TEST-NET address.

### Changelog
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: Potential OpenSSH Daemon Exploitation Attempt - Client Crash Penalty

### Example Log Event
<!--
Fill this in case of false positive fixes
-->

```text
Jul 10 17:42:04 ubuntu-lab sshd[1515]: Session process 2035 unpriv child crash for connection from 203.0.113.10 to 10.0.2.15
Jul 10 17:42:04 ubuntu-lab sshd[1515]: srclimit_penalise: ipv4: new 203.0.113.10/32 active penalty of 90 seconds for penalty: caused crash
Jul 10 17:42:20 ubuntu-lab sshd[1515]: drop connection #0 from [203.0.113.10]:44212 on [10.0.2.15]:22 penalty: caused crash
```

### Fixed Issues
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
N/A - new rule, not linked to an existing issue.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)

The rule follows the SigmaHQ conventions (filename `lnx_sshd_*`, UUID v4, Title Case, `status: experimental`, commit-pinned references, event-based detection).