### PR TITLE
Fix: Remove ver.exe Binary Match Since ver Is a CMD Built-in

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_webshell_recon_commands_and_processes.yml
+++ b/rules/windows/process_creation/proc_creation_win_webshell_recon_commands_and_processes.yml
@@ -85,7 +85,6 @@ detection:
               - '\systeminfo.exe'
               - '\tasklist.exe'
               - '\tracert.exe'
-              - '\ver.exe'
               - '\wevtutil.exe'
               - '\whoami.exe'
         - OriginalFileName:
@@ -101,7 +100,6 @@ detection:
               - 'sysinfo.exe'
               - 'tasklist.exe'
               - 'tracert.exe'
-              - 'ver.exe'
               - 'VSSADMIN.EXE'
               - 'wevtutil.exe'
               - 'whoami.exe'

--- a/rules/windows/process_creation/proc_creation_win_webshell_recon_commands_and_processes.yml
+++ b/rules/windows/process_creation/proc_creation_win_webshell_recon_commands_and_processes.yml
@@ -8,7 +8,7 @@ references:
     - https://www.huntress.com/blog/threat-advisory-oh-no-cleo-cleo-software-actively-being-exploited-in-the-wild
 author: Florian Roth (Nextron Systems), Jonhnathan Ribeiro, Anton Kutepov, oscd.community, Chad Hudson, Matt Anderson
 date: 2017-01-01
-modified: 2024-12-14
+modified: 2026-07-14
 tags:
     - attack.persistence
     - attack.discovery


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

This PR removes `ver.exe` from the `Image|endswith` and `OriginalFileName` matches in the **Webshell Detection With Command Line Keywords** rule. `ver` is an internal command supported by `cmd.exe`, not a standalone executable named `ver.exe`.

Reference: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/ver

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

fix: Webshell Detection With Command Line Keywords - remove invalid ver.exe binary matches

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

Not applicable.

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

Not applicable.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)