### PR TITLE
feat(windows): add Remote Registry service start detection (T1003.002)

### DIFF
--- a/rules/windows/builtin/system/service_control_manager/win_system_service_start_remote_registry.yml
+++ b/rules/windows/builtin/system/service_control_manager/win_system_service_start_remote_registry.yml
@@ -1,0 +1,48 @@
+title: Remote Registry Service Started
+id: 9f3b4e1a-2c7d-4f8b-a1e5-3d6c9b0f2e4a
+status: experimental
+description: |
+    Detects the Remote Registry service entering the running state via Windows System
+    Event 7036, emitted by the Service Control Manager into the Windows System channel.
+
+    On Windows Server 2025 the Remote Registry service is set to Automatic start with a
+    named-pipe trigger on the winreg pipe, so it stays stopped until a remote registry
+    request opens that pipe. Tools such as impacket secretsdump and nxc/netexec open the
+    winreg pipe over SMB, which starts the service and lets them read the SAM hive to
+    recover local account password hashes. The service returns to the stopped state
+    about a second later, so the 7036 running event is short-lived.
+
+    Verified on Windows Server 2025 Core against nxc --sam: the alert fired within
+    seconds of dump completion, and the System log showed a paired 7036 stopped event
+    one second after the running event, confirming the service reverted.
+
+    Blind spot: the 7036 running event appears only on a transition into the running
+    state, so a host where Remote Registry is already running stays silent for this rule.
+
+    param1 and param2 are localized strings, so this rule applies to English-language
+    Windows installations.
+references:
+    - https://github.com/fortra/impacket/blob/570f283331612662a945f85b8f2216796956a9cb/impacket/examples/secretsdump.py
+    - https://learn.microsoft.com/en-us/windows-server/security/windows-services/security-guidelines-for-disabling-system-services-in-windows-server
+author: sebafvs
+date: 2026-07-30
+tags:
+    - attack.credential-access
+    - attack.t1003.002
+logsource:
+    product: windows
+    service: system
+detection:
+    selection:
+        Provider_Name: 'Service Control Manager'
+        EventID: 7036
+        param1: 'Remote Registry'
+        param2: 'running'
+    condition: selection
+falsepositives:
+    - Administrators manually starting Remote Registry for legitimate remote management
+    - Group Policy or MDM enabling Remote Registry across the fleet
+    - Remote management tools (SCCM, PDQ Deploy, Ansible) that use the Remote Registry protocol
+    - Backup software (Veeam, Acronis) reading registry hives remotely
+    - Any management activity that triggers the service's demand-start on Server editions
+level: medium


### PR DESCRIPTION
  <!--
  Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

  !!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
  -->

  ### Summary of the Pull Request

  <!--
  **Please note that this section is required and must be filled**
  A short summary of your pull request.
  -->

Detects Windows System Event 7036 for the Remote Registry service entering the running state. On Windows Server the service is Automatic with a named-pipe trigger on the winreg pipe, so it stays stopped until a remote registry request arrives. impacket secretsdump and nxc/netexec open that pipe over SMB to read the SAM hive, which starts the service and produces a short-lived 7036 event.

Verified on Windows Server 2025 Core against `nxc smb --sam`: the running event fired, followed one second later by the paired stopped event confirming reversion. Level is set to `medium` because legitimate remote management and backup tooling (SCCM, PDQ, Ansible, Veeam) also start this service, as reflected in the false positives list.

 ### Changelog

  <!--
  ** Don't remove this comment **
  You need to add one line for every changed file of the PR and prefix one of the following tags:
  new:    <title>
  update:    <title> - <optional comment>
  fix:    <title> - <optional comment>
  remove:    <title> - <optional comment>
  chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

  e.g.
  new: Brute-Force Attacks on Azure Admin Account
  update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
  fix: Malware User Agent - remove legitimate Firefox UA
  chore: workflow - update checkout version
  remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
  -->

  new: Remote Registry Service Started

  ### Example Log Event

  <!--
  Fill this in case of false positive fixes
  -->

Windows System log, Event 7036 captured on Windows Server 2025 Core when `nxc smb --sam` started the service:

```xml
  <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
    <System>
      <Provider Name='Service Control Manager' Guid='{555908d1-a6d7-4695-8e1e-26931d2012f4}' EventSourceName='Service Control Manager'/>
      <EventID Qualifiers='16384'>7036</EventID>
      <Level>4</Level>
      <TimeCreated SystemTime='2026-07-30T17:00:04.3246757Z'/>
      <EventRecordID>2634</EventRecordID>
      <Execution ProcessID='740' ThreadID='940'/>
      <Channel>System</Channel>
      <Computer>WIN01.blackwood.corp</Computer>
    </System>
    <EventData>
      <Data Name='param1'>Remote Registry</Data>
      <Data Name='param2'>running</Data>
    </EventData>
  </Event>
```

  ### Fixed Issues

  <!--
  Link the fixed issues here, in case your commit fixes issues with rules or code
  -->

  ### SigmaHQ Rule Creation Conventions

  - If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
