### PR TITLE
Add emerging-threats rule for BlueNoroff fake-meeting ClickFix kit

### DIFF
--- a/rules-emerging-threats/2026/TA/Lazarus/proc_creation_win_apt_bluenoroff_fake_meeting_clickfix.yml
+++ b/rules-emerging-threats/2026/TA/Lazarus/proc_creation_win_apt_bluenoroff_fake_meeting_clickfix.yml
@@ -1,0 +1,39 @@
+title: BlueNoroff Fake Meeting Kit ClickFix PowerShell Execution
+id: 8a496c42-229b-4f1b-a4bf-1e42e43ee310
+status: experimental
+description: |
+    Detects the PowerShell command that the BlueNoroff fake Zoom/Teams meeting
+    ClickFix kit instructs a target to paste during a call. The command sets the
+    kit's MEETING_* environment variables and carries the hardcoded
+    AUTH_API_TOKEN value before decoding and running a downloaded payload. This
+    rule is keyed on the kit's own strings, so it is narrower than the generic
+    ClickFix rules already in the ruleset.
+references:
+    - https://www.jumpsec.com/guides/inside-a-dprk-bluenoroff-clickfix-kit/
+    - https://github.com/farbodghasemlu/bluenoroff-fake-meeting-kit
+author: 'farbodghasemlu'
+date: 2026-09-01
+tags:
+    - attack.execution
+    - attack.t1059.001
+    - attack.t1204.001
+    - attack.g0032
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: windows
+detection:
+    selection_shell:
+        Image|endswith:
+            - '\powershell.exe'
+            - '\pwsh.exe'
+    selection_kit:
+        CommandLine|contains:
+            - 'MEETING_SDK_VERSION'
+            - 'MEETING_JWT'
+            - 'sahfuehf29385hsdfuiewhf'
+    condition: all of selection_*
+falsepositives:
+    - Unlikely. The kit-specific token and environment variable names have no
+      known legitimate use.
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

Adds one emerging-threats rule for the BlueNoroff (DPRK, a Lazarus subgroup)
fake Zoom/Teams meeting ClickFix kit that was active in August 2026. The rule
detects the PowerShell command the kit instructs a target to paste during a
call: a command that sets the kit's `MEETING_*` environment variables and
carries the hardcoded `AUTH_API_TOKEN` value before decoding and running a
downloaded payload.

The rule is keyed on the kit's own strings (`MEETING_SDK_VERSION`,
`MEETING_JWT`, and the token `sahfuehf29385hsdfuiewhf`), so it is narrower and
higher-fidelity than the generic ClickFix rules already in the ruleset. It does
not duplicate them.

This is a small addition to work already published by JUMPSEC ("Inside a DPRK
BlueNoroff ClickFix Kit", 2026-07-24) and Arctic Wolf (May 2026). Full analysis
and indicators: https://github.com/farbodghasemlu/bluenoroff-fake-meeting-kit

Existing coverage checked before submitting: the ruleset already has generic
ClickFix rules (for example `proc_creation_win_susp_clickfix_filefix_execution.yml`)
and Defender-exclusion rules (for example
`proc_creation_win_powershell_defender_exclusion.yml`). This PR does not touch
either. It adds only the actor-specific rule.

### Changelog

new: BlueNoroff Fake Meeting Kit ClickFix PowerShell Execution

### Example Log Event

Not a false-positive fix. The rule matches a `powershell.exe` or `pwsh.exe`
process whose command line contains the kit's `MEETING_SDK_VERSION` or
`MEETING_JWT` variable or the `sahfuehf29385hsdfuiewhf` token.

### Fixed Issues

None.

### SigmaHQ Rule Creation Conventions

- The rule validates with `sigma check` (0 errors, 0 issues) and with the
  repository `.yamllint` configuration.
- It is placed under `rules-emerging-threats/` because it is tied to a specific
  actor and campaign, and carries the `detection.emerging-threats` tag.
- False-positive profile: the environment variable names and the hardcoded token
  have no known legitimate use, so false positives are unlikely.
- The XAMPP server banner seen on the kit's lure hosts
  (`Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12`) is not used by this rule.
  On its own that banner matches more than 3,300 unrelated hosts, so it is not a
  reliable indicator.
