### PR TITLE
Add New ChainDrop NPM Supply-Chain Attack Rules

### DIFF
--- a/rules-emerging-threats/2026/Malware/ChainDrop/dns_query_win_malware_chaindrop_c2.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/dns_query_win_malware_chaindrop_c2.yml
@@ -1,0 +1,33 @@
+title: ChainDrop Supply-Chain Attack DNS Indicators
+id: 1a9e09db-78db-4a77-976e-ca543e7b443d
+status: experimental
+description: |
+    Detects DNS queries to attacker-controlled infrastructure used by the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04.
+    The payload exfiltrates RSA-encrypted credential bundles to "npm-cache.com" over HTTPS, and resolves rotating fallback infrastructure such as "awqhnjewqjkl.icu" through an Ethereum smart contract, a technique known as EtherHiding.
+references:
+    - https://unit42.paloaltonetworks.com/chaindrop-npm-worm-analysis/
+    - https://www.microsoft.com/en-us/security/blog/2026/08/04/chaindrop-supply-chain-compromise-anatomy-self-propagating-worm/
+    - https://www.elastic.co/security-labs/shai-hulud-chaindrop-npm-supply-chain
+    - https://www.stepsecurity.io/blog/chaindrop-npm-worm
+author: Harsh Thakur
+date: 2026-08-11
+tags:
+    - attack.command-and-control
+    - attack.t1071.001
+    - attack.exfiltration
+    - attack.t1041
+    - detection.emerging-threats
+logsource:
+    category: dns_query
+    product: windows
+detection:
+    selection:
+        QueryName:
+            - 'npm-cache.com'
+            - 'pypi-get.com'
+            - 'js-mirror.com'
+            - 'awqhnjewqjkl.icu'
+    condition: selection
+falsepositives:
+    - Unlikely
+level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/dns_query_win_malware_chaindrop_c2.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/dns_query_win_malware_chaindrop_c2.yml
@@ -1,5 +1,8 @@
 title: ChainDrop Supply-Chain Attack DNS Indicators
 id: 1a9e09db-78db-4a77-976e-ca543e7b443d
+related:
+    - id: ac5a4e3f-7f9d-6abc-d8ea-3b4c5f6a7b8c
+      type: similar
 status: experimental
 description: |
     Detects DNS queries to attacker-controlled infrastructure used by the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04.

--- a/rules-emerging-threats/2026/Malware/ChainDrop/file_event_lnx_malware_chaindrop.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/file_event_lnx_malware_chaindrop.yml
@@ -3,6 +3,10 @@ id: 98fbf2fa-4059-440a-9d1a-3198a6c6239f
 related:
     - id: 28a4e0f6-1076-459b-81ec-710b3c28e4a3
       type: similar
+    - id: 2b5e4d3f-7c9a-4fab-a8d1-3e6f5a7b8c9d
+      type: similar
+    - id: 0aba5685-6db6-486f-88ef-29a99c545cfd
+      type: similar
 status: experimental
 description: |
     Detects file creation indicators associated with the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04.

