### PR TITLE
macOS: cover `launchctl bootstrap`, add AMOS LaunchDaemon install and wallet replacement rules

### DIFF
--- a/rules-emerging-threats/2025/Malware/Atomic-MacOS-Stealer/file_event_macos_malware_amos_persistence.yml
+++ b/rules-emerging-threats/2025/Malware/Atomic-MacOS-Stealer/file_event_macos_malware_amos_persistence.yml
@@ -5,9 +5,12 @@ description: |
     Detects creation of persistence artifacts placed by Atomic MacOS Stealer in macOS systems. Recent Atomic MacOS Stealer variants have been observed dropping these to maintain persistent access after compromise.
 references:
     - https://moonlock.com/amos-backdoor-persistent-access
+    - https://www.iru.com/blog/atomic-stealer-amos-returns
+    - https://github.com/raimurokko/macos-threat-tracking/blob/main/campaigns/2026-08-04-cloudflare-clickfix/stage4_payload.md
     - https://github.com/bobby-tablez/TTP-Threat-Feeds/blob/45398914e631f8372c3a9fbcd339ff65ffff1b17/results/2025/10/20251001-161956-trendmicro-atomic-macos-stealer-(amos).yml#L44
 author: Jason Phang Vern - Onn, Robbin Ooi Zhen Heng (Gen Digital)
 date: 2025-11-22
+modified: 2026-08-07
 tags:
     - attack.persistence
     - attack.privilege-escalation
@@ -25,7 +28,19 @@ detection:
         TargetFilename|startswith: '/Users/'
         TargetFilename|endswith: '.helper'
     selection_launchdaemon:
-        TargetFilename: '/Library/LaunchDaemons/com.finder.helper.plist'
+        TargetFilename|startswith: '/Library/LaunchDaemons/'
+        TargetFilename|endswith:
+            # Documented 2025-11
+            - '/com.finder.helper.plist'
+            # 2026-08 variants imitating genuine Apple service names; the real
+            # services carry no .helper or .worker suffix
+            - '/com.apple.accountsd.helper.plist'
+            - '/com.apple.metadata.mds.worker.plist'
+    selection_hidden_support_dir:
+        # Staging directories mimicking Apple service names, 2026-08 variants
+        TargetFilename|contains:
+            - '/Library/Application Support/.com.apple.accountsd/'
+            - '/Library/Application Support/.com.apple.metadata.mds/'
     condition: 1 of selection_*
 falsepositives:
     - Unknown

--- a/rules-emerging-threats/2025/Malware/Atomic-MacOS-Stealer/proc_creation_macos_malware_amos_launchdaemon_install.yml
+++ b/rules-emerging-threats/2025/Malware/Atomic-MacOS-Stealer/proc_creation_macos_malware_amos_launchdaemon_install.yml
@@ -1,0 +1,40 @@
+title: Atomic MacOS Stealer - LaunchDaemon Installed With Piped Password
+id: b6e333c0-5bfb-43e2-a924-96235c2473c5
+status: experimental
+description: |
+    Detects the privilege-escalation step recent Atomic MacOS Stealer variants use to install their LaunchDaemon. The stealer phishes the user's password with a fake system dialog, validates it locally with dscl, then pipes it into sudo to copy a payload to a root-owned location, chown it to root:wheel and bootstrap it as a system daemon.
+    The observable is the piped credential rather than the daemon itself: legitimate tooling that installs a LaunchDaemon runs with privileges it already holds, and does not feed a password into sudo -S on stdin.
+    Complements file_event_macos_malware_amos_persistence.yml, which matches the dropped artefacts of one specific build. Daemon labels vary between builds - com.finder.helper is documented, samples in 2026-08 use labels imitating Apple services such as com.apple.accountsd.helper and com.apple.metadata.mds.worker - so this rule deliberately keys on the installation sequence instead of on a label.
+references:
+    - https://moonlock.com/amos-backdoor-persistent-access
+    - https://www.iru.com/blog/atomic-stealer-amos-returns
+    - https://github.com/raimurokko/macos-threat-tracking/blob/main/campaigns/2026-08-04-cloudflare-clickfix/stage4_payload.md
+    - https://attack.mitre.org/techniques/T1543/004/
+author: Novum Analytica GmbH
+date: 2026-08-07
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1543.004
+    - attack.t1548.003
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_sudo_stdin:
+        CommandLine|contains: 'sudo -S'
+    selection_daemon_action:
+        CommandLine|contains:
+            - 'launchctl bootstrap system'
+            - '/Library/LaunchDaemons/'
+            - 'chown root:wheel'
+    condition: all of selection_*
+fields:
+    - CommandLine
+    - ParentImage
+    - ParentCommandLine
+    - User
+falsepositives:
+    - Automation that deliberately supplies a sudo password on stdin, for example unattended provisioning scripts. These are rare on end-user endpoints and worth finding regardless.
+level: high

