### PR TITLE
Add detection for owner added to service principal

### DIFF
--- a/rules/cloud/azure/audit_logs/azure_owner_added_to_service_principal.yml
+++ b/rules/cloud/azure/audit_logs/azure_owner_added_to_service_principal.yml
@@ -1,0 +1,34 @@
+title: Owner Added To Azure Service Principal
+id: 26385dec-200b-4b42-9cc9-2e61ed9b1bdb
+status: experimental
+description: |
+    Detects when a new owner is added to an Azure service principal. Service principal
+    ownership grants the ability to manage the object's credentials (add password or
+    certificate credentials, consent to permissions) without requiring a tenant-wide
+    admin role, which can be used to authenticate as the service principal for
+    persistence or privilege escalation. This complements azure_app_owner_added.yml,
+    which covers owners added to an application but does not fire for service
+    principals that have no locally-owned application registration, for example
+    enterprise applications added from the gallery.
+references:
+    - https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-audit-activities#core-directory
+    - https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/assign-app-owners
+    - https://www.microsoft.com/en-us/security/blog/2024/01/25/midnight-blizzard-guidance-for-responders-on-nation-state-attack/
+author: descambiado
+date: 2026-08-31
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098.003
+logsource:
+    product: azure
+    service: auditlogs
+detection:
+    selection:
+        operationName: 'Add owner to service principal'
+    condition: selection
+falsepositives:
+    - Co-owner assignments during application onboarding
+    - Ownership transfers between teams
+    - Automated provisioning pipelines assigning service principal ownership
+level: medium


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

Adds a detection rule for `Add owner to service principal` in Azure AD audit logs.

This is a revival of `azure_ad_service_principal_owner_added.yml` from SigmaHQ PR #6025, closed 2026-05-29 along with 4 sibling PRs for lack of tenant validation. Rewritten, not copied (new id, new title, updated description), same idea, this time with the piece that was missing: a live event captured before writing the rule, not just the reference docs.

`azure_owner_removed_from_application_or_service_principal.yml` already covers `Remove owner from service principal` and `Remove owner from application`. Of the two directions, only removal is covered. There is no rule for adding an owner to a service principal specifically, and that's the direction that matters to an attacker: ownership grants credential management (add password or certificate credentials, consent to permissions) without needing a tenant-wide admin role. This is the persistence mechanism Microsoft documented in the 2024 Midnight Blizzard (APT29) guidance.

Scope note, since I got this wrong on the first pass: I initially wrote this rule to also match `Add owner to application`, thinking that was uncovered too. It isn't. `azure_app_owner_added.yml` (2022, Morowczynski/Bercik) already covers it. Caught that before submitting by re-checking the existing ruleset, not after, so this PR is scoped to the service principal case only.

I considered folding this into `azure_app_owner_added.yml` instead, to mirror how the removal side is one combined rule, but kept it separate. Extending someone else's already-merged rule is a bigger, more invasive change than adding a new narrowly scoped one, and it risks affecting existing detections people already rely on for a title and scope that specifically say "application." Happy to combine them if a maintainer prefers that shape.

**Verification.** Reproduced the action in my own Entra ID tenant (`descambiadogmail.onmicrosoft.com`, free tier plus Entra ID P2 trial) and captured the real event before writing the rule.

First attempt: added a test user as owner of a locally registered app through its App Registration. Result: `Add owner to application` only. App Registrations and their paired Service Principal share one owners list in that case, so the SP-specific operation never fires. That also explains why the 2022 rule alone doesn't cover the gap this PR is closing, for apps that don't have a local App Registration.

To generate the actual gap I added a gallery enterprise application (no local App Registration, SP object only) and added the test user as its owner from the Enterprise Applications Owners blade. See Example Log Event below for the real fields captured.

Also checked whether this holds outside the Portal, since a real attacker is more likely to use the Graph API directly than click through a web UI. Added a second gallery application and granted the same ownership with a raw POST to `/v1.0/servicePrincipals/{id}/owners/$ref` through the Graph API, no Portal involved. Same activity type, `Add owner to service principal`, same fields, only the actor's user agent changed (`AZURECLI/...` instead of a browser). The detection isn't Portal-specific.

Deleted both test apps after capturing the events, tenant is back to its prior state.

**Testing.** `python tests/test_logsource.py` and `python tests/test_rules.py` pass. `sigma check --fail-on-error --fail-on-issues --validation-config tests/sigma_cli_conf.yml` against this rule: 0 errors, 0 issues (first draft tripped `SigmahqStatusToHighIssue` for starting at `status: test`, fixed to `experimental`). Also ran an actual query conversion (pySigma, `kusto` backend, `azuremonitor` pipeline) against the real `AuditLogs` table schema, not just structural validation, using `azure_owner_removed_from_application_or_service_principal.yml` as a control (fails the same way, confirming the lowercase `operationName` field is Sigma's normalized name for this logsource across the whole folder, not a defect in this rule). With the field casing patched only for the syntax check, logic untouched, the resulting query is:

```
AuditLogs
| where OperationName =~ "Add owner to service principal"
```

which matches the live event's activity type character for character.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: Owner Added To Azure Service Principal

### Example Log Event

Real audit log entry captured in my tenant when adding an owner to a service principal that has no locally owned App Registration (fields as shown in the Entra admin center audit log detail, correlation id and object ids redacted):

```
Activity type: Add owner to service principal
Category: ApplicationManagement
Service: Core Directory
Status: success
Initiated by (actor): a real user (type User, not a service principal)
Target 1: type User (the account granted ownership)
Target 2: type ServicePrincipal (the service principal that gained an owner)
```

### Fixed Issues

Revives the idea from #6025, closed 2026-05-29, this time with the tenant validation that was missing.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
