### PR TITLE
Add ADSI/WinNT provider detection to local user creation rule

### DIFF
--- a/rules/windows/powershell/powershell_script/posh_ps_create_local_user.yml
+++ b/rules/windows/powershell/powershell_script/posh_ps_create_local_user.yml
@@ -6,7 +6,7 @@ references:
     - https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1136.001/T1136.001.md
 author: '@ROxPinTeddy'
 date: 2020-04-11
-modified: 2022-12-25
+modified: 2026-08-23
 tags:
     - attack.execution
     - attack.t1059.001
@@ -17,9 +17,14 @@ logsource:
     category: ps_script
     definition: 'Requirements: Script Block Logging must be enabled'
 detection:
-    selection:
+    selection_cmdlet:
         ScriptBlockText|contains: 'New-LocalUser'
-    condition: selection
+    selection_adsi:
+        ScriptBlockText|contains|all:
+           - 'WinNT://'
+           - '.Create('
+           - 'User'
+    condition: selection_cmdlet or selection_adsi
 falsepositives:
     - Legitimate user creation
 level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->
Adds detection for local user account creation via the ADSI/WinNT COM provider ([ADSI]"WinNT://..." + .Create("User", ...)), which the existing rule misses since it only matches the New-LocalUser cmdlet text.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->
update: PowerShell Create Local User - add detection for account creation via ADSI/WinNT provider

### Example Log Event

<!--
Fill this in case of false positive fixes
-->
ScriptBlockText: $computer = [ADSI]"WinNT://$env:COMPUTERNAME"
$user = $computer.Create("User", "testuser")
$user.SetPassword("Password123!")
$user.SetInfo()

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->
Fixes #6057
### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