--- a/rules-emerging-threats/2026/Malware/ChainDrop/file_event_lnx_malware_chaindrop.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/file_event_lnx_malware_chaindrop.yml
@@ -1,0 +1,48 @@
+title: ChainDrop Supply-Chain Attack File Creation Indicators - Linux
+id: 98fbf2fa-4059-440a-9d1a-3198a6c6239f
+related:
+    - id: 28a4e0f6-1076-459b-81ec-710b3c28e4a3
+      type: similar
+status: experimental
+description: |
+    Detects file creation indicators associated with the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04.
+    The worm drops its obfuscated second-stage payload as "Math_Symbol.js" or "math_init.js", copies the "setup.mjs" dropper into the ".claude" and ".vscode" project directories so that agent and editor startup hooks re-execute it, and installs a latent "gh-token-monitor" component as a systemd user service or macOS LaunchAgent.
+references:
+    - https://unit42.paloaltonetworks.com/chaindrop-npm-worm-analysis/
+    - https://www.stepsecurity.io/blog/chaindrop-npm-worm
+    - https://www.elastic.co/security-labs/shai-hulud-chaindrop-npm-supply-chain
+    - https://www.microsoft.com/en-us/security/blog/2026/08/04/chaindrop-supply-chain-compromise-anatomy-self-propagating-worm/
+author: Harsh Thakur
+date: 2026-08-11
+tags:
+    - attack.initial-access
+    - attack.t1195.002
+    - attack.execution
+    - attack.t1059.007
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1546
+    - attack.t1543.002
+    - detection.emerging-threats
+logsource:
+    category: file_event
+    product: linux
+detection:
+    selection_payload_files:
+        TargetFilename|endswith:
+            - '/Math_Symbol.js'
+            - '/math_init.js'
+    selection_agent_editor_persistence:
+        TargetFilename|endswith:
+            - '/.claude/setup.mjs'
+            - '/.claude/math_init.js'
+            - '/.vscode/setup.mjs'
+    selection_token_monitor:
+        TargetFilename|endswith:
+            - '/gh-token-monitor.sh'
+            - '/gh-token-monitor.service'
+            - '/com.user.gh-token-monitor.plist'
+    condition: 1 of selection_*
+falsepositives:
+    - Unlikely
+level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/file_event_win_malware_chaindrop.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/file_event_win_malware_chaindrop.yml
@@ -3,6 +3,8 @@ id: 28a4e0f6-1076-459b-81ec-710b3c28e4a3
 related:
     - id: 98fbf2fa-4059-440a-9d1a-3198a6c6239f
       type: similar
+    - id: 8a3f2c1e-5d7b-4e9a-b6c8-1f2a3d4e5f6a
+      type: similar
 status: experimental
 description: |
     Detects file creation indicators associated with the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04.

--- a/rules-emerging-threats/2026/Malware/ChainDrop/file_event_win_malware_chaindrop.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/file_event_win_malware_chaindrop.yml
@@ -1,0 +1,42 @@
+title: ChainDrop Supply-Chain Attack File Creation Indicators - Windows
+id: 28a4e0f6-1076-459b-81ec-710b3c28e4a3
+related:
+    - id: 98fbf2fa-4059-440a-9d1a-3198a6c6239f
+      type: similar
+status: experimental
+description: |
+    Detects file creation indicators associated with the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04.
+    The worm drops its obfuscated second-stage payload as "Math_Symbol.js" or "math_init.js" and copies the "setup.mjs" dropper into the ".claude" and ".vscode" project directories, where a Claude Code "SessionStart" hook and a Visual Studio Code "folderOpen" task re-execute it whenever the project is opened.
+references:
+    - https://unit42.paloaltonetworks.com/chaindrop-npm-worm-analysis/
+    - https://www.stepsecurity.io/blog/chaindrop-npm-worm
+    - https://www.elastic.co/security-labs/shai-hulud-chaindrop-npm-supply-chain
+    - https://www.microsoft.com/en-us/security/blog/2026/08/04/chaindrop-supply-chain-compromise-anatomy-self-propagating-worm/
+author: Harsh Thakur
+date: 2026-08-11
+tags:
+    - attack.initial-access
+    - attack.t1195.002
+    - attack.execution
+    - attack.t1059.007
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1546
+    - detection.emerging-threats
+logsource:
+    category: file_event
+    product: windows
+detection:
+    selection_payload_files:
+        TargetFilename|endswith:
+            - '\Math_Symbol.js'
+            - '\math_init.js'
+    selection_agent_editor_persistence:
+        TargetFilename|endswith:
+            - '\.claude\setup.mjs'
+            - '\.claude\math_init.js'
+            - '\.vscode\setup.mjs'
+    condition: 1 of selection_*
+falsepositives:
+    - Unlikely
+level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_credential_access.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_credential_access.yml
@@ -25,8 +25,16 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection_cloud_cli:
+    selection_bun_parent:
         ParentImage|endswith: '/bun'
+  # Scope to Bun processes running out of an npm package tree or out of the temporary runtime
+  # staging directory the dropper creates. The Microsoft hunting query applies the same
+  # node_modules gate. A developer's own Bun script calling these CLIs will not match.
+    selection_supply_chain_context:
+        ParentCommandLine|contains:
+            - 'node_modules'
+            - 'bun-dl-'
+    selection_cloud_cli:
         CommandLine|contains:
             - 'gh auth token'
             - 'gcloud config config-helper'
