### PR TITLE
New Agent Skills Installation Attempt Via Node - Linux

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_node_new_agent_skills_installed.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_node_new_agent_skills_installed.yml
@@ -1,0 +1,40 @@
+title: New Agent Skills Installation Attempt Via Node - Linux
+id: ab582088-55d2-48f2-b707-ee5699d127cd
+related:
+    - id: afa71271-6a97-4e47-810f-83120fb1a4ce
+      type: similar
+status: experimental
+description: |
+    Detects the attempt to install new skills for AI agents using the "npx skills" command on Linux systems.
+    Agent skills enhance AI agents with new capabilities, but attackers may abuse this mechanism to inject malicious commands executed by the agent on behalf of the user.
+    The "npx skills" command can install skills for various agents (e.g., Claude Code, Cursor, and others).
+    Analysts should review any installed skills to verify their legitimacy.
+    Note: Tune this rule based on whether AI agent tooling is allowed in your environment.
+    In environments where such tooling is authorized, this detection may reflect normal activity and the alert level should be adjusted accordingly.
+    In environments where AI agent tooling is not permitted, this activity is likely suspicious and may require immediate investigation.
+references:
+    - https://blog.lukaszolejnik.com/supply-chain-risk-of-agentic-ai-infecting-infrastructures-via-skill-worms/
+    - https://github.com/vercel-labs/skills/blob/1f7fbc8d0e49c4e0601d364696bd1bdd15e80967/README.md
+    - https://opensourcemalware.com/blog/clawdbot-skills-ganked-your-crypto
+    - https://promptintel.novahunting.ai/molt
+author: Ritika <YOUR GITHUB HANDLE>
+date: 2026-07-21
+tags:
+    - attack.execution
+    - attack.t1059.007
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        Image|endswith: '/node'
+    selection_cli:
+        CommandLine|contains|all:
+            - 'npx-cli.js'
+            - 'skills '
+            - ' add '
+    condition: all of selection_*
+falsepositives:
+    - This rule will be triggered when a new agent skill is installed regardless if it is benign or malicious.
+    - High false positive rate expected in environments where AI agent tooling is authorized and commonly used, such as developer workstations or CI/CD build agents.
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Adds a Linux detection rule for AI agent skill installation using `npx skills add`, extending the existing Windows detection to improve platform coverage. The rule adapts the detection logic for Linux while preserving the original detection intent.

### Changelog

new: New Agent Skills Installation Attempt Via Node - Linux

### Example Log Event

N/A

### Fixed Issues

N/A
