### PR TITLE
Add AmnesiaStealer macOS Detection Rules

### DIFF
--- a/rules-emerging-threats/2026/Malware/AmnesiaStealer/file_event_macos_malware_amnesiastealer_artifacts.yml
+++ b/rules-emerging-threats/2026/Malware/AmnesiaStealer/file_event_macos_malware_amnesiastealer_artifacts.yml
@@ -1,0 +1,40 @@
+title: AmnesiaStealer File Artifacts
+id: f98c03a0-3cd0-430e-b872-5eae3563aad0
+status: experimental
+description: |
+    Detects staging, credential and persistence artifacts created by AmnesiaStealer, including the cleartext copy of the phished user password,
+    the hidden stream module directory holding recovered browser Safe Storage keys and cloned profiles, the build variant marker dropped in the
+    staging directory, and the LaunchDaemon plist staged in "/tmp" before it is installed with the phished password.
+references:
+    - https://www.jamf.com/blog/amnesia-stealer-macos-infostealer-clickfix/
+author: Robbin Ooi Zhen Heng
+date: 2026-09-02
+tags:
+    - attack.credential-access
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.collection
+    - attack.stealth
+    - attack.t1555.003
+    - attack.t1543.004
+    - attack.t1564.001
+    - detection.emerging-threats
+logsource:
+    category: file_event
+    product: macos
+detection:
+    selection_password_file:
+        TargetFilename|startswith: '/Users/'
+        TargetFilename|endswith: '/.pwd'
+    selection_stream_module:
+        TargetFilename|contains: '/.local/share/.stream/'
+    selection_build_marker:
+        TargetFilename|endswith: '/BUILD_V3_MARKER.txt'
+    selection_persistence_stage:
+        TargetFilename: '/tmp/starter'
+    selection_dropper_dir:
+        TargetFilename|startswith: '/tmp/.com.apple.dt.'
+    condition: 1 of selection_*
+falsepositives:
+    - Unlikely
+level: high

--- a/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_browser_debug_hijack.yml
+++ b/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_browser_debug_hijack.yml
@@ -1,0 +1,31 @@
+title: AmnesiaStealer Headless Browser Remote Debugging Hijack
+id: b9a76020-ca1d-48e8-879d-e767627a208e
+status: experimental
+description: |
+    Detects the AmnesiaStealer stage 2 stream module launching a legitimate Chromium based browser in old headless mode with the DevTools
+    remote debugging port exposed and origin checks disabled. The operator drives the resulting Chrome DevTools Protocol channel to navigate,
+    click and export already decrypted cookies from a clone of the victim profile, bypassing Safe Storage encryption entirely.
+references:
+    - https://www.jamf.com/blog/amnesia-stealer-macos-infostealer-clickfix/
+author: Robbin Ooi Zhen Heng
+date: 2026-09-02
+tags:
+    - attack.credential-access
+    - attack.collection
+    - attack.t1539
+    - attack.t1185
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_headless:
+        CommandLine|contains: '--headless=old'
+    selection_debug:
+        CommandLine|contains: '--remote-debugging-port='
+    selection_origins:
+        CommandLine|contains: '--remote-allow-origins='
+    condition: all of selection_*
+falsepositives:
+    - Browser automation and end to end testing frameworks that intentionally relax remote debugging origin checks.
+level: high

--- a/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_clickfix_loader.yml
+++ b/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_clickfix_loader.yml
@@ -1,0 +1,39 @@
+title: AmnesiaStealer ClickFix Loader Execution
+id: 7cf65e8d-5291-4b5d-acc2-777b68874af1
+status: experimental
+description: |
+    Detects the one-liner AmnesiaStealer delivers through its ClickFix lure, where the victim is coerced into pasting a shell command that
+    retrieves a build-specific dropper from the builder endpoint and pipes it straight into a shell. The request carries a per-execution token
+    and a build identifier, so the response body is never written to disk before execution.
+references:
+    - https://www.jamf.com/blog/amnesia-stealer-macos-infostealer-clickfix/
+author: Robbin Ooi Zhen Heng
+date: 2026-09-02
+tags:
+    - attack.initial-access
+    - attack.execution
+    - attack.t1204.004
+    - attack.t1059.004
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_download:
+        CommandLine|contains:
+            - 'curl '
+            - 'wget '
+    selection_endpoint:
+        CommandLine|contains|all:
+            - '/d/command?t='
+            - '&b='
+    selection_pipe:
+        CommandLine|contains:
+            - '| bash'
+            - '|bash'
+            - '| sh'
+            - '|sh'
+    condition: all of selection_*
+falsepositives:
+    - Unlikely
+level: critical

