### PR TITLE
chore: fix typo in known-FPs.csv rule name

### DIFF
--- a/.github/workflows/known-FPs.csv
+++ b/.github/workflows/known-FPs.csv
@@ -22,7 +22,7 @@ bef0bc5a-b9ae-425d-85c6-7b2d705980c6;Python Initiated Connection;146\.75\.117\.5
 81325ce1-be01-4250-944f-b4789644556f;Suspicius Schtasks From Env Var Folder;TVInstallRestore
 6ea3bf32-9680-422d-9f50-e90716b12a66;UAC Bypass Via Wsreset;EventType: DeleteKey
 43f487f0-755f-4c2a-bce7-d6d2eec2fcf8;Suspicious Add Scheduled Task From User AppData Temp;TVInstallRestore
-c187c075-bb3e-4c62-b4fa-beae0ffc211f;Deteled Rule in Windows Firewall with Advanced Security;Dropbox.*\\netsh\.exe
+c187c075-bb3e-4c62-b4fa-beae0ffc211f;Deleted Rule in Windows Firewall with Advanced Security;Dropbox.*\\netsh\.exe
 69aeb277-f15f-4d2d-b32a-55e883609563;Disabling Windows Event Auditing;Computer: .*
 ac175779-025a-4f12-98b0-acdaeb77ea85;PowerShell Script Run in AppData;\\Evernote-
 1f2b5353-573f-4880-8e33-7d04dcf97744;Sysmon Configuration Modification;Computer: evtx-PC


### PR DESCRIPTION
### Summary of the Pull Request

Fixes a spelling mistake in the `RuleName` column of `.github/workflows/known-FPs.csv`: `Deteled` -> `Deleted`.

No functional change. `matchgrep.sh` parses the file with `while IFS=\; read -r id _name fpstring` and uses only `${id}` and `${fpstring}` in its `grep` expression, so the `RuleName` column is descriptive only and is never matched against.

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

### Changelog

chore: known-FPs.csv - fix typo in the RuleName column

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow
-->

### Example Log Event

N/A - not a false positive fix.

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

N/A

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
