### PR TITLE
Fix Added Credentials to Existing Application

### DIFF
--- a/rules/cloud/azure/audit_logs/azure_app_credential_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_app_credential_added.yml
@@ -6,7 +6,7 @@ references:
     - https://learn.microsoft.com/en-us/entra/architecture/security-operations-applications#application-credentials
 author: Mark Morowczynski '@markmorow', Bailey Bercik '@baileybercik'
 date: 2022-05-26
-modified: 2025-07-18
+modified: 2026-08-20
 tags:
     - attack.privilege-escalation
     - attack.t1098.001
@@ -17,7 +17,7 @@ logsource:
 detection:
     selection:
         properties.message:
-            - Update application – Certificates and secrets management
+            - Update application - Certificates and secrets management
             - Update Service principal/Update Application
     condition: selection
 falsepositives:

--- a/rules/cloud/azure/audit_logs/azure_app_credential_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_app_credential_added.yml
@@ -17,8 +17,8 @@ logsource:
 detection:
     selection:
         properties.message:
-            - Update application - Certificates and secrets management
-            - Update Service principal/Update Application
+            - 'Update application - Certificates and secrets management'
+            - 'Update Service principal/Update Application'
     condition: selection
 falsepositives:
     - When credentials are added/removed as part of the normal working hours/workflows

--- a/rules/cloud/azure/audit_logs/azure_app_credential_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_app_credential_added.yml
@@ -17,7 +17,7 @@ logsource:
 detection:
     selection:
         properties.message:
-            - 'Update application - Certificates and secrets management'
+            - 'Update application - Certificates and secrets management' # See https://github.com/SigmaHQ/sigma/pull/6247#issuecomment-5463002942
             - 'Update Service principal/Update Application'
     condition: selection
 falsepositives:


### PR DESCRIPTION
### Summary of the Pull Request

`Added Credentials to Existing Application` selects on `Update application – Certificates and secrets management`, where the dash is `U+2013 EN DASH`. The operation name Entra actually emits uses `U+002D HYPHEN-MINUS`, so that selection value cannot match. See the note at the end for a second, separate question about this rule that I could not settle.

I noticed this while adding a client secret to an app registration in my own tenant and comparing the audit event against the rule.

### Changelog

fix: Added Credentials to Existing Application - replace en dash with hyphen in operation name

### Example Log Event

Adding a client secret via App registrations > Certificates & secrets produced:

```
Activity        : Update application - Certificates and secrets management
Category        : ApplicationManagement
Correlation id  : 8ca63c26-293d-49ac-98b5-b8e037faf2aa
Status          : success
Initiated by    : User
AppId           : <app under test>
```

Worth noting for anyone else chasing this: the Entra portal *renders* the operation name with an en dash in its UI, which is what makes the typo easy to introduce and hard to spot. The stored value is a plain hyphen.

Cross-checks against sources that consume the same field:

- Microsoft's own Azure-Sentinel content uses `U+002D` in at least six files, including `Add uncommon credential type to application [Nobelium].yaml` and `CredentialsAddAfterAdminConsentedToApp[Nobelium].yaml`.
- Elastic's `persistence_entra_id_application_credential_modification` also uses `U+002D`.

I also scanned the rest of the ruleset for `U+2013` and `U+2014` to check whether this was a convention I was misreading. Every other en dash is deliberate homoglyph matching, and two of them carry a comment saying so:

- `proc_creation_win_apt_mint_sandstorm_*` uses `[-/–]` inside a character class.
- `posh_pm_clear_powershell_history` and `posh_ps_clear_powershell_history` use `'–HistorySaveStyle'` with the comment `# not sure if the homoglyph –/- is intended, just checking for both`.

This one is a literal operation name with no regex and no comment, which is what convinced me it is a typo rather than intentional.

`modified` bumped per convention. Tests pass locally (`tests/test_rules.py`, 11 tests).

### Fixed Issues

None filed.

### Two things I could not verify

Being precise about what this PR does and does not establish. The en dash definitely prevents that value from matching. Whether fixing it is *sufficient* to make the rule fire depends on two things I could not confirm:

1. **The field name.** This rule uses `properties.message`. Looking across `rules/cloud/azure/audit_logs/`, that field appears on rules dated 2022, while the two most recently authored rules there (`azure_ad_new_root_ca_added`, `azure_ad_certificate_based_authencation_enabled`, both 2024) use `OperationName`. I do not know whether `properties.message` is still a supported alias or is stale, and there is no Azure pipeline in the repo for me to check against, so I have deliberately not touched it. If it is stale, this rule needs that change too and my fix alone is not enough.

2. **The second selection value.** `Update Service principal/Update Application` does not appear anywhere in Microsoft's published content. I have left it alone because I could not tell whether it is a legacy label, something emitted only by a path I did not exercise, or dead.

Happy to extend this PR to cover either if you tell me which way the taxonomy currently goes.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
