### PR TITLE
feat(windows): add ligolo-ng agent detection rules (T1572)

### DIFF
--- a/rules/windows/network_connection/net_connection_win_hktl_ligolo_ng_default_port.yml
+++ b/rules/windows/network_connection/net_connection_win_hktl_ligolo_ng_default_port.yml
@@ -1,0 +1,32 @@
+title: HackTool - Ligolo-NG Default Port Network Connection
+id: c0946792-2e41-4ef4-9784-badec993458f
+related:
+    - id: 7a7bf6b6-dc32-4d96-9d2c-9c14be658502
+      type: similar
+status: experimental
+description: |
+    Detects network connections on TCP port 11601, the default listening port of the
+    ligolo-ng proxy server. In reverse mode the agent dials out to the attacker's proxy
+    on this port, so the agent host sees an outbound connection. In bind mode the agent
+    listens on this port and the proxy connects in, so the agent host sees an inbound
+    connection. The rule matches the port in either direction to cover both modes.
+    Port-only detection is trivially evadable by changing the port at runtime (--srvport
+    flag on the proxy). Correlate with the companion ligolo-ng agent execution rule for
+    higher confidence.
+references:
+    - https://github.com/nicocha30/ligolo-ng
+author: sebafvs
+date: 2026-07-30
+tags:
+    - attack.command-and-control
+    - attack.t1572
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    selection:
+        DestinationPort: 11601
+    condition: selection
+falsepositives:
+    - Any legitimate service that happens to use TCP port 11601. Verify with process context.
+level: low

--- a/rules/windows/process_creation/proc_creation_win_hktl_ligolo_ng.yml
+++ b/rules/windows/process_creation/proc_creation_win_hktl_ligolo_ng.yml
@@ -1,0 +1,44 @@
+title: HackTool - Ligolo-NG Agent Execution
+id: 7a7bf6b6-dc32-4d96-9d2c-9c14be658502
+related:
+    - id: c0946792-2e41-4ef4-9784-badec993458f
+      type: similar
+status: experimental
+description: |
+    Detects execution of the ligolo-ng agent, a tunneling tool that creates a full network
+    pivot between a compromised host and an attacker-controlled proxy server. The agent
+    supports bind mode (agent listens, proxy connects in) and reverse mode (agent dials out).
+
+    Detection uses two independent branches:
+    - Image path containing "ligolo": catches default release filenames. Note: OriginalFileName
+      is not set in ligolo-ng release builds (Go toolchain does not embed it), making Image
+      the only reliable PE-level anchor. Evadable by renaming the binary.
+    - CLI flags --ignore-cert with --connect or --bind: catches execution regardless of
+      binary name. Evadable by patching the binary to remove flag names.
+
+    Correlate with the companion ligolo-ng default port network connection rule for
+    higher confidence.
+references:
+    - https://github.com/nicocha30/ligolo-ng
+author: sebafvs
+date: 2026-07-30
+tags:
+    - attack.command-and-control
+    - attack.t1572
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        Image|contains: 'ligolo'
+    selection_cli_cert:
+        CommandLine|contains: '--ignore-cert'
+    selection_cli_mode:
+        CommandLine|contains:
+            - '--connect'
+            - '--bind'
+    condition: selection_img or (selection_cli_cert and selection_cli_mode)
+falsepositives:
+    - Any binary with "ligolo" in its path, since the Image branch is evadable by renaming
+    - Legitimate tunneling or VPN tools that coincidentally use --ignore-cert with --connect or --bind flags
+level: high