--- a/rules-emerging-threats/2025/Malware/Atomic-MacOS-Stealer/proc_creation_macos_malware_amos_wallet_app_replacement.yml
+++ b/rules-emerging-threats/2025/Malware/Atomic-MacOS-Stealer/proc_creation_macos_malware_amos_wallet_app_replacement.yml
@@ -1,0 +1,55 @@
+title: Atomic MacOS Stealer - Cryptocurrency Wallet Application Replaced
+id: afdfb87c-23da-48ef-9586-f1c72c5e931b
+status: experimental
+description: |
+    Detects Atomic MacOS Stealer replacing an installed cryptocurrency wallet application with an attacker-supplied build. The stealer terminates the running application with pkill, deletes the bundle from /Applications as root using a password phished from the user, downloads a replacement archive and unpacks it back into /Applications with ditto.
+    Ledger Wallet, Trezor Suite and Exodus are the observed targets, fetched as app.zip, apptwo.zip and appex.zip from a /zxc/ path. Those archive names have stayed constant across at least three unrelated hosts since 2025-11, which makes the path segment worth matching independently of the domain.
+    This is distinct from the collection behaviour covered by proc_creation_macos_malware_amos_curl_post.yml: the wallet is not read, it is replaced. A user who subsequently enters a seed phrase enters it into code the operator controls, so a hit warrants treating the wallet contents as lost rather than merely exposed.
+references:
+    - https://moonlock.com/amos-backdoor-persistent-access
+    - https://www.iru.com/blog/atomic-stealer-amos-returns
+    - https://github.com/raimurokko/macos-threat-tracking/blob/main/campaigns/2026-08-04-cloudflare-clickfix/stage4_payload.md
+    - https://attack.mitre.org/techniques/T1554/
+author: Novum Analytica GmbH
+date: 2026-08-07
+tags:
+    - attack.persistence
+    - attack.impact
+    - attack.t1554
+    - attack.t1105
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_wallet_removal:
+        CommandLine|contains: 'sudo -S rm -r'
+        CommandLine|contains:
+            - '/Applications/Ledger Wallet.app'
+            - '/Applications/Trezor Suite.app'
+            - '/Applications/Exodus.app'
+    selection_zxc_fetch:
+        Image|endswith: '/curl'
+        CommandLine|contains:
+            - '/zxc/app.zip'
+            - '/zxc/apptwo.zip'
+            - '/zxc/appex.zip'
+    selection_unpack:
+        Image|endswith: '/ditto'
+        CommandLine|contains|all:
+            - '-x -k'
+            - '/Applications'
+        CommandLine|contains:
+            - '/tmp/app.zip'
+            - '/tmp/apptwo.zip'
+            - '/tmp/appex.zip'
+    condition: 1 of selection_*
+fields:
+    - CommandLine
+    - ParentImage
+    - ParentCommandLine
+    - User
+falsepositives:
+    - Wallet vendors ship their own updaters, but those replace the bundle under the user's own privileges from the vendor domain, not via sudo -S from a /zxc/ path.
+    - An administrator removing one of these applications by hand would match the removal selection only if they used sudo -S with a piped password.
+level: high

--- a/rules/macos/process_creation/proc_creation_macos_launchctl_execution.yml
+++ b/rules/macos/process_creation/proc_creation_macos_launchctl_execution.yml
@@ -10,6 +10,7 @@ references:
     - https://www.loobins.io/binaries/launchctl/
 author: Pratinav Chandra
 date: 2024-05-13
