### PR TITLE
Add Administrator Changed Authentication Method Of Another User

### DIFF
--- a/rules/cloud/azure/audit_logs/azure_ad_admin_changed_authentication_method_of_another_user.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_admin_changed_authentication_method_of_another_user.yml
@@ -5,7 +5,7 @@ related:
       type: similar
     - id: fa84aaf5-8142-43cd-9ec2-78cfebf878ce
       type: similar
-status: experimental
+status: test
 description: |
     Detects an administrator registering, updating or deleting MFA security info on another user's
     account in Entra ID. An attacker holding administrative access can attach a factor they control

--- a/rules/cloud/azure/audit_logs/azure_ad_admin_changed_authentication_method_of_another_user.yml
+++ b/rules/cloud/azure/audit_logs/azure_ad_admin_changed_authentication_method_of_another_user.yml
@@ -1,0 +1,44 @@
+title: Administrator Changed Authentication Method Of Another User
+id: bf01ebb6-7dde-40f4-b502-cd22cb121859
+related:
+    - id: 4d78a000-ab52-4564-88a5-7ab5242b20c7
+      type: similar
+    - id: fa84aaf5-8142-43cd-9ec2-78cfebf878ce
+      type: similar
+status: experimental
+description: |
+    Detects an administrator registering, updating or deleting MFA security info on another user's
+    account in Entra ID. An attacker holding administrative access can attach a factor they control
+    to a victim account, satisfying MFA without changing the password and without the account owner
+    noticing. Temporary Access Pass registrations are excluded, as they are already covered by
+    "Temporary Access Pass Added To An Account".
+references:
+    - https://learn.microsoft.com/en-us/entra/identity/authentication/howto-mfa-userdevicesettings
+    - https://learn.microsoft.com/en-us/entra/architecture/security-operations-privileged-accounts
+author: descambiado
+date: 2026-05-13
+tags:
+    - attack.persistence
+    - attack.credential-access
+    - attack.defense-impairment
+    - attack.t1556.006
+logsource:
+    product: azure
+    service: auditlogs
+    definition: 'Requirements: The TargetResources array needs to be mapped accurately in order for the Temporary Access Pass exclusion to work'
+detection:
+    selection:
+        LoggedByService: 'Authentication Methods'
+        Category: 'UserManagement'
+        OperationName:
+            - 'Admin registered security info'
+            - 'Admin updated security info'
+            - 'Admin deleted security info'
+    filter_main_temporary_access_pass:
+        TargetResources.modifiedProperties|contains: 'TemporaryAccessPass'
+    condition: selection and not 1 of filter_main_*
+falsepositives:
+    - Help desk MFA resets on behalf of locked-out users
+    - Onboarding workflows registering initial MFA for new hires
+    - Identity governance automation managing security info
+level: medium


### PR DESCRIPTION
### Summary of the Pull Request

Detects an administrator registering, updating or deleting MFA security info on another user's account. `Change to Authentication Method` covers the user-initiated path and `Temporary Access Pass Added To An Account` covers the TAP case; this fills the gap between them, so it is scoped the same way and filters TAP out to avoid overlapping.

This is one rule from #6012, which was closed because the logic was not backed by real log data. I have since stood up an Entra ID tenant, triggered the activity, and the captured event is below. Submitting one rule rather than the original batch so the evidence can actually be checked.

### Changelog

new: Administrator Changed Authentication Method Of Another User

### Example Log Event

Captured by adding a phone authentication method to a test user from the Entra admin center.

```json
{
  "activityDisplayName": "Admin registered security info",
  "loggedByService": "Authentication Methods",
  "category": "UserManagement",
  "correlationId": "60d0e1b2-984b-463a-8a06-77f828a6bd44",
  "result": "success",
  "resultReason": "Admin registered phone method for user",
  "initiatedBy": {
    "user": {
      "id": "cf1ba85e-738c-4562-ae1d-287a3a19af02",
      "userPrincipalName": "<admin-upn>",
      "ipAddress": "<redacted>"
    }
  },
  "targetResources": [
    {
      "type": "User",
      "id": "9d04e09a-ed28-4e8a-8f31-f53e02fe989d",
      "userPrincipalName": "testuser1@<tenant>.onmicrosoft.com",
      "modifiedProperties": [
        { "displayName": "Phone.Phone.Id",          "newValue": "\"3179e48a-750b-4051-897c-87b9720928f7\"" },
        { "displayName": "Phone.Phone.PhoneType",   "newValue": "\"Mobile\"" },
        { "displayName": "Phone.Phone.PhoneNumber", "newValue": "\"+34 600000000\"" }
      ]
    }
  ]
}
```

Registering a Temporary Access Pass on the same account produced `Admin registered security info` with `resultReason` of `Admin registered temporary access pass method for user` and modified properties namespaced `TemporaryAccessPass.*` (id, start and end time, single-use flag). The phone case is namespaced `Phone.Phone.*`, so the two are cleanly separable. `filter_main_temporary_access_pass` keys on that, which is why the rules stay disjoint.

One thing I would like a steer on. `Temporary Access Pass Added To An Account` identifies the TAP case with `Status: Admin registered temporary access pass method for user`, but `Status` carries `Success` or `failure` in the other rules in this folder. I did not want to build my exclusion on a field whose meaning looks inconsistent, so I used `TargetResources.modifiedProperties` instead, following `Authentication Methods Policy Update`. If `Status` does map to `resultReason` in the current taxonomy then either field works and I am happy to switch for symmetry.

Two things from the tenant that are not in the documentation:

1. The same admin action also writes a second event from `Core Directory` as `Update user`, carrying `StrongAuthenticationMethod` and `StrongAuthenticationUserDetails` in `modifiedProperties`. That twin is initiated by the first-party service principal `Azure Credential Configuration Endpoint Service`, not the administrator, so it is the wrong record to attribute from. This rule matches the `Authentication Methods` record, which carries the real actor.
2. Ingestion is uneven if anyone reproduces this: the `Core Directory` event appeared within a minute, the `Authentication Methods` one took roughly 20 minutes.

Two calls I would happily change:

- `level` is `medium` rather than `high`. Help desk MFA resets are a common legitimate operation, and `Change to Authentication Method` is `medium` with a similar false positive profile. Raise it if you read the admin-on-behalf-of case as more severe.
- `Admin updated security info` and `Admin deleted security info` stay in the selection as documented operation names in the same family, but I only triggered the registration case, so I have not seen their event shape. `Disabled MFA to Bypass Authentication Mechanisms` covers `Disable Strong Authentication` but not the admin deletion path, which is why I kept it. Happy to drop both and keep only what I verified.

### Fixed Issues

Supersedes the MFA rule from #6012.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
