### PR TITLE
Add ClickLock Stealer macOS Detection Rules

### DIFF
--- a/rules-emerging-threats/2026/Malware/ClickLock-Stealer/file_event_macos_malware_clicklock_artifacts.yml
+++ b/rules-emerging-threats/2026/Malware/ClickLock-Stealer/file_event_macos_malware_clicklock_artifacts.yml
@@ -1,0 +1,39 @@
+title: ClickLock Stealer File Artifacts
+id: aaef3aca-48ac-4ec5-8d2d-51e24ed9c98d
+status: experimental
+description: |
+    Detects persistence and staging artifacts associated with ClickLock Stealer, including its credential-stealing LaunchAgents, hidden module
+    directory, and the persistent GSocket backdoor masquerading as an iCloud component.
+references:
+    - https://www.group-ib.com/blog/clicklock-stealer-macos-malware/
+author: Robbin Ooi Zhen Heng
+date: 2026-07-28
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.stealth
+    - attack.t1036.005
+    - attack.t1543.001
+    - attack.t1564.001
+    - detection.emerging-threats
+logsource:
+    category: file_event
+    product: macos
+detection:
+    selection_launchagent:
+        TargetFilename|startswith: '/Users/'
+        TargetFilename|endswith:
+            - '/Library/LaunchAgents/com.authirity.plist'
+            - '/Library/LaunchAgents/com.chromer.plist'
+    selection_modules:
+        TargetFilename|startswith: '/Users/'
+        TargetFilename|endswith:
+            - '/.cacheb/zoom'
+            - '/.cacheb/chromer'
+    selection_backdoor:
+        TargetFilename|startswith: '/Users/'
+        TargetFilename|contains: '/Library/Application Support/iCloudsync/'
+    condition: 1 of selection_*
+falsepositives:
+    - Unlikely
+level: high

--- a/rules-emerging-threats/2026/Malware/ClickLock-Stealer/proc_creation_macos_malware_clicklock_keychain_access.yml
+++ b/rules-emerging-threats/2026/Malware/ClickLock-Stealer/proc_creation_macos_malware_clicklock_keychain_access.yml
@@ -1,0 +1,31 @@
+title: ClickLock Stealer Chrome Safe Storage Key Access
+id: deb0c2e6-fda5-43ed-8bea-0dfab4650772
+status: experimental
+description: |
+    Detects a shell script invoking the macOS security utility to retrieve a browser Safe Storage key. ClickLock Stealer uses this behavior while
+    coercing the victim to approve a genuine Keychain prompt, allowing stolen Chromium data to be decrypted offline.
+references:
+    - https://www.group-ib.com/blog/clicklock-stealer-macos-malware/
+author: Robbin Ooi Zhen Heng
+date: 2026-07-28
+tags:
+    - attack.credential-access
+    - attack.t1555.001
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection:
+        Image|endswith: '/security'
+        ParentImage|endswith:
+            - '/bash'
+            - '/sh'
+            - '/zsh'
+        CommandLine|contains|all:
+            - 'find-generic-password'
+            - 'Safe Storage'
+    condition: selection
+falsepositives:
+    - Legitimate shell scripts that retrieve browser Safe Storage keys from Keychain.
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

Adds two experimental macOS detection rules for ClickLock Stealer based on Group-IB research.

The rules detect:

- Persistence and staging artifacts associated with the credential-stealing LaunchAgents and hidden modules, plus the persistent GSocket backdoor disguised as an iCloud component.
- Shell-driven access to the Chrome Safe Storage key through the macOS `security` utility.

Reference:

- https://www.group-ib.com/blog/clicklock-stealer-macos-malware/

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: ClickLock Stealer File Artifacts
new: ClickLock Stealer Chrome Safe Storage Key Access

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

ClickLock credential-stealer LaunchAgent:
TargetFilename: `/Users/alice/Library/LaunchAgents/com.authirity.plist`

ClickLock Keychain-stealer LaunchAgent:
TargetFilename: `/Users/alice/Library/LaunchAgents/com.chromer.plist`

ClickLock hidden credential-stealer module:
TargetFilename: `/Users/alice/.cacheb/zoom`

ClickLock hidden Keychain-stealer module:
TargetFilename: `/Users/alice/.cacheb/chromer`

ClickLock persistent GSocket backdoor:
TargetFilename: `/Users/alice/Library/Application Support/iCloudsync/iCloud`

ClickLock Chrome Safe Storage key access:
Image: `/usr/bin/security`
ParentImage: `/bin/bash`
CommandLine: `/usr/bin/security find-generic-password -w -s "Chrome Safe Storage"`

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
