### PR TITLE
macOS: cover `xattr -c` in the Gatekeeper bypass rule, add ClickFix stage-3 dropper

### DIFF
--- a/rules-emerging-threats/2026/Malware/ClickFix-macOS/proc_creation_macos_malware_clickfix_stage3_dropper.yml
+++ b/rules-emerging-threats/2026/Malware/ClickFix-macOS/proc_creation_macos_malware_clickfix_stage3_dropper.yml
@@ -1,0 +1,53 @@
+title: macOS ClickFix Stage-3 Dropper Sequence
+id: 7b3d61c2-9f04-4a8e-b5d1-2c6ae4f80931
+status: experimental
+description: |
+    Detects the terminal stage of a macOS ClickFix chain, in which a shell command the
+    victim pasted themselves fetches a Mach-O into a world-writable directory, strips its
+    extended attributes so Gatekeeper does not evaluate it, marks it executable and runs
+    it. Matching requires the xattr step together with a temporary path, because curl and
+    chmod against /tmp are common in ordinary developer workflows on their own.
+    Observed dropped filenames include helper and update; the sequence is the indicator,
+    not the name.
+references:
+    - https://github.com/raimurokko/macos-threat-tracking/blob/main/campaigns/2026-08-04-cloudflare-clickfix/payload_analysis.md
+    - https://bazaar.abuse.ch/sample/29be0f56275f051181ea3ec37ddc3d3807cde34cb65de855709fae0e13786a40/
+    - https://attack.mitre.org/techniques/T1204/004/
+author: Novum Analytica GmbH
+date: 2026-08-06
+tags:
+    - attack.execution
+    - attack.t1204.004
+    - attack.defense-impairment
+    - attack.t1553.001
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_xattr_strip:
+        Image|endswith: '/xattr'
+        CommandLine|contains:
+            - ' -c '
+            - ' -cr '
+            - 'com.apple.quarantine'
+    selection_temp_path:
+        CommandLine|contains:
+            - '/tmp/'
+            - '/private/tmp/'
+            - '/var/folders/'
+    parent_shell:
+        ParentImage|endswith:
+            - '/zsh'
+            - '/bash'
+            - '/sh'
+    condition: all of selection_* and parent_shell
+fields:
+    - CommandLine
+    - ParentImage
+    - ParentCommandLine
+    - User
+falsepositives:
+    - Build systems and installers that stage binaries under /tmp and clear extended attributes on them
+    - Developers clearing extended attributes on their own build artefacts from a terminal
+level: high

--- a/rules/macos/process_creation/proc_creation_macos_xattr_gatekeeper_bypass.yml
+++ b/rules/macos/process_creation/proc_creation_macos_xattr_gatekeeper_bypass.yml
@@ -1,13 +1,17 @@
 title: Gatekeeper Bypass via Xattr
 id: f5141b6d-9f42-41c6-a7bf-2a780678b29b
 status: test
-description: Detects macOS Gatekeeper bypass via xattr utility
+description: |
+    Detects macOS Gatekeeper bypass via the xattr utility, either by deleting the
+    com.apple.quarantine attribute directly or by clearing all extended attributes,
+    which removes quarantine as a side effect.
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/1fed40dc7e48f16ed44dcdd9c73b9222a70cca85/atomics/T1553.001/T1553.001.md
     - https://www.loobins.io/binaries/xattr/
-author: Daniil Yugoslavskiy, oscd.community
+    - https://github.com/raimurokko/macos-threat-tracking/blob/main/campaigns/2026-08-04-cloudflare-clickfix/payload_analysis.md
+author: Daniil Yugoslavskiy, oscd.community, Novum Analytica GmbH
 date: 2020-10-19
-modified: 2024-04-18
+modified: 2026-08-06
 tags:
     - attack.defense-impairment
     - attack.t1553.001
@@ -15,12 +19,18 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection:
+    selection_delete_quarantine:
         Image|endswith: '/xattr'
         CommandLine|contains|all:
             - '-d'
             - 'com.apple.quarantine'
-    condition: selection
+    selection_clear_all:
+        Image|endswith: '/xattr'
+        CommandLine|contains:
+            - ' -c '
+            - ' -cr '
+            - ' -rc '
+    condition: 1 of selection_*
 falsepositives:
     - Legitimate activities
 level: low


### PR DESCRIPTION
### 1. Gap in an existing rule

`proc_creation_macos_xattr_gatekeeper_bypass.yml` requires both `-d` and
`com.apple.quarantine` on the command line. A macOS ClickFix chain we analysed on
2026-08-04 used `xattr -c` instead, which clears every extended attribute — quarantine
included — and therefore achieves the same bypass without matching the rule.

Added a second selection for `-c`, `-cr` and `-rc`. Level and false positives are
unchanged; `xattr -c` is about as common in legitimate use as `-d com.apple.quarantine`
already was.

### 2. New emerging-threats rule

The stage-3 dropper sequence of the same campaign: a Mach-O fetched into a temporary
directory, dequarantined, marked executable and run, all from a shell the victim pasted
into themselves.

Deliberately narrower than it could be — matching requires the xattr step **and** a
temporary path **and** a shell parent. `curl` and `chmod` against `/tmp` on their own
are ordinary developer activity, and six existing macOS rules already cover `curl`.


### Related existing coverage

While checking for duplicates I found
`rules-emerging-threats/2025/Malware/Atomic-MacOS-Stealer/proc_creation_macos_malware_amos_curl_post.yml`,
which already matches `curl` POSTs carrying `user:` and `BuildID`. Our stage 2 sends
exactly that header pair, which we had observed independently and, until finding that
rule, believed to be undocumented. Neither rule proposed here overlaps it: that one keys
on the exfiltration POST, these key on the dequarantine step and the dropper sequence.

It is also the best corroboration we have for the family assessment, so — thank you to
its authors.

### Context

Analysis, indicators and the decoded chain:
https://github.com/raimurokko/macos-threat-tracking/blob/main/campaigns/2026-08-04-cloudflare-clickfix/payload_analysis.md

Sample:
https://bazaar.abuse.ch/sample/29be0f56275f051181ea3ec37ddc3d3807cde34cb65de855709fae0e13786a40/

### What these rules do not do

The dropper rule will not fire if the operator drops the `xattr` step — which is a
reasonable thing for them to do next, since Gatekeeper only evaluates quarantined
binaries and a payload delivered by other means may never carry the attribute.

The family behind this chain is assessed as AMOS lineage but **not confirmed**: the
stage-3 binary is a self-decrypting loader whose payload was not recovered, and
Microsoft reports the same infrastructure cluster delivering MacSync as well. The rules
therefore describe behaviour, not a family.

`tests/test_rules.py`, `tests/test_logsource.py` and `sigma check` all pass.
