### PR TITLE
Add macOS rule for browser credential database query via a database CLI utility

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_browser_credential_db_query_via_db_cli.yml
+++ b/rules/macos/process_creation/proc_creation_macos_browser_credential_db_query_via_db_cli.yml
@@ -1,0 +1,43 @@
+title: Browser Credential Database Query Via Database CLI Utility - MacOS
+id: 4e0d4a1c-8d2b-4d19-9c1e-2a4f8e6b7c35
+related:
+    - id: 24c77512-782b-448a-8950-eddb0785fc71
+      type: similar
+    - id: 4833155a-4053-4c9c-a997-777fcea0baa7
+      type: similar
+status: experimental
+description: |
+    Detects a command line database client such as "sqlite3" or "duckdb" reading a browser credential, cookie or autofill database.
+    Chromium stores these in "Login Data", "Cookies" and "Web Data", and Firefox stores them in "cookies.sqlite" and "key4.db".
+    Because "sqlite3" ships with macOS and is signed by Apple, this technique lets an attacker read the databases without dropping an unsigned binary on the host.
+    Opening the database through a "file:" URI with the "immutable=1" parameter also avoids the lock that a running browser holds, so the browser does not have to be killed first.
+references:
+    - https://www.loobins.io/binaries/sqlite3/
+    - https://redcanary.com/blog/threat-intelligence/clipping-silver-sparrows-wings/
+    - https://www.jamf.com/blog/crashstealer-macos-infostealer-analysis/
+author: clivoa
+date: 2026-08-15
+tags:
+    - attack.credential-access
+    - attack.t1555.003
+    - attack.t1539
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_img:
+        Image|endswith:
+            - '/sqlite3'
+            - '/duckdb'
+    selection_db:
+        CommandLine|contains:
+            - 'Login Data'
+            - 'Web Data'
+            - '/Cookies'
+            - 'cookies.sqlite'
+            - 'key4.db'
+    condition: all of selection_*
+falsepositives:
+    - Backup, migration or browser forensics tooling that reads these databases through a database CLI utility
+    - Administrators or developers inspecting their own browser profile from a terminal
+level: medium


### PR DESCRIPTION
This adds a macOS `process_creation` rule for a command line database client reading a browser credential, cookie or autofill database.

## Why

Windows already has coverage for this. `SQLite Chromium Profile Data DB Access` (`24c77512`) and `SQLite Firefox Profile Data DB Access` (`4833155a`) both watch for the `sqlite` binary against browser profile databases, and five more Windows rules reference `Login Data` or `key4.db` through file access or PowerShell. On macOS there is nothing. Grepping the current master for `Login Data`, `logins.json`, `key4.db` and `cookies.sqlite` returns seven rules, all of them Windows, and no macOS rule anywhere in the repo matches `sqlite3` at all.

That gap matters more on macOS than on Windows, because `/usr/bin/sqlite3` is present on every install and signed by Apple:

```
Identifier=com.apple.sqlite3
```

An attacker reading the credential database with it never drops an unsigned binary, so controls keyed on code signing trust or on an unknown process touching the profile directory do not fire.

The LOOBins entry for `sqlite3` documents the same binary being used against browser cookie databases, tagged for credential access and cookie theft. I linked the two Windows rules with `related: similar`.

## The immutable=1 detail

The LOOBins one-liner for Firefox starts with `killall firefox`, and the existing Atomic Red Team macOS test for T1555.003 copies the database to `/tmp` first. Both are working around the same thing: Chrome holds a lock on the database while it runs.

Measured on macOS 26.5.2, with Chrome running:

```
$ sqlite3 "$HOME/Library/Application Support/Google/Chrome/Default/Login Data" "SELECT count(*) FROM logins;"
Error: in prepare, database is locked (5)

$ sqlite3 "file:$HOME/Library/Application Support/Google/Chrome/Default/Login Data?immutable=1" "SELECT count(*) FROM logins;"
1
```

Opening it through a `file:` URI with `immutable=1` reads it without taking a lock, so the browser stays up and nothing gets copied. The rule matches both forms, since the database name is on the command line either way.

## Testing

Real process telemetry, captured on macOS 26.5.2 (arm64) while the query ran. Home directory redacted:

```
Image       = /usr/bin/sqlite3
CommandLine = /usr/bin/sqlite3 file:/Users/<user>/Library/Application Support/Google/Chrome/Default/Login Data?immutable=1 SELECT origin_url, username_value FROM logins;
```

Checking the rule logic against that capture and against five other cases:

| Case | Result |
|---|---|
| Captured `Login Data` query above | match |
| `sqlite3` on `Cookies`, plain path, no `immutable` | match |
| `sqlite3` on a Firefox `key4.db` | match |
| `sqlite3` on `com.apple.LaunchServices.QuarantineEventsV2` (captured) | no match |
| `sqlite3` on `com.apple.TCC/TCC.db` | no match |
| `grep -r 'Login Data' .` | no match |

The two quarantine and TCC cases are the other documented LOOBins uses of `sqlite3`, so they are the ones most likely to be confused with this rule. Neither matches.

Repository checks, all clean:

```
python tests/test_logsource.py          Ran 3 tests, OK
python tests/test_rules.py              Ran 11 tests, OK
sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml
                                        0 errors, 0 condition errors, 0 issues
```

## One design choice worth a second opinion

The Windows Chromium rule requires a profile path (`\User Data\`) as well as a database name. I did not require a path here, so that `cd` into the profile directory followed by `sqlite3 Cookies ...` still matches. The cost is a wider surface, which is why this is `medium` with two concrete false positives rather than `high` with `Unknown`. Happy to add a path selection and raise the level if you would rather keep it consistent with the Windows rules.
