### PR TITLE
Deprecate rule adf876b3 and add broader PowerShell port discovery rule (#6132)

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_network_reconnaissance.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_network_reconnaissance.yml
@@ -1,0 +1,29 @@
+title: PowerShell Network Reconnaissance and Port Probing Activity
+id: 5b4e7a31-628d-4b47-b3c9-f19b1836a992 # A fresh, unique rule ID
+status: experimental
+description: Detects the use of PowerShell script blocks containing network connectivity verification tools or raw .NET socket probing to discover active internal services and host mappings.
+references:
+    - https://learn.microsoft.com/en-us/powershell/module/nettcpip/test-netconnection?view=windowsserver2022-ps
+    - https://attack.mitre.org/techniques/T1046/
+author: Keshon Karishan (KKarishan)
+date: 2026-07-15 
+tags:
+    - attack.discovery
+    - attack.t1046
+logsource:
+    product: windows
+    category: ps_script
+    definition: 'Requirements: Script Block Logging must be enabled'
+detection:
+    selection_cmdlet:
+        ScriptBlockText|contains:
+            - 'Test-NetConnection'
+            - 'tnc '
+    selection_socket:
+        ScriptBlockText|contains|all:
+            - 'System.Net.Sockets.TcpClient'
+            - '.Connect('
+    condition: selection_cmdlet or selection_socket
+falsepositives:
+    - Internal diagnostic scripts executed by network administrators.
+level: medium

--- a/rules/windows/powershell/powershell_script/posh_ps_test_netconnection.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_test_netconnection.yml
@@ -1,14 +1,16 @@
 title: Testing Usage of Uncommonly Used Port
 id: adf876b3-f1f8-4aa9-a4e4-a64106feec06
-status: test
+status: deprecated # Changed from test to deprecated
 description: |
     Adversaries may communicate using a protocol and port paring that are typically not associated.
     For example, HTTPS over port 8088(Citation: Symantec Elfin Mar 2019) or port 587(Citation: Fortinet Agent Tesla April 2018) as opposed to the traditional port 443.
+    Note: This rule has been deprecated in favor of broader PowerShell reconnaissance rules tracking host-based port discovery.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1571/T1571.md#atomic-test-1---testing-usage-of-uncommonly-used-port-with-powershell
     - https://learn.microsoft.com/en-us/powershell/module/nettcpip/test-netconnection?view=windowsserver2022-ps
 author: frack113
 date: 2022-01-23
+modified: 2026-07-15
 tags:
     - attack.command-and-control
     - attack.t1571


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Following maintainer feedback, this PR deprecates the original T1571 host-based rule while preserving and broadening endpoint visibility by introducing a dedicated rule for Network Port Discovery (T1046) using `Test-NetConnection` and raw .NET TCP socket blocks.
<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

remove: Testing Usage of Uncommonly Used Port - deprecated in favour of 5b4e7a31-628d-4b47-b3c9-f19b1836a992
new: PowerShell Network Reconnaissance and Port Probing Activity
<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

Closes #6132
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
