### PR TITLE
Fix metadata alignment on Test-NetConnection rule (#6132)

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_test_netconnection.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_test_netconnection.yml
@@ -1,17 +1,16 @@
-title: Testing Usage of Uncommonly Used Port
+title: PowerShell Port Probing Via Test-NetConnection
 id: adf876b3-f1f8-4aa9-a4e4-a64106feec06
 status: test
-description: |
-    Adversaries may communicate using a protocol and port paring that are typically not associated.
-    For example, HTTPS over port 8088(Citation: Symantec Elfin Mar 2019) or port 587(Citation: Fortinet Agent Tesla April 2018) as opposed to the traditional port 443.
+description: Detects the use of the PowerShell cmdlet 'Test-NetConnection' to probe remote network ports, which is often used by adversaries for host discovery or network service scanning.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1571/T1571.md#atomic-test-1---testing-usage-of-uncommonly-used-port-with-powershell
     - https://learn.microsoft.com/en-us/powershell/module/nettcpip/test-netconnection?view=windowsserver2022-ps
 author: frack113
 date: 2022-01-23
+modified: 2026-07-14 # Updated to reflect today's alignment changes
 tags:
-    - attack.command-and-control
-    - attack.t1571
+    - attack.discovery
+    - attack.t1046 # Realigned to Network Service Scanning
 logsource:
     product: windows
     category: ps_script
@@ -28,5 +27,5 @@ detection:
             - ' 80 '
     condition: selection and not filter
 falsepositives:
-    - Legitimate administrative script
+    - Legitimate administrative scripts or network diagnostics run by systems administrators.
 level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
This PR modifies rule `adf876b3-f1f8-4aa9-a4e4-a64106feec06` to resolve Issue #6132. The original rule claimed to detect T1571 (Non-Standard Port), but the logic specifically tracks host-based port scanning using the PowerShell diagnostic utility `Test-NetConnection`.

We have updated the title, description, and MITRE ATT&CK tags to correctly align with Discovery (T1046) and Host/Service Scanning.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->
update: PowerShell Port Probing Via Test-NetConnection - Aligned metadata and tags with detection logic (#6132)

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
Closes #6132

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