--- a/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_keychain_unlock.yml
+++ b/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_keychain_unlock.yml
@@ -1,0 +1,33 @@
+title: AmnesiaStealer Login Keychain Unlock Via Phished Password
+id: df886d3a-9510-4671-9971-e0069e12321e
+status: experimental
+description: |
+    Detects the macOS security utility being used to unlock the login keychain with a password supplied inline on the command line.
+    AmnesiaStealer harvests the password through a fake native "Installer" prompt, validates it locally, and then replays it to unlock the
+    keychain so that browser Safe Storage keys and stored credentials can be read without further user interaction.
+references:
+    - https://www.jamf.com/blog/amnesia-stealer-macos-infostealer-clickfix/
+author: Robbin Ooi Zhen Heng
+date: 2026-09-02
+tags:
+    - attack.credential-access
+    - attack.t1555.001
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_img:
+        Image|endswith: '/security'
+    selection_cli:
+        CommandLine|contains|all:
+            - 'unlock-keychain'
+            - '-p '
+    selection_target:
+        CommandLine|contains:
+            - 'login.keychain-db'
+            - 'login.keychain'
+    condition: all of selection_*
+falsepositives:
+    - Administrative or CI scripts that unlock the login keychain non-interactively, typically on build agents.
+level: high

--- a/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_payload_staging.yml
+++ b/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_payload_staging.yml
@@ -1,0 +1,40 @@
+title: AmnesiaStealer Payload Staging And Gatekeeper Bypass
+id: d5286fdf-0fdd-4818-8dd1-6d12ee0a2751
+status: experimental
+description: |
+    Detects the AmnesiaStealer stage 0 dropper unpacking its payload into a hidden directory under "/tmp" that masquerades as an Apple developer
+    tools path, and the ad-hoc code signing and extended attribute removal it performs to defeat Gatekeeper before launching the stealer. The
+    archive is password protected to defeat automated unpacking, so the static password is a reliable additional anchor.
+references:
+    - https://www.jamf.com/blog/amnesia-stealer-macos-infostealer-clickfix/
+author: Robbin Ooi Zhen Heng
+date: 2026-09-02
+tags:
+    - attack.stealth
+    - attack.defense-impairment
+    - attack.t1036.005
+    - attack.t1553.001
+    - attack.t1027.013
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_staging_dir:
+        CommandLine|contains: '/tmp/.com.apple.dt.'
+    selection_archive_password:
+        CommandLine|contains: '-P dulin'
+    selection_gatekeeper_sign:
+        CommandLine|contains|all:
+            - 'codesign '
+            - '--force'
+            - '--deep'
+            - '--sign -'
+    selection_gatekeeper_xattr:
+        CommandLine|contains|all:
+            - 'xattr '
+            - '-cr'
+    condition: selection_staging_dir or selection_archive_password or (selection_gatekeeper_sign and selection_gatekeeper_xattr)
+falsepositives:
+    - Development or build tooling that ad-hoc signs and strips quarantine attributes from locally built binaries.
+level: high

--- a/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_sudo_password_abuse.yml
+++ b/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_sudo_password_abuse.yml
@@ -1,0 +1,35 @@
+title: AmnesiaStealer Privileged Collection Via Piped Password
+id: b9ad8ed0-f83e-47ba-9d03-1458e11c49d9
+status: experimental
+description: |
+    Detects a phished password being piped into sudo through standard input to read protected user data or to install persistence.
+    AmnesiaStealer replays the password captured by its fake "Installer" prompt this way in order to copy the Apple Notes database and to
+    load its root LaunchDaemon, since neither action would otherwise succeed without an interactive authorisation prompt.
+references:
+    - https://www.jamf.com/blog/amnesia-stealer-macos-infostealer-clickfix/
+author: Robbin Ooi Zhen Heng
+date: 2026-09-02
+tags:
+    - attack.privilege-escalation
+    - attack.collection
+    - attack.t1548.003
+    - attack.t1005
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_sudo_stdin:
+        CommandLine|contains|all:
+            - 'echo '
+            - 'sudo -S'
+    selection_target:
+        CommandLine|contains:
+            - 'NoteStore.sqlite'
+            - 'launchctl load'
+            - 'launchctl bootstrap'
+            - '/Library/Keychains/'
+    condition: all of selection_*
+falsepositives:
+    - Poorly written administrative scripts that pass a password to sudo over standard input.
+level: high

--- a/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_tcc_snapshot_bypass.yml
+++ b/rules-emerging-threats/2026/Malware/AmnesiaStealer/proc_creation_macos_malware_amnesiastealer_tcc_snapshot_bypass.yml
@@ -1,0 +1,33 @@
+title: AmnesiaStealer TCC Bypass Via APFS Snapshot Mount
+id: e1957b7d-c85f-4f17-8cef-6a093268c783
+status: experimental
+description: |
+    Detects the CVE-2020-9771 style TCC bypass reused by AmnesiaStealer, which enumerates local Time Machine snapshots and mounts one read-only
+    with the nobrowse option in order to read TCC protected files such as the Safari cookie store and the TCC database from outside the paths
+    that TCC guards. The malware performs this twice, once for Safari cookies and once for the TCC database.
+references:
+    - https://www.jamf.com/blog/amnesia-stealer-macos-infostealer-clickfix/
+author: Robbin Ooi Zhen Heng
+date: 2026-09-02
+tags:
+    - attack.stealth
+    - attack.credential-access
+    - attack.t1006
+    - detection.emerging-threats
+logsource:
+    category: process_creation
+    product: macos
+detection:
+    selection_mount:
+        Image|endswith: '/mount_apfs'
+        CommandLine|contains|all:
+            - 'nobrowse'
+            - '.SNAPSHOT'
+    selection_mountpoint:
+        CommandLine|contains:
+            - '/tmp/.snap_read'
+            - '/tmp/.snap_tcc'
+    condition: 1 of selection_*
+falsepositives:
+    - Backup or forensic tooling that mounts local APFS snapshots for read-only inspection.
+level: high

