### PR TITLE
Add detection rules for CISA/NSA/FBI advisory AA26-194A (FSB Center 16 router config theft via SNMP/TFTP)

### DIFF
--- a/rules-placeholder/network/firewall/net_firewall_tftp_config_exfil_from_management_segment.yml
+++ b/rules-placeholder/network/firewall/net_firewall_tftp_config_exfil_from_management_segment.yml
@@ -1,0 +1,32 @@
+title: Outbound TFTP Transfer from Network Device Management Segment
+id: cfacfeb4-df02-449d-a300-b5c747d6f625
+status: experimental
+description: |
+    Detects outbound TFTP (UDP/69) sessions originating from network device
+    management subnets to external destinations, consistent with the
+    configuration-exfiltration step described in CISA advisory AA26-194A
+    (actors copy configs as config.bkp/output.txt then transfer via TFTP).
+references:
+    - https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-194a
+author: Zach Vessey
+date: 2026-07-16
+tags:
+    - attack.exfiltration
+    - attack.t1048.003
+logsource:
+    category: firewall
+detection:
+    selection:
+        dst_port: 69
+        proto: udp
+        src_ip|cidr|expand: '%management_networks%'
+    filter_internal_dst:
+        dst_ip|cidr:
+            - '10.0.0.0/8'
+            - '172.16.0.0/12'
+            - '192.168.0.0/16'
+    condition: selection and not filter_internal_dst
+falsepositives:
+    - Legitimate scheduled TFTP config/firmware backups to an approved external
+      backup host (should be added to an allowlist)
+level: high

--- a/rules/network/firewall/net_firewall_snmp_config_access_attempt.yml
+++ b/rules/network/firewall/net_firewall_snmp_config_access_attempt.yml
@@ -1,0 +1,28 @@
+title: Potential Network Device Configuration Theft via SNMP
+id: 4590f85b-97d6-4575-b45f-624d39b2d487
+status: experimental
+description: |
+    Detects network connections to SNMP (UDP/161), consistent with the
+    reconnaissance and configuration-write access described in CISA/NSA/FBI
+    joint advisory AA26-194A, in which FSB Center 16 actors abused exposed
+    SNMP services on routers to trigger configuration-copy operations.
+references:
+    - https://www.cisa.gov/news-events/cybersecurity-advisories/aa26-194a
+author: Zach Vessey
+date: 2026-07-16
+tags:
+    - attack.collection
+    - attack.reconnaissance
+    - attack.t1595.002
+logsource:
+    category: firewall
+detection:
+    selection:
+        dst_port: 161
+        proto: udp
+    condition: selection
+falsepositives:
+    - Legitimate SNMP monitoring/polling traffic from authorized NMS (network
+      management system) hosts — this rule should be scoped with a source-IP
+      allowlist in production deployments.
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Adds two detection rules covering the attack chain described in CISA/NSA/FBI joint advisory AA26-194A (Russian FSB Center 16 targeting network devices via SNMP configuration theft and TFTP exfiltration). One rule detects SNMP connection attempts consistent with the advisory's described weak-community-string abuse; the other detects outbound TFTP transfers from a management subnet, matching the config-exfil step described in the advisory.

Validation performed:
- `python tests/test_logsource.py` — pass
- `python tests/test_rules.py` — pass
- `sigma check --validation-config tests/sigma_cli_conf.yml` — 0 errors, 0 issues
- Converted both rules to Splunk SPL and Elastic Lucene/EQL via sigma-cli to confirm cross-SIEM conversion logic

Note: the SNMP rule originally targeted `product: zeek`/`service: snmp`, but SNMP isn't currently a registered Zeek service in the SigmaHQ taxonomy, so it uses the generic `firewall` category instead (matching on port/protocol rather than SNMP-specific fields). Open to feedback on this approach.

### Changelog

new: Potential Network Device Configuration Theft via SNMP
new: Outbound TFTP Transfer from Network Device Management Segment

### Example Log Event

N/A