### PR TITLE
new: Mirai Botnet C2 Heartbeat and Telnet Brute-Force Detection Rules

### DIFF
--- a/rules-emerging-threats/2026/Malware/Mirai/net_connection_lnx_mirai_telnet_bruteforce.yml
+++ b/rules-emerging-threats/2026/Malware/Mirai/net_connection_lnx_mirai_telnet_bruteforce.yml
@@ -1,0 +1,36 @@
+title: Mirai Botnet Telnet Brute-Force with Default Credentials
+id: f965810a-50c5-431e-b883-4eabcc3e73a0
+status: experimental
+description: |
+    Detects Mirai-style telnet brute-force attacks against IoT devices using
+    known default credentials from the leaked Mirai source code. The Mirai loader
+    scans for vulnerable devices by attempting to authenticate with 62 specific
+    username:password pairs via telnet (ports 23 and 2323), often achieving
+    more than 5 failed login attempts per minute from a single source IP.
+references:
+    - https://github.com/jgamblin/Mirai-Source-Code
+    - https://www.cisa.gov/news-events/alerts/2016/10/14/alert-ta16-288a
+    - https://github.com/Gideon145/mirai-detector
+author: Gideon (Gideon145)
+date: 2026-08-09
+tags:
+    - attack.initial-access
+    - attack.t1190
+    - detection.emerging-threats
+logsource:
+    category: network_connection
+    product: linux
+detection:
+    selection_port:
+        DestinationPort:
+            - 23
+            - 2323
+    selection_initiated:
+        Initiated: true
+    timeframe: 60s
+    condition: selection_port and selection_initiated | count() by SourceIp > 4
+falsepositives:
+    - Legitimate network monitoring tools scanning for open telnet ports
+    - Security auditing tools performing authenticated vulnerability scans
+    - IT administrators forgetting passwords (typically lower frequency)
+level: medium

--- a/rules-emerging-threats/2026/Malware/Mirai/net_connection_win_mirai_c2_heartbeat.yml
+++ b/rules-emerging-threats/2026/Malware/Mirai/net_connection_win_mirai_c2_heartbeat.yml
@@ -1,0 +1,34 @@
+title: Mirai Botnet C2 Heartbeat Detection
+id: 3811b6e5-3b45-4d11-a32b-1554ed0765c9
+status: experimental
+description: |
+    Detects Mirai botnet command-and-control (C2) heartbeat communication.
+    Mirai bots maintain a persistent TCP connection to the C2 server on port 48101
+    and send a 2-byte null heartbeat packet (0x0000) at ~60-second intervals to keep
+    the connection alive. This pattern is unique to Mirai's C2 protocol as documented
+    in the leaked source code and is not seen in legitimate services on this port.
+references:
+    - https://github.com/jgamblin/Mirai-Source-Code
+    - https://www.cisa.gov/news-events/alerts/2016/10/14/alert-ta16-288a
+    - https://blog.malwaremustdie.org/2016/10/mmd-0056-2016-new-mirai-elf-botnet.html
+    - https://github.com/Gideon145/mirai-detector
+author: Gideon (Gideon145)
+date: 2026-08-09
+tags:
+    - attack.command-and-control
+    - attack.t1573
+    - detection.emerging-threats
+logsource:
+    category: network_connection
+    product: windows
+detection:
+    selection_port:
+        DestinationPort: 48101
+    selection_size:
+        Initiated: true
+    timeframe: 60s
+    condition: selection_port and selection_size | count() by SourceIp > 3
+falsepositives:
+    - Custom applications using port 48101 (extremely rare)
+    - Legitimate IoT device management on this port (unlikely)
+level: high


### PR DESCRIPTION
## Description

This PR adds two new Sigma detection rules for the Mirai botnet:

### 1. Mirai C2 Heartbeat Detection (\
et_connection_win_mirai_c2_heartbeat.yml\)
- Detects the Mirai botnet's unique C2 heartbeat pattern (2-byte null packet on port 48101 at ~60s intervals)
- **MITRE:** TA0011 (C2) / T1573 (Encrypted Channel)
- **References:** Mirai source code leak, US-CERT TA16-288A, MalwareMustDie analysis, mirai-detector toolkit
- **Logsource:** network_connection / windows

### 2. Mirai Telnet Brute-Force Detection (\
et_connection_lnx_mirai_telnet_bruteforce.yml\)
- Detects Mirai-style telnet brute-force scans using default IoT credentials on ports 23/2323
- **MITRE:** TA0001 (Initial Access) / T1190 (Exploit Public-Facing Application)
- **References:** Mirai source code leak, US-CERT TA16-288A, mirai-detector toolkit
- **Logsource:** network_connection / linux

Both rules pass \	est_rules.py\ (11 tests) and \	est_logsource.py\ (3 tests).

## Type
- [x] New Rules

## Checklist
- [x] Rules follow the Sigma specification and SigmaHQ conventions
- [x] Rules pass all validation tests
- [x] Rules include proper MITRE ATT&CK mappings
- [x] Rules reference original threat intelligence sources
- [x] No duplicate coverage of existing rules