### PR TITLE
new: Suspicious Hidden Password Prompt Via Osascript

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_susp_osascript_hidden_password_prompt.yml
+++ b/rules/macos/process_creation/proc_creation_macos_susp_osascript_hidden_password_prompt.yml
@@ -1,0 +1,35 @@
+title: Suspicious Hidden Password Prompt Via Osascript
+id: 7f2b6e3a-4c9d-4b1e-9a2f-3d8c5e6f7a10
+status: experimental
+description: |
+    Detects AppleScript dialogs requesting hidden user input using
+    "display dialog ... with hidden answer", a technique commonly used by
+    macOS malware to phish local user credentials.
+references:
+    - https://embracethered.com/blog/posts/2021/spoofing-credential-dialogs/
+    - https://attack.mitre.org/techniques/T1056/002/
+    - https://unit42.paloaltonetworks.com/openclaw-ai-supply-chain-risk/
+author: Ritika (@IsThisRitika)
+date: 2026-07-21
+tags:
+    - attack.credential-access
+    - attack.t1056.002
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_tool:
+        Image|endswith: '/osascript'
+    selection_dialog:
+        CommandLine|contains|all:
+            - 'display dialog'
+            - 'hidden answer'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate MDM or self-service tooling (e.g. Jamf Connect, Kandji, Munki)
+      prompting users for passwords during FileVault, password reset, or device
+      provisioning workflows.
+    - Internal administration or helpdesk scripts that intentionally use
+      "display dialog ... with hidden answer" to collect credentials during
+      machine setup.
+level: high


### PR DESCRIPTION
## Summary

This PR adds a new macOS process creation rule to detect AppleScript dialogs requesting hidden user input using `display dialog ... with hidden answer`.

This technique is commonly used by macOS malware to phish local user credentials by displaying a native-looking password prompt.

## Detection

- Logsource: macOS / process_creation
- Detects `osascript` executions containing:
  - `display dialog`
  - `hidden answer`

## ATT&CK

- T1056.002 – GUI Input Capture

## References

- https://embracethered.com/blog/posts/2021/spoofing-credential-dialogs/
- https://attack.mitre.org/techniques/T1056/002/

## Testing

- `python tests/test_logsource.py` ✅
- `python tests/test_rules.py` ✅