### PR TITLE
Add post-quantum / quantum-attack threat-hunting rules (PQC) [RFC]

### DIFF
--- a/rules-threat-hunting/network/pqc/pqc_app_rsa_jwt_signature_usage.yml
+++ b/rules-threat-hunting/network/pqc/pqc_app_rsa_jwt_signature_usage.yml
@@ -1,0 +1,30 @@
+title: Application JWT Signed With Quantum-Vulnerable Algorithm (RS256/ES256)
+id: 6c8a1912-867b-4b5a-a0fe-c3035a9b7c63
+status: experimental
+description: A JSON Web Token signed with RS256/RS384/ES256/ES384 was observed in
+  application traffic. These rely on RSA/ECDSA and are forgeable on a CRQC. Inventory
+  rule for application-layer signing that a network CBOM and a source-code CBOM should
+  reconcile.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.credential-access
+- attack.t1552
+- attack.t1550.001
+logsource:
+  category: proxy
+detection:
+  selection:
+    cs-header|contains:
+    - alg":"RS256
+    - alg":"RS384
+    - alg":"ES256
+    - alg":"ES384
+  condition: selection
+falsepositives:
+- Universal until application signing migrates to PQC/hybrid; inventory finding, not
+  an intrusion alert.
+level: low
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_bulk_outbound_tls_capture_hndl_pattern.yml
+++ b/rules-threat-hunting/network/pqc/pqc_bulk_outbound_tls_capture_hndl_pattern.yml
@@ -1,0 +1,32 @@
+title: Bulk Outbound TLS Session Egress (Possible HNDL Harvesting)
+id: 16498c07-a831-4b71-bccb-2673454f4b7d
+status: experimental
+description: A single external destination received an unusually large volume of distinct
+  TLS sessions/bytes over a short window - a pattern consistent with bulk ciphertext
+  collection for harvest-now-decrypt-later. Best used as a correlation/threshold rule
+  tuned to the environment; the static form here flags very large single-destination
+  TLS egress.
+references:
+- https://www.cisa.gov/quantum
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.collection
+- attack.t1040
+- attack.exfiltration
+- attack.t1030
+logsource:
+  product: zeek
+  service: conn
+detection:
+  selection:
+    service: ssl
+    conn_state: SF
+  large_transfer:
+    orig_bytes|gte: 1073741824
+  condition: selection and large_transfer
+falsepositives:
+- Legitimate large TLS transfers (backups, replication, CDN origin pulls). Tune threshold
+  and destination allowlist per environment.
+level: low
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_dnssec_quantum_vulnerable_signing_algorithm.yml
+++ b/rules-threat-hunting/network/pqc/pqc_dnssec_quantum_vulnerable_signing_algorithm.yml
@@ -1,0 +1,31 @@
+title: DNSSEC Using Quantum-Vulnerable Signing Algorithm
+id: 7107671f-9897-4308-83a6-bdde7f4d4d0a
+status: experimental
+description: A DNSKEY/RRSIG uses an RSA or ECDSA DNSSEC algorithm (5, 7, 8, 10, 13,
+  14). DNSSEC signatures are forgeable on a CRQC via Shor's algorithm; post-quantum
+  DNSSEC algorithms are not yet widely deployed. Inventory rule for the DNS control
+  plane.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.resource-development
+- attack.t1587.003
+logsource:
+  product: zeek
+  service: dns
+detection:
+  selection:
+    dnssec_algorithm:
+    - 5
+    - 7
+    - 8
+    - 10
+    - 13
+    - 14
+  condition: selection
+falsepositives:
+- Universal until PQC DNSSEC (algorithms 16/17) is deployed.
+level: low
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_ipsec_ike_classical_only_key_exchange.yml
+++ b/rules-threat-hunting/network/pqc/pqc_ipsec_ike_classical_only_key_exchange.yml
@@ -1,0 +1,36 @@
+title: IPsec/IKE Classical-Only Key Exchange
+id: 633008a9-1063-4b8d-b443-3962479d5178
+status: experimental
+description: An IKE proposal used a classical-only Diffie-Hellman group (14, 19, 20,
+  21) with no post-quantum additional key exchange (RFC 9370). VPN traffic negotiated
+  this way is a harvest-now-decrypt-later exposure for site-to-site and remote-access
+  tunnels.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+- https://www.rfc-editor.org/rfc/rfc9370
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.collection
+- attack.t1040
+- attack.command-and-control
+- attack.t1573
+logsource:
+  category: firewall
+detection:
+  selection:
+    ike_dh_group:
+    - 14
+    - 19
+    - 20
+    - 21
+  filter_pqc:
+    ike_additional_ke|contains:
+    - mlkem
+    - kyber
+    - pqc
+  condition: selection and not filter_pqc
+falsepositives:
+- VPN concentrators not yet supporting RFC 9370 PQC IKE (expected).
+level: medium
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_large_encrypted_archive_exfil_staging.yml
+++ b/rules-threat-hunting/network/pqc/pqc_large_encrypted_archive_exfil_staging.yml
@@ -1,0 +1,32 @@
+title: Large Encrypted Archive Transfer (Ciphertext Staging)
+id: 46f77d54-d9eb-45d7-918c-96d15d31a991
+status: experimental
+description: A large encrypted/compressed archive (zip, gzip, 7z, encrypted blob)
+  was transferred over the network. In the harvest-now-decrypt-later model, adversaries
+  stage collected ciphertext for later quantum decryption. Correlate with the bulk-TLS-egress
+  rule and DLP context.
+references:
+- https://www.cisa.gov/quantum
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.exfiltration
+- attack.t1560
+- attack.t1030
+logsource:
+  product: zeek
+  service: files
+detection:
+  selection:
+    mime_type:
+    - application/zip
+    - application/gzip
+    - application/x-7z-compressed
+    - application/octet-stream
+  large_file:
+    total_bytes|gte: 536870912
+  condition: selection and large_file
+falsepositives:
+- Legitimate backups and software distribution; tune size and path.
+level: low
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_ssh_quantum_vulnerable_kex_or_hostkey.yml
+++ b/rules-threat-hunting/network/pqc/pqc_ssh_quantum_vulnerable_kex_or_hostkey.yml
@@ -1,0 +1,38 @@
+title: SSH Quantum-Vulnerable Key Exchange or Host Key
+id: cf2c8707-f7cd-46bf-aa6d-27425645d82f
+status: experimental
+description: An SSH session used a classical key-exchange (diffie-hellman-group*,
+  ecdh-*, curve25519 without a PQC hybrid) or an ssh-rsa/ecdsa host key. OpenSSH 9.0+
+  offers the sntrup761x25519 post-quantum hybrid KEX; its absence is a harvest-now-decrypt-later
+  exposure for SSH.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.credential-access
+- attack.t1040
+- attack.lateral-movement
+logsource:
+  product: zeek
+  service: ssh
+detection:
+  selection_kex:
+    kex_alg|contains:
+    - diffie-hellman-group
+    - ecdh-sha2
+    - curve25519-sha256
+  selection_hostkey:
+    host_key_alg|contains:
+    - ssh-rsa
+    - ecdsa-sha2
+  filter_pqc:
+    kex_alg|contains:
+    - sntrup
+    - mlkem
+    - kyber
+  condition: (selection_kex or selection_hostkey) and not filter_pqc
+falsepositives:
+- Environments not yet on OpenSSH 9.0+ PQC hybrid (expected).
+level: medium
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_tls_classical_only_key_exchange.yml
+++ b/rules-threat-hunting/network/pqc/pqc_tls_classical_only_key_exchange.yml
@@ -1,0 +1,39 @@
+title: Classical-Only TLS Key Exchange (Harvest-Now-Decrypt-Later Exposure)
+id: a7c369d8-c1e9-4282-a672-af0e62966ddd
+status: experimental
+description: 'A TLS session negotiated a classical-only key-exchange group (X25519,
+  secp256r1, ffdhe*) with no post-quantum hybrid. Traffic protected this way is exposed
+  to harvest-now-decrypt-later: an adversary can record it today and decrypt it once
+  a CRQC exists. Inventory rule to surface endpoints that have not adopted a PQC hybrid
+  group such as X25519MLKEM768.'
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+- https://www.cisa.gov/quantum
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.collection
+- attack.t1040
+- attack.credential-access
+- attack.t1557
+logsource:
+  product: zeek
+  service: ssl
+detection:
+  selection:
+    curve:
+    - x25519
+    - secp256r1
+    - secp384r1
+    - ffdhe2048
+    - ffdhe3072
+  filter_pqc:
+    curve|contains:
+    - mlkem
+    - kyber
+  condition: selection and not filter_pqc
+falsepositives:
+- Environments that have not yet begun PQC migration (expected); this is an inventory/coverage
+  finding, not an attack alert.
+level: low
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_tls_deprecated_protocol_version.yml
+++ b/rules-threat-hunting/network/pqc/pqc_tls_deprecated_protocol_version.yml
@@ -1,0 +1,28 @@
+title: Deprecated TLS Protocol Version Negotiated
+id: 31513e91-89f7-4953-909a-ef6600afd4b2
+status: experimental
+description: TLS 1.0 or TLS 1.1 was negotiated. These versions lack modern forward
+  secrecy and cannot carry post-quantum hybrid key exchange, so any endpoint using
+  them is both classically weak and unable to become quantum-safe without an upgrade.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.collection
+- attack.t1040
+logsource:
+  product: zeek
+  service: ssl
+detection:
+  selection:
+    version:
+    - TLSv10
+    - TLSv11
+    - TLS 1.0
+    - TLS 1.1
+  condition: selection
+falsepositives:
+- Legacy internal systems pending decommission.
+level: high
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_tls_legacy_weak_cipher_suite.yml
+++ b/rules-threat-hunting/network/pqc/pqc_tls_legacy_weak_cipher_suite.yml
@@ -1,0 +1,32 @@
+title: Legacy or Weak TLS Cipher Suite Negotiated
+id: 9fbcf61f-332a-432e-a0f6-4fdcfbaa3a34
+status: experimental
+description: A TLS session negotiated a legacy/weak cipher suite (3DES, RC4, NULL,
+  EXPORT, or an anonymous suite). These are classically broken or brittle and further
+  weakened by Grover's algorithm; none support a post-quantum migration path.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.credential-access
+- attack.t1040
+- attack.t1557
+logsource:
+  product: zeek
+  service: ssl
+detection:
+  selection:
+    cipher|contains:
+    - 3DES
+    - DES_
+    - RC4
+    - _NULL_
+    - EXPORT
+    - _anon_
+    - MD5
+  condition: selection
+falsepositives:
+- Legacy appliances that cannot be upgraded (should be isolated).
+level: high
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_tls_server_downgrade_from_pqc_offer.yml
+++ b/rules-threat-hunting/network/pqc/pqc_tls_server_downgrade_from_pqc_offer.yml
@@ -1,0 +1,33 @@
+title: TLS Server Downgrade From Offered PQC Hybrid Group
+id: 87ffb82c-28d7-4b13-a5a3-e58182972af8
+status: experimental
+description: The client offered a post-quantum hybrid key-exchange group (e.g. X25519MLKEM768)
+  but the server selected a classical group. This silently forfeits quantum protection
+  even where the client is PQC-ready, and can indicate a misconfigured or downgrade-forcing
+  middlebox. Requires ClientHello supported-groups visibility.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.collection
+- attack.t1040
+logsource:
+  product: zeek
+  service: ssl
+detection:
+  client_offered_pqc:
+    client_supported_groups|contains:
+    - mlkem
+    - kyber
+  server_chose_classical:
+    curve:
+    - x25519
+    - secp256r1
+    - secp384r1
+  condition: client_offered_pqc and server_chose_classical
+falsepositives:
+- Servers not yet PQC-capable (expected); becomes actionable once the server is supposed
+  to support hybrid KEX.
+level: medium
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_x509_long_lived_classical_certificate.yml
+++ b/rules-threat-hunting/network/pqc/pqc_x509_long_lived_classical_certificate.yml
@@ -1,0 +1,30 @@
+title: Long-Lived Classical Certificate Spanning the CRQC Horizon
+id: 44c6ccc9-ea66-4d64-a24e-8051d0c3e27f
+status: experimental
+description: A certificate using a classical (RSA/ECC) key with a validity period
+  extending past the projected cryptographically-relevant-quantum-computer window
+  (~2030-2035). Data protected under such a certificate must remain confidential past
+  the point where the key may be broken. Numeric validity comparison is done in post-processing;
+  this rule surfaces classical long-lived certs for review.
+references:
+- https://www.cisa.gov/quantum
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.collection
+- attack.t1040
+logsource:
+  product: zeek
+  service: x509
+detection:
+  selection:
+    certificate.key_alg|contains:
+    - rsa
+    - ecPublicKey
+    - id-ecPublicKey
+  condition: selection
+falsepositives:
+- Short-lived certs (filter by validity period downstream); inventory finding.
+level: low
+license: DRL-1.1

