### PR TITLE
new: SSH Authorized Keys Modification

### DIFF
--- a/rules/linux/file_event/file_event_lnx_ssh_authorized_keys_modification.yml
+++ b/rules/linux/file_event/file_event_lnx_ssh_authorized_keys_modification.yml
@@ -1,0 +1,26 @@
+title: SSH Authorized Keys Modification
+id: e7806bcc-7464-4ecd-9dd5-22bf0e3cb0f3
+status: experimental
+description: |
+    Detects the creation or modification of the 'authorized_keys' file on Linux systems.
+    Attackers often modify this file to maintain persistence by adding their own public key to a user's authorized_keys file.
+references:
+    - https://attack.mitre.org/techniques/T1098/004/
+author: Sri Charan
+date: 2026-07-28
+tags:
+    - attack.persistence
+    - attack.t1098.004
+logsource:
+    product: linux
+    category: file_event
+detection:
+    selection:
+        TargetFilename|endswith: '/.ssh/authorized_keys'
+    filter_main_sshd:
+        Image|endswith: '/sshd'
+    condition: selection and not 1 of filter_main_*
+falsepositives:
+    - Legitimate administration activities (e.g. ssh-copy-id)
+    - Configuration management tools (Ansible, Chef, Puppet) managing SSH keys
+level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Adds a detection rule for SSH Authorized Keys Modification. Attackers often modify the `.ssh/authorized_keys` file to maintain persistence by adding their own public key to a user's `authorized_keys` file (MITRE T1098.004). This rule addresses a known gap where `file_event` rules are preferred over `process_creation` due to typical stealth techniques involving file modification via redirects or text editors.

### Changelog

new: SSH Authorized Keys Modification

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
