### PR TITLE
new: WSL COM Proxy-Stub Loaded by Non-WSL Process

### DIFF
--- a/rules/windows/image_load/image_load_wsl_com_proxystub_non_wsl.yml
+++ b/rules/windows/image_load/image_load_wsl_com_proxystub_non_wsl.yml
@@ -1,0 +1,40 @@
+title: WSL COM Proxy-Stub Loaded by Non-WSL Process
+id: 16926aae-e41e-4978-b704-855ae7cea9e7
+status: experimental
+description: |
+    Detects a process that is not a known Windows Subsystem for Linux (WSL) binary loading
+    "wslserviceproxystub.dll", the COM proxy-stub used to marshal calls to the ILxssUserSession
+    interface exposed by wslservice.exe. Tooling that starts WSL guest execution by calling
+    CreateLxProcess over COM directly, without spawning wsl.exe, must load this proxy-stub to
+    marshal the interface. A load by a non-WSL image is therefore a strong indicator of COM-based
+    WSL activation that leaves no wsl.exe command line for process-creation detections to observe.
+references:
+    - https://specterops.io/blog/2026/01/16/one-wsl-bof-to-rule-them-all/
+    - https://github.com/MayerDaniel/the-one-wsl-bof
+    - https://jonny-johnson.medium.com/wsl-com-hooking-rtti-3abbf873d61f
+    - https://github.com/microsoft/WSL/blob/master/doc/docs/technical-documentation/wslservice.exe.md
+author: Ai Thanh Vu, VinSOC Lab
+date: 2026-07-15
+tags:
+    - attack.execution
+    - attack.t1559.001
+logsource:
+    category: image_load
+    product: windows
+detection:
+    selection:
+        ImageLoaded|endswith: '\wslserviceproxystub.dll'
+    filter_main_wsl_binaries:
+        Image|endswith:
+            - '\wsl.exe'
+            - '\wslservice.exe'
+            - '\wslhost.exe'
+            - '\wslrelay.exe'
+            - '\wslg.exe'
+            - '\wslconfig.exe'
+            - '\wsldevicehost.exe'
+    condition: selection and not 1 of filter_main_*
+falsepositives:
+    - Windows Subsystem for Linux management or endpoint-security tooling that legitimately activates the WSL COM interface; allowlist by image path or code signer
+    - Future first-party WSL client binaries not present in the filter list
+level: high


### PR DESCRIPTION
### Summary

Adds an `image_load` rule detecting the **COM-direct WSL activation** technique: a non-WSL process loading `wslserviceproxystub.dll`, the COM proxy-stub used to marshal calls to the `ILxssUserSession` interface exposed by `wslservice.exe`.

All five existing SigmaHQ WSL rules are `logsource: process_creation` keyed on the `wsl.exe` command line. The published SpecterOps *One WSL BOF* (Jan 2026) runs guest commands via `ILxssUserSession::CreateLxProcess` over COM **without ever spawning `wsl.exe`**, which defeats command-line-based WSL detection. Any process taking that path must load the COM proxy-stub, so a load of `wslserviceproxystub.dll` by a non-WSL image is a high-fidelity indicator of this evasion — observable at the module-load layer (Sysmon Event ID 7) with no hook and no in-guest agent.

### Changelog

```
new: WSL COM Proxy-Stub Loaded by Non-WSL Process
```

### Detection

- **Data source:** Sysmon Event ID 7 (`image_load`), Windows.
- **Logic:** alert when `wslserviceproxystub.dll` is loaded by any image other than a known first-party WSL binary (`wsl.exe`, `wslservice.exe`, `wslhost.exe`, `wslrelay.exe`, `wslg.exe`, `wslconfig.exe`, `wsldevicehost.exe`).
- **ATT&CK:** T1559.001 (Inter-Process Communication: Component Object Model) — Execution.

### Testing

- Passes `sigma check` (0 errors / 0 issues) and the repository rule-convention tests.
- False-positive baseline: on a clean host, only WSL's own binaries load `wslserviceproxystub.dll` (verified across Docker Desktop's WSL2 backend and VS Code Remote-WSL sessions).
- True positive: fires on a benign reproduction of the published COM-direct activation on WSL 2.6.3, attributed to the non-WSL caller.

### References

- https://specterops.io/blog/2026/01/16/one-wsl-bof-to-rule-them-all/
- https://github.com/MayerDaniel/the-one-wsl-bof
- https://jonny-johnson.medium.com/wsl-com-hooking-rtti-3abbf873d61f
- https://github.com/microsoft/WSL/blob/master/doc/docs/technical-documentation/wslservice.exe.md
