### PR TITLE
Add rule: DNS Query Using NULL Record Type (T1071.004)

### DIFF
--- a/rules/network/dns/net_dns_tunneling_null_record_query.yml
+++ b/rules/network/dns/net_dns_tunneling_null_record_query.yml
@@ -1,0 +1,41 @@
+title: DNS Query Using NULL Record Type
+id: 77461855-8eb5-4e8b-b82e-26bec23277ca
+status: experimental
+description: |
+    Detects a DNS query using the NULL record type. NULL records are rarely
+    used in legitimate DNS traffic but are commonly used by DNS tunneling
+    tools, such as iodine, because they can carry more payload per query
+    than standard A/AAAA lookups. Existing public DNS tunneling detections
+    are largely based on overall query volume or lists of known tunneling
+    domains and tools, this rule targets NULL-type query behavior
+    specifically, filling a gap not covered by those approaches, and can
+    catch novel or custom tunneling tools that aren't on any known-domain
+    list.
+
+    Validated against real traffic, 100% detection rate against captured
+    iodine tunneling traffic, 2782 out of 2782 queries, 0 false positives
+    against captured benign DNS traffic, 242 queries. Analysts should treat
+    a single NULL query as low-signal on its own, and prioritize
+    investigation when NULL queries repeat many times to the same domain in
+    a short window, which is a stronger indicator of tunneling activity.
+    See referenced project for full methodology.
+references:
+    - https://github.com/Shelaz303/dns-tunneling-detector
+    - https://patrick-bareiss.com/detect-c2-traffic-over-dns-using-sigma/
+    - https://code.kryo.se/iodine/
+author: Shelaz303
+date: 2026-07-21
+logsource:
+    category: dns
+detection:
+    selection:
+        qtype_name: 'NULL'
+    condition: selection
+falsepositives:
+    - Legitimate software that intentionally uses NULL DNS records, uncommon
+level: medium
+tags:
+    - attack.command-and-control
+    - attack.t1071.004
+    - attack.exfiltration
+    - attack.t1048


### PR DESCRIPTION
## Summary

Adds a new detection rule for DNS tunneling activity based on DNS NULL
record query type usage.

## Why this rule

Existing DNS tunneling coverage in this repo (e.g. net_dns_c2_detection.yml,
net_dns_susp_b64_queries.yml) is based on query volume or base64-encoded
query strings. This rule targets a different, currently uncovered signal:
DNS NULL record type usage, which is rare in legitimate traffic but
commonly used by tunneling tools (e.g. iodine) since NULL records carry
more payload per query than standard A/AAAA lookups.

## Validation

I built and tested a working Python/scapy detector using this exact logic
against real captured traffic:

- Malicious traffic (iodine DNS tunnel): 2,782/2,782 NULL-type queries
  correctly identified (100%)
- Benign traffic (normal browsing DNS): 0/242 false positives (0%)

Full methodology, capture process, and detector code:
https://github.com/Shelaz303/dns-tunneling-detector

## Testing performed

- [x] python3 tests/test_logsource.py — pass
- [x] python3 tests/test_rules.py — pass
- [x] sigma check --fail-on-error --fail-on-issues --validation-config
      tests/sigma_cli_conf.yml rules/network/dns/ — 0 errors, 0 issues

## Notes

A single NULL-type query is a moderate-confidence signal on its own
(level: medium) — analysts should prioritize investigation when NULL
queries repeat many times to the same domain in a short window, which is
a much stronger tunneling indicator. I originally intended to express that
volume threshold as a Sigma correlation rule, but found the main repo's
legacy test scripts (test_logsource.py, test_rules.py) don't yet handle
correlation-type rules (no logsource field), and there are no existing
correlation rules in the repo to model against. Happy to revisit this as
a follow-up if correlation rule support is added to the test suite.
