### PR TITLE
new: Redis Server Process Writing To SSH Authorized Keys File

### DIFF
--- a/rules/linux/file_event/file_event_lnx_redis_authorized_keys_write.yml
+++ b/rules/linux/file_event/file_event_lnx_redis_authorized_keys_write.yml
@@ -1,0 +1,29 @@
+title: Redis Server Process Writing To SSH Authorized Keys File
+id: 5a6dff70-3536-49cb-b14a-f39da78d417c
+status: experimental
+description: |
+    Detects the redis-server process writing to a user's SSH authorized_keys file.
+    An unauthenticated Redis instance can be made to write its database to an arbitrary
+    path via CONFIG SET dir and CONFIG SET dbfilename followed by SAVE, which is used to
+    append an attacker-controlled SSH public key and gain persistent shell access.
+    A legitimate Redis deployment does not write to this path.
+references:
+    - https://hacktricks.wiki/en/network-services-pentesting/6379-pentesting-redis.html
+    - https://the-hunters-ledger.com/hunting-detections/seasia-gov-exploitation-toolkit-144-172-106-236-detections/
+author: The Hunters Ledger
+date: 2026-07-17
+tags:
+    - attack.persistence
+    - attack.privilege-escalation
+    - attack.t1098.004
+logsource:
+    category: file_event
+    product: linux
+detection:
+    selection:
+        Image|endswith: '/redis-server'
+        TargetFilename|endswith: '/.ssh/authorized_keys'
+    condition: selection
+falsepositives:
+    - Unlikely. No legitimate Redis deployment configuration writes to this file
+level: high


### PR DESCRIPTION
<!--
Thanks for your contribution. Please make sure to fill the contents of this template with the necessary information to ease and speed up the review process.

!!! PLEASE DO NOT DELETE ANY SECTION, COMMENT OR THE CONTENT OF THE TEMPLATE. !!!
-->

### Summary of the Pull Request

<!--
**Please note that this section is required and must be filled**
A short summary of your pull request.
-->

Adds one rule detecting the `redis-server` process writing to a user's SSH `authorized_keys` file.

An unauthenticated Redis instance can be directed to write its database to an arbitrary path using `CONFIG SET dir`, `CONFIG SET dbfilename` and `SAVE`. Appending an attacker public key to `authorized_keys` is the usual outcome and gives persistent shell access. A legitimate Redis deployment has no reason to write to that path, so the rule is a two field match with no allowlist.

I observed this technique in an intrusion set used against government hosts in Southeast Asia, alongside a planted key whose comment identified the operator's own VPS.

Before writing it I checked the ruleset for overlap. `T1098.004` has no rules in the repository, and no Linux `file_event` rule keys on `redis-server` or on `authorized_keys`.

Validated locally: `sigma check` with `tests/sigma_cli_conf.yml` reports 0 errors and 0 issues, `yamllint` with the repo config passes, `tests/test_logsource.py` and `tests/test_rules.py` both pass, and the duplicate-id check returns clean. The `check-baseline` replay does not apply here, since that corpus is Windows EVTX and this is a Linux rule.

### Changelog

<!--
** Don't remove this comment **
You need to add one line for every changed file of the PR and prefix one of the following tags:
new:	<title>
update:	<title> - <optional comment>
fix:	<title> - <optional comment>
remove:	<title> - <optional comment>
chore: for non-detection related changes (e.g. dates/titles) and changes on workflow

e.g.
new: Brute-Force Attacks on Azure Admin Account
update: Suspicious Microsoft Office Child Process - add MSPUB.EXE
fix: Malware User Agent - remove legitimate Firefox UA
chore: workflow - update checkout version
remove: Suspicious Office Execution - deprecated in favour of 8f922766-a1d3-4b57-9966-b27de37fddd2
-->

new: Redis Server Process Writing To SSH Authorized Keys File

### Example Log Event

<!--
Fill this in case of false positive fixes
-->

Not a false positive fix. Included only to show the two fields the rule matches, which follow the same mapping the existing `rules/linux/file_event/` rules use.

```xml
<Event>
  <System><Provider Name="Linux-Sysmon"/><EventID>11</EventID></System>
  <EventData>
    <Data Name="Image">/usr/bin/redis-server</Data>
    <Data Name="TargetFilename">/root/.ssh/authorized_keys</Data>
  </EventData>
</Event>
```

### Fixed Issues

<!--
Link the fixed issues here, in case your commit fixes issues with rules or code
-->

N/A, this adds a new rule and does not fix a tracked issue.

### SigmaHQ Rule Creation Conventions

- If your PR adds new rules, please consider following and applying these [conventions](https://github.com/SigmaHQ/sigma-specification/blob/main/sigmahq/)
