### PR TITLE
Fix Initiatied.By and Sucess typos in Account Created Or Deleted By Non Approved Actor

### DIFF
--- a/rules-placeholder/cloud/azure/audit_logs/azure_ad_account_created_deleted_nonapproved_user.yml
+++ b/rules-placeholder/cloud/azure/audit_logs/azure_ad_account_created_deleted_nonapproved_user.yml
@@ -21,9 +21,9 @@ detection:
         properties.message:
             - Add user
             - Delete user
-        Status: Sucess
+        Status: Success
     valid_admin:
-        Initiatied.By|expand: '%ApprovedUserUpn%'
+        InitiatedBy|expand: '%ApprovedUserUpn%'
     condition: selection and not valid_admin
 falsepositives:
     - Legit administrative action


### PR DESCRIPTION
### Summary of the Pull Request

Two spelling fixes in `azure_ad_account_created_deleted_nonapproved_user.yml`.

`Initiatied.By` is a misspelling of `InitiatedBy`, with an extra `i` and a stray dot. It appears exactly once in the whole repository, so it is a typo rather than a convention. Because the field cannot bind, the `valid_admin` block never matches and the negation in `selection and not valid_admin` never excludes anything.

`Sucess` is a misspelling of `Success`.

Checked against a live Log Analytics workspace fed by Entra ID diagnostic settings:

```
AuditLogs | where Initiatied.By == 'x' | count
Failed to resolve expression 'Initiatied.By'

AuditLogs | where tostring(InitiatedBy) has 'UPN' | count
valid query
```

The control matters: the corrected spelling resolves against the same table, so the rejection is the engine resolving column names rather than an empty workspace.

**Deliberately not changed, and worth stating plainly: this does not by itself make the rule fire.** `Status` is not a column in the `AuditLogs` table either, so the selection still has a field that cannot bind. I left it alone because #5993 is currently settling the field convention for this folder's sibling under `rules/`, and this file should follow whatever that lands on rather than diverge here. These two are only the unambiguous spelling fixes.

`%ApprovedUserUpn%` is untouched: `rules-placeholder/` uses placeholders by design.

### Changelog

```
update: Account Created Or Deleted By Non Approved Actor - fix Initiatied.By and Sucess typos
```

### Example Log Event

Not applicable, this is a spelling fix to field and value names. The field resolution evidence is above.

### Fixed Issues

None.

### SigmaHQ Rule Creation Conventions

- [x] I have read the [SigmaHQ conventions](https://github.com/SigmaHQ/sigma-specification/tree/main/sigmahq)
