### PR TITLE
new: Command Execution via Git Ext Transport

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_git_ext_transport_execution.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_git_ext_transport_execution.yml
@@ -1,0 +1,63 @@
+title: Command Execution via Git Ext Transport - Linux
+id: 734fdfff-634f-495f-8dd0-523a6c06f3cf
+related:
+    - id: ecf26065-2948-4e4d-b63a-7f1f14656912
+      type: similar
+    - id: 4eed6400-61a7-459a-a65e-88562b863b8e
+      type: similar
+status: experimental
+description: |
+    Detects Git's "ext::" remote helper transport, which runs the command named in the remote URL and wires its stdin and stdout to the Git protocol stream.
+    Git classifies "ext" as a known-dangerous protocol and ships it with a default policy of "never", so the helper runs only after protocol.ext.allow or GIT_ALLOW_PROTOCOL loosens that policy, frequently on the attacker's own command line.
+    The URL reaches Git from the command line, from a repository-local config, or from a .gitmodules entry during recursive submodule initialization, so the scheme does not always appear in the invoking command.
+references:
+    - https://git-scm.com/docs/git-remote-ext
+    - https://git-scm.com/docs/git-config
+    - https://security.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-3113858
+    - https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-3112221
+    - https://www.vulncheck.com/advisories/hermes-webui-rce-via-git-configuration-injection
+author: David Burkett (@signalblur)
+date: 2026-08-11
+tags:
+    - attack.execution
+    - attack.t1059
+    - attack.t1059.004
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_helper:
+        Image|endswith: '/git'
+        CommandLine|contains: ' remote-ext '
+    filter_helper_docs:
+        CommandLine|contains: ' remote-ext --help'
+    selection_url_main:
+        Image|endswith: '/git'
+        CommandLine|contains: 'ext::'
+    selection_url_verb:
+        CommandLine|contains:
+            - ' clone '
+            - ' fetch '
+            - ' pull '
+            - ' push '
+            - ' remote '
+            - ' ls-remote '
+            - ' submodule'
+            - ' archive '
+            - ' config '
+    filter_url_docs:
+        CommandLine|contains:
+            - ' help '
+            - '--help'
+    filter_url_message:
+        CommandLine|contains:
+            - ' commit '
+            - ' tag '
+            - ' -m '
+    selection_child:
+        ParentImage|endswith: '/git'
+        ParentCommandLine|contains: ' remote-ext '
+    condition: (selection_helper and not filter_helper_docs) or (all of selection_url_* and not 1 of filter_url_*) or selection_child
+falsepositives:
+    - Deliberate use of the ext transport to customize a connection, such as an "ext::ssh -i /path/to/key user@host %S repo" remote. This requires an administrator to override the default protocol policy first and is worth confirming regardless.
+level: high

--- a/rules/macos/process_creation/proc_creation_macos_git_ext_transport_execution.yml
+++ b/rules/macos/process_creation/proc_creation_macos_git_ext_transport_execution.yml
@@ -1,0 +1,63 @@
+title: Command Execution via Git Ext Transport - MacOS
+id: ecf26065-2948-4e4d-b63a-7f1f14656912
+related:
+    - id: 734fdfff-634f-495f-8dd0-523a6c06f3cf
+      type: similar
+    - id: 4eed6400-61a7-459a-a65e-88562b863b8e
+      type: similar
+status: experimental
+description: |
+    Detects Git's "ext::" remote helper transport, which runs the command named in the remote URL and wires its stdin and stdout to the Git protocol stream.
+    Git classifies "ext" as a known-dangerous protocol and ships it with a default policy of "never", so the helper runs only after protocol.ext.allow or GIT_ALLOW_PROTOCOL loosens that policy, frequently on the attacker's own command line.
+    The URL reaches Git from the command line, from a repository-local config, or from a .gitmodules entry during recursive submodule initialization, so the scheme does not always appear in the invoking command.
+references:
+    - https://git-scm.com/docs/git-remote-ext
+    - https://git-scm.com/docs/git-config
+    - https://security.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-3113858
+    - https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-3112221
+    - https://www.vulncheck.com/advisories/hermes-webui-rce-via-git-configuration-injection
+author: David Burkett (@signalblur)
+date: 2026-08-11
+tags:
+    - attack.execution
+    - attack.t1059
+    - attack.t1059.004
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_helper:
+        Image|endswith: '/git'
+        CommandLine|contains: ' remote-ext '
+    filter_helper_docs:
+        CommandLine|contains: ' remote-ext --help'
+    selection_url_main:
+        Image|endswith: '/git'
+        CommandLine|contains: 'ext::'
+    selection_url_verb:
+        CommandLine|contains:
+            - ' clone '
+            - ' fetch '
+            - ' pull '
+            - ' push '
+            - ' remote '
+            - ' ls-remote '
+            - ' submodule'
+            - ' archive '
+            - ' config '
+    filter_url_docs:
+        CommandLine|contains:
+            - ' help '
+            - '--help'
+    filter_url_message:
+        CommandLine|contains:
+            - ' commit '
+            - ' tag '
+            - ' -m '
+    selection_child:
+        ParentImage|endswith: '/git'
+        ParentCommandLine|contains: ' remote-ext '
+    condition: (selection_helper and not filter_helper_docs) or (all of selection_url_* and not 1 of filter_url_*) or selection_child
+falsepositives:
+    - Deliberate use of the ext transport to customize a connection, such as an "ext::ssh -i /path/to/key user@host %S repo" remote. This requires an administrator to override the default protocol policy first and is worth confirming regardless.
+level: high