@@ -34,11 +42,14 @@ detection:
             - 'azd auth token'
   # GitHub Actions runner memory scraping to recover secrets that were masked in the log output
     selection_runner_memory:
-        ParentImage|endswith: '/bun'
         CommandLine|contains|all:
             - '/proc/'
             - '/mem'
-    condition: 1 of selection_*
+  # Legitimate package tooling is invoked through node_modules/.bin, whereas the worm executes
+  # its payload directly from the package directory.
+    filter_main_package_binaries:
+        ParentCommandLine|contains: '/node_modules/.bin/'
+    condition: selection_bun_parent and selection_supply_chain_context and (selection_cloud_cli or selection_runner_memory) and not filter_main_package_binaries
 falsepositives:
-    - Bun-based developer tooling or CI helper scripts that legitimately read cloud or GitHub access tokens.
+    - Bun-based release or deployment tooling executed from inside a package directory that legitimately reads cloud or GitHub access tokens.
 level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_credential_access.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_credential_access.yml
@@ -3,6 +3,8 @@ id: 908741a7-fb51-4f42-b2f0-ee4c1740bab6
 related:
     - id: 2a244d2c-df4d-40c3-8e4f-a7ef95a38192
       type: similar
+    - id: eb827bbd-670a-4d58-8446-c464d8ac2323
+      type: similar
 status: experimental
 description: |
     Detects the ChainDrop (Mini Shai-Hulud variant) second-stage payload harvesting credentials by spawning cloud and code-hosting CLI tools from the Bun runtime.

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_credential_access.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_credential_access.yml
@@ -1,0 +1,44 @@
+title: ChainDrop Supply-Chain Attack Credential Access via Bun - Linux
+id: 908741a7-fb51-4f42-b2f0-ee4c1740bab6
+related:
+    - id: 2a244d2c-df4d-40c3-8e4f-a7ef95a38192
+      type: similar
+status: experimental
+description: |
+    Detects the ChainDrop (Mini Shai-Hulud variant) second-stage payload harvesting credentials by spawning cloud and code-hosting CLI tools from the Bun runtime.
+    After the "setup.mjs" dropper launches the obfuscated payload under Bun, the malware shells out to "gh", "gcloud", "az" and "azd" to mint access tokens, and on GitHub Actions runners dumps the "Runner.Worker" process memory to recover masked secrets.
+    This rule targets the behaviour rather than the payload filename, so it remains effective if the campaign rotates its script names.
+references:
+    - https://www.microsoft.com/en-us/security/blog/2026/08/04/chaindrop-supply-chain-compromise-anatomy-self-propagating-worm/
+    - https://www.stepsecurity.io/blog/chaindrop-npm-worm
+    - https://unit42.paloaltonetworks.com/chaindrop-npm-worm-analysis/
+    - https://www.elastic.co/security-labs/shai-hulud-chaindrop-npm-supply-chain
+author: Harsh Thakur
+date: 2026-08-11
+tags:
+    - attack.credential-access
+    - attack.t1552.001
+    - attack.t1528
+    - attack.t1003
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_cloud_cli:
+        ParentImage|endswith: '/bun'
+        CommandLine|contains:
+            - 'gh auth token'
+            - 'gcloud config config-helper'
+            - 'az account get-access-token'
+            - 'azd auth token'
+  # GitHub Actions runner memory scraping to recover secrets that were masked in the log output
+    selection_runner_memory:
+        ParentImage|endswith: '/bun'
+        CommandLine|contains|all:
+            - '/proc/'
+            - '/mem'
+    condition: 1 of selection_*
+falsepositives:
+    - Bun-based developer tooling or CI helper scripts that legitimately read cloud or GitHub access tokens.
+level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_execution.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_execution.yml
@@ -1,0 +1,59 @@
+title: ChainDrop Supply-Chain Attack Execution Indicators - Linux
+id: 1dd63f56-544d-418e-bb3a-dbf5118a0130
+related:
+    - id: 564893d9-0364-409b-8ffd-12a7a9a23823
+      type: similar
+status: experimental
+description: |
+    Detects process execution indicators associated with the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04, which compromised the "keyv" and "cacheable" package families and propagated to over 400 packages.
+    A malicious "preinstall" lifecycle hook runs the "setup.mjs" dropper via Node.js, which downloads an official Bun runtime into a temporary "bun-dl-" staging directory and then executes the obfuscated second-stage credential stealer "Math_Symbol.js" or "math_init.js".
+references:
+    - https://www.microsoft.com/en-us/security/blog/2026/08/04/chaindrop-supply-chain-compromise-anatomy-self-propagating-worm/
+    - https://www.elastic.co/security-labs/shai-hulud-chaindrop-npm-supply-chain
+    - https://www.stepsecurity.io/blog/chaindrop-npm-worm
+    - https://unit42.paloaltonetworks.com/chaindrop-npm-worm-analysis/
+    - https://www.aikido.dev/blog/keyv-and-friends-compromised-in-npm-supply-chain-attack
+author: Harsh Thakur
+date: 2026-08-11
+tags:
+    - attack.initial-access
+    - attack.t1195.002
+    - attack.execution
+    - attack.t1059.007
+    - attack.command-and-control
+    - attack.t1105
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: linux
+detection:
+    selection_dropper:
+        Image|endswith:
+            - '/node'
+            - '/nodejs'
+        CommandLine|contains: 'setup.mjs'
+    selection_payload:
+        Image|endswith: '/bun'
+        CommandLine|contains:
+            - 'Math_Symbol.js'
+            - 'math_init.js'
+  # Node.js retrieving the official Bun runtime is the dropper's ingress step. The URL and archives
+  # are legitimate, so the parent process is required to avoid alerting on genuine Bun installations.
+    selection_node_fetches_bun:
+        ParentImage|endswith:
+            - '/node'
+            - '/nodejs'
+        CommandLine|contains:
+            - 'oven-sh/bun/releases/download'
+            - 'bun-linux-x64-baseline.zip'
+            - 'bun-linux-x64-musl-baseline.zip'
+            - 'bun-linux-aarch64.zip'
+    selection_bun_staging:
+        ParentImage|endswith:
+            - '/node'
+            - '/nodejs'
+        CommandLine|contains: 'bun-dl-'
+    condition: 1 of selection_*
+falsepositives:
+    - Legitimate projects that ship a build or bootstrap script named "setup.mjs" and execute it via Node.js.
+level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_execution.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_execution.yml
@@ -27,11 +27,24 @@ logsource:
     category: process_creation
     product: linux
 detection:
