### PR TITLE
Add 3 rules from a PyArmor-obfuscated PyInstaller loader detonation

### DIFF
--- a/rules/windows/file/file_event/file_event_win_pyarmor_runtime_in_pyinstaller_extraction.yml
+++ b/rules/windows/file/file_event/file_event_win_pyarmor_runtime_in_pyinstaller_extraction.yml
@@ -1,0 +1,41 @@
+title: Potential PyArmor Obfuscated PyInstaller Payload Extraction
+id: 677086ae-fcc3-4202-93b0-61932ab8ad36
+status: experimental
+description: |
+    Detects the PyArmor runtime extension being written into a PyInstaller one-file extraction
+    directory. PyInstaller unpacks to a _MEI prefixed folder at runtime, and the presence of
+    pyarmor_runtime inside that folder means the bundled Python bytecode was deliberately
+    obfuscated before packaging. The combination is common in commodity Python malware and rare
+    in software an enterprise buys or builds.
+references:
+    - https://bazaar.abuse.ch/sample/d97ea10d1dbfe2a69e0d2387e8985635b20628495918abd54c4b052c0acf05b1/
+    - https://tria.ge/260817-ktkv8swgra
+related:
+    - id: 27cf3735-02a9-4c63-91fc-2a03e651f8cf
+      type: similar
+    - id: fc5cd64c-4e5f-46f3-b402-557f3128c842
+      type: similar
+author: David Clayton - CTI @ thetechcollective
+date: 2026-08-17
+tags:
+    - attack.stealth
+    - attack.t1027.002
+    - stp.2
+logsource:
+    category: file_event
+    product: windows
+    definition: 'Requires file creation logging, from Sysmon EventID 11 or equivalent EDR file telemetry, with Temp paths not excluded by the Sysmon configuration'
+detection:
+    selection_pyinstaller_extraction:
+        TargetFilename|contains: '\_MEI'
+    selection_pyarmor_runtime:
+        TargetFilename|contains: 'pyarmor_runtime'
+    condition: all of selection_*
+fields:
+    - TargetFilename
+    - Image
+    - User
+falsepositives:
+    - Commercial or internal Python applications distributed as PyInstaller bundles with PyArmor licence protection applied. This is the main expected source of noise and is most likely on developer and engineering estates.
+    - Security or automation tooling packaged by a third party using the same build chain.
+level: medium

--- a/rules/windows/process_creation/proc_creation_win_double_extension_exec_user_writable.yml
+++ b/rules/windows/process_creation/proc_creation_win_double_extension_exec_user_writable.yml
@@ -1,0 +1,79 @@
+title: Suspicious Double Extension Executable Launched From User Writable Path
+id: fc5cd64c-4e5f-46f3-b402-557f3128c842
+status: experimental
+description: |
+    Detects execution of a binary whose filename ends in a document, archive, or source code
+    extension followed by .exe, from a user-writable location such as Temp, Downloads, or
+    C:\Users\Public. The observed cluster ships as composer.php.exe and composer.dat.exe,
+    imitating a Composer artefact so a developer double-clicking it believes they are opening
+    a PHP or data file.
+references:
+    - https://bazaar.abuse.ch/sample/d97ea10d1dbfe2a69e0d2387e8985635b20628495918abd54c4b052c0acf05b1/
+    - https://tria.ge/260817-ktkv8swgra
+related:
+    - id: 27cf3735-02a9-4c63-91fc-2a03e651f8cf
+      type: similar
+    - id: 677086ae-fcc3-4202-93b0-61932ab8ad36
+      type: similar
+author: David Clayton - CTI @ thetechcollective
+date: 2026-08-17
+tags:
+    - attack.stealth
+    - attack.t1036.007
+    - attack.execution
+    - attack.t1204.002
+    - stp.4
+logsource:
+    category: process_creation
+    product: windows
+    definition: 'Requires process creation logging, from Sysmon EventID 1, Windows Security 4688, or EDR process telemetry'
+detection:
+    selection_user_writable:
+        Image|contains:
+            - '\AppData\Local\Temp\'
+            - '\AppData\Roaming\'
+            - '\Users\Public\'
+            - '\Downloads\'
+            - '\Windows\Temp\'
+    selection_double_extension:
+        Image|endswith:
+            - '.php.exe'
+            - '.dat.exe'
+            - '.pdf.exe'
+            - '.doc.exe'
+            - '.docx.exe'
+            - '.xls.exe'
+            - '.xlsx.exe'
+            - '.ppt.exe'
+            - '.pptx.exe'
+            - '.rtf.exe'
+            - '.txt.exe'
+            - '.csv.exe'
+            - '.json.exe'
+            - '.xml.exe'
+            - '.log.exe'
+            - '.jpg.exe'
+            - '.jpeg.exe'
+            - '.png.exe'
+            - '.gif.exe'
+            - '.svg.exe'
+            - '.zip.exe'
+            - '.rar.exe'
+            - '.7z.exe'
+            - '.iso.exe'
+            - '.js.exe'
+            - '.py.exe'
+            - '.ps1.exe'
+            - '.lock.exe'
+            - '.cfg.exe'
+            - '.ini.exe'
+    condition: all of selection_*
+fields:
+    - Image
+    - CommandLine
+    - ParentImage
+    - User
+falsepositives:
+    - Self-extracting archives and installers that legitimately embed a data extension in the filename, for example a vendor package named with an internal build identifier.
+    - Developer build output where a toolchain names artefacts after their source file, which is plausible on a build agent or engineering workstation.
+level: high