--- a/rules/windows/process_creation/proc_creation_win_git_ext_transport_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_git_ext_transport_execution.yml
@@ -1,0 +1,66 @@
+title: Command Execution via Git Ext Transport - Windows
+id: 4eed6400-61a7-459a-a65e-88562b863b8e
+related:
+    - id: 734fdfff-634f-495f-8dd0-523a6c06f3cf
+      type: similar
+    - id: ecf26065-2948-4e4d-b63a-7f1f14656912
+      type: similar
+status: experimental
+description: |
+    Detects Git's "ext::" remote helper transport, which runs the command named in the remote URL and wires its stdin and stdout to the Git protocol stream.
+    Git classifies "ext" as a known-dangerous protocol and ships it with a default policy of "never", so the helper runs only after protocol.ext.allow or GIT_ALLOW_PROTOCOL loosens that policy, frequently on the attacker's own command line.
+    Git for Windows exposes the helper either as a git.exe subcommand or as a separate git-remote-ext.exe, so this rule covers both invocation forms.
+references:
+    - https://git-scm.com/docs/git-remote-ext
+    - https://git-scm.com/docs/git-config
+    - https://security.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-3113858
+    - https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-3112221
+    - https://www.vulncheck.com/advisories/hermes-webui-rce-via-git-configuration-injection
+author: David Burkett (@signalblur)
+date: 2026-08-11
+tags:
+    - attack.execution
+    - attack.t1059
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_helper_subcmd:
+        Image|endswith: '\git.exe'
+        CommandLine|contains: ' remote-ext '
+    selection_helper_binary:
+        Image|endswith: '\git-remote-ext.exe'
+    filter_helper_docs:
+        CommandLine|contains: ' remote-ext --help'
+    selection_url_main:
+        Image|endswith: '\git.exe'
+        CommandLine|contains: 'ext::'
+    selection_url_verb:
+        CommandLine|contains:
+            - ' clone '
+            - ' fetch '
+            - ' pull '
+            - ' push '
+            - ' remote '
+            - ' ls-remote '
+            - ' submodule'
+            - ' archive '
+            - ' config '
+    filter_url_docs:
+        CommandLine|contains:
+            - ' help '
+            - '--help'
+    filter_url_message:
+        CommandLine|contains:
+            - ' commit '
+            - ' tag '
+            - ' -m '
+    selection_child:
+        ParentImage|endswith:
+            - '\git.exe'
+            - '\git-remote-ext.exe'
+        ParentCommandLine|contains: 'remote-ext'
+    condition: (1 of selection_helper_* and not filter_helper_docs) or (all of selection_url_* and not 1 of filter_url_*) or selection_child
+falsepositives:
+    - Deliberate use of the ext transport to customize a connection, such as an "ext::ssh -i /path/to/key user@host %S repo" remote. This requires an administrator to override the default protocol policy first and is worth confirming regardless.
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
Three `process_creation` rules for Git's `ext::` remote helper transport, which runs the command named in a remote URL. Git documents `ext` as known-dangerous with a default policy of `never`; published PoCs (CVE-2022-24439, CVE-2022-25912) pass `-c protocol.ext.allow=always` alongside the URL, and CVE-2026-49959 reaches it from an attacker-controlled `.git/config`. No existing rule references `ext::`.

Detection keys on the helper process, not the URL string. When the `ext::` URL is held in a repository-local config, no process carries `ext::` at all — the command line is `git fetch origin` and the helper's is `git remote-ext origin <command>`. The constant across all three delivery shapes (command line, repo config, `.gitmodules`) is the `git remote-ext` process. `' submodule'` omits a trailing space intentionally, to match the internal `git submodule--helper` as well as `git submodule add`.

Matching command lines, with `Image` ending in `/git`:

```
git -c protocol.ext.allow=always clone "ext::sh -c id" /tmp/x
git ls-remote "ext::sh -c id"
git remote add origin "ext::sh -c id"
git config remote.origin.url "ext::sh -c id"
git submodule add "ext::sh -c id" s
```

The first still matches when the default protocol policy refuses the transport, so a blocked attempt is as visible as a successful one. Where the URL sits in a repository-local config instead, the helper and payload events carry `/usr/libexec/git-core/git remote-ext origin sh -c id` as `CommandLine` and `ParentCommandLine` respectively. Not matched: `git commit -m "support ext:: remotes"`, `git help remote-ext`, or a bare `git fetch origin`.

The Windows rule is derived from Git's source (`git.c` registers `remote-ext` with no platform guard) and has not been executed on Windows; it covers both the `git.exe remote-ext` and standalone `git-remote-ext.exe` forms.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->
new: Command Execution via Git Ext Transport - Linux
new: Command Execution via Git Ext Transport - MacOS
new: Command Execution via Git Ext Transport - Windows

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
