### PR TITLE
Typo in proxy_exploit_cve_2023_36884_office_windows_html_rce_extenstion_ip_pattern_traffic.yml

### DIFF
--- a/rules-emerging-threats/2023/Exploits/CVE-2023-36884/proxy_exploit_cve_2023_36884_office_windows_html_rce_extenstion_ip_pattern_traffic.yml
+++ b/rules-emerging-threats/2023/Exploits/CVE-2023-36884/proxy_exploit_cve_2023_36884_office_windows_html_rce_extenstion_ip_pattern_traffic.yml
@@ -1,4 +1,4 @@
-title: Potential CVE-2303-36884 URL Request Pattern Traffic
+title: Potential CVE-2023-36884 URL Request Pattern Traffic
 id: d9365e39-febd-4a4b-8441-3ca91bb9d333
 status: test
 description: Detects a specific URL pattern containing a specific extension and parameters pointing to an IP address. This pattern was seen being used by RomCOM potentially exploiting CVE-2023-36884

--- a/rules-emerging-threats/2023/Exploits/CVE-2023-36884/proxy_exploit_cve_2023_36884_office_windows_html_rce_extenstion_ip_pattern_traffic.yml
+++ b/rules-emerging-threats/2023/Exploits/CVE-2023-36884/proxy_exploit_cve_2023_36884_office_windows_html_rce_extenstion_ip_pattern_traffic.yml
@@ -6,6 +6,7 @@ references:
     - https://blogs.blackberry.com/en/2023/07/romcom-targets-ukraine-nato-membership-talks-at-nato-summit
 author: X__Junior
 date: 2023-07-12
+modified: 2026-06-14
 tags:
     - attack.command-and-control
     - cve.2023-36884


### PR DESCRIPTION
### Summary of the Pull Request

Corrects typo "CVE-2303-36884" -> "CVE-2023-36884"

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

update:	Potential CVE-2303-36884 URL Request Pattern Traffic - changed the rule title to the actual CVE number. Filename and id stay unchanged.

### Example Log Event

### Fixed Issues

CVE-2303-36884 is not a real CVE number but appears on a number of sites that produce content based on this repo.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
