### PR TITLE
rules: add AWS Secrets Manager batch secret retrieval detection

### DIFF
--- a/rules/cloud/aws/cloudtrail/aws_secretsmanager_batch_secret_retrieval.yml
+++ b/rules/cloud/aws/cloudtrail/aws_secretsmanager_batch_secret_retrieval.yml
@@ -1,0 +1,25 @@
+title: AWS Secrets Manager Batch Secret Retrieval
+id: e3d894a1-a964-41e3-9378-93eed957c8d9
+status: experimental
+description: |
+    Detects a single call to the AWS Secrets Manager "BatchGetSecretValue" API, which returns the values of multiple secrets in one request selected by filter.
+    Legitimate applications usually read a specific secret with GetSecretValue, so a batch retrieval can indicate an adversary or an enumeration tool bulk dumping credentials from the secrets store.
+references:
+    - https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_BatchGetSecretValue.html
+    - https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets.html
+author: Chris (ChrisJr404)
+date: 2026-08-26
+tags:
+    - attack.credential-access
+    - attack.t1555.006
+logsource:
+    product: aws
+    service: cloudtrail
+detection:
+    selection:
+        eventSource: secretsmanager.amazonaws.com
+        eventName: BatchGetSecretValue
+    condition: selection
+falsepositives:
+    - Secrets synchronization, backup, or rotation tooling that legitimately enumerates multiple secrets. Verify the user identity, user agent, and source address before responding.
+level: medium


### PR DESCRIPTION
Adds a CloudTrail rule for the AWS Secrets Manager BatchGetSecretValue API. A single call to this API returns the values of multiple secrets at once selected by filter, which is a common bulk credential access and enumeration behavior, whereas normal applications read one specific secret with GetSecretValue. There is currently no Secrets Manager coverage under rules/cloud/aws. Reference: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_BatchGetSecretValue.html