### PR TITLE
fix(posh_ps_create_local_user): add ADSI/WinNT local user creation detection

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_create_local_user.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_create_local_user.yml
@@ -1,25 +1,32 @@
-title: PowerShell Create Local User
-id: 243de76f-4725-4f2e-8225-a8a69b15ad61
+title: PowerShell Local User Creation
+id: b5af6a38-b7bb-4a7f-9cbf-4adaece63748
 status: test
-description: Detects creation of a local user via PowerShell
+description: Detects local user account creation via PowerShell — including both
+             the New-LocalUser cmdlet and the ADSI/WinNT COM provider method,
+             which does not use New-LocalUser and is missed by cmdlet-only detections.
 references:
-    - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1136.001/T1136.001.md
-author: '@ROxPinTeddy'
-date: 2020-04-11
-modified: 2022-12-25
+    - https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.localaccounts/new-localuser
+    - https://attack.mitre.org/techniques/T1136/001/
+    - https://github.com/SigmaHQ/sigma/issues/6057
+author: Char0n1507
+date: 2026/07/27
 tags:
-    - attack.execution
-    - attack.t1059.001
     - attack.persistence
     - attack.t1136.001
 logsource:
     product: windows
     category: ps_script
-    definition: 'Requirements: Script Block Logging must be enabled'
+    definition: 'Script Block Logging must be enabled (Event ID 4104)'
 detection:
-    selection:
-        ScriptBlockText|contains: 'New-LocalUser'
-    condition: selection
+    selection_cmdlet:
+        ScriptBlockText|contains:
+            - 'New-LocalUser'
+    selection_adsi:
+        ScriptBlockText|contains|all:
+            - 'WinNT://'
+            - '.Create("User"'
+    condition: 1 of selection_*
 falsepositives:
-    - Legitimate user creation
+    - Legitimate admin scripts provisioning local service accounts via ADSI
+    - Automated provisioning tools (e.g., Ansible, DSC) using ADSI
 level: medium


### PR DESCRIPTION
## Summary
Fixes #6057 — coverage gap where local account creation via the ADSI/WinNT 
COM provider was not detected by the existing New-LocalUser-only rule.

## Changes
- Added `selection_adsi` to catch `[ADSI]"WinNT://..."` + `.Create("User",...)` 
  in ScriptBlockText (Event ID 4104)
- Condition uses `1 of selection_*` so either method triggers the rule

## Testing
Validated with sigma-cli 3.1.0 / pySigma 1.4.0 : 0 errors, 0 issues.
Lab-verified by issue reporter on Windows 11, PowerShell 5.1, Script Block 
Logging enabled: ADSI technique fires Event 4104 but original rule did not match.

## MITRE ATT&CK
T1136.001  Create Account: Local Account