### PR TITLE
new: Mirai Telnet Scanning Detection Rule

### DIFF
--- a/rules-emerging-threats/2026/Malware/Mirai/net_connection_lnx_mirai_telnet_scan.yml
+++ b/rules-emerging-threats/2026/Malware/Mirai/net_connection_lnx_mirai_telnet_scan.yml
@@ -1,0 +1,62 @@
+title: Potential Mirai Telnet Scanning Activity
+id: 9a7f3c2d-4e5b-4a1c-8d2f-3b6a9c1e5d7f
+status: experimental
+description: |
+    Detects outbound TCP connections to telnet ports (23, 2323) and Mirai C2 port (48101)
+    from processes running outside standard Linux system binary paths, targeting external
+    IP addresses. Mirai bots perform rapid sequential telnet scans across the IPv4 address
+    space using a hardcoded list of 62 default IoT credentials to identify and infect
+    vulnerable devices. By combining destination port matching with process path context,
+    this rule distinguishes Mirai-style scanning from legitimate telnet client usage.
+references:
+    - https://github.com/Gideon145/mirai-detector
+    - https://www.cisa.gov/sites/default/files/FactSheets/NCCIC%20ICS_FactSheet_Mirai_Vulnerable_IoT_Devices_S508C.pdf
+    - https://www.bleepingcomputer.com/news/security/new-mirai-botnet-variants-continue-to-target-iot-and-unpatched-systems/
+author: Gideon Opukeme
+date: 2026-08-11
+tags:
+    - attack.initial_access
+    - attack.t1190
+    - attack.discovery
+    - attack.t1046
+    - detection.emerging_threats
+logsource:
+    category: network_connection
+    product: linux
+detection:
+    selection_telnet_scan:
+        DestinationPort:
+            - 23
+            - 2323
+            - 48101
+        Initiated: true
+        Protocol: 'tcp'
+    filter_main_system_binaries:
+        Image|startswith:
+            - '/usr/bin/'
+            - '/bin/'
+            - '/sbin/'
+            - '/usr/sbin/'
+            - '/usr/lib/'
+            - '/lib/'
+            - '/opt/'
+    filter_main_internal_ips:
+        DestinationIp|startswith:
+            - '10.'
+            - '192.168.'
+            - '172.'
+            - '127.'
+    filter_main_known_tools:
+        Image|endswith:
+            - '/nmap'
+            - '/masscan'
+            - '/zmap'
+            - '/nc'
+            - '/netcat'
+    condition: selection_telnet_scan and not 1 of filter_main_*
+falsepositives:
+    - Custom administration scripts executed from user home directories
+    - Security scanning tools installed outside standard system paths
+    - IoT device management platforms performing health checks on non-standard ports
+    - Legitimate telnet clients symlinked or copied to non-standard locations
+level: medium


### PR DESCRIPTION
Adds a Sigma detection rule for Mirai botnet telnet scanning activity. Combines destination port matching (23, 2323, 48101) with process path context — only triggers when connections originate from outside standard Linux system binary paths. Uses standard filter_main_* pattern to exclude system binaries, internal IPs, and known scanning tools. Addresses feedback from closed PR #6214 (multi-indicator logic, single-event format, proper FP filtering). MITRE ATT&CK: T1190, T1046.