### PR TITLE
new: Federated Identity Credential Added To Entra Application Or Managed Identity

### DIFF
--- a/rules/cloud/azure/audit_logs/azure_app_federated_identity_credential_added.yml
+++ b/rules/cloud/azure/audit_logs/azure_app_federated_identity_credential_added.yml
@@ -1,0 +1,32 @@
+title: Federated Identity Credential Added To Entra Application Or Managed Identity
+id: 6e6bffed-fc61-4943-b0f4-6f072c8c3ddc
+status: experimental
+description: |
+    Detects when a federated identity credential is added to an Entra ID application or service principal (managed identity).
+    Workload identity federation establishes a trust with an external OIDC issuer (such as a CI/CD pipeline) that can then obtain tokens and authenticate as the target identity without a secret or certificate.
+    An adversary who can modify an application or service principal can abuse this to gain persistent access that survives secret and certificate rotation.
+references:
+    - https://dirkjanm.io/persisting-with-federated-credentials-entra-apps-managed-identities/
+    - https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation
+    - https://learn.microsoft.com/en-us/graph/api/application-post-federatedidentitycredentials
+author: Eduard Arbona '@earbona23'
+date: 2026-09-06
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098.001
+logsource:
+    product: azure
+    service: auditlogs
+    definition: 'Requirements: The TargetResources array needs to be mapped accurately in order for this rule to work'
+detection:
+    selection:
+        OperationName:
+            - 'Update application'
+            - 'Update service principal'
+        TargetResources.modifiedProperties|contains: 'FederatedIdentityCredentials'
+    condition: selection
+falsepositives:
+    - Legitimate onboarding of workload identity federation for CI/CD or other external OIDC workloads (e.g. GitHub Actions, Azure DevOps, GitLab).
+    - Application owners or DevOps configuring passwordless authentication for an application or managed identity.
+level: high


### PR DESCRIPTION
### Summary

New detection rule: **Federated Identity Credential Added To Entra Application Or Managed Identity**.

Adding a federated identity credential (FIC) establishes workload identity federation — a trust with an external OIDC issuer that can then obtain tokens and authenticate as the target application or service principal **without a secret or certificate**. An adversary who can modify an application or service principal can add a FIC pointing at an issuer/subject they control (e.g. an attacker-owned GitHub Actions repo) to gain persistence that survives secret and certificate rotation. This is a distinct persistence primitive from adding a password/certificate credential (already covered by `azure_app_credential_added.yml`) and from domain federation changes (`azure_federation_modified.yml`).

### Detection logic

Fires on the Entra ID audit event for a FIC being added to either object type:

- `OperationName` is `Update application` (app registration) or `Update service principal` (service principal / managed identity), **and**
- `TargetResources.modifiedProperties` contains `FederatedIdentityCredentials`.

The `modifiedProperties` discriminator is what keeps the rule specific — a benign `Update service principal` event (e.g. a `DisplayName` change) does not match. Field taxonomy and the `modifiedProperties|contains` pattern mirror the existing `azure_ad_certificate_based_authencation_enabled.yml`.

Verified the exact operation name (`Update service principal`) and the modified-property display name (`FederatedIdentityCredentials`) against a real Entra audit-log sample, plus Microsoft's workload identity federation documentation and dirkjanm's research.

### MITRE ATT&CK

- T1098.001 — Account Manipulation: Additional Cloud Credentials (Persistence / Privilege Escalation).

### Notes

Complements a hardening check for the same technique — flagging FICs on privileged applications/service principals — so the preventive and detective sides line up.

### Validation

- `sigma check --validation-config tests/sigma_cli_conf.yml <rule>` → 0 errors, 0 issues (pySigma validators-sigmahq 0.21.0).
- `python3 tests/test_rules.py` → 11 tests OK.
- `python3 tests/test_logsource.py` → 3 tests OK.
