### PR TITLE
chore: :lock: restrict automated workflows to SigmaHQ org only

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -7,6 +7,7 @@ name: PR Labeler Workflow
 
 jobs:
   triage:
+    if: github.repository_owner == 'SigmaHQ'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/ref-archiver.yml
+++ b/.github/workflows/ref-archiver.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   archive:
+    if: github.repository_owner == 'SigmaHQ'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ name: Create Release
 jobs:
   build:
     name: Create Release
+    if: github.repository_owner == 'SigmaHQ'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/sigma-rule-deprecated.yml
+++ b/.github/workflows/sigma-rule-deprecated.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   pull-master:
+    if: github.repository_owner == 'SigmaHQ'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/update-heatmap.yml
+++ b/.github/workflows/update-heatmap.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   generate-heatmap:
+    if: github.repository_owner == 'SigmaHQ'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Restrict workflows that create Pull Requests or GitHub Releases to only run on the SigmaHQ organization repository, preventing them from executing on forks.

### Changelog

chore: restrict release workflow to SigmaHQ org only
chore: restrict deprecated summary workflow to SigmaHQ org only
chore: restrict reference archiver workflow to SigmaHQ org only
chore: restrict ATT&CK heatmap update workflow to SigmaHQ org only
chore: restrict PR labeler workflow to SigmaHQ org only

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

N/A