-    selection_dropper:
+  # The dropper is executed by the preinstall hook from inside the installed package
+  # directory, whereas a project's own bootstrap script of the same name runs from the
+  # project root. Requiring the npm package tree removes that false positive class.
+    selection_dropper_package_tree:
         Image|endswith:
             - '/node'
             - '/nodejs'
         CommandLine|contains: 'setup.mjs'
+        CurrentDirectory|contains: 'node_modules'
+  # Persistence re-execution carries the agent or editor directory in the command line,
+  # which is not a location a legitimate bootstrap script is invoked from.
+    selection_dropper_persistence:
+        Image|endswith:
+            - '/node'
+            - '/nodejs'
+        CommandLine|contains:
+            - '.claude/setup.mjs'
+            - '.vscode/setup.mjs'
     selection_payload:
         Image|endswith: '/bun'
         CommandLine|contains:
@@ -55,5 +68,5 @@ detection:
         CommandLine|contains: 'bun-dl-'
     condition: 1 of selection_*
 falsepositives:
-    - Legitimate projects that ship a build or bootstrap script named "setup.mjs" and execute it via Node.js.
+    - Unlikely
 level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_execution.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_lnx_malware_chaindrop_execution.yml
@@ -3,6 +3,10 @@ id: 1dd63f56-544d-418e-bb3a-dbf5118a0130
 related:
     - id: 564893d9-0364-409b-8ffd-12a7a9a23823
       type: similar
+    - id: 3c6f5e4a-8d0b-6abc-d9e2-4f7a6b8c9d0e
+      type: similar
+    - id: eb827bbd-670a-4d58-8446-c464d8ac2323
+      type: similar
 status: experimental
 description: |
     Detects process execution indicators associated with the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04, which compromised the "keyv" and "cacheable" package families and propagated to over 400 packages.

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_credential_access.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_credential_access.yml
@@ -24,14 +24,26 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection:
+    selection_bun_parent:
         ParentImage|endswith: '\bun.exe'
