### PR TITLE
Add Git configuration command execution rules

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_git_config_shell_value.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_git_config_shell_value.yml
@@ -1,0 +1,54 @@
+title: Shell Command in Git Configuration Value - Linux
+id: f1a78b88-269b-408f-b2b4-bfb7a8750107
+related:
+    - id: b6c7f0a4-8cdb-45c3-aec9-7e1b12940be7
+      type: similar
+    - id: b179883a-72e1-4807-a157-811e26dfa6ae
+      type: similar
+status: experimental
+description: |
+    Detects a Git configuration key set on the command line to a value that invokes a shell or a scripting interpreter.
+    Git runs the values of keys such as core.pager, core.fsmonitor, core.editor, diff.external and sequence.editor as commands during ordinary operations, and treats a credential.helper or alias value beginning with an exclamation mark as a shell snippet, so one "-c key=value" pair turns a routine Git command into command execution.
+    Attacker-supplied Git configuration is a documented remote code execution path, reached either through a crafted command line or through configuration written into a repository that a later Git command reads.
+references:
+    - https://git-scm.com/docs/git-config
+    - https://www.vulncheck.com/advisories/hermes-webui-rce-via-git-configuration-injection
+author: David Burkett (@signalblur)
+date: 2026-08-11
+tags:
+    - attack.execution
+    - attack.t1059.004
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_img:
+        Image|endswith: '/git'
+    selection_config_key:
+        CommandLine|contains:
+            - 'alias.'
+            - 'core.alternateRefsCommand'
+            - 'core.editor'
+            - 'core.fsmonitor'
+            - 'core.pager'
+            - 'core.sshCommand'
+            - 'credential.helper'
+            - 'diff.external'
+            - 'filter.'
+            - 'pager.'
+            - 'sequence.editor'
+    selection_shell_value:
+        CommandLine|contains:
+            - '/dev/tcp/'
+            - '=!'
+            - 'nc -e'
+            - 'perl -e'
+            - 'python -c'
+            - 'python3 -c'
+            - 'ruby -e'
+            - 'sh -c'
+    condition: all of selection_*
+falsepositives:
+    - A shell based credential helper set inline, such as the AWS CodeCommit helper, whose value legitimately begins with an exclamation mark.
+    - A Git command whose arguments quote both a configuration key and a shell invocation, such as a commit message that describes this behaviour.
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_git_pack_proxy_program_override.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_git_pack_proxy_program_override.yml
@@ -1,0 +1,39 @@
+title: Git Pack or Proxy Program Override - Linux
+id: 4aa2611d-1286-4694-b2d7-6070c33f86b6
+related:
+    - id: 07a6e448-bb76-4b68-8102-6484c21ea4fc
+      type: similar
+    - id: c2aa5eed-954c-4b1a-9e52-2ebb0afcf4d8
+      type: similar
+status: experimental
+description: |
+    Detects Git being told to run a caller-supplied program in place of one of the helpers it normally starts for itself.
+    The "--upload-pack" and "--receive-pack" options, their "remote.<name>.uploadpack" and "remote.<name>.receivepack" configuration equivalents, "uploadpack.packObjectsHook" and "core.gitProxy" each name a program that Git executes while moving objects to or from a repository.
+    Against a local path or a local clone that program runs on the host issuing the command, which turns an otherwise ordinary looking Git invocation into command execution.
+references:
+    - https://git-scm.com/docs/git-config
+    - https://git-scm.com/docs/git-clone
+    - https://git-scm.com/docs/git-push
+author: David Burkett (@signalblur)
+date: 2026-08-11
+tags:
+    - attack.execution
+    - attack.t1059.004
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection:
+        Image|endswith: '/git'
+        CommandLine|contains:
+            - '--receive-pack'
+            - '--upload-pack'
+            - '.receivepack'
+            - '.uploadpack'
+            - 'core.gitProxy'
+            - 'uploadpack.packObjectsHook'
+    condition: selection
+falsepositives:
+    - Connecting to a server that keeps Git outside the default path, which is the documented reason to pass "--upload-pack" or "--receive-pack".
+    - A proxy program configured for the deprecated "git://" protocol in an environment that still restricts direct outbound connections.
+level: medium

