### PR TITLE
posh_ps_create_local_user: cover local user creation via ADSI/WinNT provider

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_create_local_user.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_create_local_user.yml
@@ -1,12 +1,13 @@
 title: PowerShell Create Local User
 id: 243de76f-4725-4f2e-8225-a8a69b15ad61
 status: test
-description: Detects creation of a local user via PowerShell
+description: Detects creation of a local user via PowerShell (New-LocalUser cmdlet or ADSI/WinNT provider)
 references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1136.001/T1136.001.md
+    - https://github.com/WiLL75G/sigma-rule-validation-create-local-user
 author: '@ROxPinTeddy'
 date: 2020-04-11
-modified: 2022-12-25
+modified: 2026-08-12
 tags:
     - attack.execution
     - attack.t1059.001
@@ -17,9 +18,17 @@ logsource:
     category: ps_script
     definition: 'Requirements: Script Block Logging must be enabled'
 detection:
-    selection:
+    selection_new_localuser:
         ScriptBlockText|contains: 'New-LocalUser'
-    condition: selection
+    selection_adsi_create:
+        ScriptBlockText|contains:
+            - '[ADSI]"WinNT://'
+            - '.Create("User",'
+    selection_adsi_create_single_quote:
+        ScriptBlockText|contains:
+            - '[ADSI]"WinNT://'
+            - ".Create('User',"
+    condition: 1 of selection_*
 falsepositives:
     - Legitimate user creation
 level: medium


### PR DESCRIPTION
## Summary

Fixes #6057 — `posh_ps_create_local_user.yml` only matched `New-LocalUser`, missing local account creation via the ADSI/WinNT provider (e.g. `$user.Create("User", "name"); $user.SetInfo()`), which the reporter verified live via Event 4104 Script Block Logging.

## Changes

Extended the detection with two ADSI/WinNT selections (double- and single-quoted `User` class variants), detected when the script block both binds the WinNT provider (`[ADSI]"WinNT://`) and calls `.Create("User", ...)`:

```yaml
    selection_new_localuser:
        ScriptBlockText|contains: 'New-LocalUser'
    selection_adsi_create:
        ScriptBlockText|contains:
            - '[ADSI]"WinNT://'
            - '.Create("User",'
    selection_adsi_create_single_quote:
        ScriptBlockText|contains:
            - '[ADSI]"WinNT://'
            - ".Create('User',"
    condition: 1 of selection_*
```

Also updated the description and added the reporter's validation methodology as a reference.

## Verification

- `sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml <rule>` -> 0 errors, 0 condition errors, 0 issues
- `tests/test_logsource.py` -> OK
- `yamllint` with repo config -> clean