### PR TITLE
fix: add Ninite/WinRAR filter to Potential Defense Evasion Via Binary Rename

### DIFF
--- a/.github/workflows/known-FPs.csv
+++ b/.github/workflows/known-FPs.csv
@@ -9,7 +9,6 @@ e28a5a99-da44-436d-b7a0-2afc20a5f413;Whoami Execution;WindowsPowerShell
 8ac03a65-6c84-4116-acad-dc1558ff7a77;Sysmon Configuration Change;(sysmon-intense\.xml|sysmonconfig-trace\.xml)
 8ac03a65-6c84-4116-acad-dc1558ff7a77;Sysmon Configuration Change;Computer: (evtx-PC|Agamemnon)
 4358e5a5-7542-4dcb-b9f3-87667371839b;ISO or Image Mount Indicator in Recent Files;_Office_Professional_Plus_
-36480ae1-a1cb-4eaa-a0d6-29801d7e9142;Renamed Binary;WinRAR
 73bba97f-a82d-42ce-b315-9182e76c57b1;Imports Registry Key From a File;Evernote
 6741916F-B4FA-45A0-8BF8-8249C702033A;Added Rule in Windows Firewall with Advanced Security;\\Integration\\Integrator\.exe
 00bb5bd5-1379-4fcf-a965-a5b6f7478064;Setting Change in Windows Firewall with Advanced Security;Level: 4  Task: 0

--- a/rules/windows/process_creation/proc_creation_win_renamed_binary.yml
+++ b/rules/windows/process_creation/proc_creation_win_renamed_binary.yml
@@ -46,7 +46,11 @@ detection:
             - '\net1.exe'
             - '\netsh.exe'
             - '\InstallUtil.exe'
-    condition: selection and not filter
+    filter_optional_ninite:
+        OriginalFileName: 'WinRAR.exe'
+        Image|endswith: '\target.exe'
+        ParentImage|endswith: '\Ninite.exe'
+    condition: selection and not filter and not 1 of filter_optional_*
 falsepositives:
     - Custom applications use renamed binaries adding slight change to binary name. Typically this is easy to spot and add to whitelist
 level: medium


### PR DESCRIPTION
### Summary of the Pull Request

`Potential Defense Evasion Via Binary Rename` (`36480ae1-a1cb-4eaa-a0d6-29801d7e9142`) fires on three clean baselines — `win10-client`, `win11-client` and `win11-client-2023` — where Ninite installs WinRAR. Ninite downloads the genuine WinRAR setup, writes it into a random `%TEMP%` folder under the name `target.exe`, and runs it silently, so `OriginalFileName` is `WinRAR.exe` while `Image` is not.

It was suppressed in `known-FPs.csv` rather than filtered, so this PR fixes the rule and removes the suppression.

**Why the filter is narrow.** The existing `filter:` block matches on `Image|endswith` alone, with no link back to the corresponding `OriginalFileName`. Adding `\target.exe` to that list would therefore have excluded that filename for **all eleven** binaries in `selection`, including `cmd.exe` and `netsh.exe`. The new block instead requires `OriginalFileName`, `Image` and `ParentImage` together, so nothing outside this specific Ninite/WinRAR case is affected.

Everything involved here sits in a user-writable `%TEMP%` path, so this exclusion cannot be made hard to bypass. The aim was to keep it as small as possible rather than to claim it is unbypassable.

**Stability.** Observed identically on three baseline images spanning two years and two WinRAR versions (6.10 and 6.24): `Image` always ends in `\target.exe`, `ParentImage` always ends in `\Ninite.exe`.

**Verification**

| Rule state | Matches on win10 / win11 / win11-2023 |
|---|---|
| before this change | 1 / 1 / 1 |
| with the filter | 0 / 0 / 0 |
| filter deliberately broken (`\NiniteZZZ.exe`) | 1 / 1 / 1 |
| filter restored | 0 / 0 / 0 |

`tests/test_rules.py` (11 tests) and `tests/test_logsource.py` (3 tests) both pass.

The regression sample for this rule (`renamed-netsh.exe`, `OriginalFileName: netsh.exe`) has an `OriginalFileName` other than `WinRAR.exe`, so the new filter does not apply to it and the rule still matches it once.

### Changelog

fix: Potential Defense Evasion Via Binary Rename - add filter for the WinRAR installer launched by Ninite
chore: ci: remove the now-fixed WinRAR entry from known-FPs.csv

### Example Log Event

```
Image: C:\Users\user\AppData\Local\Temp\46F399~1\target.exe
FileVersion: 6.10.0
Description: WinRAR archiver
Product: WinRAR
Company: Alexander Roshal
OriginalFileName: WinRAR.exe
CommandLine: "C:\Users\user\AppData\Local\Temp\46F399~1\target.exe" /S
ParentImage: C:\Users\user\AppData\Local\Temp\0cb1bbbb-88d4-11ec-89b1-080027dfe1cd\Ninite.exe
ParentCommandLine: "C:\Users\user\AppData\Local\Temp\0cb1bbbb-88d4-11ec-89b1-080027dfe1cd\Ninite.exe" "b845c9e7079256f205188f5dcf5982e9650c8197" /fullpath "Z:\Ninite-Win10-Installer.exe" /relaunch
```

### Fixed Issues

N/A

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