--- a/rules/macos/process_creation/proc_creation_macos_git_config_shell_value.yml
+++ b/rules/macos/process_creation/proc_creation_macos_git_config_shell_value.yml
@@ -1,0 +1,54 @@
+title: Shell Command in Git Configuration Value - MacOS
+id: b6c7f0a4-8cdb-45c3-aec9-7e1b12940be7
+related:
+    - id: f1a78b88-269b-408f-b2b4-bfb7a8750107
+      type: similar
+    - id: b179883a-72e1-4807-a157-811e26dfa6ae
+      type: similar
+status: experimental
+description: |
+    Detects a Git configuration key set on the command line to a value that invokes a shell or a scripting interpreter.
+    Git runs the values of keys such as core.pager, core.fsmonitor, core.editor, diff.external and sequence.editor as commands during ordinary operations, and treats a credential.helper or alias value beginning with an exclamation mark as a shell snippet, so one "-c key=value" pair turns a routine Git command into command execution.
+    Attacker-supplied Git configuration is a documented remote code execution path, reached either through a crafted command line or through configuration written into a repository that a later Git command reads.
+references:
+    - https://git-scm.com/docs/git-config
+    - https://www.vulncheck.com/advisories/hermes-webui-rce-via-git-configuration-injection
+author: David Burkett (@signalblur)
+date: 2026-08-11
+tags:
+    - attack.execution
+    - attack.t1059.004
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_img:
+        Image|endswith: '/git'
+    selection_config_key:
+        CommandLine|contains:
+            - 'alias.'
+            - 'core.alternateRefsCommand'
+            - 'core.editor'
+            - 'core.fsmonitor'
+            - 'core.pager'
+            - 'core.sshCommand'
+            - 'credential.helper'
+            - 'diff.external'
+            - 'filter.'
+            - 'pager.'
+            - 'sequence.editor'
+    selection_shell_value:
+        CommandLine|contains:
+            - '/dev/tcp/'
+            - '=!'
+            - 'nc -e'
+            - 'perl -e'
+            - 'python -c'
+            - 'python3 -c'
+            - 'ruby -e'
+            - 'sh -c'
+    condition: all of selection_*
+falsepositives:
+    - A shell based credential helper set inline, such as the AWS CodeCommit helper, whose value legitimately begins with an exclamation mark.
+    - A Git command whose arguments quote both a configuration key and a shell invocation, such as a commit message that describes this behaviour.
+level: high

