### PR TITLE
Add .NET startup hook persistence detection

### DIFF
--- a/rules/windows/registry/registry_set/registry_set_dotnet_startup_hooks.yml
+++ b/rules/windows/registry/registry_set/registry_set_dotnet_startup_hooks.yml
@@ -1,0 +1,26 @@
+title: Potential .NET Startup Hook Persistence
+id: c69f1c1c-d571-41ea-aecc-1de968362750
+status: experimental
+description: |
+    Detects the persistent configuration of a .NET startup hook through the "DOTNET_STARTUP_HOOKS" environment variable.
+    An assembly configured in this variable is loaded and executed before the entry point of every affected .NET application.
+references:
+    - https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_startup_hooks
+    - https://persistence-info.github.io/Data/dotnetstartuphooks.html
+author: bushidoSen
+date: 2026-07-13
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.stealth
+    - attack.t1574
+logsource:
+    category: registry_set
+    product: windows
+detection:
+    selection:
+        TargetObject|endswith: '\DOTNET_STARTUP_HOOKS'
+    condition: selection
+falsepositives:
+    - Legitimate observability, profiling, or development tooling that configures a .NET startup hook persistently
+level: medium

--- a/rules/windows/registry/registry_set/registry_set_dotnet_startup_hooks.yml
+++ b/rules/windows/registry/registry_set/registry_set_dotnet_startup_hooks.yml
@@ -10,6 +10,7 @@ references:
 author: bushidoSen
 date: 2026-07-13
 tags:
+    - attack.execution
     - attack.persistence
     - attack.privilege-escalation
     - attack.stealth


### PR DESCRIPTION
### Summary of the Pull Request

Adds a Windows registry rule that detects persistent configuration of the `DOTNET_STARTUP_HOOKS` environment variable.

The .NET host loads each managed assembly specified by this variable and calls its `StartupHook.Initialize()` method synchronously before the application's `Main` entry point. Persisting this variable in the user or system environment can therefore cause attacker-controlled managed code to execute inside subsequently launched .NET applications.

The rule uses the generic Windows `registry_set` category and the canonical `TargetObject` field so it can be mapped to Sysmon Event ID 13 and equivalent EDR registry telemetry. The detection is intentionally limited to the exact environment-variable value name.

### Changelog

new: Potential .NET Startup Hook Persistence

### Example Log Event

Not applicable; this PR adds a new rule rather than correcting a false positive.

Example canonical fields expected from a matching Sysmon Event ID 13:

```text
EventID: 13
EventType: SetValue
TargetObject: HKU\<SID>\Environment\DOTNET_STARTUP_HOOKS
Details: C:\SigmaTest\StartupHook.dll
```

### Fixed Issues

None.

### SigmaHQ Rule Creation Conventions

- [x] New rule uses `experimental` status.
- [x] Filename follows the `registry_set_*` convention.
- [x] Title and level follow SigmaHQ conventions.
- [x] Public references document both the execution primitive and its persistence location.
- [x] Duplicate coverage was checked in `rules`, `rules-threat-hunting`, and `rules-emerging-threats`.
- [x] `python tests/test_logsource.py` passed.
- [x] `python tests/test_rules.py` passed.
- [x] Sigma CLI strict validation passed with 0 errors and 0 issues.