--- a/rules-threat-hunting/network/pqc/pqc_x509_quantum_vulnerable_certificate_signature.yml
+++ b/rules-threat-hunting/network/pqc/pqc_x509_quantum_vulnerable_certificate_signature.yml
@@ -1,0 +1,37 @@
+title: X.509 Certificate Signed With Quantum-Vulnerable Algorithm
+id: f2f6e5c5-9314-4866-8851-d3a5c5a5bd96
+status: experimental
+description: An observed X.509 certificate is signed with RSA or ECDSA (or a SHA-1-based
+  signature). Shor's algorithm breaks RSA/ECDSA signatures on a CRQC (Trust-Now-Forge-Later).
+  Inventory rule to build the certificate side of a cryptographic bill of materials.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.resource-development
+- attack.t1587
+- attack.t1552.004
+logsource:
+  product: zeek
+  service: x509
+detection:
+  selection:
+    certificate.sig_alg|contains:
+    - rsa
+    - ecdsa
+    - sha1With
+    - sha1WithRSA
+  filter_pqc:
+    certificate.sig_alg|contains:
+    - mldsa
+    - dilithium
+    - sphincs
+    - slhdsa
+    - falcon
+  condition: selection and not filter_pqc
+falsepositives:
+- Universal until PQC certificate issuance is adopted; inventory finding, not an intrusion
+  signal.
+level: medium
+license: DRL-1.1