--- a/rules/macos/process_creation/proc_creation_macos_git_pack_proxy_program_override.yml
+++ b/rules/macos/process_creation/proc_creation_macos_git_pack_proxy_program_override.yml
@@ -1,0 +1,39 @@
+title: Git Pack or Proxy Program Override - MacOS
+id: 07a6e448-bb76-4b68-8102-6484c21ea4fc
+related:
+    - id: 4aa2611d-1286-4694-b2d7-6070c33f86b6
+      type: similar
+    - id: c2aa5eed-954c-4b1a-9e52-2ebb0afcf4d8
+      type: similar
+status: experimental
+description: |
+    Detects Git being told to run a caller-supplied program in place of one of the helpers it normally starts for itself.
+    The "--upload-pack" and "--receive-pack" options, their "remote.<name>.uploadpack" and "remote.<name>.receivepack" configuration equivalents, "uploadpack.packObjectsHook" and "core.gitProxy" each name a program that Git executes while moving objects to or from a repository.
+    Against a local path or a local clone that program runs on the host issuing the command, which turns an otherwise ordinary looking Git invocation into command execution.
+references:
+    - https://git-scm.com/docs/git-config
+    - https://git-scm.com/docs/git-clone
+    - https://git-scm.com/docs/git-push
+author: David Burkett (@signalblur)
+date: 2026-08-11
+tags:
+    - attack.execution
+    - attack.t1059.004
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection:
+        Image|endswith: '/git'
+        CommandLine|contains:
+            - '--receive-pack'
+            - '--upload-pack'
+            - '.receivepack'
+            - '.uploadpack'
+            - 'core.gitProxy'
+            - 'uploadpack.packObjectsHook'
+    condition: selection
+falsepositives:
+    - Connecting to a server that keeps Git outside the default path, which is the documented reason to pass "--upload-pack" or "--receive-pack".
+    - A proxy program configured for the deprecated "git://" protocol in an environment that still restricts direct outbound connections.
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_git_config_shell_value.yml
+++ b/rules/windows/process_creation/proc_creation_win_git_config_shell_value.yml
@@ -1,0 +1,62 @@
+title: Shell Command in Git Configuration Value - Windows
+id: b179883a-72e1-4807-a157-811e26dfa6ae
+related:
+    - id: f1a78b88-269b-408f-b2b4-bfb7a8750107
+      type: similar
+    - id: b6c7f0a4-8cdb-45c3-aec9-7e1b12940be7
+      type: similar
+status: experimental
+description: |
+    Detects a Git configuration key set on the command line to a value that invokes a shell or a scripting interpreter.
+    Git runs the values of keys such as core.pager, core.fsmonitor, core.editor, diff.external and sequence.editor as commands during ordinary operations, and treats a credential.helper or alias value beginning with an exclamation mark as a shell snippet, so one "-c key=value" pair turns a routine Git command into command execution.
+    Windows records the command line as a single string, so the quoting around such a value is preserved and is matched here alongside the bare form.
+    Git for Windows also ships a POSIX shell, which is why the Unix interpreter spellings are matched next to the native ones.
+references:
+    - https://git-scm.com/docs/git-config
+    - https://www.vulncheck.com/advisories/hermes-webui-rce-via-git-configuration-injection
+author: David Burkett (@signalblur)
+date: 2026-08-11
+tags:
+    - attack.execution
+    - attack.t1059
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        Image|endswith: '\git.exe'
+    selection_config_key:
+        CommandLine|contains:
+            - 'alias.'
+            - 'core.alternateRefsCommand'
+            - 'core.editor'
+            - 'core.fsmonitor'
+            - 'core.pager'
+            - 'core.sshCommand'
+            - 'credential.helper'
+            - 'diff.external'
+            - 'filter.'
+            - 'pager.'
+            - 'sequence.editor'
+    selection_shell_value:
+        CommandLine|contains:
+            - '/dev/tcp/'
+            - '=!'
+            - '="!'
+            - "='!"
+            - 'cmd /c'
+            - 'cmd.exe /c'
+            - 'nc -e'
+            - 'perl -e'
+            - 'powershell -'
+            - 'powershell.exe -'
+            - 'pwsh -'
+            - 'python -c'
+            - 'python3 -c'
+            - 'ruby -e'
+            - 'sh -c'
+    condition: all of selection_*
+falsepositives:
+    - A shell based credential helper set inline, such as the AWS CodeCommit helper, whose value legitimately begins with an exclamation mark.
+    - A Git command whose arguments quote both a configuration key and a shell invocation, such as a commit message that describes this behaviour.
+level: high

