### PR TITLE
new: silent-call rules

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_sudo_gdb_attach_pid1.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_sudo_gdb_attach_pid1.yml
@@ -1,0 +1,49 @@
+title: Sudo GDB Attach to PID 1
+id: c6e908ad-59ff-43a3-8884-87ead9dad726
+status: experimental
+description: |
+    Detects sudo executions of gdb attaching to PID 1 with a command file (i.e.,
+    '--command=' or '-x ') located in temporary directories ('/tmp', '/var/tmp',
+    '/dev/shm'). This pattern indicates an attempt to escalate privileges by abusing
+    misconfigured sudoers entries permitting passwordless gdb execution, as observed
+    against Cisco CUCM 15.x where the 'tomcat' user can run
+    'sudo -n /usr/bin/gdb -pid 1 --command=/tmp/gdb_file'.
+references:
+    - https://github.com/0xReadingSteiner/Silent-Call/blob/f91488d674f17b4a3b16754b0dc49f07d61ef35e/poc.sh
+author: mromanode
+date: 2026-08-13
+tags:
+    - attack.privilege-escalation
+    - attack.t1548.003
+    - cve.2026-54121
+logsource:
+    product: linux
+    category: process_creation
+    definition: |
+        Requires process creation logs from auditd (/var/log/audit/audit.log) or
+        logging systems that capture the executed image and full command line.
+detection:
+    selection_sudo:
+        Image|endswith: '/sudo'
+    selection_gdb:
+        CommandLine|contains: 'gdb'
+    selection_pid_1:
+        CommandLine|re: '(-pid\s+1|--pid[=\s]1|-p\s+1)'
+    selection_command_file:
+        CommandLine|contains:
+            - '--command='
+            - '--command '
+            - '-x '
+    selection_temp_path:
+        CommandLine|re: '/tmp/|/var/tmp/|/dev/shm/'
+    filter_optional_devel_env:
+        ParentImage|contains:
+            - 'eclipse'
+            - 'vscode'
+            - 'intellij'
+    condition: all of selection_* and not 1 of filter_optional_*
+falsepositives:
+    - Legitimate system administrators debugging PID 1 (rare in production)
+    - Development environments with authorized debugging of the init process
+    - Security or monitoring tooling legitimately attaching debuggers to system processes
+level: high

--- a/rules/linux/process_creation/proc_creation_lnx_sudo_gdb_attach_pid1.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_sudo_gdb_attach_pid1.yml
@@ -15,7 +15,6 @@ date: 2026-08-13
 tags:
     - attack.privilege-escalation
     - attack.t1548.003
-    - cve.2026-54121
 logsource:
     product: linux
     category: process_creation

--- a/rules/web/proxy_generic/proxy_tomcat_manager_deploy.yml
+++ b/rules/web/proxy_generic/proxy_tomcat_manager_deploy.yml
@@ -1,0 +1,44 @@
+title: Tomcat Manager WAR File Deployment
+id: b8f4a1e2-6c3d-4e9f-8a1b-2c3d4e5f6a7b
+status: experimental
+description: |
+    Detects HTTP PUT or POST requests targeting Apache Tomcat Manager deployment
+    endpoints to deploy a malicious WAR and achieve RCE. The exploitation bypasses the
+    Manager's source-address restriction (i.e., forged 'X-Forwarded-For: 127.0.0.1'
+    header) and uploads the archive in the request body, not in the URI, with
+    deployment parameters such as 'path=/<app>&update=true'.
+references:
+    - https://github.com/0xReadingSteiner/Silent-Call/blob/f91488d674f17b4a3b16754b0dc49f07d61ef35e/poc.sh
+author: mromanode
+date: 2026-08-14
+tags:
+    - attack.initial-access
+    - attack.t1190
+logsource:
+    category: proxy
+    definition: |
+        Requires web proxy logs (e.g., Squid, Blue Coat, Palo Alto, F5) or WAF logs that
+        capture the HTTP request method, full request URI, and user agent (for the
+        DevOps tool filter).
+detection:
+    selection_manager:
+        cs-uri|contains:
+            - '/manager/deploy'
+            - '/manager/text/deploy'
+            - '/manager/html/upload'
+    selection_method:
+        cs-method:
+            - 'PUT'
+            - 'POST'
+    filter_optional_devops_tools:
+        c-useragent|contains:
+            - 'Jenkins'
+            - 'Maven'
+            - 'Gradle'
+            - 'Ansible'
+    condition: all of selection_* and not 1 of filter_optional_*
+falsepositives:
+    - Legitimate administrative deployment of WAR files from authorized build servers (Jenkins, Maven, Gradle).
+    - Internal DevOps automation platforms deploying applications through Tomcat Manager.
+    - Manual administrative deployment of WAR files via the Tomcat Manager HTML or text interface.
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

Adds new detection rules covering the Silent;Call exploit chain against Cisco CUCM 15.x, where an attacker bypasses Tomcat Manager's source-address restriction via a forged `X-Forwarded-For: 127.0.0.1` header, deploys a malicious WAR file to achieve RCE as the `tomcat` user, and escalates to root by abusing a sudoers entry permitting passwordless gdb execution against PID 1.

The rules cover the full attack chain:

- Web-level: PUT/POST requests to Tomcat Manager deployment endpoints (`/manager/deploy`, `/manager/text/deploy`, `/manager/html/upload`)
- Process-level: `sudo gdb` attach to PID 1 with command files (`--command=`, `-x `) in temporary directories

### Changelog

- new: Tomcat Manager WAR File Deployment
- new: Sudo GDB Attach to PID 1

### Example Log Event

### Fixed Issues

### SigmaHQ Rule Creation Conventions

If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)