### PR TITLE
New rule: Script Interpreter Spawning Credential Scanner - macOS

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_susp_script_interpretor_spawn_credential_scanner.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_script_interpretor_spawn_credential_scanner.yml
@@ -1,0 +1,44 @@
+title: Script Interpreter Spawning Credential Scanner - macOS
+id: 822e6453-105c-4934-ae40-253ac188f5ff
+related:
+    - id: 0f60b28c-64dd-4e2c-9a63-5334d3e3a6e6
+      type: similar
+    - id: f0025a69-e1b7-4dda-a53c-db21fa2d4071
+      type: similar
+status: experimental
+description: |
+    Detects a script interpreter process (like node.js or bun) spawning a known credential scanning tool (e.g., trufflehog, gitleaks).
+    This behavior is indicative of an attempt to find and steal secrets, as seen in the "Shai-Hulud: The Second Coming" campaign.
+references:
+    - https://github.com/asyncapi/cli/blob/2efa4dff59bc3d3cecdf897ccf178f99b115d63d/bun_environment.js
+    - https://www.stepsecurity.io/blog/sha1-hulud-the-second-coming-zapier-ens-domains-and-other-prominent-npm-packages-compromised
+    - https://www.endorlabs.com/learn/shai-hulud-2-malware-campaign-targets-github-and-cloud-credentials-using-bun-runtime
+    - https://semgrep.dev/blog/2025/digging-for-secrets-sha1-hulud-the-second-coming-of-the-npm-worm/
+author: Ritika (IsThisRitika)
+date: 2026-07-21
+tags:
+    - attack.credential-access
+    - attack.t1552
+    - attack.execution
+    - attack.collection
+    - attack.t1005
+    - attack.t1059.007
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_parent:
+        ParentImage|endswith:
+            - '/node'
+            - '/bun'
+    selection_child:
+        - Image|endswith:
+              - '/trufflehog'
+              - '/gitleaks'
+        - CommandLine|contains:
+              - 'trufflehog'
+              - 'gitleaks'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate pre-commit hooks or CI/CD pipeline jobs that use a script to run a credential scanner as part of a security check.
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

Adds a macOS equivalent of the existing Windows and Linux rules that detect a script interpreter (node.js or bun) spawning a credential scanning tool (trufflehog or gitleaks). This completes platform coverage for the detection logic associated with the Shai-Hulud npm supply-chain campaign while keeping the detection logic consistent with the existing sibling rules.

### Changelog

new: Script Interpreter Spawning Credential Scanner - macOS

### Example Log Event

N/A

### Fixed Issues

N/A