--- a/rules/windows/process_creation/proc_creation_win_git_pack_proxy_program_override.yml
+++ b/rules/windows/process_creation/proc_creation_win_git_pack_proxy_program_override.yml
@@ -1,0 +1,39 @@
+title: Git Pack or Proxy Program Override - Windows
+id: c2aa5eed-954c-4b1a-9e52-2ebb0afcf4d8
+related:
+    - id: 4aa2611d-1286-4694-b2d7-6070c33f86b6
+      type: similar
+    - id: 07a6e448-bb76-4b68-8102-6484c21ea4fc
+      type: similar
+status: experimental
+description: |
+    Detects Git being told to run a caller-supplied program in place of one of the helpers it normally starts for itself.
+    The "--upload-pack" and "--receive-pack" options, their "remote.<name>.uploadpack" and "remote.<name>.receivepack" configuration equivalents, "uploadpack.packObjectsHook" and "core.gitProxy" each name a program that Git executes while moving objects to or from a repository.
+    Against a local path or a local clone that program runs on the host issuing the command, which turns an otherwise ordinary looking Git invocation into command execution.
+references:
+    - https://git-scm.com/docs/git-config
+    - https://git-scm.com/docs/git-clone
+    - https://git-scm.com/docs/git-push
+author: David Burkett (@signalblur)
+date: 2026-08-11
+tags:
+    - attack.execution
+    - attack.t1059
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        Image|endswith: '\git.exe'
+        CommandLine|contains:
+            - '--receive-pack'
+            - '--upload-pack'
+            - '.receivepack'
+            - '.uploadpack'
+            - 'core.gitProxy'
+            - 'uploadpack.packObjectsHook'
+    condition: selection
+falsepositives:
+    - Connecting to a server that keeps Git outside the default path, which is the documented reason to pass "--upload-pack" or "--receive-pack".
+    - A proxy program configured for the deprecated "git://" protocol in an environment that still restricts direct outbound connections.
+level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
Two `process_creation` rule families for Git configuration that names a program Git then runs. No existing rule references any of these keys or options.

**Shell Command in Git Configuration Value** (`high`) matches a configuration key set on the command line to a value that invokes a shell or an interpreter. Git executes the values of `core.pager`, `core.fsmonitor`, `core.editor`, `core.sshCommand`, `core.alternateRefsCommand`, `diff.external`, `sequence.editor`, `pager.<cmd>` and `filter.<name>.clean` during ordinary operations, and treats a `credential.helper` or `alias.<name>` value beginning with `!` as a shell snippet.

**Git Pack or Proxy Program Override** (`medium`) matches `--upload-pack`, `--receive-pack`, the `remote.<name>.uploadpack` and `remote.<name>.receivepack` configuration equivalents, `uploadpack.packObjectsHook` and `core.gitProxy`. Against a local path these run on the host issuing the command.

Every primitive listed was confirmed executing on git 2.52.0 before it was included, with the single exception noted at the end. Matching command lines:

```
git -c credential.helper='!sh -c id' ls-remote https://x/y
git -c core.pager='sh -c id' log -1
git -c core.fsmonitor='sh -c id' status
git clone --upload-pack='touch /tmp/pwn' /src /dst
git -c core.gitProxy=/tmp/p.sh ls-remote git://h.invalid/x
```

Not matched: `git -c core.pager=cat log`, `git -c core.editor=vim commit`, `git -c core.fsmonitor=true status`, `git config credential.helper osxkeychain`, `git -c filter.lfs.clean='git-lfs clean -- %f' add .`, and `git config --global alias.lg '!git log --graph'` — the common shell alias, which carries no `=` before the `!`.

The Windows rule adds the quoted spellings, because Windows records the command line as one string and keeps the quoting the other two platforms strip. It also keeps the Unix interpreter forms, since Git for Windows ships a POSIX shell.

`uploadpack.packObjectsHook` is the one keyword included on documentation rather than on a local observation. git-config(1) states that when `upload-pack` would run `git pack-objects`, "it will run this shell command instead", and that the key "is only respected when it is specified in protected configuration" — the scope that covers the `-c` form this rule matches. It is a server-side key, and I could not drive it from a client-side test here, so I am flagging it rather than implying it was measured like the rest.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->
new: Shell Command in Git Configuration Value - Linux
new: Shell Command in Git Configuration Value - MacOS
new: Shell Command in Git Configuration Value - Windows
new: Git Pack or Proxy Program Override - Linux
new: Git Pack or Proxy Program Override - MacOS
new: Git Pack or Proxy Program Override - Windows

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