+  # Scope to Bun processes running out of an npm package tree or out of the temporary runtime
+  # staging directory the dropper creates. The Microsoft hunting query applies the same
+  # node_modules gate. A developer's own Bun script calling these CLIs will not match.
+    selection_supply_chain_context:
+        ParentCommandLine|contains:
+            - 'node_modules'
+            - 'bun-dl-'
+    selection_cloud_cli:
         CommandLine|contains:
             - 'gh auth token'
             - 'gcloud config config-helper'
             - 'az account get-access-token'
             - 'azd auth token'
-    condition: selection
+  # Legitimate package tooling is invoked through node_modules\.bin, whereas the worm executes
+  # its payload directly from the package directory.
+    filter_main_package_binaries:
+        ParentCommandLine|contains: '\node_modules\.bin\'
+    condition: all of selection_* and not filter_main_package_binaries
 falsepositives:
-    - Bun-based developer tooling or CI helper scripts that legitimately read cloud or GitHub access tokens.
+    - Bun-based release or deployment tooling executed from inside a package directory that legitimately reads cloud or GitHub access tokens.
 level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_credential_access.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_credential_access.yml
@@ -3,6 +3,8 @@ id: 2a244d2c-df4d-40c3-8e4f-a7ef95a38192
 related:
     - id: 908741a7-fb51-4f42-b2f0-ee4c1740bab6
       type: similar
+    - id: 5299fadf-f228-4526-8274-251db1960be9
+      type: similar
 status: experimental
 description: |
     Detects the ChainDrop (Mini Shai-Hulud variant) second-stage payload harvesting credentials by spawning cloud and code-hosting CLI tools from the Bun runtime.

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_credential_access.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_credential_access.yml
@@ -1,0 +1,37 @@
+title: ChainDrop Supply-Chain Attack Credential Access via Bun - Windows
+id: 2a244d2c-df4d-40c3-8e4f-a7ef95a38192
+related:
+    - id: 908741a7-fb51-4f42-b2f0-ee4c1740bab6
+      type: similar
+status: experimental
+description: |
+    Detects the ChainDrop (Mini Shai-Hulud variant) second-stage payload harvesting credentials by spawning cloud and code-hosting CLI tools from the Bun runtime.
+    After the "setup.mjs" dropper launches the obfuscated payload under Bun, the malware shells out to "gh", "gcloud", "az" and "azd" to mint access tokens.
+    This rule targets the behaviour rather than the payload filename, so it remains effective if the campaign rotates its script names.
+references:
+    - https://www.microsoft.com/en-us/security/blog/2026/08/04/chaindrop-supply-chain-compromise-anatomy-self-propagating-worm/
+    - https://www.stepsecurity.io/blog/chaindrop-npm-worm
+    - https://unit42.paloaltonetworks.com/chaindrop-npm-worm-analysis/
+    - https://www.elastic.co/security-labs/shai-hulud-chaindrop-npm-supply-chain
+author: Harsh Thakur
+date: 2026-08-11
+tags:
+    - attack.credential-access
+    - attack.t1552.001
+    - attack.t1528
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection:
+        ParentImage|endswith: '\bun.exe'
+        CommandLine|contains:
+            - 'gh auth token'
+            - 'gcloud config config-helper'
+            - 'az account get-access-token'
+            - 'azd auth token'
+    condition: selection
+falsepositives:
+    - Bun-based developer tooling or CI helper scripts that legitimately read cloud or GitHub access tokens.
+level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_execution.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_execution.yml
@@ -3,6 +3,10 @@ id: 564893d9-0364-409b-8ffd-12a7a9a23823
 related:
     - id: 1dd63f56-544d-418e-bb3a-dbf5118a0130
       type: similar