--- a/rules-threat-hunting/windows/pqc/pqc_kerberos_pkinit_rsa_certificate_auth.yml
+++ b/rules-threat-hunting/windows/pqc/pqc_kerberos_pkinit_rsa_certificate_auth.yml
@@ -1,0 +1,28 @@
+title: Kerberos PKINIT Using RSA Certificate Authentication
+id: af6b6c23-2f01-4061-b354-67ff876675a5
+status: experimental
+description: A Kerberos pre-authentication used a certificate (PKINIT). Where the
+  certificate key is RSA/ECC, the ticket-granting trust chain is forgeable on a CRQC
+  (Trust-Now-Forge-Later). Surfaces certificate-based Kerberos auth for PQC-capable
+  PKI migration planning.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.credential-access
+- attack.t1558
+- attack.lateral-movement
+- attack.t1550
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4768
+    CertificateThumbprint|exists: true
+  condition: selection
+falsepositives:
+- Smart-card/PKINIT environments (expected); inventory finding.
+level: low
+license: DRL-1.1

--- a/rules-threat-hunting/windows/pqc/pqc_kerberos_rc4_hmac_etype.yml
+++ b/rules-threat-hunting/windows/pqc/pqc_kerberos_rc4_hmac_etype.yml
@@ -1,0 +1,28 @@
+title: Kerberos RC4-HMAC Encryption Type In Use
+id: 00680db5-20a1-4273-a081-8732c7e3913b
+status: experimental
+description: A Kerberos ticket used the RC4-HMAC encryption type (etype 0x17). RC4/MD-based
+  Kerberos crypto is classically weak, enables Kerberoasting, and is further weakened
+  by Grover's algorithm. Migrate to AES etypes as a prerequisite to a quantum-safe
+  identity plane.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.credential-access
+- attack.t1558.003
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID:
+    - 4768
+    - 4769
+    TicketEncryptionType: '0x17'
+  condition: selection
+falsepositives:
+- Legacy services pinned to RC4 (should be remediated).
+level: medium
+license: DRL-1.1

