### PR TITLE
Add CrashStealer macOS Detection Rules

### DIFF
--- a/rules-emerging-threats/2026/Malware/CrashStealer/file_event_macos_malware_crashstealer_artifacts.yml
+++ b/rules-emerging-threats/2026/Malware/CrashStealer/file_event_macos_malware_crashstealer_artifacts.yml
@@ -1,0 +1,44 @@
+title: CrashStealer File Artifacts
+id: 1c616b41-b407-4016-982e-6a5705d7c034
+status: experimental
+description: |
+    Detects staging, persistence, and collection artifacts associated with CrashStealer, a macOS infostealer that impersonates Apple's
+    CrashReporter component.
+references:
+    - https://www.jamf.com/blog/crashstealer-macos-infostealer-analysis/
+author: Robbin Ooi Zhen Heng
+date: 2026-07-28
+tags:
+    - attack.collection
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.stealth
+    - attack.t1036.005
+    - attack.t1074.001
+    - attack.t1543.001
+    - attack.t1564.001
+    - detection.emerging-threats
+logsource:
+    category: file_event
+    product: macos
+detection:
+    selection_staged_app:
+        TargetFilename|endswith: '/private/tmp/.CrashReporter/CrashReporter.app/Contents/MacOS/CrashReporter'
+    selection_persistence:
+        TargetFilename|startswith: '/Users/'
+        TargetFilename|endswith:
+            - '/Library/Caches/com.apple.crashreporter/CrashReporter.app/Contents/MacOS/CrashReporter'
+            - '/Library/LaunchAgents/com.apple.crashreporter.helper.plist'
+    selection_archive:
+        TargetFilename|startswith: '/Users/'
+        TargetFilename|contains|all:
+            - '/.cache/com.apple.crashreporter/.zx_'
+            - '.zip'
+    selection_keychain_staging:
+        TargetFilename|startswith: '/Users/'
+        TargetFilename|contains: '/.cache/com.apple.crashreporter/.brw_'
+        TargetFilename|endswith: '/Keychain/login.keychain-db'
+    condition: 1 of selection_*
+falsepositives:
+    - Unlikely
+level: high

--- a/rules-emerging-threats/2026/Malware/CrashStealer/proc_creation_macos_malware_crashstealer_dropper.yml
+++ b/rules-emerging-threats/2026/Malware/CrashStealer/proc_creation_macos_malware_crashstealer_dropper.yml
@@ -1,0 +1,49 @@
+title: CrashStealer Dropper Activity
+id: 1975d961-36e0-4022-b4cf-30992db600df
+status: experimental
+description: |
+    Detects distinctive CrashStealer dropper activity, including mounting its disk image without verification, removing quarantine attributes,
+    stripping the staged application's signature, and re-signing the hidden application bundle with an ad-hoc identity.
+references:
+    - https://www.jamf.com/blog/crashstealer-macos-infostealer-analysis/
+author: Robbin Ooi Zhen Heng
+date: 2026-07-28
+tags:
+    - attack.defense-impairment
+    - attack.execution
+    - attack.stealth
+    - attack.t1553.001
+    - attack.t1553.002
+    - attack.t1564.001
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_mount:
+        Image|endswith: '/hdiutil'
+        CommandLine|contains|all:
+            - 'attach'
+            - '-nobrowse'
+            - '-noverify'
+            - 'CrashReporter.dmg'
+    selection_xattr:
+        Image|endswith: '/xattr'
+        CommandLine|contains|all:
+            - '-cr'
+            - '/tmp/.CrashReporter'
+    selection_remove_signature:
+        Image|endswith: '/codesign'
+        CommandLine|contains|all:
+            - '--remove-signature'
+            - '/tmp/.CrashReporter'
+    selection_adhoc_sign:
+        Image|endswith: '/codesign'
+        CommandLine|contains|all:
+            - '-s -'
+            - '--deep'
+            - '/tmp/.CrashReporter'
+    condition: 1 of selection_*
+falsepositives:
+    - Unlikely
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

Adds two experimental macOS detection rules for CrashStealer based on Jamf Threat Labs research.

The rules detect:

- Staging, persistence, and collection artifacts associated with the fake CrashReporter application, including its hidden execution path, LaunchAgent, re-signed payload, encrypted archives, and staged login Keychain.
- Distinctive dropper activity involving a disk image mounted without verification, recursive extended-attribute removal, signature stripping, and ad-hoc re-signing of the hidden application bundle.

The detections focus on endpoint-visible behavioral and filesystem artifacts instead of short-lived network infrastructure or file hashes.

Validation completed successfully with strict `yamllint` and Sigma CLI validation. The repository logsource and legacy rule tests also pass for this rule set.

Reference:

- https://www.jamf.com/blog/crashstealer-macos-infostealer-analysis/

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: CrashStealer File Artifacts
new: CrashStealer Dropper Activity

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

CrashStealer staged application:
TargetFilename: `/private/tmp/.CrashReporter/CrashReporter.app/Contents/MacOS/CrashReporter`

CrashStealer persistent application:
TargetFilename: `/Users/<username>/Library/Caches/com.apple.crashreporter/CrashReporter.app/Contents/MacOS/CrashReporter`

CrashStealer LaunchAgent:
TargetFilename: `/Users/<username>/Library/LaunchAgents/com.apple.crashreporter.helper.plist`

CrashStealer collection archive:
TargetFilename: `/Users/<username>/.cache/com.apple.crashreporter/.zx_c67e4203.zip`

CrashStealer staged keychain:
TargetFilename: `/Users/<username>/.cache/com.apple.crashreporter/.brw_example/Keychain/login.keychain-db`

CrashStealer dropper commands:
`hdiutil attach CrashReporter.dmg -nobrowse -noverify -mountpoint /tmp/_vol`
`xattr -cr /tmp/.CrashReporter`
`codesign --remove-signature /tmp/.CrashReporter/CrashReporter.app`
`codesign -s - --deep /tmp/.CrashReporter/CrashReporter.app`

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

None.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