+    - id: 9b4f3d2e-6e8c-5fab-c7d9-2a3b4e5f6a7b
+      type: similar
+    - id: 5299fadf-f228-4526-8274-251db1960be9
+      type: similar
 status: experimental
 description: |
     Detects process execution indicators associated with the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04, which compromised the "keyv" and "cacheable" package families and propagated to over 400 packages.

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_execution.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_execution.yml
@@ -1,0 +1,52 @@
+title: ChainDrop Supply-Chain Attack Execution Indicators - Windows
+id: 564893d9-0364-409b-8ffd-12a7a9a23823
+related:
+    - id: 1dd63f56-544d-418e-bb3a-dbf5118a0130
+      type: similar
+status: experimental
+description: |
+    Detects process execution indicators associated with the ChainDrop (Mini Shai-Hulud variant) npm supply-chain worm reported on 2026-08-04, which compromised the "keyv" and "cacheable" package families and propagated to over 400 packages.
+    A malicious "preinstall" lifecycle hook runs the "setup.mjs" dropper via Node.js, which downloads an official Bun runtime into a temporary "bun-dl-" staging directory and then executes the obfuscated second-stage credential stealer "Math_Symbol.js" or "math_init.js".
+references:
+    - https://www.microsoft.com/en-us/security/blog/2026/08/04/chaindrop-supply-chain-compromise-anatomy-self-propagating-worm/
+    - https://www.elastic.co/security-labs/shai-hulud-chaindrop-npm-supply-chain
+    - https://www.stepsecurity.io/blog/chaindrop-npm-worm
+    - https://unit42.paloaltonetworks.com/chaindrop-npm-worm-analysis/
+    - https://www.aikido.dev/blog/keyv-and-friends-compromised-in-npm-supply-chain-attack
+author: Harsh Thakur
+date: 2026-08-11
+tags:
+    - attack.initial-access
+    - attack.t1195.002
+    - attack.execution
+    - attack.t1059.007
+    - attack.command-and-control
+    - attack.t1105
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_dropper:
+        Image|endswith: '\node.exe'
+        CommandLine|contains: 'setup.mjs'
+    selection_payload:
+        Image|endswith: '\bun.exe'
+        CommandLine|contains:
+            - 'Math_Symbol.js'
+            - 'math_init.js'
+  # Node.js retrieving the official Bun runtime is the dropper's ingress step. The URL and archives
+  # are legitimate, so the parent process is required to avoid alerting on genuine Bun installations.
+    selection_node_fetches_bun:
+        ParentImage|endswith: '\node.exe'
+        CommandLine|contains:
+            - 'oven-sh/bun/releases/download'
+            - 'bun-windows-x64-baseline.zip'
+            - 'bun-windows-aarch64.zip'
+    selection_bun_staging:
+        ParentImage|endswith: '\node.exe'
+        CommandLine|contains: 'bun-dl-'
+    condition: 1 of selection_*
+falsepositives:
+    - Legitimate projects that ship a build or bootstrap script named "setup.mjs" and execute it via Node.js.
+level: high

--- a/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_execution.yml
+++ b/rules-emerging-threats/2026/Malware/ChainDrop/proc_creation_win_malware_chaindrop_execution.yml
@@ -27,9 +27,20 @@ logsource:
     category: process_creation
     product: windows
 detection:
-    selection_dropper:
+  # The dropper is executed by the preinstall hook from inside the installed package
+  # directory, whereas a project's own bootstrap script of the same name runs from the
+  # project root. Requiring the npm package tree removes that false positive class.
+    selection_dropper_package_tree:
         Image|endswith: '\node.exe'
         CommandLine|contains: 'setup.mjs'
+        CurrentDirectory|contains: 'node_modules'
+  # Persistence re-execution carries the agent or editor directory in the command line,
+  # which is not a location a legitimate bootstrap script is invoked from.
+    selection_dropper_persistence:
+        Image|endswith: '\node.exe'
+        CommandLine|contains:
+            - '.claude\setup.mjs'
+            - '.vscode\setup.mjs'
     selection_payload:
         Image|endswith: '\bun.exe'
         CommandLine|contains:
@@ -48,5 +59,5 @@ detection:
         CommandLine|contains: 'bun-dl-'
     condition: 1 of selection_*
 falsepositives:
-    - Legitimate projects that ship a build or bootstrap script named "setup.mjs" and execute it via Node.js.
+    - Unlikely
 level: high


### PR DESCRIPTION
Adds 7 rules for the ChainDrop npm supply-chain worm (Mini Shai-Hulud variant) reported on 2026-08-04, which compromised the keyv and cacheable package families and spread to 444 packages across 2,212 versions.

