### PR TITLE
feat: Add Python One-Liners with Base64 Decoding macOS rule

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_python_base64_encoded_execution.yml
+++ b/rules/macos/process_creation/proc_creation_macos_python_base64_encoded_execution.yml
@@ -1,0 +1,45 @@
+title: Python One-Liners with Base64 Decoding - macOS
+id: 20787d51-2fc4-4ff1-82d8-b434d0fa3427
+related:
+    - id: 50a0aa3d-ab16-4594-a8aa-5145a6e6792b
+      type: similar
+    - id: 55e862a8-dd9c-4651-807a-f21fcad56716
+      type: similar
+status: experimental
+description: |
+    Detects the use of Python's base64 decoding functions in command line executions on macOS systems.
+    Malicious scripts often use python one-liners to decode and execute base64-encoded payloads, which is a common technique for obfuscation and evasion.
+references:
+    - https://docs.python.org/3/library/base64.html
+    - https://www.virustotal.com/gui/file/bc43e925d7b4b74319f6e74e836a96f1997ba404e14ac566cf12a21e9da463db/behavior
+    - https://cloud.google.com/blog/topics/threat-intelligence/cybercriminals-weaponize-fake-ai-websites
+author: Ritika (IsThisRitika)
+date: 2026-07-21
+tags:
+    - attack.execution
+    - attack.stealth
+    - attack.t1059.006
+    - attack.t1027.010
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_img:
+        Image|contains: '/python'
+    selection_cli:
+        CommandLine|contains|all:
+            - 'import'
+            - 'base64'
+            - ' -c'
+        CommandLine|contains:
+            - '.decode'
+            - 'b16decode'
+            - 'b32decode'
+            - 'b32hexdecode'
+            - 'b64decode'
+            - 'b85decode'
+            - 'z85decode'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate use of Python for decoding data, which is uncommon in typical enterprise environments but possible in development or data analysis contexts.
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

This pull request adds a new macOS Sigma rule to detect Python one-liners that use Base64 decoding functions. It complements the existing Windows and Linux detection rules by providing equivalent detection coverage for macOS.

### Changelog

new: Python One-Liners with Base64 Decoding - macOS

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

* [x] I have followed the SigmaHQ rule creation conventions.
