### PR TITLE
New Rule: Potential Indirect Command Execution Via XBootMgr.EXE

### DIFF
--- a/rules/windows/process_creation/proc_creation_win_xbootmgr_indirect_command_execution.yml
+++ b/rules/windows/process_creation/proc_creation_win_xbootmgr_indirect_command_execution.yml
@@ -1,0 +1,28 @@
+title: Potential Indirect Command Execution Via XBootMgr.EXE
+id: 446e9bb7-804d-4dfe-9a9f-576d9ce35a3b
+status: experimental
+description: |
+    Detects execution of "xbootmgr.exe" (Windows Performance Toolkit boot/trace tool) with the "-callBack" or "-preTraceCmd" arguments, which cause it to launch an arbitrary executable before or after a performance trace completes.
+    This can be abused as a way to execute a payload through a legitimate, signed Microsoft binary.
+references:
+    - https://github.com/LOLBAS-Project/LOLBAS/blob/9c5e3841081cac342e7603093253cb51512c8369/yml/OtherMSBinaries/XBootMgr.yml
+author: Geovanny Basantes
+date: 2026-08-25
+tags:
+    - attack.stealth
+    - attack.t1202
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_img:
+        - Image|endswith: '\xbootmgr.exe'
+        - OriginalFileName: 'xbootmgr.exe'
+    selection_cli:
+        CommandLine|contains:
+            - '-callBack'
+            - '-preTraceCmd'
+    condition: all of selection*
+falsepositives:
+    - Legitimate performance-trace automation scripts that use the "-callBack" or "-preTraceCmd" parameters
+level: medium


### PR DESCRIPTION
## Summary
- Adds a new detection rule for `xbootmgr.exe` (Windows Performance Toolkit), a LOLBIN that can be abused for indirect command execution (MITRE T1202) via its `-callBack` or `-preTraceCmd` arguments, which launch an arbitrary executable before/after a performance trace.
- Reference: https://github.com/LOLBAS-Project/LOLBAS/blob/9c5e3841081cac342e7603093253cb51512c8369/yml/OtherMSBinaries/XBootMgr.yml
- Checked for overlap: no existing merged rule covers this binary, and no open/closed PR in the repo already targets it.

## Test plan
- [x] `python tests/test_logsource.py` passes
- [x] `python tests/test_rules.py` passes
- [x] `sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml` passes with 0 errors, 0 issues