### PR TITLE
Add macOS Keychain password retrieval detection

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_security_keychain_password_retrieval.yml
+++ b/rules/macos/process_creation/proc_creation_macos_security_keychain_password_retrieval.yml
@@ -1,0 +1,34 @@
+title: Keychain Password Retrieval Via Security Command
+id: c3c68a87-17e0-48da-a308-59593028fbf4
+status: experimental
+description: |
+    Detects the retrieval of generic or internet passwords from the macOS
+    Keychain using the built-in security command-line utility.
+references:
+    - https://www.unix.com/man-page/osx/1/security/
+    - https://www.trendmicro.com/en_gb/research/25/i/an-mdr-analysis-of-the-amos-stealer-campaign.html
+    - https://www.group-ib.com/blog/clicklock-stealer-macos-malware/
+    - https://objective-see.org/blog/blog_0x88.html
+author: Jason Phang Vern - Onn
+date: 2026-07-27
+tags:
+    - attack.credential-access
+    - attack.t1555.001
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_img:
+        Image|endswith: '/security'
+    selection_command:
+        CommandLine|contains:
+            - 'find-generic-password'
+            - 'find-internet-password'
+    selection_password_output:
+        CommandLine|contains:
+            - ' -w'
+            - ' -g'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate applications, administrative scripts or automation retrieving credentials stored in the macOS Keychain
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Adds a macOS process creation rule to detect password retrieval from Keychain generic and internet password items using the built-in `security` utility with the `-w` or `-g` options.

### Changelog

new: Keychain Password Retrieval Via Security Command