Placed in `rules-emerging-threats/2026/Malware/ChainDrop/`, following the layout of the TanStack pack from #6008. Purely additive, no existing files changed.

## Why existing rules do not cover this

The repo already has Shai-Hulud (2025) and TanStack (2026) packs. I checked each against the ChainDrop artefacts and none of them fire, because every selector keys on something this wave replaced:

- `..._shai_hulud_malicious_node_bun_execution` keys on `bun_environment.js` and `bun.sh/install`. ChainDrop uses `Math_Symbol.js` / `math_init.js` and pulls Bun v1.3.13 from the GitHub releases URL.
- `..._shai_hulud_indicator` keys on `Shai-Hulud` / `SHA1HULUD` in the command line. In this wave those strings only appear in attacker repo descriptions, never on a command line.
- `..._shai_hulud_malicious_npm_package_installation` keys on a hard-coded Nov-2025 package list. ChainDrop hit `keyv@6.0.0`, `flat-cache@6.1.24`, `file-entry-cache@11.1.6` and others.
- `..._shai_hululd_exfiltration` keys on the old `webhook.site` URL. ChainDrop posts to `npm-cache.com:443/router`.
- `file_event_lnx_mal_shai_hulud_workflow` keys on `.github/workflows/shai-hulud-workflow.yml`. ChainDrop persists via `.claude/` and `.vscode/` instead.
- `..._tanstack_supply_chain` keys on `tanstack_runner.js` and `.claude/router_runtime.js`.
- `dns_query_win_malware_tanstack_supply_chain_c2` keys on `git-tanstack.com`.

Worth flagging: `node setup.mjs` is the lead hunting query in both the Microsoft and Elastic write-ups, and it is not in any detection block in this repo today. It appears in the TanStack rule description text only.

## Rules

| File | Covers |
|---|---|
| `proc_creation_{lnx,win}_malware_chaindrop_execution.yml` | preinstall dropper, Bun download and staging, payload execution |
| `proc_creation_{lnx,win}_malware_chaindrop_credential_access.yml` | cloud and GitHub token harvesting, Actions runner memory scrape |
| `file_event_{lnx,win}_malware_chaindrop.yml` | payload drop, `.claude` / `.vscode` persistence, `gh-token-monitor` |
| `dns_query_win_malware_chaindrop_c2.yml` | exfil and EtherHiding fallback domains |

Linux and Windows counterparts are cross-linked with `related:`.

## Detection chain

On an infected host the chain is: `npm install` runs the `preinstall` hook, which runs `node setup.mjs`, which downloads Bun into a `bun-dl-` temp dir and executes `Math_Symbol.js` under it. That payload then shells out to `gh auth token`, `az account get-access-token` and similar, writes `.claude/setup.mjs` for persistence, and exfils to `npm-cache.com`.

The execution rule covers the first three steps, the credential access rule the fourth, the file event rule the fifth, and the DNS rule the last. A hit on the dropper alone tells you a lifecycle hook ran an unexpected script. A hit on the payload or credential selections alongside it means the second stage detonated and tokens need rotating.

## False positive handling

Every selection is gated on process context rather than on a command or filename alone, because the raw indicators are all things that occur legitimately. The Bun release URL is the official one, `gh auth token` is an ordinary command, and `setup.mjs` is an ordinary filename. In each case the distinguishing signal is where the process is running, not what it is running:

| Command line | Context | Result |
|---|---|---|
| `curl -fsSL .../bun-v1.3.13/bun-linux-x64-baseline.zip` | parent is `node` | fires |
| `curl -fsSL .../bun-v1.3.13/bun-linux-x64-baseline.zip` | parent is `bash` | silent |
| `curl -fsSL https://bun.sh/install \| bash` | parent is `bash` | silent |
| `gh auth token` | parent `bun`, running from `node_modules` | fires |
| `gh auth token` | parent `bun`, running `scripts/deploy.ts` | silent |
| `gh auth token` | parent `bun`, via `node_modules/.bin/semantic-release` | silent |
| `gh auth token` | parent is `bash` | silent |
| `node setup.mjs` | cwd inside `node_modules/<pkg>` | fires |
| `node setup.mjs` | cwd is the project root | silent |
| `node .claude/setup.mjs` | any | fires |