### PR DESCRIPTION
  <!--
  Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

  !!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
  -->

  ### Summary of the Pull Request

  <!--
  **Please note that this section is required and must be filled**
  A short summary of your pull request.
  -->

  Adds two related Sigma rules for the ligolo-ng tunneling tool (T1572, Protocol Tunneling):

  - **Process creation** (`level: high`): matches the agent by image path containing "ligolo", or by `--ignore-cert` combined with a `--connect` or `--bind` mode flag. The CLI branch catches a renamed binary.
  OriginalFileName is absent in ligolo-ng release builds (the Go toolchain does not embed it), so Image is the only reliable PE-level anchor.
  - **Network connection** (`level: low`): matches TCP port 11601, the ligolo default proxy port, in either direction. Reverse mode produces an outbound connection on the agent host and bind mode an inbound one,
  so the rule does not filter on connection direction. Intended for correlation with the process rule.

  Verified in a lab on Windows Server 2025 Core: the CLI branch fired on a renamed `agent.exe` in `--connect` mode and on `ligolo-agent.exe` in `--bind` mode, the image branch fired on the ligolo-named binary,
  and the network rule matched the bind-mode inbound connection to port 11601.

  ### Changelog

  <!--
  ** Don't remove this comment **
  You need to add one line for every changed file of the PR and prefix one of the following tags:
  new:    <title>
  update:    <title> - <optional comment>
  fix:    <title> - <optional comment>
  remove:    <title> - <optional comment>
  chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

  e.g.
  new: Brute-Force Attacks on Azure Admin Account
  update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
  fix: Malware User Agent - remove legitimate Firefox UA
  chore: workflow - update checkout version
  remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
  -->

  new: HackTool - Ligolo-NG Agent Execution
  new: HackTool - Ligolo-NG Default Port Network Connection

  ### Example Log Event

  <!--
  Fill this in case of false positive fixes
  -->

  Sysmon Event ID 1 (process creation), CLI branch catching a renamed binary in reverse mode. Note `OriginalFileName` is empty, confirming ligolo-ng release builds do not embed it:

  ```xml
  <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
    <System>
      <Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/>
      <EventID>1</EventID>
      <TimeCreated SystemTime='2026-07-30T01:42:52.9680596Z'/>
      <Channel>Microsoft-Windows-Sysmon/Operational</Channel>
      <Computer>WIN01.blackwood.corp</Computer>
    </System>
    <EventData>
      <Data Name='Image'>C:\Windows\Temp\agent.exe</Data>
      <Data Name='OriginalFileName'>-</Data>
      <Data Name='CommandLine'>"C:\Windows\Temp\agent.exe" --connect 10.40.40.10:11601 --ignore-cert</Data>
      <Data Name='User'>BLACKWOOD\helpdesk</Data>
      <Data Name='ParentImage'>C:\Windows\System32\wsmprovhost.exe</Data>
    </EventData>
  </Event>
  ```

  Sysmon Event ID 3 (network connection), bind-mode agent listening on the default port. The agent host sees an inbound connection, so `Initiated` is false and `DestinationPort` is 11601:

  ```xml
  <Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
    <System>
      <Provider Name='Microsoft-Windows-Sysmon' Guid='{5770385f-c22a-43e0-bf4c-06f5698ffbd9}'/>
      <EventID>3</EventID>
      <TimeCreated SystemTime='2026-07-30T01:44:04.1897038Z'/>
      <Channel>Microsoft-Windows-Sysmon/Operational</Channel>
      <Computer>WIN01.blackwood.corp</Computer>
    </System>
    <EventData>
      <Data Name='Image'>C:\Windows\Temp\agent.exe</Data>
      <Data Name='User'>BLACKWOOD\helpdesk</Data>
      <Data Name='Protocol'>tcp</Data>
      <Data Name='Initiated'>false</Data>
      <Data Name='SourceIp'>10.40.40.10</Data>
      <Data Name='SourcePort'>49754</Data>
      <Data Name='DestinationIp'>10.30.30.10</Data>
      <Data Name='DestinationPort'>11601</Data>
    </EventData>
  </Event>
  ```

  ### Fixed Issues

  <!--
  Link the fixed issues here, in case your commit fixes issues with rules or code
  -->

  ### SigmaHQ Rule Creation Conventions

  - If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