--- a/rules-threat-hunting/windows/pqc/pqc_windows_ntlm_legacy_authentication.yml
+++ b/rules-threat-hunting/windows/pqc/pqc_windows_ntlm_legacy_authentication.yml
@@ -1,0 +1,26 @@
+title: NTLM (MD4/MD5-Based) Authentication Observed
+id: 9d26bf7f-412d-47a9-9fb3-3d5347a14e05
+status: experimental
+description: An NTLM authentication event was logged. NTLM relies on MD4/MD5, which
+  are classically weak and trivially accelerated by Grover's algorithm, and NTLM is
+  separately exposed to Pass-the-Hash. Surfaces quantum-and-classically weak authentication
+  for migration to Kerberos with PQC-capable PKINIT or to modern password hashing.
+references:
+- https://csrc.nist.gov/pubs/ir/8547/ipd
+author: TAI Creative LLC
+date: '2026-07-16'
+tags:
+- attack.credential-access
+- attack.t1110
+- attack.t1550.002
+logsource:
+  product: windows
+  service: security
+detection:
+  selection:
+    EventID: 4776
+  condition: selection
+falsepositives:
+- Legacy applications requiring NTLM; expected in unmigrated domains.
+level: medium
+license: DRL-1.1


### PR DESCRIPTION
## Summary

