### PR TITLE
Add Moodle detection rules (web server logs) - initial coverage

### DIFF
--- a/rules/web/product/moodle/web_moodle_cron_endpoint_external_access.yml
+++ b/rules/web/product/moodle/web_moodle_cron_endpoint_external_access.yml
@@ -1,0 +1,35 @@
+title: Moodle Cron Endpoint Accessed From External Address
+id: eb36448d-2512-482d-ad99-9feab85ef500
+status: experimental
+description: |
+    Detects requests to Moodle's web cron endpoint from an address outside RFC1918 space.
+    Moodle documentation recommends restricting web cron to the local host or to a defined set of
+    trusted addresses. Where it is left open, an unauthenticated attacker can repeatedly trigger the
+    full scheduled task run, which is both a denial of service primitive and a way to force execution
+    of tasks registered by an installed plugin.
+references:
+    - https://docs.moodle.org/en/Cron
+    - https://docs.moodle.org/en/Site_security_settings
+author: Sanket Taware (@sankettaware16)
+date: 2026-07-31
+tags:
+    - attack.execution
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1053
+logsource:
+    category: webserver
+detection:
+    selection:
+        cs-uri-stem|endswith: '/admin/cron.php'
+    filter_main_internal:
+        c-ip|cidr:
+            - '127.0.0.0/8'
+            - '10.0.0.0/8'
+            - '172.16.0.0/12'
+            - '192.168.0.0/16'
+    condition: selection and not 1 of filter_main_*
+falsepositives:
+    - Sites that deliberately drive web cron from an external scheduler or uptime monitor
+    - Reverse proxies and load balancers that do not preserve the original client address, which will make every request appear external
+level: high

--- a/rules/web/product/moodle/web_moodle_executable_download_from_file_storage.yml
+++ b/rules/web/product/moodle/web_moodle_executable_download_from_file_storage.yml
@@ -1,0 +1,48 @@
+title: Executable Or Script File Served From Moodle File Storage
+id: 98afeaf3-7305-42d9-8ea9-a9c968d903e7
+status: experimental
+description: |
+    Detects successful downloads of executable or script file types through Moodle's file serving
+    endpoints. Course files, assignment submissions and draft areas accept arbitrary uploads from any
+    enrolled user, which makes a Moodle site an attractive and highly trusted distribution point for
+    malware aimed at other members of the institution.
+references:
+    - https://docs.moodle.org/dev/File_API
+    - https://docs.moodle.org/en/Site_security_settings
+author: Sanket Taware (@sankettaware16)
+date: 2026-07-31
+tags:
+    - attack.execution
+    - attack.t1204.002
+logsource:
+    category: webserver
+detection:
+    selection_endpoint:
+        cs-uri-stem|contains:
+            - '/pluginfile.php'
+            - '/draftfile.php'
+            - '/tokenpluginfile.php'
+            - '/webservice/pluginfile.php'
+    selection_extension:
+        cs-uri-stem|endswith:
+            - '.bat'
+            - '.chm'
+            - '.cmd'
+            - '.exe'
+            - '.hta'
+            - '.jar'
+            - '.lnk'
+            - '.msi'
+            - '.ps1'
+            - '.scr'
+            - '.vbe'
+            - '.vbs'
+            - '.wsf'
+    selection_status:
+        sc-status: 200
+    condition: all of selection_*
+falsepositives:
+    - Programming, systems or security courses that distribute compiled binaries, JAR files or scripts as teaching material
+    - Software packaged as a course resource by teaching staff
+    - Assignment briefs that require students to submit compiled artefacts
+level: medium

--- a/rules/web/product/moodle/web_moodle_php_execution_in_upload_path.yml
+++ b/rules/web/product/moodle/web_moodle_php_execution_in_upload_path.yml
@@ -1,0 +1,37 @@
+title: PHP File Served From Moodle Upload Or Static Content Path
+id: 28b7d590-3fb1-4cca-b67b-c74ee2dc904d
+status: experimental
+description: |
+    Detects a successful request for a .php file located under a Moodle directory that should only ever
+    serve uploaded content or static assets. Moodle deliberately stores uploaded files outside the web
+    root and serves them through pluginfile.php, so a PHP file answering with 200 from one of these
+    paths means either the data directory has been exposed to the web server or a script has been
+    written into the document root - both of which are consistent with a web shell.
+    A 200 response for anything under the Moodle data directory is a serious misconfiguration in its own
+    right and should be investigated even if the file is not PHP.
+references:
+    - https://docs.moodle.org/en/Security_recommendations
+    - https://docs.moodle.org/dev/File_API
+author: Sanket Taware (@sankettaware16)
+date: 2026-07-31
+tags:
+    - attack.persistence
+    - attack.t1505.003
+logsource:
+    category: webserver
+detection:
+    selection_extension:
+        cs-uri-stem|endswith: '.php'
+    selection_path:
+        cs-uri-stem|contains:
+            - '/moodledata/'
+            - '/filedir/'
+            - '/pix/'
+            - '/userpix/'
+            - '/repository/draftfiles/'
+    selection_status:
+        sc-status: 200
+    condition: all of selection_*
+falsepositives:
+    - A theme or plugin that ships a PHP file under a pix directory - verify against the plugin source before excluding
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

This PR adds the first Sigma coverage for Moodle, the most widely deployed open-source LMS in the education sector. No Moodle rules currently exist in the repository. It adds three single-event `category: webserver` rules under `rules/web/product/moodle/`, following the existing `rules/web/product/` convention (`apache`, `nginx`):

- **PHP File Served From Moodle Upload Or Static Content Path** — web shell indicator. Moodle stores uploads outside the web root and serves them through `pluginfile.php`, so a `.php` file answering 200 from an upload/static path means an exposed data directory or a script dropped into the document root.
- **Executable Or Script File Served From Moodle File Storage** — executable/script file types served through Moodle's file-serving endpoints. Any enrolled user can upload arbitrary files, which makes a Moodle site a trusted malware distribution point inside an institution.
- **Moodle Cron Endpoint Accessed From External Address** — `/admin/cron.php` requested from outside RFC1918 space. Moodle docs recommend restricting web cron; left open it allows unauthenticated triggering of the full scheduled task run.

The rules were developed against a production Moodle deployment (Apache access logs shipped to Elastic) and use the webserver taxonomy field names. All local checks pass: `sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml`, `tests/test_rules.py`, and `tests/test_logsource.py`.

A follow-up PR with further Moodle rules (login/token brute force, bulk personal data collection via web service functions) is planned once this one settles. Happy to adjust folder location, field names or anything else to match maintainer preference.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: PHP File Served From Moodle Upload Or Static Content Path
new: Executable Or Script File Served From Moodle File Storage
new: Moodle Cron Endpoint Accessed From External Address

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

Sanitized Apache access log lines that trigger each rule:

    203.0.113.50 - - [31/Jul/2026:10:15:32 +0530] "GET /moodle/pix/shell.php HTTP/1.1" 200 1832 "-" "Mozilla/5.0"
    203.0.113.50 - - [31/Jul/2026:10:16:10 +0530] "GET /moodle/pluginfile.php/123/mod_resource/content/1/setup.exe HTTP/1.1" 200 481832 "-" "Mozilla/5.0"
    198.51.100.23 - - [31/Jul/2026:10:17:44 +0530] "GET /moodle/admin/cron.php HTTP/1.1" 200 512 "-" "curl/8.5.0"

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions
