### PR TITLE
fix: correct regression test match counts

### DIFF
--- a/regression_data/rules/windows/file/file_event/file_event_win_anydesk_artefact/info.yml
+++ b/regression_data/rules/windows/file/file_event/file_event_win_anydesk_artefact/info.yml
@@ -9,5 +9,5 @@ regression_tests_info:
     - name: Positive Detection Test
       type: evtx
       provider: Microsoft-Windows-Sysmon
-      match_count: 1
+      match_count: 3
       path: regression_data/rules/windows/file/file_event/file_event_win_anydesk_artefact/0b9ad457-2554-44c1-82c2-d56a99c42377.evtx

--- a/regression_data/rules/windows/file/file_event/file_event_win_cred_dump_tools_dropped_files/info.yml
+++ b/regression_data/rules/windows/file/file_event/file_event_win_cred_dump_tools_dropped_files/info.yml
@@ -9,5 +9,5 @@ regression_tests_info:
     - name: Positive Detection Test
       type: evtx
       provider: Microsoft-Windows-Sysmon
-      match_count: 1
+      match_count: 3
       path: regression_data/rules/windows/file/file_event/file_event_win_cred_dump_tools_dropped_files/8fbf3271-1ef6-4e94-8210-03c2317947f6.evtx

--- a/regression_data/rules/windows/registry/registry_set/registry_set_change_security_zones/info.yml
+++ b/regression_data/rules/windows/registry/registry_set/registry_set_change_security_zones/info.yml
@@ -9,5 +9,5 @@ regression_tests_info:
     - name: Positive Detection Test
       type: evtx
       provider: Microsoft-Windows-Sysmon
-      match_count: 1
+      match_count: 3
       path: regression_data/rules/windows/registry/registry_set/registry_set_change_security_zones/45e112d0-7759-4c2a-aa36-9f8fb79d3393.evtx

--- a/regression_data/rules/windows/registry/registry_set/registry_set_disable_administrative_share/info.yml
+++ b/regression_data/rules/windows/registry/registry_set/registry_set_disable_administrative_share/info.yml
@@ -9,5 +9,5 @@ regression_tests_info:
     - name: Positive Detection Test
       type: evtx
       provider: Microsoft-Windows-Sysmon
-      match_count: 1
+      match_count: 2
       path: regression_data/rules/windows/registry/registry_set/registry_set_disable_administrative_share/c7dcacd0-cc59-4004-b0a4-1d6cdebe6f3e.evtx


### PR DESCRIPTION
### Summary of the Pull Request

Update the expected `match_count` for four regression tests whose values were too low. Running `tests/regression_tests_runner.py` reported these rules as matching more events than declared in their `info.yml`, which would make the regression tests fail.

The following rules now declare the actual number of matches:

- `file_event_win_anydesk_artefact` (`0b9ad457-2554-44c1-82c2-d56a99c42377`): `1` → `3`
- `file_event_win_cred_dump_tools_dropped_files` (`8fbf3271-1ef6-4e94-8210-03c2317947f6`): `1` → `3`
- `registry_set_change_security_zones` (`45e112d0-7759-4c2a-aa36-9f8fb79d3393`): `1` → `3`
- `registry_set_disable_administrative_share` (`c7dcacd0-cc59-4004-b0a4-1d6cdebe6f3e`): `1` → `2`

### Changelog


<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

chore: update regression test match counts for anydesk_artefact, cred_dump_tools_dropped_files, change_security_zones, disable_administrative_share

### Example Log Event

N/A

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

N/A - no rules modified.