### PR TITLE
Add rule: Sudo GTFOBins Shell Escape Privilege Escalation - Linux

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_priv_esc_sudo_gtfobins_parent.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_priv_esc_sudo_gtfobins_parent.yml
@@ -1,0 +1,49 @@
+title: Potential Privilege Escalation Via Sudo GTFOBins Shell Escape - Linux
+id: 4c8e2f7a-1b6d-4e93-8a2f-7d5c9b3e1a4f
+status: experimental
+description: |
+    Detects a GTFOBins-listed binary spawning a shell as a direct child of sudo.
+    This indicates a low-privileged user with narrow sudo rights on a single
+    binary (via sudoers misconfiguration) escaping to a root shell.
+references:
+    - https://gtfobins.github.io/
+author: Aymane Boualam
+date: 2026-08-05
+tags:
+    - attack.privilege-escalation
+    - attack.t1548.003
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_parent:
+        ParentImage|endswith: '/sudo'
+    selection_img:
+        Image|endswith:
+            - '/find'
+            - '/vim'
+            - '/vi'
+            - '/awk'
+            - '/less'
+            - '/more'
+            - '/python'
+            - '/python3'
+            - '/perl'
+            - '/nmap'
+            - '/man'
+            - '/gdb'
+            - '/ftp'
+    selection_cli:
+        CommandLine|contains:
+            - '/bin/sh'
+            - '/bin/bash'
+            - '/bin/dash'
+            - '/bin/zsh'
+            - '-exec'
+            - '!bash'
+            - '!sh'
+    condition: all of selection_*
+falsepositives:
+    - Legitimate administrative use of these binaries under sudo is rare but
+      possible in scripted maintenance tasks — review CommandLine context.
+level: high


### PR DESCRIPTION
Detects a GTFOBins-listed binary spawning a shell as a direct child of sudo (ParentImage: sudo), indicating privilege escalation via a narrow/misconfigured sudoers entry.

This differs from existing individual GTFOBins rules (e.g. proc_creation_lnx_vim_shell_execution, proc_creation_lnx_find_shell_execution) which check the binary + shell spawn but not the sudo parent context.

Validated with `sigma check` - no errors or issues.