--- a/rules-emerging-threats/2026/Malware/AmnesiaStealer/proxy_malware_amnesiastealer_c2.yml
+++ b/rules-emerging-threats/2026/Malware/AmnesiaStealer/proxy_malware_amnesiastealer_c2.yml
@@ -1,0 +1,31 @@
+title: AmnesiaStealer C2 Communication - Proxy
+id: 8ec94165-b704-4896-9fc2-c0f0fda3b11b
+status: experimental
+description: |
+    Detects outbound requests to AmnesiaStealer delivery and command and control infrastructure, covering the ClickFix delivery domains and the
+    panel API routes the Rust stealer uses to register an infected host, poll for tasking and upload the archived staging directory.
+references:
+    - https://www.jamf.com/blog/amnesia-stealer-macos-infostealer-clickfix/
+author: Robbin Ooi Zhen Heng
+date: 2026-09-02
+tags:
+    - attack.command-and-control
+    - attack.exfiltration
+    - attack.t1071.001
+    - attack.t1041
+    - detection.emerging-threats
+logsource:
+    category: proxy
+detection:
+    selection_domains:
+        c-uri|contains:
+            - 'allllowef.space'
+            - 'github.aoitour.com'
+    selection_api:
+        c-uri|contains:
+            - '/api/bot/join'
+            - '/api/bot/actions?build_id='
+    condition: 1 of selection_*
+falsepositives:
+    - Unlikely
+level: high


### PR DESCRIPTION
### Summary of the Pull Request

Adds eight emerging-threat rules for **AmnesiaStealer**, a macOS infostealer documented by Jamf Threat Labs. The malware is delivered through a ClickFix lure that has the victim paste a `curl | bash` one-liner, drops a password-protected ZIP containing a Rust stage 1 stealer, and can pull down a stage 2 "stream" module that drives a headless browser over the Chrome DevTools Protocol.

The rules target behaviour rather than build-specific constants wherever possible, since the operator panel generates fresh tokens and build IDs per retrieval:

| Rule | Behaviour |
| --- | --- |
| `..._clickfix_loader` | The ClickFix one-liner: a download utility fetching the builder's `/d/command?t=<token>&b=<build>` endpoint and piping the response into a shell |
| `..._payload_staging` | Payload unpacked into `/tmp/.com.apple.dt.<random>` (masquerading as an Apple developer tools path), plus the ad-hoc `codesign`/`xattr -cr` Gatekeeper bypass |
| `..._keychain_unlock` | `security unlock-keychain -p` replaying the password phished via the fake native "Installer" prompt |
| `..._tcc_snapshot_bypass` | The CVE-2020-9771 TCC bypass: mounting a local APFS snapshot `nobrowse` to read Safari cookies and `TCC.db` |
| `..._browser_debug_hijack` | Stage 2 launching a Chromium browser with `--headless=old` and an exposed DevTools remote debugging port to export already-decrypted cookies |
| `..._sudo_password_abuse` | The phished password piped into `sudo -S` to read the Apple Notes database and load the root LaunchDaemon |
| `..._artifacts` (file_event) | The cleartext `~/.pwd` password file, the `~/.local/share/.stream/` module directory, `BUILD_V3_MARKER.txt`, and the `/tmp/starter` plist staged before installation |
| `..._c2` (proxy) | Delivery domains and the panel's `/api/bot/join` and `/api/bot/actions?build_id=` routes |

Validated locally with `sigma check --fail-on-error --fail-on-issues` against `tests/sigma_cli_conf.yml` (0 errors, 0 issues), plus `tests/test_rules.py`, `tests/test_logsource.py` and `yamllint`.

### Changelog

new: AmnesiaStealer ClickFix Loader Execution
new: AmnesiaStealer Payload Staging And Gatekeeper Bypass
new: AmnesiaStealer Login Keychain Unlock Via Phished Password
new: AmnesiaStealer TCC Bypass Via APFS Snapshot Mount
new: AmnesiaStealer Headless Browser Remote Debugging Hijack
new: AmnesiaStealer Privileged Collection Via Piped Password
new: AmnesiaStealer File Artifacts
new: AmnesiaStealer C2 Communication - Proxy

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
