### PR TITLE
new: Suspicious Bpftool State Modification

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_susp_bpftool.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_susp_bpftool.yml
@@ -1,0 +1,36 @@
+title: Suspicious Bpftool State Modification
+id: a444680c-0216-4f1a-8a4f-8e88b7d1b632
+status: experimental
+description: |
+    Detects the execution of the 'bpftool' command to load, attach, or pin eBPF programs and maps.
+    Adversaries and rootkits (e.g., BPFDoor, Symbiote) often leverage eBPF for stealthy persistence and network evasion.
+    While 'bpftool' is a legitimate administrative utility for introspection, unauthorized usage to load or modify eBPF objects outside of known administrative scripts is highly suspicious.
+references:
+    - https://www.elastic.co/security-labs/getting-bpfdoor-off-its-hinges
+    - https://redcanary.com/blog/ebpf-for-security/
+    - https://attack.mitre.org/techniques/T1547/006/
+author: Sri Charan
+date: 2026-07-28
+tags:
+    - attack.persistence
+    - attack.defense-evasion
+    - attack.t1547.006
+    - attack.t1562
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        - Image|endswith: '/bpftool'
+        - CommandLine|contains: 'bpftool '
+    selection_cmd:
+        CommandLine|contains:
+            - ' prog load'
+            - ' prog attach'
+            - ' prog pin'
+            - ' map pin'
+            - ' prog detach'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate execution of bpftool by system administrators for network troubleshooting or observability tool deployments (e.g., Cilium, Datadog).
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Adds a detection rule for suspicious state modification using `bpftool`. Adversaries and rootkits (e.g., BPFDoor, Symbiote) often leverage eBPF for stealthy persistence and network evasion (MITRE T1547.006). This rule focuses on detecting the loading, attaching, or pinning of eBPF programs and maps via `bpftool`, which is highly suspicious outside of known administrative scripts or observability deployments.

### Changelog

new: Suspicious Bpftool State Modification

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
