### PR TITLE
feat: Add PUA - TruffleHog Execution macOS rule

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_pua_trufflehog.yml
+++ b/rules/macos/process_creation/proc_creation_macos_pua_trufflehog.yml
@@ -1,0 +1,45 @@
+title: PUA - TruffleHog Execution - macOS
+id: 89342720-1682-492a-9d2d-ba34db0df713
+related:
+    - id: 44030449-b0df-4c94-aae1-502359ab28ee
+      type: similar
+    - id: d7a650c4-226c-451e-948f-cc490db506aa
+      type: similar
+status: experimental
+description: |
+    Detects execution of TruffleHog, a tool used to search for secrets in different platforms like Git, Jira, Slack, SharePoint, etc. that could be used maliciously.
+    While it is a legitimate tool, intended for use in CI pipelines and security assessments,
+    It was observed in the Shai-Hulud malware campaign targeting npm packages to steal sensitive information.
+references:
+    - https://github.com/trufflesecurity/trufflehog
+    - https://www.getsafety.com/blog-posts/shai-hulud-npm-attack
+author: Ritika (IsThisRitika)
+date: 2026-07-21
+tags:
+    - attack.discovery
+    - attack.credential-access
+    - attack.t1083
+    - attack.t1552.001
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_img:
+        Image|endswith: '/trufflehog'
+    selection_cli_platform:
+        CommandLine|contains:
+            - ' docker --image '
+            - ' Git '
+            - ' GitHub '
+            - ' Jira '
+            - ' Slack '
+            - ' Confluence '
+            - ' SharePoint '
+            - ' s3 '
+            - ' gcs '
+    selection_cli_verified:
+        CommandLine|contains: ' --results=verified'
+    condition: selection_img or all of selection_cli_*
+falsepositives:
+    - Legitimate use of TruffleHog by security teams or developers.
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

This pull request adds a macOS Sigma rule to detect TruffleHog execution. It complements the existing Windows and Linux detection rules by providing equivalent detection coverage for macOS.

### Changelog

new: PUA - TruffleHog Execution - macOS

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- [x] I have followed the SigmaHQ rule creation conventions.