This is a **draft / RFC** proposing a set of **experimental threat-hunting rules for post-quantum cryptography (PQC) exposure and quantum-attack-adjacent TTPs**. As of mid-2026 the public Sigma corpus has essentially no PQC-specific detection content, and organizations under NIST/CISA post-quantum migration timelines are starting to ask "would we even see harvest-now-decrypt-later collection or classical-only key exchange?"

15 rules, placed under `rules-threat-hunting/network/pqc/` (12) and `rules-threat-hunting/windows/pqc/` (3):

- Classical-only / deprecated / downgraded TLS, SSH, and IKE key exchange (harvest-now-decrypt-later exposure)
- Quantum-vulnerable X.509 certificate and DNSSEC signatures (RSA/ECDSA)
- Bulk TLS egress and encrypted-archive staging (HNDL ciphertext collection)
- Legacy auth weakened by Grover's algorithm (NTLM, RC4-HMAC Kerberos, RSA PKINIT)
- Application JWT signed with RS256/ES256

## Notes for maintainers

- All 15 rules pass `sigma check` (**0 errors, 0 issues**).
- All are `status: experimental`. Several are inventory/hygiene-style hunting rules (e.g. "classical cert signature in use"); field names reflect common Zeek/Windows telemetry but availability varies by sensor and enabled scripts, so they are written to be tuned per environment.
- **Guidance welcome on placement and scope** — happy to relocate (e.g. `rules-emerging-threats/`), split behavioral vs. inventory rules, or trim to the subset the project considers in-scope.

Opening as a draft to solicit that feedback before finalizing.