### PR TITLE
fix: macOS network service scanning filter matches any 'l', not the netcat listen flag

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_network_service_scanning.yml
+++ b/rules/macos/process_creation/proc_creation_macos_network_service_scanning.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1046/T1046.md
 author: Alejandro Ortuno, oscd.community
 date: 2020-10-21
-modified: 2021-11-27
+modified: 2026-07-27
 tags:
     - attack.discovery
     - attack.t1046
@@ -23,7 +23,9 @@ detection:
             - '/nmap'
             - '/telnet'
     filter:
-        CommandLine|contains: 'l'
+        CommandLine|contains:
+            - ' --listen '
+            - ' -l '
     condition: (selection_1 and not filter) or selection_2
 falsepositives:
     - Legitimate administration activities

--- a/rules/macos/process_creation/proc_creation_macos_network_service_scanning.yml
+++ b/rules/macos/process_creation/proc_creation_macos_network_service_scanning.yml
@@ -22,11 +22,9 @@ detection:
         Image|endswith:
             - '/nmap'
             - '/telnet'
-    filter:
-        CommandLine|contains:
-            - ' --listen '
-            - ' -l '
-    condition: (selection_1 and not filter) or selection_2
+    filter_main_nc_listen:
+        CommandLine|re: '\s--?(?:[a-z46]{0,5}l[a-z46]{0,4})'
+    condition: (selection_1 and not 1 of filter_main_*) or selection_2
 falsepositives:
     - Legitimate administration activities
 level: low


### PR DESCRIPTION
## Summary

The filter on this rule is meant to exclude netcat running as a listener, but it's `CommandLine|contains: 'l'`, a bare letter rather than the `-l`/`--listen` flag. With `condition: (selection_1 and not filter) or selection_2`, the netcat branch only fires when the command line contains no letter `l` at all.

So a real network-service scan gets silently suppressed whenever the command line has an `l` in it:

- `nc -zv leader.internal.corp 4444` gets filtered out (there's an `l` in the hostname)
- `nc -zv mail.local 22` gets filtered out too
- `nc -l 4444`, a genuine listener, is correctly excluded

Any target with an `l` in its hostname, and `.local`/`.lan` in particular, means the T1046 discovery scan this rule is for never alerts.

The Linux version of essentially the same rule, `proc_creation_lnx_susp_network_utilities_execution.yml`, already does this correctly with `' --listen '` / `' -l '`. This change makes the macOS one match, so the filter excludes actual listener invocations instead of any command with the letter `l`.

## Changelog

fix: macOS network service scanning filter matches any letter `l` instead of the netcat listen flag
