### PR TITLE
new: add registry detection for workfolders app paths hijack persistence

### DIFF
--- a/proc_registry_win_workfolders_app_paths_hijack.yml
+++ b/proc_registry_win_workfolders_app_paths_hijack.yml
@@ -1,0 +1,24 @@
+title: App Paths Registry Hijack Via WorkFolders Persistence
+id: 5b6c8a31-b8ef-4df1-be71-cfd506de7d49
+status: experimental
+description: Detects the creation or modification of the App Paths registry key for control.exe within the current user hive (HKCU), which can be abused by adversaries to achieve code execution or persistence via the native WorkFolders.exe binary.
+references:
+    - https://lolbas-project.github.io/lolbas/Binaries/WorkFolders/
+author: Christian Murphy-Sykes (@ShadowSkillZ)
+date: 2026/07/10
+tags:
+    - attack.persistence
+    - attack.privilege_escalation
+    - attack.t1218
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        TargetObject|contains: 'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\control.exe'
+    filter_legitimate:
+        TargetObject|startswith: 'HKLM\'
+    condition: selection and not filter_legitimate
+falsepositives:
+    - Highly unusual administrative software deployment customizations mapping custom Control Panel applets via HKCU.
+level: high


### PR DESCRIPTION
<!--
Thank you for your contribution to the Sigma repository!

Please review the following checklist before submitting your pull request:
- [x] Ensure that the rule is written in the correct format.
- [x] Ensure that the rule is placed in the correct directory.
- [x] Ensure that the rule passes the tests (run `sigma check`).
-->

### Summary of the Pull Request
This pull request introduces a new Windows registry detection rule to identify persistence and privilege escalation techniques leveraging the native `WorkFolders.exe` binary. Specifically, it tracks the creation or modification of the `App Paths` registry key for `control.exe` within the current user hive (`HKCU`).

Adversaries can exploit this configuration to achieve arbitrary code execution or establish long-term persistence by hijacking the application execution path when `WorkFolders.exe` is called.

### Changelog
* new: App Paths Registry Hijack Via WorkFolders Persistence

### Example Log Event
```yaml
EventCode: 13
TargetObject: 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\control.exe'
Details: 'C:\Users\Public\icmps.dll'
Image: 'C:\Windows\System32\reg.exe'