+modified: 2026-08-07
 tags:
     - attack.privilege-escalation
     - attack.execution
@@ -27,6 +28,7 @@ detection:
             - 'submit'
             - 'load'
             - 'start'
+            - 'bootstrap'
     condition: selection
 falsepositives:
     - Legitimate administration activities is expected to trigger false positives. Investigate the command line being passed to determine if the service or launch agent are suspicious.


### PR DESCRIPTION
### Summary

Four changes to macOS coverage, from reverse engineering the payload of a ClickFix chain in August 2026. The payload decrypted to AMOS, and diffing it against the two existing `Atomic-MacOS-Stealer` rules showed what they already cover and where the gaps are.

I want to be explicit that most of the *behaviour* here is not a new discovery — the LaunchDaemon persistence, the wallet replacement and the `/zxc/` paths are documented by Moonlock and IRU, and the existing rules by Gen Digital already cover part of it. What is new is a variant whose labels have moved, and two behaviours with no rule attached yet.

### 1. `launchctl bootstrap` is not matched (`rules/macos/`)

`proc_creation_macos_launchctl_execution.yml` matches `submit`, `load` and `start`. It does not match `bootstrap`, which is the modern replacement for `load` and what the sample uses (`launchctl bootstrap system <plist>`).

This is not AMOS-specific, which is why the change is in `rules/` rather than emerging-threats. `modified:` bumped, author untouched.

### 2. AMOS persistence rule pins a label that has changed

`file_event_macos_malware_amos_persistence.yml` matches the literal `/Library/LaunchDaemons/com.finder.helper.plist`. Samples from 2026-08 imitate genuine Apple service names instead:

| | |
|---|---|
| `com.apple.accountsd.helper` | real service is `com.apple.accountsd`, no `.helper` |
| `com.apple.metadata.mds.worker` | real service is `com.apple.metadata.mds`, no `.worker` |

Generalised to a `startswith` on the directory plus a list of known suffixes, and extended with the dot-prefixed staging directories the same builds use (`~/Library/Application Support/.com.apple.accountsd/`, `.com.apple.metadata.mds/`). Original author and `date:` preserved, `modified:` added.

### 3. New — `proc_creation_macos_malware_amos_launchdaemon_install.yml`

Covers the escalation step rather than the artefacts, so it survives the label churn in point 2.

AMOS phishes the password with a fake "System Preferences" dialog, validates it with `dscl . authonly`, then pipes it into `sudo -S` to copy the payload, `chown root:wheel` it and bootstrap it. **The piped credential is the durable observable** — tooling that legitimately installs a LaunchDaemon already holds the privileges and does not feed a password to `sudo -S` on stdin.

Complements the file_event rule rather than replacing it; both are worth running.

### 4. New — `proc_creation_macos_malware_amos_wallet_app_replacement.yml`

No equivalent upstream that I could find. AMOS does not only read wallet data — it terminates Ledger Wallet, Trezor Suite and Exodus, deletes the bundles as root and unpacks attacker-supplied builds into `/Applications` with `ditto`.

The archive names `app.zip`, `apptwo.zip`, `appex.zip` under a `/zxc/` path have been constant across at least three unrelated hosts since 2025-11 (`isnimitz[.]com`, `wusetail[.]com`, and the host in our case), so the path segment is matched independently of the domain.

The distinction is operational: a user who enters a seed phrase after this has entered it into the operator's code. The wallet is lost, not exposed — different advice to the victim than "rotate your credentials".

### Testing

`tests/test_rules.py` — 11 tests, OK. Schema validator — clean.

### Related

Analysis, IOCs and the emulation tooling used to decrypt the payload: [stage4_payload.md](https://github.com/raimurokko/macos-threat-tracking/blob/main/campaigns/2026-08-04-cloudflare-clickfix/stage4_payload.md). Sample on [MalwareBazaar](https://bazaar.abuse.ch/sample/29be0f56275f051181ea3ec37ddc3d3807cde34cb65de855709fae0e13786a40/).

Separate from #6205, which covers the delivery chain rather than the payload. No file overlap between the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)