Three specific gates do that work:

- **Bun downloads require a Node.js parent.** A developer fetching Bun by hand, or via `bun.sh/install`, has a shell parent. The worm has `node` fetch it mid `npm install`.
- **Credential access requires the parent Bun process to be running from `node_modules` or from the dropper's `bun-dl-` staging directory**, which is the same `node_modules` gate the Microsoft hunting query uses, with `node_modules/.bin/` excluded so legitimate release tooling such as semantic-release or changesets does not match.
- **The dropper requires `CurrentDirectory` inside `node_modules`**, since the `preinstall` hook executes from the installed package directory whereas a project's own bootstrap script of the same name runs from the project root. The persistence re-execution path is handled by a separate selection, since `.claude/setup.mjs` and `.vscode/setup.mjs` carry their location in the command line.

Credential access is gated on behaviour rather than filename on purpose. This campaign has already renamed its payload twice (`bun_environment.js`, then `tanstack_runner.js`, now `Math_Symbol.js`), which is why the older packs miss it, so a rule keyed on the Bun parent and package tree should survive the next rename.

One recall caveat worth stating plainly: where a pipeline does not populate `CurrentDirectory`, the dropper event on its own cannot be separated from a benign `setup.mjs`, so it will not alert. The same infection is still caught seconds later by the payload, staging and file event selections, which do not depend on that field.

Three published IOCs are deliberately left out because in these log sources they would be false positive generators, not detections:

- `.github/workflows/codeql_analysis.yml` is a normal filename. The malicious part is the injected `${{ toJSON(secrets) }}` content, which `file_event` cannot see.
- `.claude/settings.json` and `.vscode/tasks.json` are written constantly by Claude Code and VS Code. Again the malice is in the contents.
- The Ethereum RPC endpoints used for EtherHiding (`eth.llamarpc.com`, `go.getblock.io`, `eth-mainnet.nodereal.io`) are legitimate infrastructure. Only confirmed attacker apexes are in the DNS rule.

SHA256 hashes from the reports are in `references` rather than as selectors, since there is no usable hash field here and they do not survive a payload rebuild.

## Testing

```
yamllint --strict                                          pass
python tests/test_logsource.py                             OK (3 tests)
python tests/test_rules.py                                 OK (11 tests)
sigma check --fail-on-error --fail-on-issues \
  --validation-config tests/sigma_cli_conf.yml             0 errors, 0 issues
```

An earlier revision raised two `SigmahqTagsTechniquesWithoutTacticsIssue` findings on the file_event rules, since `T1546` and `T1543.002` map to both Persistence and Privilege Escalation. Fixed by adding `attack.privilege-escalation`.

I also ran the selectors against a synthetic event set built from the published telemetry: 33 events covering every documented artefact across the five reports were each matched by at least one rule, and 30 benign developer and CI events produced no hits at all. The benign set includes every paired case in the table above, plus Bun release tooling (`semantic-release`, `changeset publish`) calling `gh auth token` from `node_modules/.bin`, a Bun deploy script calling `az account get-access-token`, legitimate `setup.mjs` execution from a project root on both platforms, `bun run` from `node_modules`, legitimate `.vscode/tasks.json` and `.claude/settings.json` writes, a CodeQL workflow file, an ordinary `mathjs/lib/math.js`, and `registry.npmjs.org` DNS.

## References

- https://www.microsoft.com/en-us/security/blog/2026/08/04/chaindrop-supply-chain-compromise-anatomy-self-propagating-worm/
- https://www.elastic.co/security-labs/shai-hulud-chaindrop-npm-supply-chain
- https://unit42.paloaltonetworks.com/chaindrop-npm-worm-analysis/
- https://www.stepsecurity.io/blog/chaindrop-npm-worm
- https://www.aikido.dev/blog/keyv-and-friends-compromised-in-npm-supply-chain-attack

Happy to split this up, adjust tags, or tighten the `setup.mjs` selector if you prefer. The `attack.t1003` tag on the Linux credential access rule covers the `/proc/<pid>/mem` scrape and can be dropped if `t1552.001` is enough.
