### PR TITLE
New Rule: Potential Ingress Tool Transfer Via Msoxmled.EXE

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_msoxmled_ingress_tool_transfer.yml
+++ b/rules/windows/process_creation/proc_creation_win_msoxmled_ingress_tool_transfer.yml
@@ -1,0 +1,28 @@
+title: Potential Ingress Tool Transfer Via Msoxmled.EXE
+id: 8d9be576-683f-4f33-80bf-d6961d4c1879
+status: experimental
+description: |
+    Detects execution of "msoxmled.exe" (Microsoft Office XML Editor) with the "/verb open" argument pointed at a remote URL.
+    This LOLBIN is meant to open local XML documents in Microsoft Office, but when pointed at a network location it will download and cache the remote payload, making it a potential ingress tool transfer technique.
+references:
+    - https://github.com/LOLBAS-Project/LOLBAS/blob/9c5e3841081cac342e7603093253cb51512c8369/yml/OSBinaries/Msoxmled.yml
+author: Geovanny Basantes
+date: 2026-08-25
+tags:
+    - attack.command-and-control
+    - attack.t1105
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\msoxmled.exe'
+        - OriginalFileName: 'msoxmled.exe'
+    selection_cli:
+        CommandLine|contains: '/verb'
+    selection_url:
+        CommandLine|re: '(?i)https?://'
+    condition: all of selection*
+falsepositives:
+    - Unknown
+level: medium


### PR DESCRIPTION
## Summary
- Adds a new detection rule for `msoxmled.exe` (Microsoft Office XML Editor), a LOLBIN that can be abused for ingress tool transfer (MITRE T1105) when invoked with `/verb open` pointed at a remote URL instead of a local XML document.
- Reference: https://github.com/LOLBAS-Project/LOLBAS/blob/9c5e3841081cac342e7603093253cb51512c8369/yml/OSBinaries/Msoxmled.yml
- No existing Sigma rule covers this binary/technique.

## Test plan
- [x] `python tests/test_logsource.py` passes
- [x] `python tests/test_rules.py` passes
- [x] `sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml` passes with 0 errors, 0 issues