### PR TITLE
Replace legacy rule with a new one

### DIFF
--- a/deprecated/windows/posh_ps_test_netconnection.yml
+++ b/deprecated/windows/posh_ps_test_netconnection.yml
@@ -9,6 +9,7 @@ references:
     - https://learn.microsoft.com/en-us/powershell/module/nettcpip/test-netconnection?view=windowsserver2022-ps
 author: frack113
 date: 2022-01-23
+modified: 2026-08-10
 tags:
     - attack.command-and-control
     - attack.t1571

--- a/rules/windows/powershell/powershell_script/posh_ps_port_probing_network_cmdlet.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_port_probing_network_cmdlet.yml
@@ -1,0 +1,55 @@
+title: Port Probing Via PowerShell Network Cmdlets Or .NET Sockets
+id: 0f0a89f7-0fae-48f6-bb47-26c7b9e3c5bd
+related:
+    - id: adf876b3-f1f8-4aa9-a4e4-a64106feec06
+      type: obsolete
+status: experimental
+description: |
+    Detects the use of built-in PowerShell network diagnostic cmdlets or .NET socket classes to probe a specific TCP port on a local or remote host.
+    Adversaries may use "Test-NetConnection" or "Test-Connection" with an explicit port, or directly instantiate .NET "Net.Sockets.Socket"/"Net.Sockets.TcpClient" objects and call their connect methods, to enumerate reachable network services as a precursor to lateral movement.
+references:
+    - https://learn.microsoft.com/en-us/powershell/module/nettcpip/test-netconnection?view=windowsserver2022-ps
+    - https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/test-connection?view=powershell-7.4
+    - https://learn.microsoft.com/en-us/dotnet/api/system.net.sockets.tcpclient.connect
+    - https://learn.microsoft.com/en-us/dotnet/api/system.net.sockets.socket.connect
+    - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1571/T1571.md#atomic-test-1---testing-usage-of-uncommonly-used-port-with-powershell
+author: Norbert Jaśniewicz (AlphaSOC)
+date: 2026-08-10
+tags:
+    - attack.discovery
+    - attack.t1046
+logsource:
+    product: windows
+    category: ps_script
+    definition: 'Requirements: Script Block Logging must be enabled'
+detection:
+    selection_tnc:
+        # Match Test-NetConnection or tnc with port flag. Flags in PowerShell may be abbreviated to the shortest unambiguous prefix.
+        ScriptBlockText|re|i: '(Test-NetConnection|tnc)[^\r\n]*[ \t]-(((Remote)?(P|Po|Por|Port))|Comm|Commo|Common|CommonT|CommonTC|CommonTCP|CommonTCPP|CommonTCPPo|CommonTCPPor|CommonTCPPort)[: \t]'
+    selection_tc:
+        ScriptBlockText|re|i: '(Test-Connection)[^\r\n]*[ \t]-(Tc|Tcp|TcpP|TcpPo|TcpPor|TcpPort)[: \t]'
+    selection_dotnet_class:
+        ScriptBlockText|contains:
+            - 'Net.Sockets.Socket'
+            - 'Net.Sockets.TcpClient'
+    selection_dotnet_method:
+        ScriptBlockText|contains:
+            - '.Connect('
+            - '.ConnectAsync('
+            - '.BeginConnect('
+    selection_tcpclient_ctor:
+        # The "TcpClient(host, port)" constructor connects immediately, so no separate connect call is made.
+        # An argument separator is required before the closing parenthesis, so the non-connecting default constructor is not matched.
+        # Line breaks are allowed inside the argument list, since PowerShell does not require a continuation character within parentheses.
+        #
+        # Note: System.Net.Sockets.Socket does not have analogous constructor.
+        ScriptBlockText|re|i:
+            # New-Object Net.Sockets.TcpClient("host", port)
+            - 'Net\.Sockets\.TcpClient\([^)]*,'
+            # [Net.Sockets.TcpClient]::new("host", port)
+            - 'Net\.Sockets\.TcpClient\]::new\([^)]*,'
+    condition: selection_tnc or selection_tc or all of selection_dotnet_* or selection_tcpclient_ctor
+falsepositives:
+    - Infrastructure monitoring and health-check scripts
+    - Administrators troubleshooting network connectivity or firewall rules
+level: low

--- a/rules/windows/powershell/powershell_script/posh_ps_test_netconnection.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_test_netconnection.yml
@@ -1,6 +1,6 @@
 title: Testing Usage of Uncommonly Used Port
 id: adf876b3-f1f8-4aa9-a4e4-a64106feec06
-status: test
+status: deprecated
 description: |
     Adversaries may communicate using a protocol and port paring that are typically not associated.
     For example, HTTPS over port 8088(Citation: Symantec Elfin Mar 2019) or port 587(Citation: Fortinet Agent Tesla April 2018) as opposed to the traditional port 443.


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request
<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
This PR deprecates a rule that matched uses of `Test-NetConnection` powershell command. It also introduces new rule meant to provide improved coverage for the retired rule. It includes additional commands, including .Net classes. It has broader scope and does not have explicit filter, since it introduced unexpected false negatives. The chosen severity for the new rule is 'low'. 

The CLI tools selection is limited, but includes what's likely available on any windows host and can be easliy used to probe TCP ports.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: Port Probing Via PowerShell Network Cmdlets Or .NET Sockets
remove: Testing Usage of Uncommonly Used Port - deprecated in favour of 0f0a89f7-0fae-48f6-bb47-26c7b9e3c5bd

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

Closes https://github.com/SigmaHQ/sigma/issues/6132
<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