--- a/rules/windows/process_creation/proc_creation_win_wmic_defender_exclusion_added.yml
+++ b/rules/windows/process_creation/proc_creation_win_wmic_defender_exclusion_added.yml
@@ -1,0 +1,55 @@
+title: Suspicious Microsoft Defender Exclusion Added Via WMIC
+id: 27cf3735-02a9-4c63-91fc-2a03e651f8cf
+status: experimental
+description: |
+    Detects WMIC being used to add or modify a Microsoft Defender exclusion by calling the
+    MSFT_MpPreference class in the root\Microsoft\Windows\Defender namespace. Administrators
+    and vendor installers overwhelmingly use the Add-MpPreference PowerShell cmdlet for this,
+    so the WMIC path is a strong signal of an automated payload carving out a safe staging
+    directory before writing to it.
+references:
+    - https://bazaar.abuse.ch/sample/d97ea10d1dbfe2a69e0d2387e8985635b20628495918abd54c4b052c0acf05b1/
+    - https://tria.ge/260817-ktkv8swgra
+related:
+    - id: fc5cd64c-4e5f-46f3-b402-557f3128c842
+      type: similar
+    - id: 677086ae-fcc3-4202-93b0-61932ab8ad36
+      type: similar
+author: David Clayton - CTI @ thetechcollective
+date: 2026-08-17
+tags:
+    - attack.stealth
+    - attack.t1564.012
+    - attack.defense-impairment
+    - attack.t1685
+    - attack.execution
+    - attack.t1047
+    - stp.4
+logsource:
+    category: process_creation
+    product: windows
+    definition: 'Requires process creation logging with command line capture, from Sysmon EventID 1, Windows Security 4688 with command line auditing enabled, or EDR process telemetry'
+detection:
+    selection_wmic:
+        - Image|endswith: '\wmic.exe'
+        - OriginalFileName: 'wmic.exe'
+    selection_defender_class:
+        CommandLine|contains: 'MSFT_MpPreference'
+    selection_exclusion_property:
+        CommandLine|contains:
+            - 'ExclusionPath'
+            - 'ExclusionProcess'
+            - 'ExclusionExtension'
+            - 'ExclusionIpAddress'
+    condition: all of selection_*
+fields:
+    - CommandLine
+    - ParentImage
+    - ParentCommandLine
+    - User
+    - IntegrityLevel
+falsepositives:
+    - Endpoint deployment or hardening scripts that apply vendor-recommended antivirus exclusions for database, backup, or virtualisation software. These normally run from a known deployment agent parent process and reference a Program Files path rather than a user-writable one.
+    - Legacy in-house automation that predates the Defender PowerShell module and still shells out to WMIC.
+    - Security product installers that register their own binaries as exclusions during setup.
+level: high


### PR DESCRIPTION
Three rules from a single detonation of a PyArmor-obfuscated PyInstaller loader
([MalwareBazaar](https://bazaar.abuse.ch/sample/d97ea10d1dbfe2a69e0d2387e8985635b20628495918abd54c4b052c0acf05b1/),
[Triage](https://tria.ge/260817-ktkv8swgra)), observed with Sysmon and Elastic Defend telemetry.

I've been candid below about coverage overlap and about one rule that has not fired, so you can
take, reshape or reject them individually rather than having to work that out yourselves.

### 1. Potential PyArmor Obfuscated PyInstaller Payload Extraction — `file_event`

Correlates PyInstaller's `_MEI` extraction directory with `pyarmor_runtime` appearing inside it.
Together they mean the bundled bytecode was deliberately obfuscated before packaging.

I could find no existing coverage — `pyarmor` returns no hits in this repository, and `_MEI`
appears only in `image_load_side_load_python.yml` and
`file_event_win_hktl_netexec_file_indicators.yml`, neither for obfuscated payloads. This is the
rule I'd most like your view on.

**Fired in testing.** The stated false positive — commercially licensed PyArmor-protected Python
applications on developer estates — is the real one and is why the level is `medium`.

### 2. Suspicious Microsoft Defender Exclusion Added Via WMIC — `process_creation`

Overlaps `proc_creation_win_wmic_namespace_defender.yml` (`51cbac1e`), which matches on
`/Namespace:\\root\Microsoft\Windows\Defender`. This one keys on the `MSFT_MpPreference` class
name plus a specific exclusion property, so it also matches a command line that reaches the class
without the `/Namespace:` form, and distinguishes an exclusion being added from Defender tampering
generally.

**Fired in testing.** If you'd prefer, I'm happy to withdraw this and instead submit a small PR
adding `MSFT_MpPreference` as an alternative selection to `51cbac1e` — that may be the better
shape and I have no attachment to a separate rule.

### 3. Suspicious Double Extension Executable Launched From User Writable Path — `process_creation`

Overlaps `proc_creation_win_susp_double_extension.yml` (`1cdd9a09`, stable). What it adds is a
user-writable path requirement and extensions not currently listed, notably `.php.exe`, `.dat.exe`
and `.lock.exe` — the observed cluster imitates a Composer artefact so a developer double-clicking
it believes they are opening a PHP file.

**This rule has not fired.** In the detonation the sample executed under its SHA256 filename, so
the condition was never met; the logic is sound on inspection but is untested against real
telemetry. If that disqualifies it, the useful part is the three extensions and I'd rather see
them added to `1cdd9a09` than have an unproven rule merged.

### Testing

- `sigma check` on all three: 0 errors, 0 condition errors, 0 issues
- `python tests/test_rules.py` with the rules in place: 11 tests, OK
- Rules 1 and 2 verified firing against the detonation telemetry; rule 3 has not fired
- No regression data supplied; happy to add it if you'd like it for any of these

Rules also published at
[Security-Distractions/sigma-rules](https://github.com/Security-Distractions/sigma-rules) under
DRL 1.1.
